### PR TITLE
inline: accept cross-module inlining with effect, secrecy and debug provenance (#3110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release builds inline small helpers across module boundaries. A dependency's
+  raw lowered module yields a per-module `Q_INLINE_BODIES` product holding every
+  body under the size bar (or `#[inline]`) that is not recursive, `noinline`,
+  `scalar` or naked; an importer acquires those bodies into storage owned by its
+  own lowering and the inline pass expands them in place. No copy is emitted, a
+  remaining call or taken address still names the provider's symbol, assembly
+  payloads, effect flags, secrecy and debug metadata travel with the body, and
+  growth is charged in live instructions and owned bytes. `#[inline]` is no
+  longer monomorphized into importers and no longer part of the lowered
+  surface; an edit to a provider body reaches importers through the product,
+  which stops propagation when the extracted bodies are unchanged. (#3110)
+
 - The System V x86-64 classifier spent a register on an eightbyte that holds
   only padding: a 16-byte aggregate with data in its first eightbyte alone (an
   over-aligned `#[align(16)] rec { a: u8; }`) rode rdi and rsi and returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   growth is charged in live instructions and owned bytes. `#[inline]` is no
   longer monomorphized into importers and no longer part of the lowered
   surface; an edit to a provider body reaches importers through the product,
-  which stops propagation when the extracted bodies are unchanged. (#3110)
+  which stops propagation when the extracted bodies are unchanged. An
+  `#[oblivious]` body is expanded only into an `#[oblivious]` caller, so its
+  instructions never leave a constant-time validated function. (#3110)
 
 - The System V x86-64 classifier spent a register on an eightbyte that holds
   only padding: a 16-byte aggregate with data in its first eightbyte alone (an

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -284,3 +284,122 @@ their shape (a `{ptr}`/`{result}` binding pair around one memory instruction).
 
 Verdict: compiler policy covered by the effect legs above; the std-side
 annotations remain Track C's S4 and are not needed for elimination.
+
+## Corpus goldens moved by this change
+
+Layer B compares `llvm-objdump` text of the `o2` build against
+`test/golden/<target>/<group>/<case>.dis`. Every corpus case folds its operands
+through `corpus.lib.fold`, whose `mix_*` entry points are small unannotated
+helpers in another module, so cross-module inlining reaches every case: each
+fold site now carries the byte loop inline instead of a call. The evidence
+below follows `doc/design/corpus-goldens-3218.md`: cases are classified by the
+first rule that applies (fewer calls, then a smaller first frame adjustment
+with no call removed, then a larger one, then an identical instruction
+multiset with frame offsets normalized, then other), calls are `call*` on
+x86-64 and `bl`/`blr` on aarch64, and the frame adjustment is the first
+`subq $N, %rsp` or `sub sp, sp, #N`. Computed by comparing each blessed golden
+with its `HEAD` version.
+
+## x86_64-linux: 91 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 91 |
+
+calls before 4304, after 1791, cases reaching zero calls 31
+frame direction: frame larger 37, frame same 44, frame smaller 10
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 65 | 322 | 22 | 5 | calls removed |
+| bits/logic_u64 | 61 | 337 | 22 | 5 | calls removed |
+| bits/shift_i32 | 68 | 366 | 28 | 11 | calls removed |
+| bits/shift_i64 | 39 | 320 | 28 | 11 | calls removed |
+| bits/shift_u32 | 67 | 357 | 27 | 10 | calls removed |
+| bits/shift_u64 | 44 | 315 | 27 | 10 | calls removed |
+| call/call_chain | 199 | 460 | 172 | 154 | calls removed |
+| call/call_float_regs | 281 | 483 | 87 | 30 | calls removed |
+| call/call_indirect | 303 | 447 | 69 | 24 | calls removed |
+| call/call_int_regs | 415 | 557 | 123 | 24 | calls removed |
+| call/call_mixed | 283 | 551 | 53 | 35 | calls removed |
+| call/call_rec_edge | 335 | 398 | 87 | 50 | calls removed |
+| call/call_rec_large | 207 | 653 | 134 | 97 | calls removed |
+| call/call_rec_small | 306 | 705 | 71 | 30 | calls removed |
+| call/call_recursive | 240 | 248 | 53 | 13 | calls removed |
+| call/call_ret_large | 489 | 1162 | 138 | 96 | calls removed |
+| call/call_ret_small | 372 | 754 | 88 | 42 | calls removed |
+| call/call_variadic | 140 | 551 | 158 | 141 | calls removed |
+| cmp/branch_nest | 97 | 131 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 106 | 210 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 109 | 206 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 106 | 210 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 109 | 206 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 95 | 185 | 6 | 0 | calls removed |
+| cmp/short_circuit | 360 | 348 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 175 | 405 | 54 | 37 | calls removed |
+| convert/bitcast | 46 | 215 | 11 | 0 | calls removed |
+| convert/ext_sign | 70 | 307 | 15 | 0 | calls removed |
+| convert/ext_zero | 70 | 305 | 15 | 0 | calls removed |
+| convert/f2f | 57 | 224 | 11 | 0 | calls removed |
+| convert/f2i | 125 | 735 | 54 | 21 | calls removed |
+| convert/f2u_high | 172 | 579 | 25 | 0 | calls removed |
+| convert/i2f | 101 | 702 | 37 | 4 | calls removed |
+| convert/trunc | 46 | 183 | 9 | 0 | calls removed |
+| float/arith_f32 | 437 | 405 | 65 | 46 | calls removed |
+| float/arith_f64 | 380 | 366 | 65 | 46 | calls removed |
+| float/cmp_f32 | 259 | 459 | 20 | 2 | calls removed |
+| float/cmp_f64 | 311 | 709 | 26 | 7 | calls removed |
+| float/special_f32 | 483 | 618 | 117 | 84 | calls removed |
+| float/special_f64 | 511 | 652 | 127 | 94 | calls removed |
+| frame/frame_align | 463 | 522 | 79 | 24 | calls removed |
+| frame/frame_large | 193 | 432 | 16 | 0 | calls removed |
+| frame/frame_spill | 149 | 373 | 32 | 15 | calls removed |
+| imm/imm_add | 66 | 332 | 25 | 8 | calls removed |
+| imm/imm_addr | 175 | 491 | 21 | 4 | calls removed |
+| imm/imm_logic | 90 | 363 | 21 | 4 | calls removed |
+| imm/imm_mov | 81 | 268 | 12 | 0 | calls removed |
+| mem/addr_modes | 299 | 517 | 36 | 19 | calls removed |
+| mem/array_index | 358 | 664 | 36 | 15 | calls removed |
+| mem/global_data | 160 | 436 | 35 | 12 | calls removed |
+| mem/global_zero | 210 | 492 | 28 | 7 | calls removed |
+| mem/loadstore | 107 | 375 | 25 | 8 | calls removed |
+| mem/ptr_arith | 233 | 491 | 29 | 8 | calls removed |
+| mem/rec_layout | 473 | 880 | 50 | 25 | calls removed |
+| mem/uni_layout | 216 | 493 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 79 | 299 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 87 | 301 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 68 | 285 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 79 | 299 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 77 | 297 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 85 | 299 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 66 | 283 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 77 | 297 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 112 | 357 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 91 | 285 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 82 | 259 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 70 | 230 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 56 | 184 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 41 | 164 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 54 | 182 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 38 | 160 | 8 | 0 | calls removed |
+| vec/autovec_loop | 502 | 550 | 10 | 0 | calls removed |
+| vec/vec_cmp_select | 301 | 534 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 265 | 217 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 310 | 273 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 413 | 273 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 1225 | 945 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 1639 | 1142 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 258 | 210 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 373 | 229 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 654 | 319 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 560 | 393 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 369 | 305 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 425 | 773 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 537 | 733 | 107 | 39 | calls removed |
+| vec/vec_mem | 1339 | 1369 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 568 | 650 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 654 | 319 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 559 | 394 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 369 | 305 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 433 | 781 | 42 | 25 | calls removed |
+

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -57,9 +57,10 @@ Resolutions against `dev` made while porting:
   (`doc/design/query-semantic-results.md`), so an edit to the provider that
   leaves every extracted body identical stops propagation at the product
   instead of re-optimizing every importer.
-- `body.mach` is written against `dev`'s opaque `IRT_PTR` (the candidate's
-  `pointee` field is the SPIR-V logical-addressing hunk owned by N4) and
-  without `IRT_TAG`, which `dev` does not have.
+- `body.mach` is written without `IRT_TAG`, which `dev` does not have. The
+  `IRT_PTR` pointee the candidate carried arrived on `dev` with #3268 (N4)
+  while this lane was open and is handled as the candidate did: a typed
+  reference is marked, remapped and re-interned through `intern_reference`.
 - `lower_parallel_enabled` and the `slot_len <= 1` gate keep `dev`'s shape; the
   candidate's change to run the prepared path unconditionally came with its
   readout test rewrite and is not part of the inline concern.
@@ -402,4 +403,107 @@ frame direction: frame larger 37, frame same 44, frame smaller 10
 | vec/vec_u32x4 | 559 | 394 | 78 | 23 | calls removed |
 | vec/vec_u64x2 | 369 | 305 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 433 | 781 | 42 | 25 | calls removed |
+
+## aarch64-linux: 91 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 91 |
+
+calls before 4304, after 1791, cases reaching zero calls 31
+frame direction: frame larger 26, frame same 9, frame smaller 32, no frame adjustment 24
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 104 | 337 | 22 | 5 | calls removed |
+| bits/logic_u64 | 79 | 315 | 22 | 5 | calls removed |
+| bits/shift_i32 | 99 | 345 | 28 | 11 | calls removed |
+| bits/shift_i64 | 135 | 326 | 28 | 11 | calls removed |
+| bits/shift_u32 | 98 | 345 | 27 | 10 | calls removed |
+| bits/shift_u64 | 131 | 325 | 27 | 10 | calls removed |
+| call/call_chain | 162 | 376 | 172 | 154 | calls removed |
+| call/call_float_regs | 294 | 378 | 87 | 30 | calls removed |
+| call/call_indirect | 235 | 363 | 69 | 24 | calls removed |
+| call/call_int_regs | 388 | 571 | 123 | 24 | calls removed |
+| call/call_mixed | 110 | 383 | 53 | 35 | calls removed |
+| call/call_rec_edge | 372 | 419 | 87 | 50 | calls removed |
+| call/call_rec_large | 179 | 655 | 134 | 97 | calls removed |
+| call/call_rec_small | 237 | 527 | 71 | 30 | calls removed |
+| call/call_recursive | 217 | 226 | 53 | 13 | calls removed |
+| call/call_ret_large | 234 | 700 | 138 | 96 | calls removed |
+| call/call_ret_small | 276 | 529 | 88 | 42 | calls removed |
+| call/call_variadic | 109 | 339 | 158 | 141 | calls removed |
+| cmp/branch_nest | 104 | 126 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 91 | 185 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 110 | 196 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 91 | 185 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 110 | 196 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 90 | 159 | 6 | 0 | calls removed |
+| cmp/short_circuit | 244 | 209 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 155 | 375 | 54 | 37 | calls removed |
+| convert/bitcast | 65 | 197 | 11 | 0 | calls removed |
+| convert/ext_sign | 96 | 279 | 15 | 0 | calls removed |
+| convert/ext_zero | 96 | 279 | 15 | 0 | calls removed |
+| convert/f2f | 51 | 199 | 11 | 0 | calls removed |
+| convert/f2i | 128 | 622 | 54 | 21 | calls removed |
+| convert/f2u_high | 85 | 456 | 25 | 0 | calls removed |
+| convert/i2f | 135 | 649 | 37 | 4 | calls removed |
+| convert/trunc | 65 | 166 | 9 | 0 | calls removed |
+| float/arith_f32 | 398 | 258 | 65 | 46 | calls removed |
+| float/arith_f64 | 392 | 234 | 65 | 46 | calls removed |
+| float/cmp_f32 | 240 | 431 | 20 | 2 | calls removed |
+| float/cmp_f64 | 175 | 418 | 26 | 7 | calls removed |
+| float/special_f32 | 278 | 399 | 117 | 84 | calls removed |
+| float/special_f64 | 307 | 396 | 127 | 94 | calls removed |
+| frame/frame_align | 363 | 395 | 79 | 24 | calls removed |
+| frame/frame_large | 170 | 400 | 16 | 0 | calls removed |
+| frame/frame_spill | 171 | 475 | 32 | 15 | calls removed |
+| imm/imm_add | 118 | 323 | 25 | 8 | calls removed |
+| imm/imm_addr | 140 | 434 | 21 | 4 | calls removed |
+| imm/imm_logic | 87 | 304 | 21 | 4 | calls removed |
+| imm/imm_mov | 85 | 262 | 12 | 0 | calls removed |
+| mem/addr_modes | 199 | 411 | 36 | 19 | calls removed |
+| mem/array_index | 212 | 444 | 36 | 15 | calls removed |
+| mem/global_data | 117 | 299 | 35 | 12 | calls removed |
+| mem/global_zero | 93 | 275 | 28 | 7 | calls removed |
+| mem/loadstore | 173 | 373 | 25 | 8 | calls removed |
+| mem/ptr_arith | 161 | 356 | 29 | 8 | calls removed |
+| mem/rec_layout | 168 | 477 | 50 | 25 | calls removed |
+| mem/uni_layout | 129 | 375 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 70 | 260 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 70 | 260 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 69 | 247 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 70 | 260 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 68 | 258 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 68 | 258 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 67 | 245 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 68 | 258 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 130 | 307 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 128 | 293 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 74 | 204 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 73 | 194 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 43 | 152 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 42 | 144 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 41 | 150 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 40 | 142 | 8 | 0 | calls removed |
+| vec/autovec_loop | 463 | 630 | 10 | 0 | calls removed |
+| vec/vec_cmp_select | 156 | 409 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 304 | 119 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 168 | 163 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 283 | 164 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 891 | 560 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 1404 | 796 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 153 | 121 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 322 | 190 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 577 | 288 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 304 | 184 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 118 | 106 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 270 | 464 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 417 | 448 | 107 | 39 | calls removed |
+| vec/vec_mem | 1189 | 1162 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 393 | 430 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 577 | 288 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 305 | 184 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 118 | 106 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 270 | 464 | 42 | 25 | calls removed |
 

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -1,0 +1,261 @@
+# Inlining acceptance inventory for #3110
+
+Roadmap item N6, phase 1. One row per acceptance bullet of #3110: what `dev`
+does at the start of this lane (`853d4c17`) with the test that shows it, what
+the three candidate commits on `archive/3218-candidate-era` add, and a verdict.
+The compiler policy is covered here with local fixtures shaped like the eight
+`std.sync.atomic` wrappers (short asm bodies with volatile memory effects); the
+std-side annotations are Track C's S4 and are not part of this lane.
+
+Candidate commits, in the order they are ported:
+
+- `c2fbd635` "fix(compiler): integrate inline bodies and final security
+  provenance". A 64-file integration commit. The hunks that belong to this lane
+  are `src/lang/me/ir/body.mach` (new), `src/lang/me/pass/inline.mach`,
+  `src/lang/me/ir.mach` (`Function.body_module`), `src/lang/me/pipeline.mach`,
+  `src/lang/me/lower/expr.mach` (`stamp_body_provider` replacing
+  `enqueue_inline_import`), `src/lang/driver.mach`, `src/lang/driver/project.mach`,
+  `src/lang/driver/passes.mach` (`Q_INLINE_BODIES`), `src/lang/query.mach`, the
+  `inline` section of `doc/language/decorators.md`, and the two driver tests
+  `inline_bodies_cross_modules_preserve_identity_effects_and_owned_metadata` and
+  `inline_body_availability_refreshes_after_unannotated_provider_edits`.
+- `602cf806` "fix(inline): retain actual providers for shared weak
+  specializations".
+- `d2a9842d` "fix(inline): make body cost independent of debug annotations so
+  -g cannot move an inlining decision".
+
+## The two designs
+
+`dev` (`195c81436`) flows a dependency body into an importer only when the
+function is a template (generic, comptime-param, pack-tailed) or carries
+`#[inline]`; the copy is monomorphized at lowering as `PUB | WEAK` under the
+origin's mangled name, and `Q_LOWERED_SURFACE` includes `#[inline]` bodies so
+an edit invalidates importers. A regular small `pub fun` in another module
+(`vec3`, `aabb_add`, `fold.mix_u64`, every `std.sync.atomic` wrapper) stays an
+out-of-line call: `should_inline` refuses `FN_FLAG_EXTERN` unconditionally.
+
+The candidate replaces that with a query product. `Q_INLINE_BODIES` (one per
+module, keyed like `Q_LOWER`) is the provider's raw lowered module after
+`mem2reg`, reduced by `body.extract` to the functions `body.candidate` admits:
+not extern, noinline, scalar or naked, not in a call cycle, and either
+`#[inline]` or fewer than `SMALL_INSTRUCTIONS` (25) live instructions, capped at
+`MAX_INSTRUCTIONS` (1024). When an importer lowers in release, `acquire_inline_bodies`
+reads that product for every extern function whose `body_module` names another
+module (stamped at lowering by `stamp_body_provider`), copies the body into a
+`body.Available` store owned by that lowering, and `pipeline.inline_available`
+attaches those bodies onto the importer's extern declarations for the duration
+of the inline pass. Nothing is emitted for the copy: an inlined call disappears,
+a remaining call or a taken address still names the provider's strong symbol,
+and the store is released with the lowering. `#[inline]` is no longer a
+monomorphization axis, so `Q_LOWERED_SURFACE` no longer carries its body; the
+invalidation edge is the `Q_INLINE_BODIES` read.
+
+Resolutions against `dev` made while porting:
+
+- `Q_INLINE_BODIES` is registered with `register_derived_equatable` and
+  `lower_output_equal`, the F2 contract for IR-module products
+  (`doc/design/query-semantic-results.md`), so an edit to the provider that
+  leaves every extracted body identical stops propagation at the product
+  instead of re-optimizing every importer.
+- `body.mach` is written against `dev`'s opaque `IRT_PTR` (the candidate's
+  `pointee` field is the SPIR-V logical-addressing hunk owned by N4) and
+  without `IRT_TAG`, which `dev` does not have.
+- `lower_parallel_enabled` and the `slot_len <= 1` gate keep `dev`'s shape; the
+  candidate's change to run the prepared path unconditionally came with its
+  readout test rewrite and is not part of the inline concern.
+
+Not taken from `c2fbd635` (owned by other lanes): the SPIR-V logical
+addressing hunks (`ir/type.mach` pointee, `ir/printer.mach`, `ir/verify.mach`
+`reference_valid`, `lower/context.mach` `LogicalTypePath`, `vecform.mach`,
+`target/abi/spirv.mach`, `target/isa/spirv/*`), the RISC-V extension hunks
+(`ct.mach` `op_known`/`CT_CAP_UNKNOWN` and its `asm.mach` consumer,
+`fe/sema/check.mach`, `target/isa/riscv/*`, `target/isa.mach`, `target.mach`),
+the linker and object-format hunks (`be/linker*.mach`, `be/obj.mach`,
+`target/of/*`, `build/cache/image.mach`, `publication/testing.mach`
+`retain_bytes`), the codegen hunks (`be/codegen/*`), `doc/cli.md`,
+`doc/language/asm.md`, `doc/language/fun.md`, the `dep/std` and `mach.toml`
+bumps, the corpus case edits and `test/golden/spirv/SKIPS`, and the
+`tests.mach` hunks outside the inline tests (`ut_single_result_n`,
+`ut_vec_diag*`, readout, SPIR-V and RISC-V tests).
+
+## Per bullet
+
+### Same-module elimination
+
+`dev`: `me/pass/inline.mach` at `OPT_RELEASE` inlines a direct call when the
+callee is `#[inline]`, or is the single caller's private helper (not
+address-taken, not exported), or has fewer than 25 non-debug instructions and
+has been duplicated fewer than `INLINE_SMALL_CALLEE_FANOUT_CAP` (16) times.
+Shown by `inline.run:small_single_use_callee_inlines_by_default`,
+`inline.run:small_high_fanout_callee_stops_fully_inlining` and
+`driver:generic_instance_call_inlines_at_release`, all of which count `OP_CALL`
+in IR. No test on `dev` counts `call` in the emitted machine text.
+
+Candidate: no policy change for the same-module case; `callee_instr_count` now
+reads `body.live_instructions`.
+
+Verdict: accepted on `dev` at the IR level. Phase 1 adds a machine-text check:
+`driver:inline_same_module_helper_leaves_no_call_in_x86_64_text` counts
+`call` mnemonics in the x86-64 assembly `codegen_module` writes.
+
+### Cross-module elimination
+
+`dev`: only `#[inline]` bodies flow, as weak monomorphized copies. Shown by
+`driver:incremental_lower_inline_body_invalidates_importers` (invalidation
+only; the int cases `2231-cross-module-inline-*` from `195c81436` were stripped
+with `int/`). An unannotated small helper in another module keeps its call.
+
+Candidate: `Q_INLINE_BODIES` plus `body.Available` as described above. Shown by
+`driver:inline_bodies_cross_modules_preserve_identity_effects_and_owned_metadata`:
+`main -> helper.wrap -> helper.first -> leaf.bump` folds to `ret 42` with zero
+`OP_CALL` in `main`, across a two-hop chain of unannotated helpers, with
+`jobs = 0` and `jobs = 2`.
+
+Verdict: gap on `dev`, closed by the port. Phase 1 adds the machine-text
+check `driver:inline_cross_module_helper_leaves_no_call_in_x86_64_text`.
+
+### Bounded growth
+
+`dev`: `INLINE_BUDGET` (1024) counts inlining events per caller, not
+instructions, so one caller may grow by 1024 x 24 instructions; `PEEL_BUDGET`
+likewise. Shown by `inline.run:exhausted_inline_budget_is_a_distinct_reported_state`
+and `inline.run:a_later_function_is_not_starved_by_an_earlier_functions_exhaustion`.
+
+Candidate: `body.Budget` charges live instructions (`MAX_INSTRUCTIONS` 1024)
+and owned bytes (`MAX_BYTES` 256 KiB) per caller during inlining, per import
+set during acquisition, and per provider during extraction; a refused charge is
+not recorded. The candidate bar `SMALL_INSTRUCTIONS` (25) is the documented
+threshold below which an unannotated helper is eligible.
+
+Verdict: accepted with the port. Phase 1 adds
+`driver:inline_helper_at_the_size_threshold_keeps_its_call` (a 25-live-instruction
+helper keeps its call, a 24-instruction one does not) with a mutation control
+on the threshold.
+
+### Recursion, indirect calls, `noinline`, unsupported asm
+
+`dev`: recursion is detected per function by a BFS from each root
+(`reaches_self`), self-recursion is peeled up to `PEEL_LEVELS` (2); an indirect
+call (callee not a `VAL_FN`) is never a candidate; `noinline`, `naked` and
+`scalar` are refused. Shown by `inline.mark_recursive:direct_self_call`,
+`inline.run:mutual_recursion_not_peeled`, `inline.run:noinline_flag_blocks_inlining`,
+`inline.run:naked_flag_blocks_inlining` and
+`driver:noinline_decorator_survives_object_all_isas`. There is no asm-specific
+refusal: an asm block is cloned with its `IrAsm` payload (`ir.clone_asm_payload`)
+and the encode-time checks (ISA tag mismatch, stack-pointer write under a
+`{name}` binding, unknown mnemonic) apply at the inlined site exactly as at the
+original; a body whose last statement does not fall through lowers to
+`unreachable` after the block (`stmt.mach asm_body_returns`) and inlines as such.
+
+Candidate: `mark_recursive` is one Tarjan traversal (`cycles_exclude_callers_and_completed_components`),
+extraction skips every member of a call cycle, `peel_eligible` refuses
+`noinline`, `scalar` and `naked` (extension of `inline.run:peels_direct_self_recursion`),
+and an extern-attached body is never treated as a free single-caller inline.
+
+Verdict: accepted with the port; the rule is documented in
+`doc/language/decorators.md`. Phase 1 adds one driver test over the four cases
+with a control per guard: `driver:inline_rule_keeps_recursive_indirect_noinline_and_naked_calls`.
+
+### Effects and order
+
+`dev`: `OP_ASM` is neither discardable, CSE-safe, movable nor speculatable and
+may call, read and write memory (`ir/opdesc.mach`); the `{name}` effect model
+(#2258) decides what the block clobbers at codegen. An inlined asm keeps its
+payload, and instruction order within the cloned blocks is the callee's order.
+Shown by `inline.run:*` cloning tests and `ctvalidate.opaque:inline_asm_forbidden`.
+
+Candidate: `copy_function` carries `asm_blocks` and `inline_sites` across the
+module boundary; `clone_instructions` re-owns constant payloads for an
+extern-attached body. Shown by the `assembly` (one `OP_ASM`, zero `OP_CALL`,
+`asm_blocks.len == 1`) and `touch` (one `OP_STORE` to the provider's global,
+which stays `is_extern` and not `is_local`) legs of the cross-module test.
+
+Verdict: accepted with the port. Phase 1 adds
+`driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order` (an atomic-shaped
+wrapper inlined cross-module: the asm survives the release pipeline with its
+result unused, two identical wrappers are not merged, and the MIR instruction
+keeps its `MirAsm` payload) and `driver:inline_naked_asm_wrapper_is_refused`.
+
+### Secrecy
+
+`dev`: `secret` on values and instructions survives cloning
+(`inline.run:preserves_secret_param_operand`); `oblivious.check_module` runs
+before the pipeline and rejects a non-`#[oblivious]` function that computes on a
+secret; `ctvalidate` validates only functions whose MIR carries `oblivious`.
+Nothing stops the inliner from moving an `#[oblivious]` callee's computation
+into a caller that is not `#[oblivious]`, where `ctvalidate` never looks at it.
+
+Candidate: `own_constant` and `copy_value` keep `secret`; the cross-module test
+checks that an `#[oblivious]` importer inlining an `#[oblivious]` provider keeps
+the secret `OP_ADD` and its flag. The caller-side hole above is untouched.
+
+Verdict: gap on both. Phase 1 closes it in the inline pass: an `#[oblivious]`
+callee is inlined only into an `#[oblivious]` caller, so the validation domain a
+function declared is the one its instructions are validated in.
+`driver:inline_oblivious_callee_stays_a_call_in_a_public_caller` with a
+mutation control.
+
+### Debug mapping
+
+`dev`: `stamp_inline_metadata` records an `InlineSite` per inlined call with
+the call location and parent site; DWARF consumes it
+(`dwarf.produce:nested_inline_debug_build_survives_real_inlining`,
+`inline.stamp_inline_metadata:carries_alloca_debug_metadata_into_the_caller`).
+`callee_instr_count` ignores `OP_DBG_VALUE` (`callee_instr_count:dbg_value_blind`)
+but the budget counted events, and phis and terminators were counted.
+
+Candidate: `copy_function` carries debug variables, expressions, alloca debug
+variables and inline sites across modules (the `assembly` leg asserts a nonzero
+`inline_site_len`). `d2a9842d` makes every cost read one `counted()` view that
+excludes `OP_DBG_VALUE` and dead arena slots (`body:debug_annotation_does_not_move_a_bodys_cost`),
+so `-g` cannot change an inlining decision.
+
+Verdict: accepted with the port. Phase 1 adds
+`driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_threshold`
+over a fixture whose callee sits one instruction under the bar with a `dbg_value`
+that would push it over.
+
+### Cache and query dependency invalidation
+
+`dev`: an `#[inline]` body is part of `Q_LOWERED_SURFACE`, so its edit
+invalidates importers (`driver:incremental_lower_inline_body_invalidates_importers`);
+an unannotated body is firewalled (`driver:incremental_lower_surface_firewall`).
+
+Candidate: `Q_INLINE_BODIES` is read through `query.get` inside the importer's
+`Q_LOWER` compute, so the edge is recorded by reading. Shown by
+`driver:inline_body_availability_refreshes_after_unannotated_provider_edits`:
+a helper that was ineligible (it names a module-local literal pool) becomes
+eligible and then changes, and the importer's `Q_LOWER` revision moves each
+round while the provider's surface does not.
+
+Verdict: accepted with the port, with the equatable registration above. The
+`dev` test is retargeted: the surface no longer moves on an `#[inline]` body
+edit and the importer still re-lowers. Phase 1 adds the early-cutoff control
+`driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal`.
+
+### Pure versus atomic controls
+
+`dev`: there is no purity model in the inliner or the pipeline; an inlining
+decision reads size and flags only, and after inlining every later pass reads
+`ir/effect.mach`, where `OP_ASM` is never discardable, CSE-safe or movable.
+Nothing classifies a short asm body as pure.
+
+Candidate: unchanged.
+
+Verdict: accepted on `dev`. The controls are the effect legs above: an inlined
+atomic-shaped wrapper whose result is unused is not removed and two identical
+ones are not merged.
+
+### The eight atomic wrappers
+
+`std.sync.atomic` at the pinned std (`168a9f76`, 1.0.1) defines `load`,
+`store`, `cas`, `fetch_add`, `fetch_sub`, `exchange`, `fence` and `spin_hint`
+as unannotated `pub fun` bodies of one `asm` block under `$if` on the build
+arch, each well under 25 live instructions after `mem2reg`. Under the ported
+policy every one is extracted into `Q_INLINE_BODIES` and inlined at its
+importers with no std-side annotation; `#[inline]` would only override the
+size bar, which they clear. The local fixtures in the phase 1 tests mirror
+their shape (a `{ptr}`/`{result}` binding pair around one memory instruction).
+
+Verdict: compiler policy covered by the effect legs above; the std-side
+annotations remain Track C's S4 and are not needed for elimination.

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -63,6 +63,16 @@ Resolutions against `dev` made while porting:
 - `lower_parallel_enabled` and the `slot_len <= 1` gate keep `dev`'s shape; the
   candidate's change to run the prepared path unconditionally came with its
   readout test rewrite and is not part of the inline concern.
+- The candidate's `Q_LOWER` compute recorded no dependency on the module's own
+  typed definition when it took the raw module `Q_INLINE_BODIES` had captured:
+  the definition read lived inside the raw lowering, which the capture skips.
+  Under the owned registration every recompute of the bodies product advanced
+  its revision and hid that; under the equatable one an edit to a provider
+  function that is not extracted left the provider's own `Q_LOWER` reused with
+  the old body. `lower_inputs` now records the definition and target reads on
+  every product built from a raw lowering, capture or not
+  (`driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal`
+  fails without it).
 
 Not taken from `c2fbd635` (owned by other lanes): the SPIR-V logical
 addressing hunks (`ir/type.mach` pointee, `ir/printer.mach`, `ir/verify.mach`
@@ -128,9 +138,11 @@ not recorded. The candidate bar `SMALL_INSTRUCTIONS` (25) is the documented
 threshold below which an unannotated helper is eligible.
 
 Verdict: accepted with the port. Phase 1 adds
-`driver:inline_helper_at_the_size_threshold_keeps_its_call` (a 25-live-instruction
-helper keeps its call, a 24-instruction one does not) with a mutation control
-on the threshold.
+`inline.run:helper_at_the_size_bar_keeps_its_call` (a two-caller helper of 24
+live instructions loses both calls, one of 25 keeps both; mutation control:
+`<` to `<=` on the bar inlines the 25-instruction body) and the `bg` leg of the
+rule test below, a 27-instruction provider body that keeps its call across
+modules.
 
 ### Recursion, indirect calls, `noinline`, unsupported asm
 
@@ -153,8 +165,12 @@ extraction skips every member of a call cycle, `peel_eligible` refuses
 and an extern-attached body is never treated as a free single-caller inline.
 
 Verdict: accepted with the port; the rule is documented in
-`doc/language/decorators.md`. Phase 1 adds one driver test over the four cases
-with a control per guard: `driver:inline_rule_keeps_recursive_indirect_noinline_and_naked_calls`.
+`doc/language/decorators.md`. Phase 1 adds one cross-module driver test over
+every case beside a small direct helper that does lose its call:
+`driver:inline_rule_keeps_recursive_indirect_noinline_naked_and_large_calls`
+(a self-recursive provider, a call through a function-pointer parameter whose
+callee operand is not a `VAL_FN`, a `noinline` provider, a `naked` asm provider
+and a body over the bar each keep exactly one call).
 
 ### Effects and order
 
@@ -171,10 +187,12 @@ extern-attached body. Shown by the `assembly` (one `OP_ASM`, zero `OP_CALL`,
 which stays `is_extern` and not `is_local`) legs of the cross-module test.
 
 Verdict: accepted with the port. Phase 1 adds
-`driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order` (an atomic-shaped
-wrapper inlined cross-module: the asm survives the release pipeline with its
-result unused, two identical wrappers are not merged, and the MIR instruction
-keeps its `MirAsm` payload) and `driver:inline_naked_asm_wrapper_is_refused`.
+`driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order`: `load`,
+`store` and `fence` shaped like the std wrappers, inlined across modules; two
+identical loads stay two `OP_ASM`, a load whose result is unused survives the
+release pipeline, store/fence/store keep their order in IR and at MIR, and each
+MIR asm keeps its `MirAsm` payload with both `{name}` bindings. The `naked`
+refusal is the `nkd` leg of the rule test.
 
 ### Secrecy
 
@@ -191,9 +209,11 @@ the secret `OP_ADD` and its flag. The caller-side hole above is untouched.
 
 Verdict: gap on both. Phase 1 closes it in the inline pass: an `#[oblivious]`
 callee is inlined only into an `#[oblivious]` caller, so the validation domain a
-function declared is the one its instructions are validated in.
-`driver:inline_oblivious_callee_stays_a_call_in_a_public_caller` with a
-mutation control.
+function declared is the one its instructions are validated in. Same-module
+`inline.run:oblivious_callee_inlines_only_into_an_oblivious_caller` and
+cross-module `driver:inline_oblivious_callee_stays_a_call_in_a_public_caller`;
+mutation control: dropping the flag check in `should_inline` inlines into the
+public caller and fails both.
 
 ### Debug mapping
 
@@ -211,9 +231,12 @@ excludes `OP_DBG_VALUE` and dead arena slots (`body:debug_annotation_does_not_mo
 so `-g` cannot change an inlining decision.
 
 Verdict: accepted with the port. Phase 1 adds
-`driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_threshold`
-over a fixture whose callee sits one instruction under the bar with a `dbg_value`
-that would push it over.
+`driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_bar`:
+a provider body of 23 live instructions with eleven locals, whose `-g` build
+adds a `dbg_value` per local, is inlined at both call sites with and without
+`-g` and the importer's `.text` bytes are identical; mutation control: counting
+`OP_DBG_VALUE` in `body.counted()` keeps the calls under `-g` and the texts
+differ.
 
 ### Cache and query dependency invalidation
 
@@ -228,10 +251,12 @@ a helper that was ineligible (it names a module-local literal pool) becomes
 eligible and then changes, and the importer's `Q_LOWER` revision moves each
 round while the provider's surface does not.
 
-Verdict: accepted with the port, with the equatable registration above. The
-`dev` test is retargeted: the surface no longer moves on an `#[inline]` body
-edit and the importer still re-lowers. Phase 1 adds the early-cutoff control
-`driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal`.
+Verdict: accepted with the port, with the equatable registration and the
+`lower_inputs` fix above. The `dev` test is retargeted: the surface no longer
+moves on an `#[inline]` body edit and the importer still re-lowers. Phase 1
+adds `driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal`:
+an edit to a `noinline` provider function moves the provider's `Q_LOWER` and
+not the importer's, and an edit to the extracted helper moves both.
 
 ### Pure versus atomic controls
 

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -610,3 +610,17 @@ frame direction: frame larger 8, frame same 5, frame smaller 64, no frame adjust
 | vec/vec_u64x2 | 980 | 400 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 2119 | 1199 | 42 | 25 | calls removed |
 
+## vec/vec_cmp_i64, added by #3271 after the tables above
+
+The case arrived on `dev` with its own goldens on every target while this lane
+was open. Merging it and re-running layer B with the merged compiler moved
+exactly that golden on each ISA and nothing else (367 pass, 1 fail, 0 skip
+per target before the bless); every previously blessed golden kept its
+content. Same classification as the rest of the corpus: the fold sites lose
+their calls.
+
+| target | lines removed | lines added | calls before | calls after | frame | class |
+| --- | --- | --- | --- | --- | --- | --- |
+| x86_64-linux | 433 | 297 | 33 | 13 | same | calls removed |
+| aarch64-linux | 269 | 164 | 33 | 13 | larger | calls removed |
+| riscv64-linux | 690 | 679 | 33 | 13 | smaller | calls removed |

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -297,8 +297,8 @@ below follows `doc/design/corpus-goldens-3218.md`: cases are classified by the
 first rule that applies (fewer calls, then a smaller first frame adjustment
 with no call removed, then a larger one, then an identical instruction
 multiset with frame offsets normalized, then other), calls are `call*` on
-x86-64 and `bl`/`blr` on aarch64, and the frame adjustment is the first
-`subq $N, %rsp` or `sub sp, sp, #N`. Computed by comparing each blessed golden
+x86-64, `bl`/`blr` on aarch64 and `jal`/`jalr` on riscv64, and the frame
+adjustment is the first `subq $N, %rsp`, `sub sp, sp, #N` or `addi sp, sp, -N`. Computed by comparing each blessed golden
 with its `HEAD` version.
 
 ## x86_64-linux: 91 goldens changed
@@ -506,4 +506,107 @@ frame direction: frame larger 26, frame same 9, frame smaller 32, no frame adjus
 | vec/vec_u32x4 | 305 | 184 | 78 | 23 | calls removed |
 | vec/vec_u64x2 | 118 | 106 | 44 | 23 | calls removed |
 | vec/vec_u8x16 | 270 | 464 | 42 | 25 | calls removed |
+
+## riscv64-linux: 91 goldens changed
+
+| classification | cases |
+| --- | --- |
+| calls removed | 91 |
+
+calls before 4304, after 1791, cases reaching zero calls 31
+frame direction: frame larger 8, frame same 5, frame smaller 64, no frame adjustment 14
+
+| golden | lines removed | lines added | calls before | calls after | class |
+| --- | --- | --- | --- | --- | --- |
+| bits/logic_u32 | 123 | 327 | 22 | 5 | calls removed |
+| bits/logic_u64 | 98 | 289 | 22 | 5 | calls removed |
+| bits/shift_i32 | 119 | 368 | 28 | 11 | calls removed |
+| bits/shift_i64 | 154 | 348 | 28 | 11 | calls removed |
+| bits/shift_u32 | 117 | 383 | 27 | 10 | calls removed |
+| bits/shift_u64 | 150 | 347 | 27 | 10 | calls removed |
+| call/call_chain | 309 | 511 | 172 | 154 | calls removed |
+| call/call_float_regs | 333 | 550 | 87 | 30 | calls removed |
+| call/call_indirect | 398 | 485 | 69 | 24 | calls removed |
+| call/call_int_regs | 478 | 697 | 123 | 24 | calls removed |
+| call/call_mixed | 235 | 467 | 53 | 35 | calls removed |
+| call/call_rec_edge | 1102 | 1242 | 87 | 50 | calls removed |
+| call/call_rec_large | 626 | 1404 | 134 | 97 | calls removed |
+| call/call_rec_small | 340 | 842 | 71 | 30 | calls removed |
+| call/call_recursive | 314 | 338 | 53 | 13 | calls removed |
+| call/call_ret_large | 701 | 1403 | 138 | 96 | calls removed |
+| call/call_ret_small | 370 | 1290 | 88 | 42 | calls removed |
+| call/call_variadic | 201 | 410 | 158 | 141 | calls removed |
+| cmp/branch_nest | 96 | 110 | 3 | 0 | calls removed |
+| cmp/cmp_i32 | 167 | 260 | 7 | 0 | calls removed |
+| cmp/cmp_i64 | 154 | 251 | 7 | 0 | calls removed |
+| cmp/cmp_u32 | 167 | 260 | 7 | 0 | calls removed |
+| cmp/cmp_u64 | 154 | 251 | 7 | 0 | calls removed |
+| cmp/loop_shapes | 101 | 175 | 6 | 0 | calls removed |
+| cmp/short_circuit | 287 | 259 | 36 | 11 | calls removed |
+| comptime/ct_runtime_agree | 228 | 435 | 54 | 37 | calls removed |
+| convert/bitcast | 81 | 198 | 11 | 0 | calls removed |
+| convert/ext_sign | 127 | 308 | 15 | 0 | calls removed |
+| convert/ext_zero | 123 | 308 | 15 | 0 | calls removed |
+| convert/f2f | 69 | 208 | 11 | 0 | calls removed |
+| convert/f2i | 152 | 690 | 54 | 21 | calls removed |
+| convert/f2u_high | 145 | 481 | 25 | 0 | calls removed |
+| convert/i2f | 189 | 676 | 37 | 4 | calls removed |
+| convert/trunc | 85 | 178 | 9 | 0 | calls removed |
+| float/arith_f32 | 418 | 335 | 65 | 46 | calls removed |
+| float/arith_f64 | 367 | 305 | 65 | 46 | calls removed |
+| float/cmp_f32 | 280 | 477 | 20 | 2 | calls removed |
+| float/cmp_f64 | 199 | 387 | 26 | 7 | calls removed |
+| float/special_f32 | 353 | 457 | 117 | 84 | calls removed |
+| float/special_f64 | 308 | 432 | 127 | 94 | calls removed |
+| frame/frame_align | 773 | 682 | 79 | 24 | calls removed |
+| frame/frame_large | 224 | 424 | 16 | 0 | calls removed |
+| frame/frame_spill | 233 | 531 | 32 | 15 | calls removed |
+| imm/imm_add | 125 | 329 | 25 | 8 | calls removed |
+| imm/imm_addr | 171 | 431 | 21 | 4 | calls removed |
+| imm/imm_logic | 97 | 326 | 21 | 4 | calls removed |
+| imm/imm_mov | 112 | 279 | 12 | 0 | calls removed |
+| mem/addr_modes | 256 | 441 | 36 | 19 | calls removed |
+| mem/array_index | 259 | 607 | 36 | 15 | calls removed |
+| mem/global_data | 255 | 452 | 35 | 12 | calls removed |
+| mem/global_zero | 186 | 358 | 28 | 7 | calls removed |
+| mem/loadstore | 193 | 369 | 25 | 8 | calls removed |
+| mem/ptr_arith | 213 | 504 | 29 | 8 | calls removed |
+| mem/rec_layout | 522 | 851 | 50 | 25 | calls removed |
+| mem/uni_layout | 244 | 459 | 32 | 15 | calls removed |
+| scalar/arith_i16 | 89 | 250 | 13 | 0 | calls removed |
+| scalar/arith_i32 | 86 | 235 | 13 | 0 | calls removed |
+| scalar/arith_i64 | 85 | 201 | 13 | 0 | calls removed |
+| scalar/arith_i8 | 89 | 250 | 13 | 0 | calls removed |
+| scalar/arith_u16 | 89 | 250 | 13 | 0 | calls removed |
+| scalar/arith_u32 | 86 | 247 | 13 | 0 | calls removed |
+| scalar/arith_u64 | 85 | 201 | 13 | 0 | calls removed |
+| scalar/arith_u8 | 90 | 239 | 13 | 0 | calls removed |
+| scalar/divrem_i32 | 149 | 285 | 13 | 0 | calls removed |
+| scalar/divrem_i64 | 146 | 268 | 13 | 0 | calls removed |
+| scalar/divrem_u32 | 93 | 230 | 10 | 0 | calls removed |
+| scalar/divrem_u64 | 86 | 203 | 10 | 0 | calls removed |
+| scalar/mul_i32 | 56 | 156 | 8 | 0 | calls removed |
+| scalar/mul_i64 | 55 | 148 | 8 | 0 | calls removed |
+| scalar/mul_u32 | 56 | 163 | 8 | 0 | calls removed |
+| scalar/mul_u64 | 55 | 141 | 8 | 0 | calls removed |
+| vec/autovec_loop | 375 | 563 | 10 | 0 | calls removed |
+| vec/vec_cmp_select | 2111 | 2093 | 169 | 109 | calls removed |
+| vec/vec_f32x2 | 488 | 347 | 37 | 16 | calls removed |
+| vec/vec_f32x3 | 543 | 369 | 33 | 9 | calls removed |
+| vec/vec_f32x4 | 1328 | 514 | 71 | 16 | calls removed |
+| vec/vec_f32x5 | 1683 | 593 | 88 | 16 | calls removed |
+| vec/vec_f32x8 | 1630 | 846 | 139 | 16 | calls removed |
+| vec/vec_f64x2 | 457 | 328 | 37 | 16 | calls removed |
+| vec/vec_i16x4 | 865 | 609 | 78 | 23 | calls removed |
+| vec/vec_i16x8 | 2931 | 896 | 146 | 23 | calls removed |
+| vec/vec_i32x4 | 1642 | 586 | 78 | 23 | calls removed |
+| vec/vec_i64x2 | 980 | 400 | 44 | 23 | calls removed |
+| vec/vec_i8x16 | 2120 | 1215 | 42 | 25 | calls removed |
+| vec/vec_lane_ops | 3104 | 3384 | 107 | 39 | calls removed |
+| vec/vec_mem | 2347 | 1011 | 78 | 19 | calls removed |
+| vec/vec_scalar_mix | 1480 | 1234 | 67 | 20 | calls removed |
+| vec/vec_u16x8 | 2925 | 926 | 146 | 23 | calls removed |
+| vec/vec_u32x4 | 1623 | 587 | 78 | 23 | calls removed |
+| vec/vec_u64x2 | 980 | 400 | 44 | 23 | calls removed |
+| vec/vec_u8x16 | 2119 | 1199 | 42 | 25 | calls removed |
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -130,7 +130,19 @@ ext fun wsa_startup(ver: u16, data: *u8) i32;
 ### `inline` — force inlining
 
 Marks a function for inlining at every call site, overriding the compiler's
-size- and use-count heuristics. Applies to functions only; takes no arguments.
+size and use-count heuristics. Applies to functions only and takes no arguments.
+The optimization pipeline must enable inlining. Indirect calls and recursive
+call cycles are not expanded by this attribute. Taking a function's address
+retains its callable identity even when direct calls are inlined.
+
+Release optimization makes small ordinary helper bodies available across source
+modules without emitting extra definitions. Extraction, import and per-caller
+expansion each have a limit of 1024 copied IR instructions and 256 KiB of owned
+payload. `inline` overrides size and use-count heuristics within those limits.
+A remaining call or taken address still names the original defining function.
+Helpers referencing compiler-local literal pools retain their calls because those
+objects have module-local identity. Named globals keep their original symbols,
+and copied instructions preserve effects, assembly bindings and debug locations.
 
 ```mach
 #[inline]
@@ -159,8 +171,8 @@ caller's instruction cache, or to hold code size down on a constrained target.
 - Purely a hint to the inliner; it does not otherwise change codegen. It binds
   at every optimization level — the debug pipeline runs no inlining pass at
   all, so `noinline` is inert (and unnecessary) there — and it will bind
-  identically to any future cross-module or LTO inlining path, which is not a
-  separate mechanism exempt from it.
+  identically when a callee body is available from another module. Recursive
+  peeling also respects `noinline` and `scalar`.
 
 ### `align(expr)` — alignment override
 

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -140,6 +140,10 @@ modules without emitting extra definitions. Extraction, import and per-caller
 expansion each have a limit of 1024 copied IR instructions and 256 KiB of owned
 payload. `inline` overrides size and use-count heuristics within those limits.
 A remaining call or taken address still names the original defining function.
+Generic, comptime and pack specializations keep their existing shared weak
+linkage. When several modules materialize that same specialization, body import
+uses an already available definition or the first acquired provider of that
+linkage, and tracks that provider as a query dependency.
 Helpers referencing compiler-local literal pools retain their calls because those
 objects have module-local identity. Named globals keep their original symbols,
 and copied instructions preserve effects, assembly bindings and debug locations.

--- a/doc/language/decorators.md
+++ b/doc/language/decorators.md
@@ -136,9 +136,14 @@ call cycles are not expanded by this attribute. Taking a function's address
 retains its callable identity even when direct calls are inlined.
 
 Release optimization makes small ordinary helper bodies available across source
-modules without emitting extra definitions. Extraction, import and per-caller
-expansion each have a limit of 1024 copied IR instructions and 256 KiB of owned
-payload. `inline` overrides size and use-count heuristics within those limits.
+modules without emitting extra definitions. A helper is small when its body has
+fewer than 25 live instructions after promotion, debug annotations excluded, so
+`-g` never moves the decision. Extraction, import and per-caller expansion each
+have a limit of 1024 copied IR instructions and 256 KiB of owned payload.
+`inline` overrides size and use-count heuristics within those limits. An
+`oblivious` function is expanded only into another `oblivious` function, so
+its instructions never leave a constant-time validated body; a `naked` or
+`noinline` function, a recursive cycle and an indirect call are never expanded.
 A remaining call or taken address still names the original defining function.
 Generic, comptime and pack specializations keep their existing shared weak
 linkage. When several modules materialize that same specialization, body import

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -72,7 +72,7 @@ fun append_phase_roots(p: *project.Project, roots: *Vector[query.QueryKey],
         val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
         var key: u64 = m.stable_id::u64;
         if (kind == query.Q_PARSE) { key = m.file_id::u64; }
-        or (kind == query.Q_LOWER || kind == query.Q_CODEGEN) { key = passes.back_half_key_for(p, m); }
+        or (kind == query.Q_INLINE_BODIES || kind == query.Q_LOWER || kind == query.Q_CODEGEN) { key = passes.back_half_key_for(p, m); }
         val added: R.Result[usize, str] = vector.push[query.QueryKey](roots, query.QueryKey{ kind: kind, key: key });
         if (R.is_err[usize, str](added)) {
             ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](added)));
@@ -96,6 +96,8 @@ fun append_backend_roots(p: *project.Project, roots: *Vector[query.QueryKey],
     if (R.is_err[R.Void, outcome.Fail](frontend)) { ret frontend; }
     val surface: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_LOWERED_SURFACE, p.emit_len);
     if (R.is_err[R.Void, outcome.Fail](surface)) { ret surface; }
+    val bodies: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_INLINE_BODIES, p.emit_len);
+    if (R.is_err[R.Void, outcome.Fail](bodies)) { ret bodies; }
     val lowered: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_LOWER, p.emit_len);
     if (R.is_err[R.Void, outcome.Fail](lowered)) { ret lowered; }
     if (codegen) { ret append_phase_roots(p, roots, query.Q_CODEGEN, p.emit_len); }
@@ -210,6 +212,7 @@ fun query_compute(p: *project.Project, kind: query.QueryKind, key: u64,
     if (kind == query.Q_TYPED_EXPORTS)   { ret passes.q_typed_exports_compute(p, key, alloc, diags); }
     if (kind == query.Q_LOWERED_SURFACE) { ret passes.q_lowered_surface_compute(p, key, alloc, diags); }
     if (kind == query.Q_LOWER)           { ret passes.q_lower_compute(p, key, alloc, diags); }
+    if (kind == query.Q_INLINE_BODIES)   { ret passes.q_inline_bodies_compute(p, key, alloc, diags); }
     if (kind == query.Q_CODEGEN)         { ret passes.q_codegen_compute(p, key, alloc, diags); }
     if (kind == query.Q_LINK)            { ret passes.q_link_compute(p, key, alloc, diags); }
     ret R.err[query.QueryOutput, fail.Fail](fail.message("query kind has no driver compute capability"));

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1255,17 +1255,27 @@ fun non_flowing_body_span(a: *ast.Ast, text: str, d: *decl.Decl) O.Option[token.
     ret O.some[token.Span](O.unwrap[*stmt.Stmt](st_o).span);
 }
 
-fun lower_raw_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
-    val s: *session.Session = p.s;
+# the inputs a module's lowering reads: its typed definition and the target. every
+# product built from a raw lowering records these on itself, whether it lowers or
+# takes the raw module another product captured, so no edit to the source can be
+# hidden behind an equal sibling product
+fun lower_inputs(p: *project.Project, key: u64) R.Result[session.ModuleId, fail.Fail] {
     val stable: session.StableModuleId = key::u32::session.StableModuleId;
-    val test_mode: bool = back_half_key_is_test(key);
-    val mid: session.ModuleId = session.module_id_for_stable(s, stable);
-    if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWER: stable id not loaded this build")); }
-    val m: *project.ModuleEntry = ?p.modules[mid::u32];
+    val mid: session.ModuleId = session.module_id_for_stable(p.s, stable);
+    if (mid == session.MODULE_NIL) { ret R.err[session.ModuleId, fail.Fail](fail.message("Q_LOWER: stable id not loaded this build")); }
     val definition: R.Result[scx.Definition, fail.Fail] = read_definition(p::ptr, mid, scx.DEFINITION_TYPED);
-    if (R.is_err[scx.Definition, fail.Fail](definition)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](definition)); }
+    if (R.is_err[scx.Definition, fail.Fail](definition)) { ret R.err[session.ModuleId, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](definition)); }
     val rt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_TARGET, 0);
-    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
+    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[session.ModuleId, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
+    ret R.ok[session.ModuleId, fail.Fail](mid);
+}
+
+fun lower_raw_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    val test_mode: bool = back_half_key_is_test(key);
+    val inputs: R.Result[session.ModuleId, fail.Fail] = lower_inputs(p, key);
+    if (R.is_err[session.ModuleId, fail.Fail](inputs)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[session.ModuleId, fail.Fail](inputs)); }
+    val mid: session.ModuleId = R.unwrap_ok[session.ModuleId, fail.Fail](inputs);
+    val m: *project.ModuleEntry = ?p.modules[mid::u32];
     val hr: R.Result[*ir.ModuleHome, str] = ir_home_new(alloc);
     if (R.is_err[*ir.ModuleHome, str](hr)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[*ir.ModuleHome, str](hr))); }
     val home: *ir.ModuleHome = R.unwrap_ok[*ir.ModuleHome, str](hr);
@@ -1329,6 +1339,8 @@ fun release_lower_output(alloc: *A.Allocator, output: query.QueryOutput) {
 
 fun lower_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     if (p.req.opt != pipeline.OPT_RELEASE) { ret lower_raw_candidate_compute(p, key, alloc, diags); }
+    val inputs: R.Result[session.ModuleId, fail.Fail] = lower_inputs(p, key);
+    if (R.is_err[session.ModuleId, fail.Fail](inputs)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[session.ModuleId, fail.Fail](inputs)); }
     var local: project.RawLowerCapture;
     local.key = key;
     val saved: *project.RawLowerCapture = p.raw_lower_capture;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -11,7 +11,6 @@ use std.types.string.str;
 use std.types.string.str_equals;
 use std.types.string.str_join;
 use std.types.string.str_len;
-use std.types.string.str_region_equals;
 use std.types.view.view;
 use std.types.view.view_eq_str;
 
@@ -45,6 +44,9 @@ use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
 use ir_equal: mach.lang.me.ir.equal;
+use mach.lang.me.ir.body;
+use mach.lang.me.pass.mem2reg;
+use inline_pass: mach.lang.me.pass.inline;
 use mach.lang.me.analysis.oblivious;
 use mach.lang.me.lower;
 use mach.lang.me.lower.testrunner;
@@ -1043,6 +1045,10 @@ pub fun prepare_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
         val rls: R.Result[R.Void, str] = query.register_derived(?p.s.queries, query.Q_LOWERED_SURFACE);
         if (R.is_err[R.Void, str](rls)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rls))); }
     }
+    if (!query.is_registered(?p.s.queries, query.Q_INLINE_BODIES)) {
+        val registered: R.Result[R.Void, str] = query.register_derived_equatable(?p.s.queries, query.Q_INLINE_BODIES, q_lower_finalize, lower_output_equal);
+        if (R.is_err[R.Void, str](registered)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](registered))); }
+    }
     if (!query.is_registered(?p.s.queries, query.Q_LOWER)) {
         val rl: R.Result[R.Void, str] = query.register_derived_equatable(?p.s.queries, query.Q_LOWER, q_lower_finalize, lower_output_equal);
         if (R.is_err[R.Void, str](rl)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rl))); }
@@ -1240,7 +1246,6 @@ fun non_flowing_body_span(a: *ast.Ast, text: str, d: *decl.Decl) O.Option[token.
             if (a.typed_names[d.data.fun_.params_start + pi].comptime) { ret O.none[token.Span](); }
             pi = pi + 1;
         }
-        if (decl_has_decorator_named(a, text, d, "inline")) { ret O.none[token.Span](); }
         body = d.data.fun_.body;
     }
     if (body == id.STMT_NIL) { ret O.none[token.Span](); }
@@ -1250,17 +1255,7 @@ fun non_flowing_body_span(a: *ast.Ast, text: str, d: *decl.Decl) O.Option[token.
     ret O.some[token.Span](O.unwrap[*stmt.Stmt](st_o).span);
 }
 
-fun decl_has_decorator_named(a: *ast.Ast, text: str, d: *decl.Decl, name: str) bool {
-    var i: u32 = 0;
-    for (i < d.decorators_len) {
-        val dec: *decl.Decorator = ?a.decorators[d.decorators_start + i];
-        if (str_region_equals(text, dec.name.offset, dec.name.len, name)) { ret true; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-fun lower_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+fun lower_raw_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val s: *session.Session = p.s;
     val stable: session.StableModuleId = key::u32::session.StableModuleId;
     val test_mode: bool = back_half_key_is_test(key);
@@ -1288,10 +1283,108 @@ fun lower_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, 
     ret ir_handle_encode(alloc, irmod, home);
 }
 
+pub fun q_inline_bodies_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    val raw: R.Result[query.QueryOutput, fail.Fail] = lower_raw_candidate_compute(p, key, alloc, diags);
+    if (R.is_err[query.QueryOutput, fail.Fail](raw)) { ret raw; }
+    val output: query.QueryOutput = R.unwrap_ok[query.QueryOutput, fail.Fail](raw);
+    var transferred: bool = false;
+    fin { if (!transferred) { release_lower_output(alloc, output); } }
+    val src: *ir.Module = ir_handle_decode(query.QueryView{value: output.bytes, value_len: output.len});
+    val normalized: R.Result[bool, str] = mem2reg.run(src);
+    if (R.is_err[bool, str](normalized)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(lower_stable_err(p, R.unwrap_err[bool, str](normalized)))); }
+    val created: R.Result[*ir.ModuleHome, str] = ir_home_new(alloc);
+    if (R.is_err[*ir.ModuleHome, str](created)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[*ir.ModuleHome, str](created))); }
+    val home: *ir.ModuleHome = R.unwrap_ok[*ir.ModuleHome, str](created);
+    val boxed: R.Result[*ir.Module, str] = A.allocate[ir.Module](?home.alloc, 1::usize);
+    if (R.is_err[*ir.Module, str](boxed)) { ir_release(alloc, home); ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[*ir.Module, str](boxed))); }
+    val dst: *ir.Module = R.unwrap_ok[*ir.Module, str](boxed);
+    val initialized: R.Result[ir.Module, str] = ir.init(?home.alloc, src.name);
+    if (R.is_err[ir.Module, str](initialized)) { ir_release(alloc, home); ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[ir.Module, str](initialized))); }
+    @dst = R.unwrap_ok[ir.Module, str](initialized);
+    val flags: R.Result[*bool, str] = A.allocate[bool](p.s.alloc, src.function_len::usize);
+    if (R.is_err[*bool, str](flags)) { ir_release(alloc, home); ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[*bool, str](flags))); }
+    val recursive: *bool = R.unwrap_ok[*bool, str](flags);
+    fin { if (recursive != nil) { A.deallocate[bool](p.s.alloc, recursive, src.function_len::usize); } }
+    val marked: R.Result[R.Void, str] = inline_pass.mark_recursive(src, recursive);
+    if (R.is_err[R.Void, str](marked)) { ir_release(alloc, home); ret R.err[query.QueryOutput, fail.Fail](fail.message(lower_stable_err(p, R.unwrap_err[R.Void, str](marked)))); }
+    val extracted: R.Result[R.Void, str] = body.extract(dst, src, ?p.target, p.s.alloc, recursive);
+    if (R.is_err[R.Void, str](extracted)) {
+        val message: str = lower_stable_err(p, R.unwrap_err[R.Void, str](extracted));
+        ir_release(alloc, home); ret R.err[query.QueryOutput, fail.Fail](fail.message(message));
+    }
+    val encoded: R.Result[query.QueryOutput, fail.Fail] = ir_handle_encode(alloc, dst, home);
+    if (R.is_err[query.QueryOutput, fail.Fail](encoded)) { ret encoded; }
+    if (p.raw_lower_capture != nil && p.raw_lower_capture.key == key && p.raw_lower_capture.output.bytes == nil) {
+        p.raw_lower_capture.output = output;
+        transferred = true;
+    }
+    ret encoded;
+}
+
+fun release_lower_output(alloc: *A.Allocator, output: query.QueryOutput) {
+    if (output.bytes == nil) { ret; }
+    q_lower_finalize(output.bytes, output.len, alloc);
+    A.deallocate[u8](alloc, output.bytes, output.len::usize);
+}
+
+fun lower_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    if (p.req.opt != pipeline.OPT_RELEASE) { ret lower_raw_candidate_compute(p, key, alloc, diags); }
+    var local: project.RawLowerCapture;
+    local.key = key;
+    val saved: *project.RawLowerCapture = p.raw_lower_capture;
+    if (saved == nil) { p.raw_lower_capture = ?local; }
+    fin {
+        p.raw_lower_capture = saved;
+        release_lower_output(alloc, local.output);
+    }
+    val available: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_INLINE_BODIES, key);
+    if (R.is_err[query.QueryView, fail.Fail](available)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](available)); }
+    if (p.raw_lower_capture.key == key && p.raw_lower_capture.output.bytes != nil) {
+        val out: query.QueryOutput = p.raw_lower_capture.output;
+        p.raw_lower_capture.output = query.QueryOutput{};
+        ret R.ok[query.QueryOutput, fail.Fail](out);
+    }
+    ret lower_raw_candidate_compute(p, key, alloc, diags);
+}
+
+fun acquire_inline_bodies(p: *project.Project, m: *ir.Module, available: *body.Available, test_mode: bool) R.Result[R.Void, fail.Fail] {
+    if (p.req.opt != pipeline.OPT_RELEASE) { ret R.ok_void[fail.Fail](); }
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        val origin: intern.StrId = m.functions[i].body_module;
+        if ((m.functions[i].flags & ir.FN_FLAG_EXTERN) == 0 || origin == intern.STR_NIL || origin == m.name) { i = i + 1; cnt; }
+        val stable: session.StableModuleId = session.stable_module_id_lookup(p.s, origin);
+        if (stable == session.STABLE_MODULE_NIL) { ret R.err[R.Void, fail.Fail](fail.message("inline body: defining module has no stable query identity")); }
+        val got: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_INLINE_BODIES, back_half_key(stable, test_mode));
+        if (R.is_err[query.QueryView, fail.Fail](got)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](got)); }
+        val provider: *ir.Module = ir_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](got));
+        if (provider == nil) { ret R.err[R.Void, fail.Fail](fail.message("inline body: provider has no owned product")); }
+        val imported: R.Result[R.Void, str] = body.acquire(available, m, provider, m.functions[i].name, ?p.target, p.s.alloc);
+        if (R.is_err[R.Void, str](imported)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[R.Void, str](imported))); }
+        i = i + 1;
+    }
+    ret R.ok_void[fail.Fail]();
+}
+
 fun q_lower_raw_compute(p: *project.Project, kind: query.QueryKind, key: u64,
                        alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     if (kind != query.Q_LOWER) { ret R.err[query.QueryOutput, fail.Fail](fail.message("raw lowering requires its Q_LOWER owner")); }
-    ret lower_candidate_compute(p, key, alloc, diags);
+    val raw: R.Result[query.QueryOutput, fail.Fail] = lower_candidate_compute(p, key, alloc, diags);
+    if (R.is_err[query.QueryOutput, fail.Fail](raw)) { ret raw; }
+    val output: query.QueryOutput = R.unwrap_ok[query.QueryOutput, fail.Fail](raw);
+    if (p.req.opt == pipeline.OPT_RELEASE) {
+        if (p.raw_lower_capture == nil || p.raw_lower_capture.available == nil) {
+            release_lower_output(alloc, output);
+            ret R.err[query.QueryOutput, fail.Fail](fail.message("prepared lowering requires its scoped body owner"));
+        }
+        val m: *ir.Module = ir_handle_decode(query.QueryView{value: output.bytes, value_len: output.len});
+        val imported: R.Result[R.Void, fail.Fail] = acquire_inline_bodies(p, m, p.raw_lower_capture.available, back_half_key_is_test(key));
+        if (R.is_err[R.Void, fail.Fail](imported)) {
+            val failure: fail.Fail = lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](imported));
+            release_lower_output(alloc, output); ret R.err[query.QueryOutput, fail.Fail](failure);
+        }
+    }
+    ret raw;
 }
 
 pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
@@ -1306,10 +1399,20 @@ pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diag
         }
     }
     val irmod: *ir.Module = ir_handle_decode(query.QueryView{ value: output.bytes, value_len: output.len });
+    var storage: body.Available;
+    var available: *body.Available = nil;
+    fin { if (available != nil) { body.available_dnit(available, irmod); } }
+    if (p.req.opt == pipeline.OPT_RELEASE) {
+        val opened: R.Result[R.Void, str] = body.available_init(?storage, irmod.name);
+        if (R.is_err[R.Void, str](opened)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](opened))); }
+        available = ?storage;
+        val imported: R.Result[R.Void, fail.Fail] = acquire_inline_bodies(p, irmod, available, back_half_key_is_test(key));
+        if (R.is_err[R.Void, fail.Fail](imported)) { ret R.err[query.QueryOutput, fail.Fail](lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](imported))); }
+    }
     val main_id: R.Result[intern.StrId, fail.Fail] = neutralize_id(p, back_half_key_is_test(key));
     if (R.is_err[intern.StrId, fail.Fail](main_id)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[intern.StrId, fail.Fail](main_id)); }
     val t_opt: ctime.Time = readout.span_begin(p.events);
-    val optimized: R.Result[R.Void, fail.Fail] = lower_optimize(p, irmod, R.unwrap_ok[intern.StrId, fail.Fail](main_id));
+    val optimized: R.Result[R.Void, fail.Fail] = lower_optimize(p, irmod, R.unwrap_ok[intern.StrId, fail.Fail](main_id), available);
     readout.item(p.events, readout.PH_OPTIMIZE, project.fqn_name(p, irmod.name), t_opt);
     readout.span_end(p.events, readout.PH_OPTIMIZE, readout.PH_LOWER, t_opt);
     if (R.is_err[R.Void, fail.Fail](optimized)) { ret R.err[query.QueryOutput, fail.Fail](lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](optimized))); }
@@ -1344,9 +1447,10 @@ fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, 
     ret R.ok[*ir.Module, fail.Fail](box);
 }
 
-fun lower_optimize(p: *project.Project, irmod: *ir.Module, main_id: intern.StrId) R.Result[R.Void, fail.Fail] {
+fun lower_optimize(p: *project.Project, irmod: *ir.Module, main_id: intern.StrId, available: *body.Available) R.Result[R.Void, fail.Fail] {
     var preq: pipeline.PipelineRequest;
     preq.module            = irmod;
+    preq.available         = available;
     preq.target             = ?p.target;
     preq.level               = p.req.opt;
     preq.vectorize_enabled   = pipeline.VectorizeEnabledOption{ v: p.req.vectorize };
@@ -1436,6 +1540,9 @@ fun lower_parallel_enabled(p: *project.Project) bool {
 
 rec PlwSlot {
     prepared: query.PreparedQuery;
+    capture: project.RawLowerCapture;
+    available: body.Available;
+    available_live: bool;
     live: bool;
     mid:    session.ModuleId;
     m:      *ir.Module;
@@ -1464,7 +1571,7 @@ fun plw_worker_main(arg: *u8) {
 
         val slot: *PlwSlot = ?pl.slots[idx_raw::usize];
         val t0: ctime.Time = ctime.monotonic();
-        val r: R.Result[R.Void, fail.Fail] = lower_optimize(pl.p, slot.m, pl.main_id);
+        val r: R.Result[R.Void, fail.Fail] = lower_optimize(pl.p, slot.m, pl.main_id, slot.capture.available);
         slot.d = ctime.time_sub(ctime.monotonic(), t0);
         if (R.is_err[R.Void, fail.Fail](r)) {
             slot.fail   = R.unwrap_err[R.Void, fail.Fail](r);
@@ -1487,6 +1594,12 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
     var result: R.Result[R.Void, fail.Fail] = run_lower_batch(p, slots, count);
     i = 0;
     for (i < count) {
+        if (slots[i].available_live) {
+            body.available_dnit(?slots[i].available, slots[i].m);
+            slots[i].available_live = false;
+        }
+        release_lower_output(p.s.queries.a, slots[i].capture.output);
+        slots[i].capture.output = query.QueryOutput{};
         if (slots[i].live) {
             val cancelled: R.Result[R.Void, str] = query.cancel_prepared(?p.s.queries, slots[i].prepared);
             if (R.is_err[R.Void, str](cancelled)) {
@@ -1498,6 +1611,21 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
         i = i + 1;
     }
     ret result;
+}
+
+fun prime_inline_bodies(p: *project.Project, capture: *project.RawLowerCapture) R.Result[R.Void, fail.Fail] {
+    val saved: *project.RawLowerCapture = p.raw_lower_capture;
+    p.raw_lower_capture = capture;
+    fin { p.raw_lower_capture = saved; }
+    val got: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_INLINE_BODIES, capture.key);
+    ret R.void_of[query.QueryView, fail.Fail](got);
+}
+
+fun prepare_lower_slot(p: *project.Project, capture: *project.RawLowerCapture) R.Result[query.PreparedQuery, fail.Fail] {
+    val saved: *project.RawLowerCapture = p.raw_lower_capture;
+    p.raw_lower_capture = capture;
+    fin { p.raw_lower_capture = saved; }
+    ret query.prepare[project.Project](?p.queries, p, query.Q_LOWER, capture.key, q_lower_raw_compute);
 }
 
 fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Result[R.Void, fail.Fail] {
@@ -1521,6 +1649,20 @@ fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Resul
     if (slot_len <= 1) {
         ret R.ok_void[fail.Fail]();
     }
+    var prime: u32 = 0;
+    for (prime < slot_len) {
+        val m: *project.ModuleEntry = ?p.modules[slots[prime].mid::u32];
+        slots[prime].capture.key = back_half_key_for(p, m);
+        if (p.req.opt == pipeline.OPT_RELEASE) {
+            val initialized: R.Result[R.Void, str] = body.available_init(?slots[prime].available, m.fqn);
+            if (R.is_err[R.Void, str](initialized)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[R.Void, str](initialized))); }
+            slots[prime].available_live = true;
+            slots[prime].capture.available = ?slots[prime].available;
+            val primed: R.Result[R.Void, fail.Fail] = prime_inline_bodies(p, ?slots[prime].capture);
+            if (R.is_err[R.Void, fail.Fail](primed)) { ret primed; }
+        }
+        prime = prime + 1;
+    }
 
     val test_mode: bool = test_build(p);
 
@@ -1529,8 +1671,7 @@ fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Resul
         val mid: session.ModuleId = slots[si].mid;
         val m:   *project.ModuleEntry = ?p.modules[mid::u32];
 
-        val prepared: R.Result[query.PreparedQuery, fail.Fail] = query.prepare[project.Project](?p.queries, p,
-            query.Q_LOWER, back_half_key_for(p, m), q_lower_raw_compute);
+        val prepared: R.Result[query.PreparedQuery, fail.Fail] = prepare_lower_slot(p, ?slots[si].capture);
         if (R.is_err[query.PreparedQuery, fail.Fail](prepared)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.PreparedQuery, fail.Fail](prepared)); }
         slots[si].prepared = R.unwrap_ok[query.PreparedQuery, fail.Fail](prepared);
         slots[si].live = true;
@@ -1541,6 +1682,7 @@ fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Resul
         si = si + 1;
     }
 
+    if (p.raw_lower_capture != nil) { ret R.err[R.Void, fail.Fail](fail.message("lower: synchronous raw capture escaped into worker execution")); }
     var nworkers: u32 = p.req.jobs;
     if (nworkers == 0)        { nworkers = 1; }
     if (nworkers > slot_len)  { nworkers = slot_len; }

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -28,6 +28,7 @@ use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
+use mach.lang.me.ir.body;
 use mach.lang.query;
 use mach.lang.session;
 use src: mach.lang.source;
@@ -211,11 +212,18 @@ pub rec TargetTuple {
     platform_name: intern.StrId;
 }
 
+pub rec RawLowerCapture {
+    key: u64;
+    output: query.QueryOutput;
+    available: *body.Available;
+}
+
 pub rec Project {
     s:            *session.Session;
     alloc:        *A.Allocator;
     req:          request.BuildRequest;
     queries:      query.QueryRuntime[Project];
+    raw_lower_capture: *RawLowerCapture;
     diags:        diagnostic.DiagnosticStore;
     config:       ProjectConfig;
     target_entry: *TargetEntry;
@@ -489,6 +497,7 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.s             = s;
     p.alloc         = s.build_alloc;
     p.req           = request.defaults();
+    p.raw_lower_capture = nil;
     p.queries.db    = nil;
     p.queries.caps.compute = nil;
     p.diags         = diagnostic.store_init(p.alloc);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7473,6 +7473,57 @@ test "mach.lang.driver:inline_body_availability_refreshes_after_unannotated_prov
     ret 0;
 }
 
+test "mach.lang.driver:inline_shared_specializations_keep_an_actual_provider_for_one_weak_linkage" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [4]str = [4]str{"main.mach", "a.mach", "b.mach", "generic.mach"};
+    var texts: [4]str;
+    texts[0] = "use a: uniontest.a;\nuse b: uniontest.b;\nuse g: uniontest.generic;\nfun main() i32 { ret g.identity[i32](0) + a.run(40) + b.run(40); }\n";
+    texts[1] = "use g: uniontest.generic;\npub fun run(v: i32) i32 { ret g.identity[i32](v) + g.add(1, v) + g.sum(v, 2::i32); }\n";
+    texts[2] = texts[1];
+    texts[3] = "pub fun identity[T](v: T) T { ret v; }\npub fun add($delta: i32, v: i32) i32 { ret v + delta; }\npub fun sum(v: i32, va: ...) i32 { var total: i32 = v; $each item in va { total = total + item; } ret total; }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 4);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val built: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 2);
+    if (R.is_err[project.Project, outcome.Fail](built)) { ret 5; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](built);
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    val aid: session.ModuleId = ut_mid(?p, ?s, "uniontest.a");
+    val bid: session.ModuleId = ut_mid(?p, ?s, "uniontest.b");
+    if (mid == session.MODULE_NIL || aid == session.MODULE_NIL || bid == session.MODULE_NIL) { ret 6; }
+    val m: *ir.Module = p.modules[mid::u32].ir_module;
+    val main: *ir.Function = ut_inline_function(?s, m, "uniontest.main.main");
+    if (ut_inline_ops(main, instruction.OP_CALL) != 0) { ret 7; }
+    var answer: bool = false;
+    var bi: u32 = 0;
+    for (bi < main.block_count) {
+        val term: O.Option[*instruction.Instruction] = ir.instruction_get(main, main.blocks[bi].terminator);
+        if (O.is_some[*instruction.Instruction](term)) {
+            val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](term);
+            if (ins.kind == instruction.OP_RET && ins.operand_count == 1 && ins.operands[0].kind == value.VAL_CONST_INT
+                && ins.operands[0].data.int_lit == 246) { answer = true; }
+        }
+        bi = bi + 1;
+    }
+    if (!answer) { ret 8; }
+    val left: *ir.Function = ut_inline_function(?s, p.modules[aid::u32].ir_module, "uniontest.generic.identity$i32");
+    val right: *ir.Function = ut_inline_function(?s, p.modules[bid::u32].ir_module, "uniontest.generic.identity$i32");
+    val local: *ir.Function = ut_inline_function(?s, m, "uniontest.generic.identity$i32");
+    if (left == nil || right == nil || local == nil || left.name != right.name || left.name != local.name
+        || (left.flags & ir.FN_FLAG_WEAK) == 0 || (right.flags & ir.FN_FLAG_WEAK) == 0 || (local.flags & ir.FN_FLAG_WEAK) == 0
+        || left.block_count == 0 || right.block_count == 0 || local.block_count == 0) { ret 9; }
+    if (local.body_module != m.name) { ret 10; }
+    ret 0;
+}
+
 test "mach.lang.driver:generic_template_emits_no_bare_body" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7280,6 +7280,199 @@ fun ut_defined_fn_with(s: *session.Session, m: *ir.Module, needle: str) u32 {
     ret n;
 }
 
+fun ut_inline_prepare(s: *session.Session, root: str, jobs: u32) R.Result[project.Project, outcome.Fail] {
+    var selection: manifest.Selection = ut_target_sel("linux");
+    selection.profile = "release";
+    val opened: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, ?selection);
+    if (R.is_err[project.Project, outcome.Fail](opened)) { ret opened; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](opened);
+    p.req.jobs = jobs;
+    val typed: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](typed)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](typed)); }
+    val lowered: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](lowered)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](lowered)); }
+    ret R.ok[project.Project, outcome.Fail](p);
+}
+
+fun ut_inline_function(s: *session.Session, m: *ir.Module, name: str) *ir.Function {
+    if (m == nil) { ret nil; }
+    var i: u32 = 0;
+    for (i < m.function_len) {
+        if (ut_id_is(s, m.functions[i].name, name)) { ret ?m.functions[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+fun ut_inline_ops(fn: *ir.Function, kind: instruction.InstrKind) u32 {
+    if (fn == nil) { ret 0xFFFFFFFF; }
+    var count: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        val block: *ir.Block = ?fn.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < block.instr_count) {
+            val ins: O.Option[*instruction.Instruction] = ir.instruction_get(fn, block.instructions[ii]);
+            if (O.is_some[*instruction.Instruction](ins) && O.unwrap[*instruction.Instruction](ins).kind == kind) { count = count + 1; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret count;
+}
+
+test "mach.lang.driver:inline_bodies_cross_modules_preserve_identity_effects_and_owned_metadata" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var names: [3]str = [3]str{"main.mach", "helper.mach", "leaf.mach"};
+    var texts: [3]str;
+    texts[0] = "use h: uniontest.helper;\nfun main() i32 { ret h.wrap(40); }\npub fun write(v: i32) i32 { ret h.touch(v); }\npub fun retained(v: i32) i32 { ret h.keep(v); }\npub fun address() fun(i32) i32 { ret h.wrap; }\npub fun literal() *u8 { ret h.literal(); }\npub fun assembly(v: i32) i32 { ret h.assembly(v); }\npub fun record(v: i32) i32 { val p: h.Pair = h.construct(v); ret p.a + p.b; }\n#[oblivious] pub fun classified(v: ^i32) ^i32 { ret h.classified(v); }\n";
+    texts[1] = "use uniontest.leaf.bump;\npub rec Pair { a: i32; b: i32; }\npub fun construct(v: i32) Pair { ret Pair{a: v, b: v + 1}; }\n#[oblivious] pub fun classified(v: ^i32) ^i32 { ret v + 1; }\nvar counter: i32 = 0;\nfun first(v: i32) i32 { ret bump(v); }\npub fun wrap(v: i32) i32 { ret first(v) + 1; }\npub fun touch(v: i32) i32 { counter = v; ret counter; }\n#[noinline] pub fun keep(v: i32) i32 { ret v + 1; }\npub fun literal() *u8 { ret \"identity\"; }\n#[inline] pub fun assembly(v: i32) i32 { var result: i32 = v; asm x86_64 { mov eax, {result}\n add eax, 1\n mov {result}, eax } ret result; }\n";
+    texts[2] = "pub fun bump(v: i32) i32 { ret v + 1; }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](scaffold)) { ret 2; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    var round: u32 = 0;
+    for (round < 2) {
+        val initialized: R.Result[session.Session, str] = session.init(?alloc);
+        if (R.is_err[session.Session, str](initialized)) { ret 3; }
+        var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+        fin { session.dnit(?s); }
+        if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 4; }
+        val lowered: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, round * 2);
+        if (R.is_err[project.Project, outcome.Fail](lowered)) { ret 5; }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](lowered);
+        fin { project.dnit_project(?p); }
+        if (p.raw_lower_capture != nil) { ret 6; }
+        val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+        val provider: session.ModuleId = ut_mid(?p, ?s, "uniontest.helper");
+        if (mid == session.MODULE_NIL || provider == session.MODULE_NIL) { ret 7; }
+        val m: *ir.Module = p.modules[mid::u32].ir_module;
+        val main: *ir.Function = ut_inline_function(?s, m, "uniontest.main.main");
+        if (ut_inline_ops(main, instruction.OP_CALL) != 0) { ret 8; }
+        var answer: bool = false;
+        var bi: u32 = 0;
+        for (bi < main.block_count) {
+            val term: O.Option[*instruction.Instruction] = ir.instruction_get(main, main.blocks[bi].terminator);
+            if (O.is_some[*instruction.Instruction](term)) {
+                val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](term);
+                if (ins.kind == instruction.OP_RET && ins.operand_count == 1 && ins.operands[0].kind == value.VAL_CONST_INT
+                    && ins.operands[0].data.int_lit == 42) { answer = true; }
+            }
+            bi = bi + 1;
+        }
+        if (!answer) { ret 9; }
+        val write: *ir.Function = ut_inline_function(?s, m, "uniontest.main.write");
+        if (ut_inline_ops(write, instruction.OP_CALL) != 0 || ut_inline_ops(write, instruction.OP_STORE) != 1) { ret 10; }
+        var external_global: bool = false;
+        var gi: u32 = 0;
+        for (gi < m.global_len) {
+            if (ut_id_is(?s, m.globals[gi].name, "uniontest.helper.counter") && m.globals[gi].is_extern && !m.globals[gi].is_local) { external_global = true; }
+            gi = gi + 1;
+        }
+        if (!external_global) { ret 11; }
+        if (ut_inline_ops(ut_inline_function(?s, m, "uniontest.main.retained"), instruction.OP_CALL) != 1
+            || ut_inline_ops(ut_inline_function(?s, m, "uniontest.main.literal"), instruction.OP_CALL) != 1) { ret 12; }
+        val external: *ir.Function = ut_inline_function(?s, m, "uniontest.helper.wrap");
+        val original: *ir.Function = ut_inline_function(?s, p.modules[provider::u32].ir_module, "uniontest.helper.wrap");
+        if (external == nil || original == nil || external.block_count != 0 || (external.flags & ir.FN_FLAG_EXTERN) == 0
+            || original.block_count == 0 || (original.flags & (ir.FN_FLAG_EXTERN | ir.FN_FLAG_WEAK)) != 0) { ret 13; }
+        val address: *ir.Function = ut_inline_function(?s, m, "uniontest.main.address");
+        var address_kept: bool = false;
+        bi = 0;
+        for (bi < address.block_count) {
+            val term: O.Option[*instruction.Instruction] = ir.instruction_get(address, address.blocks[bi].terminator);
+            if (O.is_some[*instruction.Instruction](term)) {
+                val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](term);
+                if (ins.kind == instruction.OP_RET && ins.operand_count == 1 && ins.operands[0].kind == value.VAL_FN
+                    && m.functions[ins.operands[0].data.fn_ix].name == original.name) { address_kept = true; }
+            }
+            bi = bi + 1;
+        }
+        if (!address_kept) { ret 14; }
+        val assembly: *ir.Function = ut_inline_function(?s, m, "uniontest.main.assembly");
+        if (ut_inline_ops(assembly, instruction.OP_CALL) != 0 || ut_inline_ops(assembly, instruction.OP_ASM) != 1
+            || assembly.asm_blocks.len != 1 || assembly.inline_site_len == 0) { ret 15; }
+        if (ut_inline_ops(ut_inline_function(?s, m, "uniontest.main.record"), instruction.OP_CALL) != 0) { ret 16; }
+        val classified: *ir.Function = ut_inline_function(?s, m, "uniontest.main.classified");
+        if (ut_inline_ops(classified, instruction.OP_CALL) != 0 || (classified.flags & ir.FN_FLAG_OBLIVIOUS) == 0) { ret 17; }
+        var secret_add: bool = false;
+        var ii: u32 = 0;
+        for (ii < classified.instr_len) {
+            if (classified.instrs[ii].kind == instruction.OP_ADD && classified.instrs[ii].secret) { secret_add = true; }
+            ii = ii + 1;
+        }
+        if (!secret_add) { ret 18; }
+        round = round + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.driver:inline_body_availability_refreshes_after_unannotated_provider_edits" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "leaf.mach"};
+    var versions: [3]str = [3]str{
+        "pub fun helper(v: i32) i32 { val p: *u8 = \"pool\"; ret v + (@p)::i32; }\n",
+        "pub fun helper(v: i32) i32 { ret v + 1; }\n",
+        "pub fun helper(v: i32) i32 { ret v + 2; }\n"
+    };
+    var texts: [2]str = [2]str{"use uniontest.leaf.helper;\nfun main() i32 { ret helper(41); }\n", versions[0]};
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val joined: R.Result[str, str] = path.join(?alloc, root, "src/leaf.mach");
+    if (R.is_err[str, str](joined)) { ret 5; }
+    val filename: str = R.unwrap_ok[str, str](joined);
+    fin { str_free(?alloc, filename); }
+    var previous: query.Revision = 0;
+    var surface: query.Revision = 0;
+    var round: u32 = 0;
+    for (round < 3) {
+        if (O.is_some[str](fs.write_bytes(filename, versions[round], str_len(versions[round]), 420))) { ret 6; }
+        val built: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+        if (R.is_err[project.Project, outcome.Fail](built)) { ret 7; }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](built);
+        fin { project.dnit_project(?p); }
+        val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+        val leaf: session.StableModuleId = ut_stable(?p, ?s, "uniontest.leaf");
+        if (mid == session.MODULE_NIL || leaf == session.STABLE_MODULE_NIL) { ret 8; }
+        val m: *ir.Module = p.modules[mid::u32].ir_module;
+        val fn: *ir.Function = ut_inline_function(?s, m, "uniontest.main.main");
+        var expected_calls: u32 = 0;
+        if (round == 0) { expected_calls = 1; }
+        if (ut_inline_ops(fn, instruction.OP_CALL) != expected_calls) { ret 9; }
+        if (round > 0) {
+            var answer: bool = false;
+            var bi: u32 = 0;
+            for (bi < fn.block_count) {
+                val term: O.Option[*instruction.Instruction] = ir.instruction_get(fn, fn.blocks[bi].terminator);
+                if (O.is_some[*instruction.Instruction](term)) {
+                    val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](term);
+                    if (ins.kind == instruction.OP_RET && ins.operand_count == 1 && ins.operands[0].kind == value.VAL_CONST_INT
+                        && ins.operands[0].data.int_lit == 41 + round::u64) { answer = true; }
+                }
+                bi = bi + 1;
+            }
+            if (!answer) { ret 10; }
+        }
+        val stamp: query.Revision = ut_lower_lc(?s, p.modules[mid::u32].stable_id);
+        val current_surface: query.Revision = ut_surface_lc(?s, leaf);
+        if (stamp == 0 || stamp == ~(0::query.Revision) || (round > 0 && (stamp == previous || current_surface != surface))) { ret 11; }
+        previous = stamp;
+        surface = current_surface;
+        round = round + 1;
+    }
+    ret 0;
+}
+
 test "mach.lang.driver:generic_template_emits_no_bare_body" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -7888,7 +8081,7 @@ test "mach.lang.driver:incremental_lower_inline_body_invalidates_importers" {
 
     var bad: i32 = 0;
 
-    val p1r: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
+    val p1r: R.Result[project.Project, outcome.Fail] = ut_back_half_opt(?sA, root, pipeline.OPT_RELEASE);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
@@ -7903,14 +8096,14 @@ test "mach.lang.driver:incremental_lower_inline_body_invalidates_importers" {
 
     val leaf_v2: str = "#[inline]\npub fun inl() i32 { ret 4; }\n";
     if (O.is_some[str](fs.write_bytes(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val p2r: R.Result[project.Project, outcome.Fail] = ut_back_half(?sA, root);
+    val p2r: R.Result[project.Project, outcome.Fail] = ut_back_half_opt(?sA, root, pipeline.OPT_RELEASE);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
     val lo_main_2: query.Revision = ut_lower_lc(?sA, st_main);
     val lo_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
     val sf_leaf_2: query.Revision = ut_surface_lc(?sA, st_leaf);
     project.dnit_project(?p2);
-    if (sf_leaf_2 == sf_leaf_1) { bad = 1; }
+    if (sf_leaf_2 != sf_leaf_1) { bad = 1; }
     if (lo_leaf_2 == lo_leaf_1) { bad = 1; }
     if (lo_main_2 == lo_main_1) { bad = 1; }
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7524,6 +7524,438 @@ test "mach.lang.driver:inline_shared_specializations_keep_an_actual_provider_for
     ret 0;
 }
 
+fun ut_inline_asm_text(s: *session.Session, p: *project.Project, m: *ir.Module, out: *u8, cap: usize, out_len: *usize) bool {
+    var b: UtIrTextBuf;
+    b.data = out; b.len = 0; b.cap = cap;
+    var w: writer.Writer;
+    w.ctx     = (?b)::ptr;
+    w.f_write = ut_ir_text_write;
+    val cg: R.Result[of.ObjectImage, fail.Fail] =
+        codegen.codegen_module(s, ?p.target, m, unit.ir_set_empty(), ?w, codegen.PLACEMENT_POLICY_VERSION, codegen.no_debug());
+    if (R.is_err[of.ObjectImage, fail.Fail](cg)) { ret false; }
+    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, fail.Fail](cg);
+    obj.dnit(?image);
+    @out_len = b.len;
+    ret true;
+}
+
+# lines whose first token is the `call` mnemonic
+fun ut_count_call_lines(text: *u8, len: usize) u32 {
+    var calls: u32 = 0;
+    var i: usize = 0;
+    for (i < len) {
+        for (i < len && (text[i] == 32 || text[i] == 9)) { i = i + 1; }
+        if (i + 4 <= len && text[i] == 99 && text[i + 1] == 97 && text[i + 2] == 108 && text[i + 3] == 108
+            && (i + 4 == len || text[i + 4] == 32 || text[i + 4] == 9 || text[i + 4] == 10)) { calls = calls + 1; }
+        for (i < len && text[i] != 10) { i = i + 1; }
+        i = i + 1;
+    }
+    ret calls;
+}
+
+fun ut_inline_module_calls(s: *session.Session, root: str, out: *u8, cap: usize) i32 {
+    val initialized: R.Result[session.Session, str] = session.init(s.alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret -1; }
+    var fresh: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?fresh); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?fresh.registry))) { ret -1; }
+    val lowered: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?fresh, root, 0);
+    if (R.is_err[project.Project, outcome.Fail](lowered)) { ret -1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](lowered);
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?fresh, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret -1; }
+    var len: usize = 0;
+    if (!ut_inline_asm_text(?fresh, ?p, p.modules[mid::u32].ir_module, out, cap, ?len) || len == 0) { ret -1; }
+    ret ut_count_call_lines(out, len)::i32;
+}
+
+# same-module: two small helpers, one calling the other, leave no call in the module's
+# x86-64 text; the control marks the leaf noinline and the counter sees its calls
+test "mach.lang.driver:inline_same_module_helper_leaves_no_call_in_x86_64_text" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    var text: [65536]u8;
+    var names: [1]str = [1]str{"main.mach"};
+    var texts: [1]str;
+    var round: u32 = 0;
+    for (round < 2) {
+        var prefix: str = "";
+        if (round == 1) { prefix = "#[noinline] "; }
+        val src: R.Result[str, str] = format.sprint(?alloc,
+            "{}fun add3(a: i32, b: i32, c: i32) i32 {{ ret a + b + c; }}\nfun twice(v: i32) i32 {{ ret add3(v, v, v) + add3(1, 2, v); }}\nfun main() i32 {{ ret twice(4); }}\n", prefix);
+        if (R.is_err[str, str](src)) { ret 3; }
+        texts[0] = R.unwrap_ok[str, str](src);
+        fin { str_free(?alloc, texts[0]); }
+        val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+        if (R.is_err[str, str](scaffold)) { ret 4; }
+        val root: str = R.unwrap_ok[str, str](scaffold);
+        fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+        val calls: i32 = ut_inline_module_calls(?s, root, ?text[0], 65536);
+        if (calls < 0) { ret 5; }
+        if (round == 0 && calls != 0) { ret 6; }
+        if (round == 1 && calls == 0) { ret 7; }
+        round = round + 1;
+    }
+    ret 0;
+}
+
+# cross-module: a record constructor and an integer helper from another module leave no
+# call in the importer's x86-64 text; the control marks the helper noinline
+test "mach.lang.driver:inline_cross_module_helper_leaves_no_call_in_x86_64_text" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    var text: [65536]u8;
+    var names: [2]str = [2]str{"main.mach", "helper.mach"};
+    var texts: [2]str;
+    texts[0] = "use h: uniontest.helper;\npub fun bounds(a: f32, b: f32, c: f32) f32 { val v: h.V3 = h.vec3(a, b, c); ret v.x + v.y + v.z; }\npub fun fd(a: i64, b: i64) i64 { ret h.floor_div(a, b); }\nfun main() i32 { ret 0; }\n";
+    var round: u32 = 0;
+    for (round < 2) {
+        var prefix: str = "";
+        if (round == 1) { prefix = "#[noinline] "; }
+        val src: R.Result[str, str] = format.sprint(?alloc,
+            "pub rec V3 {{ x: f32; y: f32; z: f32; }}\n{}pub fun vec3(x: f32, y: f32, z: f32) V3 {{ ret V3{{x: x, y: y, z: z}}; }}\n{}pub fun floor_div(a: i64, b: i64) i64 {{ var q: i64 = a / b; if (a % b != 0 && (a < 0) != (b < 0)) {{ q = q - 1; }} ret q; }}\n", prefix, prefix);
+        if (R.is_err[str, str](src)) { ret 3; }
+        texts[1] = R.unwrap_ok[str, str](src);
+        fin { str_free(?alloc, texts[1]); }
+        val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+        if (R.is_err[str, str](scaffold)) { ret 4; }
+        val root: str = R.unwrap_ok[str, str](scaffold);
+        fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+        val calls: i32 = ut_inline_module_calls(?s, root, ?text[0], 65536);
+        if (calls < 0) { ret 5; }
+        if (round == 0 && calls != 0) { ret 6; }
+        if (round == 1 && calls != 2) { ret 7; }
+        round = round + 1;
+    }
+    ret 0;
+}
+
+fun ut_inline_calls_of(s: *session.Session, m: *ir.Module, name: str) u32 {
+    ret ut_inline_ops(ut_inline_function(s, m, name), instruction.OP_CALL);
+}
+
+# the documented rule: a recursive callee, an indirect call, a noinline callee, a naked
+# callee and a body at or over the size bar keep their calls across modules; the small
+# direct helper beside them loses its call
+test "mach.lang.driver:inline_rule_keeps_recursive_indirect_noinline_naked_and_large_calls" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "helper.mach"};
+    var texts: [2]str;
+    texts[0] = "use h: uniontest.helper;\npub fun r(v: i32) i32 { ret h.down(v); }\npub fun ind(f: fun(i32) i32, v: i32) i32 { ret f(v); }\npub fun ni(v: i32) i32 { ret h.keep(v); }\npub fun nkd() { h.nk(); }\npub fun bg(v: i32) i32 { ret h.big(v); }\npub fun ok(v: i32) i32 { ret h.one(v); }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun down(n: i32) i32 { if (n <= 0) { ret 0; } ret down(n - 1) + 1; }\npub fun one(v: i32) i32 { ret v + 1; }\n#[noinline] pub fun keep(v: i32) i32 { ret v + 1; }\n#[naked] pub fun nk() { asm x86_64 { nop } }\npub fun big(v: i32) i32 { var a: i32 = v; a = a * 3 + 1; a = a * 5 + 2; a = a * 7 + 3; a = a * 9 + 4; a = a * 11 + 5; a = a * 13 + 6; a = a * 15 + 7; a = a * 17 + 8; a = a * 19 + 9; a = a * 21 + 10; a = a * 23 + 11; a = a * 25 + 12; a = a * 27 + 13; ret a; }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val lowered: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+    if (R.is_err[project.Project, outcome.Fail](lowered)) { ret 5; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](lowered);
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret 6; }
+    val m: *ir.Module = p.modules[mid::u32].ir_module;
+    if (ut_inline_calls_of(?s, m, "uniontest.main.r") != 1)   { ret 7; }
+    val ind: *ir.Function = ut_inline_function(?s, m, "uniontest.main.ind");
+    if (ut_inline_ops(ind, instruction.OP_CALL) != 1) { ret 8; }
+    var bi: u32 = 0;
+    for (bi < ind.block_count) {
+        var ii: u32 = 0;
+        for (ii < ind.blocks[bi].instr_count) {
+            val ins: O.Option[*instruction.Instruction] = ir.instruction_get(ind, ind.blocks[bi].instructions[ii]);
+            if (O.is_some[*instruction.Instruction](ins) && O.unwrap[*instruction.Instruction](ins).kind == instruction.OP_CALL
+                && O.unwrap[*instruction.Instruction](ins).operands[0].kind == value.VAL_FN) { ret 9; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if (ut_inline_calls_of(?s, m, "uniontest.main.ni") != 1)  { ret 10; }
+    if (ut_inline_calls_of(?s, m, "uniontest.main.nkd") != 1) { ret 11; }
+    if (ut_inline_calls_of(?s, m, "uniontest.main.bg") != 1)  { ret 12; }
+    if (ut_inline_calls_of(?s, m, "uniontest.main.ok") != 0)  { ret 13; }
+    ret 0;
+}
+
+fun ut_inline_asm_body_has(s: *session.Session, fn: *ir.Function, ordinal: u32, needle: str) bool {
+    var seen: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < fn.block_count) {
+        var ii: u32 = 0;
+        for (ii < fn.blocks[bi].instr_count) {
+            val iid: ir.InstructionId = fn.blocks[bi].instructions[ii];
+            val ins: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
+            if (O.is_some[*instruction.Instruction](ins) && O.unwrap[*instruction.Instruction](ins).kind == instruction.OP_ASM) {
+                if (seen == ordinal) {
+                    var key: ir.InstructionId = iid;
+                    val payload: R.Result[*ir.IrAsm, str] = map.get[ir.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
+                    if (R.is_err[*ir.IrAsm, str](payload)) { ret false; }
+                    val body: O.Option[str] = intern.lookup(?s.interner, R.unwrap_ok[*ir.IrAsm, str](payload).body);
+                    ret O.is_some[str](body) && str_contains(O.unwrap[str](body), needle);
+                }
+                seen = seen + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    ret false;
+}
+
+fun ut_mir_function(mm: *mir.MirModule, s: *session.Session, name: str) *mir.MirFunction {
+    var i: u32 = 0;
+    for (i < mm.function_len) {
+        if (ut_id_is(s, mm.functions[i].name, name)) { ret ?mm.functions[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# atomic-shaped wrappers (a `{ptr}`/`{result}` binding pair around one memory
+# instruction) inlined across modules keep their effects: two identical loads are not
+# merged, an unused load is not removed, store/fence/store keep their order, and at MIR
+# each asm keeps its payload and bindings
+test "mach.lang.driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "helper.mach"};
+    var texts: [2]str;
+    texts[0] = "use h: uniontest.helper;\npub fun twice(p: *i64) i64 { val a: i64 = h.load(p); val b: i64 = h.load(p); ret a + b; }\npub fun unused(p: *i64) i64 { val a: i64 = h.load(p); ret 0; }\npub fun seq(p: *i64, v: i64) { h.store(p, v); h.fence(); h.store(p, v + 1); }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun load(p: *i64) i64 { var r: i64 = 0; asm x86_64 { mov rcx, {p}\n mov rax, [rcx]\n mov {r}, rax } ret r; }\npub fun store(p: *i64, v: i64) { asm x86_64 { mov rax, {v}\n mov rcx, {p}\n xchg [rcx], rax } }\npub fun fence() { asm x86_64 { mfence } }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val lowered: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+    if (R.is_err[project.Project, outcome.Fail](lowered)) { ret 5; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](lowered);
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret 6; }
+    val m: *ir.Module = p.modules[mid::u32].ir_module;
+    val twice: *ir.Function = ut_inline_function(?s, m, "uniontest.main.twice");
+    if (ut_inline_ops(twice, instruction.OP_CALL) != 0 || ut_inline_ops(twice, instruction.OP_ASM) != 2) { ret 7; }
+    val unused: *ir.Function = ut_inline_function(?s, m, "uniontest.main.unused");
+    if (ut_inline_ops(unused, instruction.OP_CALL) != 0 || ut_inline_ops(unused, instruction.OP_ASM) != 1) { ret 8; }
+    val seq: *ir.Function = ut_inline_function(?s, m, "uniontest.main.seq");
+    if (ut_inline_ops(seq, instruction.OP_CALL) != 0 || ut_inline_ops(seq, instruction.OP_ASM) != 3) { ret 9; }
+    if (!ut_inline_asm_body_has(?s, seq, 0, "xchg") || !ut_inline_asm_body_has(?s, seq, 1, "mfence")
+        || !ut_inline_asm_body_has(?s, seq, 2, "xchg")) { ret 10; }
+    val mr: R.Result[mir.MirModule, str] = mirlower.lower_ir(?p.target, m, ?alloc, ?s.interner, ?s.sources);
+    if (R.is_err[mir.MirModule, str](mr)) { ret 11; }
+    var mm: mir.MirModule = R.unwrap_ok[mir.MirModule, str](mr);
+    val mseq: *mir.MirFunction = ut_mir_function(?mm, ?s, "uniontest.main.seq");
+    val mtwice: *mir.MirFunction = ut_mir_function(?mm, ?s, "uniontest.main.twice");
+    if (mseq == nil || mtwice == nil) { ret 12; }
+    var asms: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < mseq.block_count) {
+        var ii: u32 = 0;
+        for (ii < mseq.blocks[bi].instr_count) {
+            val mi: *mir.MirInstr = ?mseq.blocks[bi].instrs[ii];
+            if (mi.opcode == mir.MIR_ASM) {
+                if (mi.asm_block == nil) { ret 13; }
+                if (asms == 1 && !str_contains(mi.asm_block.body, "mfence")) { ret 14; }
+                if (asms != 1 && !str_contains(mi.asm_block.body, "xchg")) { ret 14; }
+                asms = asms + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if (asms != 3) { ret 15; }
+    var bound: u32 = 0;
+    bi = 0;
+    for (bi < mtwice.block_count) {
+        var ii: u32 = 0;
+        for (ii < mtwice.blocks[bi].instr_count) {
+            val mi: *mir.MirInstr = ?mtwice.blocks[bi].instrs[ii];
+            if (mi.opcode == mir.MIR_ASM && mi.asm_block != nil && mi.asm_block.bind_count == 2) { bound = bound + 1; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if (bound != 2) { ret 16; }
+    ret 0;
+}
+
+# an #[oblivious] provider body is expanded only into an #[oblivious] importer
+test "mach.lang.driver:inline_oblivious_callee_stays_a_call_in_a_public_caller" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "helper.mach"};
+    var texts: [2]str;
+    texts[0] = "use h: uniontest.helper;\npub fun open(v: ^i32) ^i32 { ret h.classified(v); }\n#[oblivious] pub fun closed(v: ^i32) ^i32 { ret h.classified(v); }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "#[oblivious] pub fun classified(v: ^i32) ^i32 { ret v + 1; }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val lowered: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+    if (R.is_err[project.Project, outcome.Fail](lowered)) { ret 5; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](lowered);
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret 6; }
+    val m: *ir.Module = p.modules[mid::u32].ir_module;
+    if (ut_inline_calls_of(?s, m, "uniontest.main.open") != 1) { ret 7; }
+    val closed: *ir.Function = ut_inline_function(?s, m, "uniontest.main.closed");
+    if (ut_inline_ops(closed, instruction.OP_CALL) != 0) { ret 8; }
+    var secret_add: bool = false;
+    var ii: u32 = 0;
+    for (ii < closed.instr_len) {
+        if (closed.instrs[ii].kind == instruction.OP_ADD && closed.instrs[ii].secret) { secret_add = true; }
+        ii = ii + 1;
+    }
+    if (!secret_add) { ret 9; }
+    ret 0;
+}
+
+fun ut_inline_text_bytes(alloc: *A.Allocator, root: str, debug: bool, out: *u8, cap: usize, out_len: *usize, out_calls: *u32) i32 {
+    val initialized: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 2; }
+    var selection: manifest.Selection = ut_target_sel("linux");
+    selection.profile = "release";
+    val opened: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, ?selection);
+    if (R.is_err[project.Project, outcome.Fail](opened)) { ret 3; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](opened);
+    fin { project.dnit_project(?p); }
+    p.req.debug = debug;
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))    { ret 4; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p)))   { ret 5; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_codegen_pass(?p))) { ret 6; }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret 7; }
+    @out_calls = ut_inline_calls_of(?s, p.modules[mid::u32].ir_module, "uniontest.main.pair");
+    val image: *of.ObjectImage = p.modules[mid::u32].object_image;
+    if (image == nil) { ret 8; }
+    var i: u32 = 0;
+    for (i < image.section_count) {
+        val sec: *of.Section = ?image.sections[i];
+        if (sec.kind == of.SK_TEXT) {
+            if (sec.len::usize > cap) { ret 9; }
+            var k: u32 = 0;
+            for (k < sec.len) { out[k] = sec.bytes[k]; k = k + 1; }
+            @out_len = sec.len::usize;
+            ret 0;
+        }
+        i = i + 1;
+    }
+    ret 10;
+}
+
+# a provider body one instruction under the size bar with eleven locals, each of which
+# `-g` annotates with a dbg_value that the old cost counted, is inlined the same way with
+# and without -g and the importer's release text is byte-identical. mutation control:
+# counting OP_DBG_VALUE in body.counted() keeps both calls under -g and the texts differ.
+test "mach.lang.driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_bar" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var names: [2]str = [2]str{"main.mach", "helper.mach"};
+    var texts: [2]str;
+    texts[0] = "use h: uniontest.helper;\npub fun pair(v: i64) i64 { ret h.mixer(v) + h.mixer(v + 1); }\nfun main() i32 { ret 0; }\n";
+    texts[1] = "pub fun mixer(v: i64) i64 { var a: i64 = v * 3 + 1; var b: i64 = a * 5 + 2; var c: i64 = b * 7 + 3; var d: i64 = c * 9 + 4; var e: i64 = d * 11 + 5; var f: i64 = e * 13 + 6; var g: i64 = f * 15 + 7; var h2: i64 = g * 17 + 8; var i: i64 = h2 * 19 + 9; var j: i64 = i * 21 + 10; var k: i64 = j * 23 + 11; ret k; }\n";
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 2; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    var plain: [65536]u8;
+    var annotated: [65536]u8;
+    var plain_len: usize = 0;
+    var annotated_len: usize = 0;
+    var plain_calls: u32 = 0;
+    var annotated_calls: u32 = 0;
+    val a: i32 = ut_inline_text_bytes(?alloc, root, false, ?plain[0], 65536, ?plain_len, ?plain_calls);
+    if (a != 0) { ret 10 + a; }
+    val b: i32 = ut_inline_text_bytes(?alloc, root, true, ?annotated[0], 65536, ?annotated_len, ?annotated_calls);
+    if (b != 0) { ret 30 + b; }
+    if (plain_calls != 0 || annotated_calls != 0) { ret 50; }
+    if (plain_len == 0 || plain_len != annotated_len) { ret 51; }
+    var i: usize = 0;
+    for (i < plain_len) {
+        if (plain[i] != annotated[i]) { ret 52; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# an edit to a provider function that is not extracted (noinline) leaves the extracted
+# bodies equal, so the importer's Q_LOWER keeps its revision while the provider's moves;
+# an edit to the extracted helper moves the importer's
+test "mach.lang.driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "leaf.mach"};
+    var versions: [3]str = [3]str{
+        "pub fun helper(v: i32) i32 { ret v + 1; }\n#[noinline] pub fun heavy(v: i32) i32 { ret v + 2; }\n",
+        "pub fun helper(v: i32) i32 { ret v + 1; }\n#[noinline] pub fun heavy(v: i32) i32 { var t: i32 = v * 3; if (t > 9) { t = t - 4; } ret t + 3; }\n",
+        "pub fun helper(v: i32) i32 { ret v + 5; }\n#[noinline] pub fun heavy(v: i32) i32 { var t: i32 = v * 3; if (t > 9) { t = t - 4; } ret t + 3; }\n"
+    };
+    var texts: [2]str = [2]str{"use uniontest.leaf.helper;\nuse uniontest.leaf.heavy;\nfun main() i32 { ret helper(1) + heavy(2); }\n", versions[0]};
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val joined: R.Result[str, str] = path.join(?alloc, root, "src/leaf.mach");
+    if (R.is_err[str, str](joined)) { ret 5; }
+    val filename: str = R.unwrap_ok[str, str](joined);
+    fin { str_free(?alloc, filename); }
+    var main_rev: query.Revision = 0;
+    var leaf_rev: query.Revision = 0;
+    var round: u32 = 0;
+    for (round < 3) {
+        if (O.is_some[str](fs.write_bytes(filename, versions[round], str_len(versions[round]), 420))) { ret 6; }
+        val built: R.Result[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+        if (R.is_err[project.Project, outcome.Fail](built)) { ret 7; }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](built);
+        fin { project.dnit_project(?p); }
+        val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+        val leaf: session.StableModuleId = ut_stable(?p, ?s, "uniontest.leaf");
+        if (mid == session.MODULE_NIL || leaf == session.STABLE_MODULE_NIL) { ret 8; }
+        if (ut_inline_calls_of(?s, p.modules[mid::u32].ir_module, "uniontest.main.main") != 1) { ret 9; }
+        val current_main: query.Revision = ut_lower_lc(?s, p.modules[mid::u32].stable_id);
+        val current_leaf: query.Revision = ut_lower_lc(?s, leaf);
+        if (current_main == 0 || current_main == ~(0::query.Revision)) { ret 10; }
+        if (round == 1 && (current_main != main_rev || current_leaf == leaf_rev)) { ret 11; }
+        if (round == 2 && (current_main == main_rev || current_leaf == leaf_rev)) { ret 12; }
+        main_rev = current_main;
+        leaf_rev = current_leaf;
+        round = round + 1;
+    }
+    ret 0;
+}
+
 test "mach.lang.driver:generic_template_emits_no_bare_body" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -134,6 +134,7 @@ pub rec Block {
 
 pub rec Function {
     name:        intern.StrId;
+    body_module: intern.StrId;
     sig:         type.IrTypeId;
 
     params:      *value.Value;
@@ -408,6 +409,7 @@ fun agg_value_dnit(m: *Module, v: *value.Value) {
 pub fun function_new(alloc: *A.Allocator, name: intern.StrId, sig: type.IrTypeId, flags: u32) Function {
     var f: Function;
     f.name        = name;
+    f.body_module = intern.STR_NIL;
     f.sig         = sig;
     f.params      = nil;
     f.param_count = 0;

--- a/src/lang/me/ir.mach
+++ b/src/lang/me/ir.mach
@@ -134,6 +134,7 @@ pub rec Block {
 
 pub rec Function {
     name:        intern.StrId;
+    # actual body provider, unique for strong linkage and selected for shared weak linkage
     body_module: intern.StrId;
     sig:         type.IrTypeId;
 

--- a/src/lang/me/ir/body.mach
+++ b/src/lang/me/ir/body.mach
@@ -1,0 +1,827 @@
+use std.collections.map;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+use mach.lang.intern;
+use mach.lang.me.ir;
+use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
+use mach.lang.me.ir.type;
+use mach.lang.me.ir.value;
+use mach.lang.target;
+use mach.lang.target.isa;
+
+pub val MAX_INSTRUCTIONS: u32 = 1024;
+pub val MAX_BYTES: usize = 262144;
+pub val SMALL_INSTRUCTIONS: u32 = 25;
+
+pub rec Budget {
+    instructions: u32;
+    bytes: usize;
+}
+
+pub fun charge(b: *Budget, instructions: u32, bytes: usize) bool {
+    if (instructions > MAX_INSTRUCTIONS - b.instructions || bytes > MAX_BYTES - b.bytes) { ret false; }
+    b.instructions = b.instructions + instructions;
+    b.bytes = b.bytes + bytes;
+    ret true;
+}
+
+fun candidate(fn: *ir.Function) bool {
+    if ((fn.flags & (ir.FN_FLAG_EXTERN | ir.FN_FLAG_NOINLINE | ir.FN_FLAG_SCALAR | ir.FN_FLAG_NAKED)) != 0) { ret false; }
+    if (fn.block_count == 0 || fn.instr_len > MAX_INSTRUCTIONS) { ret false; }
+    ret (fn.flags & ir.FN_FLAG_INLINE) != 0 || live_instructions(fn) < SMALL_INSTRUCTIONS;
+}
+
+pub fun live_instructions(fn: *ir.Function) u32 {
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < fn.block_count) {
+        val block: *ir.Block = ?fn.blocks[i];
+        count = count + block.phi_count;
+        var j: u32 = 0;
+        for (j < block.instr_count) {
+            val ins: O.Option[*instruction.Instruction] = ir.instruction_get(fn, block.instructions[j]);
+            if (O.is_some[*instruction.Instruction](ins) && O.unwrap[*instruction.Instruction](ins).kind != instruction.OP_DBG_VALUE) { count = count + 1; }
+            j = j + 1;
+        }
+        if (block.terminator != id.INSTR_NIL) { count = count + 1; }
+        i = i + 1;
+    }
+    ret count;
+}
+
+rec Copy {
+    dst: *ir.Module;
+    src: *ir.Module;
+    target: *target.Target;
+    scratch: *A.Allocator;
+    types: *type.IrTypeId;
+    marked: *bool;
+    functions: *u32;
+    globals: *u32;
+}
+
+fun copy_init(c: *Copy, dst: *ir.Module, src: *ir.Module, tgt: *target.Target, a: *A.Allocator) R.Result[R.Void, str] {
+    @c = Copy{};
+    c.dst = dst; c.src = src; c.target = tgt; c.scratch = a;
+    val tr: R.Result[*type.IrTypeId, str] = A.allocate[type.IrTypeId](a, src.types.len::usize);
+    if (R.is_err[*type.IrTypeId, str](tr)) { ret R.err[R.Void, str](R.unwrap_err[*type.IrTypeId, str](tr)); }
+    c.types = R.unwrap_ok[*type.IrTypeId, str](tr);
+    val mr: R.Result[*bool, str] = A.allocate[bool](a, src.types.len::usize);
+    if (R.is_err[*bool, str](mr)) { copy_dnit(c); ret R.err[R.Void, str](R.unwrap_err[*bool, str](mr)); }
+    c.marked = R.unwrap_ok[*bool, str](mr);
+    val fr: R.Result[*u32, str] = A.allocate[u32](a, src.function_len::usize);
+    if (R.is_err[*u32, str](fr)) { copy_dnit(c); ret R.err[R.Void, str](R.unwrap_err[*u32, str](fr)); }
+    c.functions = R.unwrap_ok[*u32, str](fr);
+    val gr: R.Result[*u32, str] = A.allocate[u32](a, src.global_len::usize);
+    if (R.is_err[*u32, str](gr)) { copy_dnit(c); ret R.err[R.Void, str](R.unwrap_err[*u32, str](gr)); }
+    c.globals = R.unwrap_ok[*u32, str](gr);
+    var i: u32 = 0;
+    for (i < src.types.len) { c.types[i] = type.IRT_NIL; c.marked[i] = false; i = i + 1; }
+    i = 0; for (i < src.function_len) { c.functions[i] = 0xFFFFFFFF; i = i + 1; }
+    i = 0; for (i < src.global_len) { c.globals[i] = 0xFFFFFFFF; i = i + 1; }
+    ret R.ok_void[str]();
+}
+
+fun copy_dnit(c: *Copy) {
+    if (c.types != nil) { A.deallocate[type.IrTypeId](c.scratch, c.types, c.src.types.len::usize); }
+    if (c.marked != nil) { A.deallocate[bool](c.scratch, c.marked, c.src.types.len::usize); }
+    if (c.functions != nil) { A.deallocate[u32](c.scratch, c.functions, c.src.function_len::usize); }
+    if (c.globals != nil) { A.deallocate[u32](c.scratch, c.globals, c.src.global_len::usize); }
+    c.types = nil; c.marked = nil; c.functions = nil; c.globals = nil;
+}
+
+fun mark_child(c: *Copy, parent: u32, child: type.IrTypeId) bool {
+    if (child::u32 >= parent) { ret false; }
+    c.marked[child::u32] = true;
+    ret true;
+}
+
+fun copy_type(c: *Copy, wanted: type.IrTypeId) R.Result[type.IrTypeId, str] {
+    if (wanted == type.IRT_NIL) { ret R.ok[type.IrTypeId, str](wanted); }
+    if (wanted >= c.src.types.len) { ret R.err[type.IrTypeId, str]("inline body: type id is out of range"); }
+    if (c.types[wanted] != type.IRT_NIL) { ret R.ok[type.IrTypeId, str](c.types[wanted]); }
+    c.marked[wanted] = true;
+    var i: u32 = wanted + 1;
+    for (i > 0) {
+        i = i - 1;
+        if (!c.marked[i] || c.types[i] != type.IRT_NIL) { cnt; }
+        val t: *type.IrType = ?c.src.types.types[i];
+        var valid: bool = true;
+        if (t.kind == type.IRT_ARRAY) { valid = mark_child(c, i, t.data.array_.element); }
+        or (t.kind == type.IRT_VECTOR) { valid = mark_child(c, i, t.data.vector_.element); }
+        or (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) {
+            var j: u32 = 0;
+            for (j < t.data.struct_.field_count) { valid = valid && mark_child(c, i, t.data.struct_.fields[j]); j = j + 1; }
+        } or (t.kind == type.IRT_FN) {
+            valid = mark_child(c, i, t.data.fn.ret_type);
+            var j: u32 = 0;
+            for (j < t.data.fn.param_count) { valid = valid && mark_child(c, i, t.data.fn.params[j]); j = j + 1; }
+        } or (t.kind == type.IRT_HANDLE) {
+            val schema: *isa.TypeDef = isa.type_def_by_tag(c.target.isa.defs, t.data.handle_.ctor);
+            if (schema == nil || schema.arity != t.data.handle_.count) { ret R.err[type.IrTypeId, str]("inline body: handle type has no matching operand schema"); }
+            var j: u32 = 0;
+            for (j < schema.arity) {
+                if (schema.operands[j] != isa.TYPE_OPERAND_WORD) { valid = valid && mark_child(c, i, t.data.handle_.operands[j]); }
+                j = j + 1;
+            }
+        }
+        if (!valid) { ret R.err[type.IrTypeId, str]("inline body: type reference does not precede its owning interned type"); }
+    }
+    i = 0;
+    for (i <= wanted) {
+        if (c.marked[i] && c.types[i] == type.IRT_NIL) {
+            val made: R.Result[type.IrTypeId, str] = copy_type_ready(c, ?c.src.types.types[i]);
+            if (R.is_err[type.IrTypeId, str](made)) { ret made; }
+            c.types[i] = R.unwrap_ok[type.IrTypeId, str](made);
+        }
+        i = i + 1;
+    }
+    ret R.ok[type.IrTypeId, str](c.types[wanted]);
+}
+
+fun copy_type_ready(c: *Copy, t: *type.IrType) R.Result[type.IrTypeId, str] {
+    val dst: *type.IrTypeTable = ?c.dst.types;
+    if (t.kind == type.IRT_VOID) { ret type.intern_void(dst); }
+    if (t.kind == type.IRT_INT) { ret type.intern_int(dst, t.data.bits); }
+    if (t.kind == type.IRT_FLOAT) { ret type.intern_float(dst, t.data.bits); }
+    if (t.kind == type.IRT_PTR) { ret type.intern_ptr(dst); }
+    if (t.kind == type.IRT_ARRAY) { ret type.intern_array(dst, c.types[t.data.array_.element], t.data.array_.count); }
+    if (t.kind == type.IRT_VECTOR) { ret type.intern_vector(dst, c.types[t.data.vector_.element], t.data.vector_.lanes); }
+    var n: u32 = 0;
+    var fields: *type.IrTypeId = nil;
+    if (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) { n = t.data.struct_.field_count; fields = t.data.struct_.fields; }
+    or (t.kind == type.IRT_FN) { n = t.data.fn.param_count; fields = t.data.fn.params; }
+    or (t.kind == type.IRT_HANDLE) { n = t.data.handle_.count; fields = t.data.handle_.operands; }
+    or { ret R.err[type.IrTypeId, str]("inline body: unknown IR type kind"); }
+    val ar: R.Result[*type.IrTypeId, str] = A.allocate[type.IrTypeId](c.scratch, n::usize);
+    if (R.is_err[*type.IrTypeId, str](ar)) { ret R.err[type.IrTypeId, str](R.unwrap_err[*type.IrTypeId, str](ar)); }
+    val mapped: *type.IrTypeId = R.unwrap_ok[*type.IrTypeId, str](ar);
+    fin { if (mapped != nil) { A.deallocate[type.IrTypeId](c.scratch, mapped, n::usize); } }
+    var schema: *isa.TypeDef = nil;
+    if (t.kind == type.IRT_HANDLE) { schema = isa.type_def_by_tag(c.target.isa.defs, t.data.handle_.ctor); }
+    var i: u32 = 0;
+    for (i < n) {
+        mapped[i] = fields[i];
+        if (schema == nil || schema.operands[i] != isa.TYPE_OPERAND_WORD) { mapped[i] = c.types[fields[i]]; }
+        i = i + 1;
+    }
+    if (t.kind == type.IRT_STRUCT) { ret type.intern_struct(dst, mapped, n, t.data.struct_.align, t.data.struct_.packed); }
+    if (t.kind == type.IRT_UNION) { ret type.intern_union(dst, mapped, n, t.data.struct_.align, t.data.struct_.packed); }
+    if (t.kind == type.IRT_FN) { ret type.intern_fn(dst, c.types[t.data.fn.ret_type], mapped, n, t.data.fn.variadic); }
+    ret type.intern_handle(dst, t.data.handle_.ctor, mapped, n);
+}
+
+fun copy_slice[T](a: *A.Allocator, src: *T, n: u32) R.Result[*T, str] {
+    if (n == 0) { ret R.ok[*T, str](nil); }
+    if (src == nil) { ret R.err[*T, str]("inline body: missing owned slice"); }
+    val r: R.Result[*T, str] = A.allocate[T](a, n::usize);
+    if (R.is_err[*T, str](r)) { ret r; }
+    val dst: *T = R.unwrap_ok[*T, str](r);
+    var i: u32 = 0;
+    for (i < n) { dst[i] = src[i]; i = i + 1; }
+    ret r;
+}
+
+# constant payloads belong to the destination module arena
+pub fun own_constant(a: *A.Allocator, original: value.Value) R.Result[value.Value, str] {
+    var v: value.Value = original;
+    if (v.kind == value.VAL_CONST_BYTES) {
+        val r: R.Result[*u8, str] = copy_slice[u8](a, v.data.bytes.ptr, v.data.bytes.len);
+        if (R.is_err[*u8, str](r)) { ret R.err[value.Value, str](R.unwrap_err[*u8, str](r)); }
+        v.data.bytes.ptr = R.unwrap_ok[*u8, str](r);
+    } or (v.kind == value.VAL_CONST_AGG) {
+        val r: R.Result[*u8, str] = copy_slice[u8](a, v.data.agg.bytes, v.data.agg.len);
+        if (R.is_err[*u8, str](r)) { ret R.err[value.Value, str](R.unwrap_err[*u8, str](r)); }
+        val bytes: *u8 = R.unwrap_ok[*u8, str](r);
+        val rr: R.Result[*value.AggReloc, str] = copy_slice[value.AggReloc](a, v.data.agg.relocs, v.data.agg.reloc_count);
+        if (R.is_err[*value.AggReloc, str](rr)) {
+            if (bytes != nil) { A.deallocate[u8](a, bytes, v.data.agg.len::usize); }
+            ret R.err[value.Value, str](R.unwrap_err[*value.AggReloc, str](rr));
+        }
+        v.data.agg.bytes = bytes;
+        v.data.agg.relocs = R.unwrap_ok[*value.AggReloc, str](rr);
+        v.data.agg.reloc_cap = v.data.agg.reloc_count;
+    }
+    ret R.ok[value.Value, str](v);
+}
+
+fun function_header(c: *Copy, ix: u32) R.Result[u32, str] {
+    if (ix >= c.src.function_len) { ret R.err[u32, str]("inline body: function id is out of range"); }
+    if (c.functions[ix] != 0xFFFFFFFF) { ret R.ok[u32, str](c.functions[ix]); }
+    val src: *ir.Function = ?c.src.functions[ix];
+    val sig: R.Result[type.IrTypeId, str] = copy_type(c, src.sig);
+    if (R.is_err[type.IrTypeId, str](sig)) { ret R.err[u32, str](R.unwrap_err[type.IrTypeId, str](sig)); }
+    val found: O.Option[u32] = ir.function_lookup(c.dst, src.name);
+    if (O.is_some[u32](found)) {
+        val at: u32 = O.unwrap[u32](found);
+        if (c.dst.functions[at].sig != R.unwrap_ok[type.IrTypeId, str](sig)) { ret R.err[u32, str]("inline body: function identity has incompatible IR signatures"); }
+        var origin: intern.StrId = src.body_module;
+        if (origin == intern.STR_NIL && (src.flags & ir.FN_FLAG_EXTERN) == 0) { origin = c.src.name; }
+        if (origin != intern.STR_NIL) {
+            if (c.dst.functions[at].body_module != intern.STR_NIL && c.dst.functions[at].body_module != origin) {
+                ret R.err[u32, str]("inline body: function identity has conflicting defining modules");
+            }
+            c.dst.functions[at].body_module = origin;
+        }
+        c.functions[ix] = at;
+        ret R.ok[u32, str](at);
+    }
+    val added: R.Result[u32, str] = ir.function_add(c.dst, src.name, R.unwrap_ok[type.IrTypeId, str](sig), src.flags | ir.FN_FLAG_EXTERN);
+    if (R.is_err[u32, str](added)) { ret added; }
+    val at: u32 = R.unwrap_ok[u32, str](added);
+    val fn: *ir.Function = ?c.dst.functions[at];
+    fn.body_module = src.body_module;
+    if (fn.body_module == intern.STR_NIL && (src.flags & ir.FN_FLAG_EXTERN) == 0) { fn.body_module = c.src.name; }
+    fn.is_import = src.is_import;
+    fn.label = src.label; fn.line = src.line; fn.section = src.section;
+    fn.stage = src.stage; fn.wg_x = src.wg_x; fn.wg_y = src.wg_y; fn.wg_z = src.wg_z;
+    fn.op_set = src.op_set; fn.op_code = src.op_code; fn.disp = src.disp; fn.ret_sem = src.ret_sem;
+    val registered: R.Result[R.Void, str] = ir.function_register(c.dst, src.name, at);
+    if (R.is_err[R.Void, str](registered)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](registered)); }
+    c.functions[ix] = at;
+    ret added;
+}
+
+fun global_header(c: *Copy, ix: u32) R.Result[u32, str] {
+    if (ix >= c.src.global_len) { ret R.err[u32, str]("inline body: global id is out of range"); }
+    if (c.globals[ix] != 0xFFFFFFFF) { ret R.ok[u32, str](c.globals[ix]); }
+    val src: *ir.Global = ?c.src.globals[ix];
+    if (src.is_local) { ret R.err[u32, str]("inline body: local pool address has no cross-module symbol identity"); }
+    val ty: R.Result[type.IrTypeId, str] = copy_type(c, src.ty);
+    if (R.is_err[type.IrTypeId, str](ty)) { ret R.err[u32, str](R.unwrap_err[type.IrTypeId, str](ty)); }
+    val found: O.Option[u32] = ir.global_lookup(c.dst, src.name);
+    if (O.is_some[u32](found)) {
+        val at: u32 = O.unwrap[u32](found);
+        if (c.dst.globals[at].ty != R.unwrap_ok[type.IrTypeId, str](ty)) { ret R.err[u32, str]("inline body: global identity has incompatible IR types"); }
+        c.globals[ix] = at;
+        ret R.ok[u32, str](at);
+    }
+    if (c.dst.global_len == c.dst.global_cap) {
+        var cap: u32 = c.dst.global_cap;
+        if (cap == 0) { cap = 8; } or { cap = cap * 2; }
+        val grown: R.Result[*ir.Global, str] = A.reallocate[ir.Global](c.dst.alloc, c.dst.globals, c.dst.global_cap::usize, cap::usize);
+        if (R.is_err[*ir.Global, str](grown)) { ret R.err[u32, str](R.unwrap_err[*ir.Global, str](grown)); }
+        c.dst.globals = R.unwrap_ok[*ir.Global, str](grown); c.dst.global_cap = cap;
+    }
+    val at: u32 = c.dst.global_len;
+    var g: ir.Global = @src;
+    g.ty = R.unwrap_ok[type.IrTypeId, str](ty);
+    g.init = value.const_int(0, g.ty);
+    g.is_extern = true;
+    c.dst.globals[at] = g;
+    c.dst.global_len = at + 1;
+    val registered: R.Result[R.Void, str] = ir.global_register(c.dst, g.name, at);
+    if (R.is_err[R.Void, str](registered)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](registered)); }
+    c.globals[ix] = at;
+    ret R.ok[u32, str](at);
+}
+
+fun copy_value(c: *Copy, a: *A.Allocator, original: value.Value) R.Result[value.Value, str] {
+    var v: value.Value = original;
+    val ty: R.Result[type.IrTypeId, str] = copy_type(c, v.ty);
+    if (R.is_err[type.IrTypeId, str](ty)) { ret R.err[value.Value, str](R.unwrap_err[type.IrTypeId, str](ty)); }
+    v.ty = R.unwrap_ok[type.IrTypeId, str](ty);
+    if (v.kind == value.VAL_FN) {
+        val r: R.Result[u32, str] = function_header(c, v.data.fn_ix);
+        if (R.is_err[u32, str](r)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](r)); }
+        v.data.fn_ix = R.unwrap_ok[u32, str](r);
+    } or (v.kind == value.VAL_GLOBAL) {
+        val r: R.Result[u32, str] = global_header(c, v.data.global_ix);
+        if (R.is_err[u32, str](r)) { ret R.err[value.Value, str](R.unwrap_err[u32, str](r)); }
+        v.data.global_ix = R.unwrap_ok[u32, str](r);
+    } or (v.kind > value.VAL_CONST_AGG) { ret R.err[value.Value, str]("inline body: unknown value kind"); }
+    ret own_constant(a, v);
+}
+
+fun copy_function(c: *Copy, ix: u32, a: *A.Allocator) R.Result[ir.Function, str] {
+    if (ix >= c.src.function_len) { ret R.err[ir.Function, str]("inline body: function id is out of range"); }
+    val src: *ir.Function = ?c.src.functions[ix];
+    val header: R.Result[u32, str] = function_header(c, ix);
+    if (R.is_err[u32, str](header)) { ret R.err[ir.Function, str](R.unwrap_err[u32, str](header)); }
+    val at: u32 = R.unwrap_ok[u32, str](header);
+    var fn: ir.Function = ir.function_new(a, src.name, c.dst.functions[at].sig, src.flags);
+    fn.body_module = src.body_module;
+    if (fn.body_module == intern.STR_NIL && (src.flags & ir.FN_FLAG_EXTERN) == 0) { fn.body_module = c.src.name; }
+    fn.is_import = src.is_import;
+    fn.label = src.label; fn.line = src.line; fn.section = src.section;
+    fn.stage = src.stage; fn.wg_x = src.wg_x; fn.wg_y = src.wg_y; fn.wg_z = src.wg_z;
+    fn.op_set = src.op_set; fn.op_code = src.op_code; fn.disp = src.disp; fn.ret_sem = src.ret_sem;
+    var storage: ir.Module;
+    storage.alloc = a;
+    var complete: bool = false;
+    fin { if (!complete) { ir.function_dnit(?storage, ?fn); } }
+    val params: R.Result[*value.Value, str] = copy_slice[value.Value](a, src.params, src.param_count);
+    if (R.is_err[*value.Value, str](params)) { ret R.err[ir.Function, str](R.unwrap_err[*value.Value, str](params)); }
+    fn.params = R.unwrap_ok[*value.Value, str](params); fn.param_count = src.param_count;
+    var i: u32 = 0;
+    for (i < fn.param_count) {
+        val v: R.Result[value.Value, str] = copy_value(c, a, src.params[i]);
+        if (R.is_err[value.Value, str](v)) { ret R.err[ir.Function, str](R.unwrap_err[value.Value, str](v)); }
+        fn.params[i] = R.unwrap_ok[value.Value, str](v); i = i + 1;
+    }
+    val br: R.Result[*ir.Block, str] = A.allocate[ir.Block](a, src.block_count::usize);
+    if (R.is_err[*ir.Block, str](br)) { ret R.err[ir.Function, str](R.unwrap_err[*ir.Block, str](br)); }
+    fn.blocks = R.unwrap_ok[*ir.Block, str](br); fn.block_cap = src.block_count;
+    i = 0; for (i < src.block_count) { fn.blocks[i] = ir.Block{}; i = i + 1; }
+    fn.block_count = src.block_count;
+    i = 0;
+    for (i < src.block_count) {
+        val sb: *ir.Block = ?src.blocks[i];
+        val db: *ir.Block = ?fn.blocks[i];
+        db.id = sb.id; db.terminator = sb.terminator;
+        val ins: R.Result[*id.InstructionId, str] = copy_slice[id.InstructionId](a, sb.instructions, sb.instr_count);
+        if (R.is_err[*id.InstructionId, str](ins)) { ret R.err[ir.Function, str](R.unwrap_err[*id.InstructionId, str](ins)); }
+        db.instructions = R.unwrap_ok[*id.InstructionId, str](ins); db.instr_count = sb.instr_count; db.instr_cap = sb.instr_count;
+        val phis: R.Result[*id.InstructionId, str] = copy_slice[id.InstructionId](a, sb.phis, sb.phi_count);
+        if (R.is_err[*id.InstructionId, str](phis)) { ret R.err[ir.Function, str](R.unwrap_err[*id.InstructionId, str](phis)); }
+        db.phis = R.unwrap_ok[*id.InstructionId, str](phis); db.phi_count = sb.phi_count; db.phi_cap = sb.phi_count;
+        val preds: R.Result[*id.BlockId, str] = copy_slice[id.BlockId](a, sb.preds, sb.pred_count);
+        if (R.is_err[*id.BlockId, str](preds)) { ret R.err[ir.Function, str](R.unwrap_err[*id.BlockId, str](preds)); }
+        db.preds = R.unwrap_ok[*id.BlockId, str](preds); db.pred_count = sb.pred_count; db.pred_cap = sb.pred_count;
+        i = i + 1;
+    }
+    val instrs: R.Result[*instruction.Instruction, str] = A.allocate[instruction.Instruction](a, src.instr_len::usize);
+    if (R.is_err[*instruction.Instruction, str](instrs)) { ret R.err[ir.Function, str](R.unwrap_err[*instruction.Instruction, str](instrs)); }
+    fn.instrs = R.unwrap_ok[*instruction.Instruction, str](instrs); fn.instr_cap = src.instr_len;
+    i = 0;
+    for (i < src.instr_len) {
+        val si: *instruction.Instruction = ?src.instrs[i];
+        val di: *instruction.Instruction = ?fn.instrs[i];
+        @di = @si; di.operands = nil; di.operand_count = 0; di.operand_cap = 0;
+        fn.instr_len = i + 1;
+        val ty: R.Result[type.IrTypeId, str] = copy_type(c, si.ty);
+        if (R.is_err[type.IrTypeId, str](ty)) { ret R.err[ir.Function, str](R.unwrap_err[type.IrTypeId, str](ty)); }
+        di.ty = R.unwrap_ok[type.IrTypeId, str](ty);
+        val aux: R.Result[type.IrTypeId, str] = copy_type(c, si.aux_ty);
+        if (R.is_err[type.IrTypeId, str](aux)) { ret R.err[ir.Function, str](R.unwrap_err[type.IrTypeId, str](aux)); }
+        di.aux_ty = R.unwrap_ok[type.IrTypeId, str](aux);
+        val ops: R.Result[*value.Value, str] = copy_slice[value.Value](a, si.operands, si.operand_count);
+        if (R.is_err[*value.Value, str](ops)) { ret R.err[ir.Function, str](R.unwrap_err[*value.Value, str](ops)); }
+        di.operands = R.unwrap_ok[*value.Value, str](ops); di.operand_count = si.operand_count; di.operand_cap = si.operand_count;
+        var oi: u32 = 0;
+        for (oi < si.operand_count) {
+            val v: R.Result[value.Value, str] = copy_value(c, a, si.operands[oi]);
+            if (R.is_err[value.Value, str](v)) { ret R.err[ir.Function, str](R.unwrap_err[value.Value, str](v)); }
+            di.operands[oi] = R.unwrap_ok[value.Value, str](v); oi = oi + 1;
+        }
+        i = i + 1;
+    }
+    val sites: R.Result[*ir.InlineSite, str] = copy_slice[ir.InlineSite](a, src.inline_sites, src.inline_site_len);
+    if (R.is_err[*ir.InlineSite, str](sites)) { ret R.err[ir.Function, str](R.unwrap_err[*ir.InlineSite, str](sites)); }
+    fn.inline_sites = R.unwrap_ok[*ir.InlineSite, str](sites); fn.inline_site_len = src.inline_site_len; fn.inline_site_cap = src.inline_site_len;
+    val ids: R.Result[*u32, str] = A.allocate[u32](c.scratch, src.instr_len::usize);
+    if (R.is_err[*u32, str](ids)) { ret R.err[ir.Function, str](R.unwrap_err[*u32, str](ids)); }
+    val identity: *u32 = R.unwrap_ok[*u32, str](ids);
+    fin { if (identity != nil) { A.deallocate[u32](c.scratch, identity, src.instr_len::usize); } }
+    i = 0; for (i < src.instr_len) { identity[i] = i; i = i + 1; }
+    i = 0;
+    for (i < src.instr_len) {
+        val iid: id.InstructionId = i::id.InstructionId;
+        val dbg: R.Result[R.Void, str] = ir.clone_dbg_metadata(?storage, src, ?fn, iid, iid);
+        if (R.is_err[R.Void, str](dbg)) { ret R.err[ir.Function, str](R.unwrap_err[R.Void, str](dbg)); }
+        val adbg: R.Result[R.Void, str] = ir.clone_alloca_dbg_var(src, ?fn, iid, iid);
+        if (R.is_err[R.Void, str](adbg)) { ret R.err[ir.Function, str](R.unwrap_err[R.Void, str](adbg)); }
+        val dv: O.Option[*ir.DbgVar] = ir.dbg_var_get(?fn, iid);
+        if (O.is_some[*ir.DbgVar](dv)) {
+            val ty: R.Result[type.IrTypeId, str] = copy_type(c, O.unwrap[*ir.DbgVar](dv).ty);
+            if (R.is_err[type.IrTypeId, str](ty)) { ret R.err[ir.Function, str](R.unwrap_err[type.IrTypeId, str](ty)); }
+            O.unwrap[*ir.DbgVar](dv).ty = R.unwrap_ok[type.IrTypeId, str](ty);
+        }
+        val av: O.Option[*ir.DbgVar] = ir.alloca_dbg_var_get(?fn, iid);
+        if (O.is_some[*ir.DbgVar](av)) {
+            val ty: R.Result[type.IrTypeId, str] = copy_type(c, O.unwrap[*ir.DbgVar](av).ty);
+            if (R.is_err[type.IrTypeId, str](ty)) { ret R.err[ir.Function, str](R.unwrap_err[type.IrTypeId, str](ty)); }
+            O.unwrap[*ir.DbgVar](av).ty = R.unwrap_ok[type.IrTypeId, str](ty);
+        }
+        val assembly: R.Result[R.Void, str] = ir.clone_asm_payload(?storage, src, ?fn, iid, iid, identity, src.instr_len);
+        if (R.is_err[R.Void, str](assembly)) { ret R.err[ir.Function, str](R.unwrap_err[R.Void, str](assembly)); }
+        val site: R.Result[R.Void, str] = ir.clone_instr_inline_site(src, ?fn, iid, iid);
+        if (R.is_err[R.Void, str](site)) { ret R.err[ir.Function, str](R.unwrap_err[R.Void, str](site)); }
+        i = i + 1;
+    }
+    complete = true;
+    ret R.ok[ir.Function, str](fn);
+}
+
+fun add_bytes(total: *usize, n: usize) bool {
+    if (n > MAX_BYTES - @total) { ret false; }
+    @total = @total + n;
+    ret true;
+}
+
+fun mark_type(c: *Copy, seen: *bool, ty: type.IrTypeId) bool {
+    if (ty == type.IRT_NIL) { ret true; }
+    if (ty >= c.src.types.len) { ret false; }
+    seen[ty] = true;
+    ret true;
+}
+
+fun value_cost(c: *Copy, seen: *bool, v: *value.Value, bytes: *usize) bool {
+    if (!mark_type(c, seen, v.ty)) { ret false; }
+    if (v.kind == value.VAL_GLOBAL) {
+        if (v.data.global_ix >= c.src.global_len || c.src.globals[v.data.global_ix].is_local) { ret false; }
+        if (!mark_type(c, seen, c.src.globals[v.data.global_ix].ty) || !add_bytes(bytes, $size_of(ir.Global))) { ret false; }
+    } or (v.kind == value.VAL_FN) {
+        if (v.data.fn_ix >= c.src.function_len) { ret false; }
+        if (!mark_type(c, seen, c.src.functions[v.data.fn_ix].sig) || !add_bytes(bytes, $size_of(ir.Function))) { ret false; }
+    } or (v.kind == value.VAL_CONST_BYTES) {
+        if (!add_bytes(bytes, v.data.bytes.len::usize)) { ret false; }
+    } or (v.kind == value.VAL_CONST_AGG) {
+        if (!add_bytes(bytes, v.data.agg.len::usize) || !add_bytes(bytes, v.data.agg.reloc_count::usize * $size_of(value.AggReloc))) { ret false; }
+        var i: u32 = 0;
+        for (i < v.data.agg.reloc_count) {
+            val r: *value.AggReloc = ?v.data.agg.relocs[i];
+            if (!r.is_fn) {
+                var gi: u32 = 0;
+                for (gi < c.src.global_len) {
+                    if (c.src.globals[gi].name == r.symbol && c.src.globals[gi].is_local) { ret false; }
+                    gi = gi + 1;
+                }
+            }
+            i = i + 1;
+        }
+    }
+    ret true;
+}
+
+fun measure(c: *Copy, fn: *ir.Function, out: *Budget) R.Result[bool, str] {
+    @out = Budget{};
+    if (!candidate(fn)) { ret R.ok[bool, str](false); }
+    val ar: R.Result[*bool, str] = A.allocate[bool](c.scratch, c.src.types.len::usize);
+    if (R.is_err[*bool, str](ar)) { ret R.err[bool, str](R.unwrap_err[*bool, str](ar)); }
+    val seen: *bool = R.unwrap_ok[*bool, str](ar);
+    fin { if (seen != nil) { A.deallocate[bool](c.scratch, seen, c.src.types.len::usize); } }
+    var i: u32 = 0;
+    for (i < c.src.types.len) { seen[i] = false; i = i + 1; }
+    var bytes: usize = $size_of(ir.Function);
+    if (!mark_type(c, seen, fn.sig)
+        || !add_bytes(?bytes, fn.instr_len::usize * $size_of(instruction.Instruction))
+        || !add_bytes(?bytes, fn.block_count::usize * $size_of(ir.Block))
+        || !add_bytes(?bytes, fn.param_count::usize * $size_of(value.Value))
+        || !add_bytes(?bytes, fn.inline_site_len::usize * $size_of(ir.InlineSite))) { ret R.ok[bool, str](false); }
+    i = 0;
+    for (i < fn.param_count) { if (!value_cost(c, seen, ?fn.params[i], ?bytes)) { ret R.ok[bool, str](false); } i = i + 1; }
+    i = 0;
+    for (i < fn.block_count) {
+        val b: *ir.Block = ?fn.blocks[i];
+        if (!add_bytes(?bytes, b.instr_count::usize * $size_of(id.InstructionId))
+            || !add_bytes(?bytes, b.phi_count::usize * $size_of(id.InstructionId))
+            || !add_bytes(?bytes, b.pred_count::usize * $size_of(id.BlockId))) { ret R.ok[bool, str](false); }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < fn.instr_len) {
+        val ins: *instruction.Instruction = ?fn.instrs[i];
+        if (!mark_type(c, seen, ins.ty) || !mark_type(c, seen, ins.aux_ty)
+            || !add_bytes(?bytes, ins.operand_count::usize * $size_of(value.Value))) { ret R.ok[bool, str](false); }
+        var oi: u32 = 0;
+        for (oi < ins.operand_count) { if (!value_cost(c, seen, ?ins.operands[oi], ?bytes)) { ret R.ok[bool, str](false); } oi = oi + 1; }
+        val dv: O.Option[*ir.DbgVar] = ir.dbg_var_get(fn, i::id.InstructionId);
+        if (O.is_some[*ir.DbgVar](dv) && !mark_type(c, seen, O.unwrap[*ir.DbgVar](dv).ty)) { ret R.ok[bool, str](false); }
+        val av: O.Option[*ir.DbgVar] = ir.alloca_dbg_var_get(fn, i::id.InstructionId);
+        if (O.is_some[*ir.DbgVar](av) && !mark_type(c, seen, O.unwrap[*ir.DbgVar](av).ty)) { ret R.ok[bool, str](false); }
+        var key: id.InstructionId = i::id.InstructionId;
+        val assembly: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
+        if (R.is_ok[*ir.IrAsm, str](assembly) && !add_bytes(?bytes,
+            R.unwrap_ok[*ir.IrAsm, str](assembly).bind_count::usize * $size_of(ir.IrAsmBind))) { ret R.ok[bool, str](false); }
+        i = i + 1;
+    }
+    if (!add_bytes(?bytes, fn.asm_blocks.cap * ($size_of(id.InstructionId) + $size_of(ir.IrAsm) + 1))
+        || !add_bytes(?bytes, fn.dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
+        || !add_bytes(?bytes, fn.alloca_dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
+        || !add_bytes(?bytes, fn.dbg_expr_ids.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgExprId) + 1))
+        || !add_bytes(?bytes, fn.instr_inline_site.cap * ($size_of(id.InstructionId) + $size_of(u32) + 1))) { ret R.ok[bool, str](false); }
+    i = 0;
+    for (i < fn.dbg_expr_len) {
+        if (!add_bytes(?bytes, $size_of(ir.DbgExpr)) || !add_bytes(?bytes, fn.dbg_exprs[i].op_count::usize * $size_of(ir.DbgOp))) { ret R.ok[bool, str](false); }
+        i = i + 1;
+    }
+    i = c.src.types.len;
+    for (i > 0) {
+        i = i - 1;
+        if (!seen[i]) { cnt; }
+        val t: *type.IrType = ?c.src.types.types[i];
+        if (!add_bytes(?bytes, $size_of(type.IrType) * 3)) { ret R.ok[bool, str](false); }
+        var fields: *type.IrTypeId = nil;
+        var count: u32 = 0;
+        var single: type.IrTypeId = type.IRT_NIL;
+        if (t.kind == type.IRT_ARRAY) { single = t.data.array_.element; }
+        or (t.kind == type.IRT_VECTOR) { single = t.data.vector_.element; }
+        or (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) { fields = t.data.struct_.fields; count = t.data.struct_.field_count; }
+        or (t.kind == type.IRT_FN) { single = t.data.fn.ret_type; fields = t.data.fn.params; count = t.data.fn.param_count; }
+        or (t.kind == type.IRT_HANDLE) { fields = t.data.handle_.operands; count = t.data.handle_.count; }
+        if (single != type.IRT_NIL && (single >= i || !mark_type(c, seen, single))) { ret R.err[bool, str]("inline body: invalid forward type reference"); }
+        if (!add_bytes(?bytes, count::usize * $size_of(type.IrTypeId))) { ret R.ok[bool, str](false); }
+        var schema: *isa.TypeDef = nil;
+        if (t.kind == type.IRT_HANDLE) {
+            schema = isa.type_def_by_tag(c.target.isa.defs, t.data.handle_.ctor);
+            if (schema == nil || schema.arity != count) { ret R.err[bool, str]("inline body: handle schema is unavailable"); }
+        }
+        var j: u32 = 0;
+        for (j < count) {
+            if (schema == nil || schema.operands[j] != isa.TYPE_OPERAND_WORD) {
+                if (fields[j] >= i || !mark_type(c, seen, fields[j])) { ret R.err[bool, str]("inline body: invalid forward type reference"); }
+            }
+            j = j + 1;
+        }
+    }
+    out.instructions = fn.instr_len;
+    out.bytes = bytes;
+    ret R.ok[bool, str](true);
+}
+
+pub fun extract(dst: *ir.Module, src: *ir.Module, tgt: *target.Target, scratch: *A.Allocator, recursive: *bool) R.Result[R.Void, str] {
+    var c: Copy;
+    val initialized: R.Result[R.Void, str] = copy_init(?c, dst, src, tgt, scratch);
+    if (R.is_err[R.Void, str](initialized)) { ret initialized; }
+    fin { copy_dnit(?c); }
+    var budget: Budget;
+    var i: u32 = 0;
+    for (i < src.function_len) {
+        if (recursive != nil && recursive[i]) { i = i + 1; cnt; }
+        var cost: Budget;
+        val eligible: R.Result[bool, str] = measure(?c, ?src.functions[i], ?cost);
+        if (R.is_err[bool, str](eligible)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](eligible)); }
+        if (R.unwrap_ok[bool, str](eligible) && charge(?budget, cost.instructions, cost.bytes)) {
+            val fn: R.Result[ir.Function, str] = copy_function(?c, i, dst.alloc);
+            if (R.is_err[ir.Function, str](fn)) { ret R.err[R.Void, str](R.unwrap_err[ir.Function, str](fn)); }
+            val at: u32 = c.functions[i];
+            ir.function_dnit(dst, ?dst.functions[at]);
+            dst.functions[at] = R.unwrap_ok[ir.Function, str](fn);
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+pub rec Available {
+    home: ir.ModuleHome;
+    storage: ir.Module;
+    indices: *u32;
+    originals: *ir.Function;
+    len: u32;
+    cap: u32;
+    budget: Budget;
+    attached: bool;
+}
+
+pub fun available_init(a: *Available, name: intern.StrId) R.Result[R.Void, str] {
+    @a = Available{};
+    val opened: O.Option[str] = ir.home_init(?a.home);
+    if (O.is_some[str](opened)) { ret R.err[R.Void, str](O.unwrap[str](opened)); }
+    val initialized: R.Result[ir.Module, str] = ir.init(?a.home.alloc, name);
+    if (R.is_err[ir.Module, str](initialized)) { ir.home_dnit(?a.home); ret R.err[R.Void, str](R.unwrap_err[ir.Module, str](initialized)); }
+    a.storage = R.unwrap_ok[ir.Module, str](initialized);
+    ret R.ok_void[str]();
+}
+
+pub fun detach(a: *Available, dst: *ir.Module) {
+    if (a == nil || !a.attached) { ret; }
+    var i: u32 = 0;
+    for (i < a.len) { dst.functions[a.indices[i]] = a.originals[i]; i = i + 1; }
+    a.attached = false;
+}
+
+pub fun available_dnit(a: *Available, dst: *ir.Module) {
+    if (a == nil) { ret; }
+    detach(a, dst);
+    ir.home_dnit(?a.home);
+}
+
+pub fun attach(a: *Available, dst: *ir.Module) R.Result[R.Void, str] {
+    if (a == nil) { ret R.ok_void[str](); }
+    if (a.attached) { ret R.err[R.Void, str]("inline body: available bodies already attached"); }
+    var i: u32 = 0;
+    for (i < a.len) {
+        val ix: u32 = a.indices[i];
+        if (ix >= dst.function_len || (dst.functions[ix].flags & ir.FN_FLAG_EXTERN) == 0
+            || dst.functions[ix].block_count != 0) { ret R.err[R.Void, str]("inline body: destination is not the original external declaration"); }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.len) {
+        val ix: u32 = a.indices[i];
+        a.originals[i] = dst.functions[ix];
+        dst.functions[ix] = a.storage.functions[i];
+        dst.functions[ix].flags = dst.functions[ix].flags | ir.FN_FLAG_EXTERN;
+        i = i + 1;
+    }
+    a.attached = true;
+    ret R.ok_void[str]();
+}
+
+pub fun contains(a: *Available, ix: u32) bool {
+    if (a == nil) { ret false; }
+    var i: u32 = 0;
+    for (i < a.len) { if (a.indices[i] == ix) { ret true; } i = i + 1; }
+    ret false;
+}
+
+pub fun acquire(a: *Available, dst: *ir.Module, provider: *ir.Module, name: intern.StrId, tgt: *target.Target, scratch: *A.Allocator) R.Result[R.Void, str] {
+    if (a.attached) { ret R.err[R.Void, str]("inline body: cannot import during inline execution"); }
+    val found: O.Option[u32] = ir.function_lookup(provider, name);
+    if (O.is_none[u32](found)) { ret R.ok_void[str](); }
+    val i: u32 = O.unwrap[u32](found);
+    var c: Copy;
+    val initialized: R.Result[R.Void, str] = copy_init(?c, dst, provider, tgt, scratch);
+    if (R.is_err[R.Void, str](initialized)) { ret initialized; }
+    fin { copy_dnit(?c); }
+    val src: *ir.Function = ?provider.functions[i];
+    val existing: O.Option[u32] = ir.function_lookup(dst, src.name);
+    if (O.is_none[u32](existing) || !candidate(src)) { ret R.ok_void[str](); }
+    val ix: u32 = O.unwrap[u32](existing);
+    if ((dst.functions[ix].flags & ir.FN_FLAG_EXTERN) == 0 || contains(a, ix)) { ret R.ok_void[str](); }
+    var cost: Budget;
+    val measured: R.Result[bool, str] = measure(?c, src, ?cost);
+    if (R.is_err[bool, str](measured)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](measured)); }
+    if (!R.unwrap_ok[bool, str](measured) || !charge(?a.budget, cost.instructions, cost.bytes)) { ret R.ok_void[str](); }
+    val copied: R.Result[ir.Function, str] = copy_function(?c, i, ?a.home.alloc);
+    if (R.is_err[ir.Function, str](copied)) { ret R.err[R.Void, str](R.unwrap_err[ir.Function, str](copied)); }
+    if (a.len == a.cap) {
+        var cap: u32 = 8;
+        if (a.cap != 0) { cap = a.cap * 2; }
+        val indices: R.Result[*u32, str] = A.reallocate[u32](?a.home.alloc, a.indices, a.cap::usize, cap::usize);
+        if (R.is_err[*u32, str](indices)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](indices)); }
+        a.indices = R.unwrap_ok[*u32, str](indices);
+        val originals: R.Result[*ir.Function, str] = A.reallocate[ir.Function](?a.home.alloc, a.originals, a.cap::usize, cap::usize);
+        if (R.is_err[*ir.Function, str](originals)) { ret R.err[R.Void, str](R.unwrap_err[*ir.Function, str](originals)); }
+        a.originals = R.unwrap_ok[*ir.Function, str](originals);
+        a.cap = cap;
+    }
+    val added: R.Result[u32, str] = ir.function_add(?a.storage, src.name, R.unwrap_ok[ir.Function, str](copied).sig, src.flags);
+    if (R.is_err[u32, str](added)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](added)); }
+    val at: u32 = R.unwrap_ok[u32, str](added);
+    ir.function_dnit(?a.storage, ?a.storage.functions[at]);
+    a.storage.functions[at] = R.unwrap_ok[ir.Function, str](copied);
+    a.indices[a.len] = ix;
+    a.len = a.len + 1;
+    ret R.ok_void[str]();
+}
+
+pub fun growth_cost(fn: *ir.Function, out: *Budget) bool {
+    @out = Budget{};
+    if (fn.instr_len > MAX_INSTRUCTIONS) { ret false; }
+    var bytes: usize = 0;
+    if (!add_bytes(?bytes, fn.instr_len::usize * $size_of(instruction.Instruction))
+        || !add_bytes(?bytes, fn.block_count::usize * $size_of(ir.Block))) { ret false; }
+    var i: u32 = 0;
+    for (i < fn.block_count) {
+        val b: *ir.Block = ?fn.blocks[i];
+        if (!add_bytes(?bytes, b.instr_count::usize * $size_of(id.InstructionId))
+            || !add_bytes(?bytes, b.phi_count::usize * $size_of(id.InstructionId))
+            || !add_bytes(?bytes, b.pred_count::usize * $size_of(id.BlockId))) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < fn.instr_len) {
+        val ins: *instruction.Instruction = ?fn.instrs[i];
+        if (!add_bytes(?bytes, ins.operand_count::usize * $size_of(value.Value))) { ret false; }
+        var oi: u32 = 0;
+        for (oi < ins.operand_count) {
+            val v: *value.Value = ?ins.operands[oi];
+            if (v.kind == value.VAL_CONST_BYTES && !add_bytes(?bytes, v.data.bytes.len::usize)) { ret false; }
+            if (v.kind == value.VAL_CONST_AGG && (!add_bytes(?bytes, v.data.agg.len::usize)
+                || !add_bytes(?bytes, v.data.agg.reloc_count::usize * $size_of(value.AggReloc)))) { ret false; }
+            oi = oi + 1;
+        }
+        var key: id.InstructionId = i::id.InstructionId;
+        val assembly: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
+        if (R.is_ok[*ir.IrAsm, str](assembly) && !add_bytes(?bytes,
+            R.unwrap_ok[*ir.IrAsm, str](assembly).bind_count::usize * $size_of(ir.IrAsmBind))) { ret false; }
+        i = i + 1;
+    }
+    if (!add_bytes(?bytes, fn.asm_blocks.cap * ($size_of(id.InstructionId) + $size_of(ir.IrAsm) + 1))
+        || !add_bytes(?bytes, fn.dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
+        || !add_bytes(?bytes, fn.alloca_dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
+        || !add_bytes(?bytes, fn.dbg_expr_ids.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgExprId) + 1))
+        || !add_bytes(?bytes, fn.instr_inline_site.cap * ($size_of(id.InstructionId) + $size_of(u32) + 1))
+        || !add_bytes(?bytes, (fn.inline_site_len::usize + 1) * $size_of(ir.InlineSite))) { ret false; }
+    i = 0;
+    for (i < fn.dbg_expr_len) {
+        if (!add_bytes(?bytes, $size_of(ir.DbgExpr)) || !add_bytes(?bytes, fn.dbg_exprs[i].op_count::usize * $size_of(ir.DbgOp))) { ret false; }
+        i = i + 1;
+    }
+    out.instructions = fn.instr_len;
+    out.bytes = bytes;
+    ret true;
+}
+
+use std.allocator.page;
+use T: std.allocator.testing;
+use mach.lang.me.ir.builder;
+
+test "mach.lang.me.ir.body:owned_constants_types_and_effect_flags_survive_provider_retirement" {
+    var source_home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?source_home))) { ret 1; }
+    var source_live: bool = true;
+    fin { if (source_live) { ir.home_dnit(?source_home); } }
+    var dest_home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?dest_home))) { ret 2; }
+    fin { ir.home_dnit(?dest_home); }
+    val sr: R.Result[ir.Module, str] = ir.init(?source_home.alloc, 1);
+    val dr: R.Result[ir.Module, str] = ir.init(?dest_home.alloc, 1);
+    if (R.is_err[ir.Module, str](sr) || R.is_err[ir.Module, str](dr)) { ret 3; }
+    var src: ir.Module = R.unwrap_ok[ir.Module, str](sr);
+    var dst: ir.Module = R.unwrap_ok[ir.Module, str](dr);
+    val byte: R.Result[type.IrTypeId, str] = type.intern_int(?src.types, 8);
+    if (R.is_err[type.IrTypeId, str](byte)) { ret 4; }
+    val array: R.Result[type.IrTypeId, str] = type.intern_array(?src.types, R.unwrap_ok[type.IrTypeId, str](byte), 4);
+    if (R.is_err[type.IrTypeId, str](array)) { ret 5; }
+    val aty: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](array);
+    val signature: R.Result[type.IrTypeId, str] = type.intern_fn(?src.types, aty, nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](signature)) { ret 6; }
+    val added: R.Result[u32, str] = ir.function_add(?src, 2, R.unwrap_ok[type.IrTypeId, str](signature), ir.FN_FLAG_INLINE);
+    if (R.is_err[u32, str](added) || R.is_err[R.Void, str](ir.function_register(?src, 2, 0))) { ret 7; }
+    var b: builder.Builder = builder.init(?src);
+    builder.set_function(?b, ?src.functions[0]);
+    val block: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](block)) { ret 8; }
+    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](block));
+    var payload: [4]u8 = [4]u8{7, 11, 19, 23};
+    var result: value.Value = value.const_agg(?payload[0], 4, nil, 0, 0, aty);
+    result.secret = true;
+    if (R.is_err[R.Void, str](builder.emit_ret(?b, result))) { ret 9; }
+    val term: id.InstructionId = src.functions[0].blocks[0].terminator;
+    src.functions[0].instrs[term].secret = true;
+    src.functions[0].instrs[term].flags = instruction.INSTR_FLAG_EXACT;
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 10; }
+    if (R.is_err[type.IrTypeId, str](type.intern_float(?dst.types, 64))) { ret 11; }
+    var tgt: target.Target;
+    val copied: R.Result[R.Void, str] = extract(?dst, ?src, ?tgt, ?backing, nil);
+    if (R.is_err[R.Void, str](copied)) { ret 12; }
+    ir.home_dnit(?source_home);
+    source_live = false;
+    payload[0] = 99;
+    val found: O.Option[u32] = ir.function_lookup(?dst, 2);
+    if (O.is_none[u32](found)) { ret 13; }
+    val fn: *ir.Function = ?dst.functions[O.unwrap[u32](found)];
+    val ins: *instruction.Instruction = ?fn.instrs[fn.blocks[0].terminator];
+    val owned: *value.Value = ?ins.operands[0];
+    if (fn.body_module != 1 || (fn.flags & ir.FN_FLAG_EXTERN) != 0 || !owned.secret || !ins.secret
+        || ins.flags != instruction.INSTR_FLAG_EXACT || owned.data.agg.bytes == ?payload[0]
+        || owned.data.agg.bytes[0] != 7 || owned.data.agg.bytes[3] != 23) { ret 14; }
+    if (dst.types.types[owned.ty].kind != type.IRT_ARRAY || dst.types.types[owned.ty].data.array_.count != 4
+        || dst.types.types[dst.types.types[owned.ty].data.array_.element].data.bits != 8) { ret 15; }
+    ret 0;
+}
+
+fun scratch_attempt(src: *ir.Module, ordinal: usize, attempts: *usize) i32 {
+    var testing: T.Testing;
+    if (O.is_some[str](T.make(?testing))) { ret 1; }
+    fin { T.dnit(?testing); }
+    T.fail_at_ordinal(?testing, ordinal);
+    var home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?home))) { ret 2; }
+    fin { ir.home_dnit(?home); }
+    val made: R.Result[ir.Module, str] = ir.init(?home.alloc, src.name);
+    if (R.is_err[ir.Module, str](made)) { ret 3; }
+    var dst: ir.Module = R.unwrap_ok[ir.Module, str](made);
+    var tgt: target.Target;
+    val copied: R.Result[R.Void, str] = extract(?dst, src, ?tgt, T.allocator_of(?testing), nil);
+    @attempts = T.attempt_count(?testing);
+    if ((ordinal == 0) != R.is_ok[R.Void, str](copied)) { ret 4; }
+    if (T.leaked(?testing) || T.double_free_count(?testing) != 0 || T.tracking_exhausted(?testing)) { ret 5; }
+    ret 0;
+}
+
+test "mach.lang.me.ir.body:scratch_refusal_releases_partial_remapping_and_budget_refusal_does_not_charge" {
+    var home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?home))) { ret 1; }
+    fin { ir.home_dnit(?home); }
+    val made: R.Result[ir.Module, str] = ir.init(?home.alloc, 1);
+    if (R.is_err[ir.Module, str](made)) { ret 2; }
+    var src: ir.Module = R.unwrap_ok[ir.Module, str](made);
+    val vt: R.Result[type.IrTypeId, str] = type.intern_void(?src.types);
+    if (R.is_err[type.IrTypeId, str](vt)) { ret 3; }
+    val signature: R.Result[type.IrTypeId, str] = type.intern_fn(?src.types, R.unwrap_ok[type.IrTypeId, str](vt), nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](signature)) { ret 4; }
+    if (R.is_err[u32, str](ir.function_add(?src, 2, R.unwrap_ok[type.IrTypeId, str](signature), ir.FN_FLAG_INLINE))) { ret 5; }
+    var b: builder.Builder = builder.init(?src);
+    builder.set_function(?b, ?src.functions[0]);
+    val block: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](block)) { ret 6; }
+    builder.set_block(?b, R.unwrap_ok[id.BlockId, str](block));
+    if (R.is_err[R.Void, str](builder.emit_ret_void(?b))) { ret 7; }
+    var attempts: usize = 0;
+    if (scratch_attempt(?src, 0, ?attempts) != 0 || attempts == 0) { ret 8; }
+    var ordinal: usize = 1;
+    for (ordinal <= attempts) {
+        var ignored: usize = 0;
+        if (scratch_attempt(?src, ordinal, ?ignored) != 0) { ret 9; }
+        ordinal = ordinal + 1;
+    }
+    var budget: Budget;
+    if (!charge(?budget, MAX_INSTRUCTIONS - 1, MAX_BYTES - 1)) { ret 10; }
+    if (charge(?budget, 2, 0) || charge(?budget, 0, 2)
+        || budget.instructions != MAX_INSTRUCTIONS - 1 || budget.bytes != MAX_BYTES - 1) { ret 11; }
+    if (!charge(?budget, 1, 1) || budget.instructions != MAX_INSTRUCTIONS || budget.bytes != MAX_BYTES) { ret 12; }
+    ret 0;
+}

--- a/src/lang/me/ir/body.mach
+++ b/src/lang/me/ir/body.mach
@@ -130,7 +130,8 @@ fun copy_type(c: *Copy, wanted: type.IrTypeId) R.Result[type.IrTypeId, str] {
         if (!c.marked[i] || c.types[i] != type.IRT_NIL) { cnt; }
         val t: *type.IrType = ?c.src.types.types[i];
         var valid: bool = true;
-        if (t.kind == type.IRT_ARRAY) { valid = mark_child(c, i, t.data.array_.element); }
+        if (t.kind == type.IRT_PTR && t.data.pointee != type.IRT_NIL) { valid = mark_child(c, i, t.data.pointee); }
+        or (t.kind == type.IRT_ARRAY) { valid = mark_child(c, i, t.data.array_.element); }
         or (t.kind == type.IRT_VECTOR) { valid = mark_child(c, i, t.data.vector_.element); }
         or (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) {
             var j: u32 = 0;
@@ -167,7 +168,10 @@ fun copy_type_ready(c: *Copy, t: *type.IrType) R.Result[type.IrTypeId, str] {
     if (t.kind == type.IRT_VOID) { ret type.intern_void(dst); }
     if (t.kind == type.IRT_INT) { ret type.intern_int(dst, t.data.bits); }
     if (t.kind == type.IRT_FLOAT) { ret type.intern_float(dst, t.data.bits); }
-    if (t.kind == type.IRT_PTR) { ret type.intern_ptr(dst); }
+    if (t.kind == type.IRT_PTR) {
+        if (t.data.pointee == type.IRT_NIL) { ret type.intern_ptr(dst); }
+        ret type.intern_reference(dst, c.types[t.data.pointee]);
+    }
     if (t.kind == type.IRT_ARRAY) { ret type.intern_array(dst, c.types[t.data.array_.element], t.data.array_.count); }
     if (t.kind == type.IRT_VECTOR) { ret type.intern_vector(dst, c.types[t.data.vector_.element], t.data.vector_.lanes); }
     var n: u32 = 0;
@@ -561,7 +565,8 @@ fun measure(c: *Copy, fn: *ir.Function, out: *Budget) R.Result[bool, str] {
         var fields: *type.IrTypeId = nil;
         var count: u32 = 0;
         var single: type.IrTypeId = type.IRT_NIL;
-        if (t.kind == type.IRT_ARRAY) { single = t.data.array_.element; }
+        if (t.kind == type.IRT_PTR) { single = t.data.pointee; }
+        or (t.kind == type.IRT_ARRAY) { single = t.data.array_.element; }
         or (t.kind == type.IRT_VECTOR) { single = t.data.vector_.element; }
         or (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) { fields = t.data.struct_.fields; count = t.data.struct_.field_count; }
         or (t.kind == type.IRT_FN) { single = t.data.fn.ret_type; fields = t.data.fn.params; count = t.data.fn.param_count; }

--- a/src/lang/me/ir/body.mach
+++ b/src/lang/me/ir/body.mach
@@ -34,8 +34,21 @@ pub fun charge(b: *Budget, instructions: u32, bytes: usize) bool {
 
 fun candidate(fn: *ir.Function) bool {
     if ((fn.flags & (ir.FN_FLAG_EXTERN | ir.FN_FLAG_NOINLINE | ir.FN_FLAG_SCALAR | ir.FN_FLAG_NAKED)) != 0) { ret false; }
-    if (fn.block_count == 0 || fn.instr_len > MAX_INSTRUCTIONS) { ret false; }
-    ret (fn.flags & ir.FN_FLAG_INLINE) != 0 || live_instructions(fn) < SMALL_INSTRUCTIONS;
+    val live: u32 = live_instructions(fn);
+    if (fn.block_count == 0 || live > MAX_INSTRUCTIONS) { ret false; }
+    ret (fn.flags & ir.FN_FLAG_INLINE) != 0 || live < SMALL_INSTRUCTIONS;
+}
+
+# what a body costs is a fact about the program, never about its debug annotation:
+# `-g` must not move an inlining decision (#1944), so a dbg_value instruction and the
+# debug variable and expression tables are not part of the body, and neither is a dead
+# arena slot. this is the one reading of "counted" every cost below shares.
+fun counted(fn: *ir.Function, iid: id.InstructionId) *instruction.Instruction {
+    val ins: O.Option[*instruction.Instruction] = ir.instruction_get(fn, iid);
+    if (O.is_none[*instruction.Instruction](ins)) { ret nil; }
+    val p: *instruction.Instruction = O.unwrap[*instruction.Instruction](ins);
+    if (p.kind == instruction.OP_DBG_VALUE) { ret nil; }
+    ret p;
 }
 
 pub fun live_instructions(fn: *ir.Function) u32 {
@@ -43,14 +56,17 @@ pub fun live_instructions(fn: *ir.Function) u32 {
     var i: u32 = 0;
     for (i < fn.block_count) {
         val block: *ir.Block = ?fn.blocks[i];
-        count = count + block.phi_count;
         var j: u32 = 0;
-        for (j < block.instr_count) {
-            val ins: O.Option[*instruction.Instruction] = ir.instruction_get(fn, block.instructions[j]);
-            if (O.is_some[*instruction.Instruction](ins) && O.unwrap[*instruction.Instruction](ins).kind != instruction.OP_DBG_VALUE) { count = count + 1; }
+        for (j < block.phi_count) {
+            if (counted(fn, block.phis[j]) != nil) { count = count + 1; }
             j = j + 1;
         }
-        if (block.terminator != id.INSTR_NIL) { count = count + 1; }
+        j = 0;
+        for (j < block.instr_count) {
+            if (counted(fn, block.instructions[j]) != nil) { count = count + 1; }
+            j = j + 1;
+        }
+        if (counted(fn, block.terminator) != nil) { count = count + 1; }
         i = i + 1;
     }
     ret count;
@@ -426,18 +442,24 @@ fun mark_type(c: *Copy, seen: *bool, ty: type.IrTypeId) bool {
     ret true;
 }
 
+fun constant_bytes(v: *value.Value, bytes: *usize) bool {
+    if (v.kind == value.VAL_CONST_BYTES) {
+        ret add_bytes(bytes, v.data.bytes.len::usize);
+    } or (v.kind == value.VAL_CONST_AGG) {
+        ret add_bytes(bytes, v.data.agg.len::usize) && add_bytes(bytes, v.data.agg.reloc_count::usize * $size_of(value.AggReloc));
+    }
+    ret true;
+}
+
 fun value_cost(c: *Copy, seen: *bool, v: *value.Value, bytes: *usize) bool {
-    if (!mark_type(c, seen, v.ty)) { ret false; }
+    if (!mark_type(c, seen, v.ty) || !constant_bytes(v, bytes)) { ret false; }
     if (v.kind == value.VAL_GLOBAL) {
         if (v.data.global_ix >= c.src.global_len || c.src.globals[v.data.global_ix].is_local) { ret false; }
         if (!mark_type(c, seen, c.src.globals[v.data.global_ix].ty) || !add_bytes(bytes, $size_of(ir.Global))) { ret false; }
     } or (v.kind == value.VAL_FN) {
         if (v.data.fn_ix >= c.src.function_len) { ret false; }
         if (!mark_type(c, seen, c.src.functions[v.data.fn_ix].sig) || !add_bytes(bytes, $size_of(ir.Function))) { ret false; }
-    } or (v.kind == value.VAL_CONST_BYTES) {
-        if (!add_bytes(bytes, v.data.bytes.len::usize)) { ret false; }
     } or (v.kind == value.VAL_CONST_AGG) {
-        if (!add_bytes(bytes, v.data.agg.len::usize) || !add_bytes(bytes, v.data.agg.reloc_count::usize * $size_of(value.AggReloc))) { ret false; }
         var i: u32 = 0;
         for (i < v.data.agg.reloc_count) {
             val r: *value.AggReloc = ?v.data.agg.relocs[i];
@@ -454,6 +476,65 @@ fun value_cost(c: *Copy, seen: *bool, v: *value.Value, bytes: *usize) bool {
     ret true;
 }
 
+# instruction_cost: one counted instruction's share of the body: its arena slot, its
+# block membership, its inline-site entry, its operands and their constant payloads,
+# and its assembly bindings. with a Copy the types and module-level values it names are
+# marked and priced as well, which is what a cross-module import pays on top.
+fun instruction_cost(fn: *ir.Function, c: *Copy, seen: *bool, iid: id.InstructionId, instructions: *u32, bytes: *usize) bool {
+    val ins: *instruction.Instruction = counted(fn, iid);
+    if (ins == nil) { ret true; }
+    @instructions = @instructions + 1;
+    if (!add_bytes(bytes, $size_of(instruction.Instruction) + $size_of(id.InstructionId)
+            + $size_of(id.InstructionId) + $size_of(u32) + 1)
+        || !add_bytes(bytes, ins.operand_count::usize * $size_of(value.Value))) { ret false; }
+    if (c != nil && (!mark_type(c, seen, ins.ty) || !mark_type(c, seen, ins.aux_ty))) { ret false; }
+    var oi: u32 = 0;
+    for (oi < ins.operand_count) {
+        val v: *value.Value = ?ins.operands[oi];
+        if (c != nil) {
+            if (!value_cost(c, seen, v, bytes)) { ret false; }
+        } or (!constant_bytes(v, bytes)) { ret false; }
+        oi = oi + 1;
+    }
+    var key: id.InstructionId = iid;
+    val assembly: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
+    if (R.is_ok[*ir.IrAsm, str](assembly) && (!add_bytes(bytes, $size_of(id.InstructionId) + $size_of(ir.IrAsm) + 1)
+        || !add_bytes(bytes, R.unwrap_ok[*ir.IrAsm, str](assembly).bind_count::usize * $size_of(ir.IrAsmBind)))) { ret false; }
+    ret true;
+}
+
+# shape: the growth an inlined copy of fn adds to its host, over the counted
+# instructions only, so the same body prices the same with and without `-g`. a nil
+# Copy prices the in-module case; a Copy adds what a cross-module import carries.
+fun shape(fn: *ir.Function, c: *Copy, seen: *bool, out: *Budget) bool {
+    @out = Budget{};
+    var instructions: u32 = 0;
+    var bytes: usize = 0;
+    if (!add_bytes(?bytes, fn.block_count::usize * $size_of(ir.Block))
+        || !add_bytes(?bytes, (fn.inline_site_len::usize + 1) * $size_of(ir.InlineSite))) { ret false; }
+    var i: u32 = 0;
+    for (i < fn.block_count) {
+        val b: *ir.Block = ?fn.blocks[i];
+        if (!add_bytes(?bytes, b.pred_count::usize * $size_of(id.BlockId))) { ret false; }
+        var j: u32 = 0;
+        for (j < b.phi_count) {
+            if (!instruction_cost(fn, c, seen, b.phis[j], ?instructions, ?bytes)) { ret false; }
+            j = j + 1;
+        }
+        j = 0;
+        for (j < b.instr_count) {
+            if (!instruction_cost(fn, c, seen, b.instructions[j], ?instructions, ?bytes)) { ret false; }
+            j = j + 1;
+        }
+        if (!instruction_cost(fn, c, seen, b.terminator, ?instructions, ?bytes)) { ret false; }
+        i = i + 1;
+    }
+    if (instructions > MAX_INSTRUCTIONS) { ret false; }
+    out.instructions = instructions;
+    out.bytes = bytes;
+    ret true;
+}
+
 fun measure(c: *Copy, fn: *ir.Function, out: *Budget) R.Result[bool, str] {
     @out = Budget{};
     if (!candidate(fn)) { ret R.ok[bool, str](false); }
@@ -463,49 +544,14 @@ fun measure(c: *Copy, fn: *ir.Function, out: *Budget) R.Result[bool, str] {
     fin { if (seen != nil) { A.deallocate[bool](c.scratch, seen, c.src.types.len::usize); } }
     var i: u32 = 0;
     for (i < c.src.types.len) { seen[i] = false; i = i + 1; }
-    var bytes: usize = $size_of(ir.Function);
+    var body_cost: Budget;
+    if (!shape(fn, c, seen, ?body_cost)) { ret R.ok[bool, str](false); }
+    var bytes: usize = body_cost.bytes;
     if (!mark_type(c, seen, fn.sig)
-        || !add_bytes(?bytes, fn.instr_len::usize * $size_of(instruction.Instruction))
-        || !add_bytes(?bytes, fn.block_count::usize * $size_of(ir.Block))
-        || !add_bytes(?bytes, fn.param_count::usize * $size_of(value.Value))
-        || !add_bytes(?bytes, fn.inline_site_len::usize * $size_of(ir.InlineSite))) { ret R.ok[bool, str](false); }
+        || !add_bytes(?bytes, $size_of(ir.Function))
+        || !add_bytes(?bytes, fn.param_count::usize * $size_of(value.Value))) { ret R.ok[bool, str](false); }
     i = 0;
     for (i < fn.param_count) { if (!value_cost(c, seen, ?fn.params[i], ?bytes)) { ret R.ok[bool, str](false); } i = i + 1; }
-    i = 0;
-    for (i < fn.block_count) {
-        val b: *ir.Block = ?fn.blocks[i];
-        if (!add_bytes(?bytes, b.instr_count::usize * $size_of(id.InstructionId))
-            || !add_bytes(?bytes, b.phi_count::usize * $size_of(id.InstructionId))
-            || !add_bytes(?bytes, b.pred_count::usize * $size_of(id.BlockId))) { ret R.ok[bool, str](false); }
-        i = i + 1;
-    }
-    i = 0;
-    for (i < fn.instr_len) {
-        val ins: *instruction.Instruction = ?fn.instrs[i];
-        if (!mark_type(c, seen, ins.ty) || !mark_type(c, seen, ins.aux_ty)
-            || !add_bytes(?bytes, ins.operand_count::usize * $size_of(value.Value))) { ret R.ok[bool, str](false); }
-        var oi: u32 = 0;
-        for (oi < ins.operand_count) { if (!value_cost(c, seen, ?ins.operands[oi], ?bytes)) { ret R.ok[bool, str](false); } oi = oi + 1; }
-        val dv: O.Option[*ir.DbgVar] = ir.dbg_var_get(fn, i::id.InstructionId);
-        if (O.is_some[*ir.DbgVar](dv) && !mark_type(c, seen, O.unwrap[*ir.DbgVar](dv).ty)) { ret R.ok[bool, str](false); }
-        val av: O.Option[*ir.DbgVar] = ir.alloca_dbg_var_get(fn, i::id.InstructionId);
-        if (O.is_some[*ir.DbgVar](av) && !mark_type(c, seen, O.unwrap[*ir.DbgVar](av).ty)) { ret R.ok[bool, str](false); }
-        var key: id.InstructionId = i::id.InstructionId;
-        val assembly: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
-        if (R.is_ok[*ir.IrAsm, str](assembly) && !add_bytes(?bytes,
-            R.unwrap_ok[*ir.IrAsm, str](assembly).bind_count::usize * $size_of(ir.IrAsmBind))) { ret R.ok[bool, str](false); }
-        i = i + 1;
-    }
-    if (!add_bytes(?bytes, fn.asm_blocks.cap * ($size_of(id.InstructionId) + $size_of(ir.IrAsm) + 1))
-        || !add_bytes(?bytes, fn.dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
-        || !add_bytes(?bytes, fn.alloca_dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
-        || !add_bytes(?bytes, fn.dbg_expr_ids.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgExprId) + 1))
-        || !add_bytes(?bytes, fn.instr_inline_site.cap * ($size_of(id.InstructionId) + $size_of(u32) + 1))) { ret R.ok[bool, str](false); }
-    i = 0;
-    for (i < fn.dbg_expr_len) {
-        if (!add_bytes(?bytes, $size_of(ir.DbgExpr)) || !add_bytes(?bytes, fn.dbg_exprs[i].op_count::usize * $size_of(ir.DbgOp))) { ret R.ok[bool, str](false); }
-        i = i + 1;
-    }
     i = c.src.types.len;
     for (i > 0) {
         i = i - 1;
@@ -535,7 +581,7 @@ fun measure(c: *Copy, fn: *ir.Function, out: *Budget) R.Result[bool, str] {
             j = j + 1;
         }
     }
-    out.instructions = fn.instr_len;
+    out.instructions = body_cost.instructions;
     out.bytes = bytes;
     ret R.ok[bool, str](true);
 }
@@ -669,56 +715,13 @@ pub fun acquire(a: *Available, dst: *ir.Module, provider: *ir.Module, name: inte
 }
 
 pub fun growth_cost(fn: *ir.Function, out: *Budget) bool {
-    @out = Budget{};
-    if (fn.instr_len > MAX_INSTRUCTIONS) { ret false; }
-    var bytes: usize = 0;
-    if (!add_bytes(?bytes, fn.instr_len::usize * $size_of(instruction.Instruction))
-        || !add_bytes(?bytes, fn.block_count::usize * $size_of(ir.Block))) { ret false; }
-    var i: u32 = 0;
-    for (i < fn.block_count) {
-        val b: *ir.Block = ?fn.blocks[i];
-        if (!add_bytes(?bytes, b.instr_count::usize * $size_of(id.InstructionId))
-            || !add_bytes(?bytes, b.phi_count::usize * $size_of(id.InstructionId))
-            || !add_bytes(?bytes, b.pred_count::usize * $size_of(id.BlockId))) { ret false; }
-        i = i + 1;
-    }
-    i = 0;
-    for (i < fn.instr_len) {
-        val ins: *instruction.Instruction = ?fn.instrs[i];
-        if (!add_bytes(?bytes, ins.operand_count::usize * $size_of(value.Value))) { ret false; }
-        var oi: u32 = 0;
-        for (oi < ins.operand_count) {
-            val v: *value.Value = ?ins.operands[oi];
-            if (v.kind == value.VAL_CONST_BYTES && !add_bytes(?bytes, v.data.bytes.len::usize)) { ret false; }
-            if (v.kind == value.VAL_CONST_AGG && (!add_bytes(?bytes, v.data.agg.len::usize)
-                || !add_bytes(?bytes, v.data.agg.reloc_count::usize * $size_of(value.AggReloc)))) { ret false; }
-            oi = oi + 1;
-        }
-        var key: id.InstructionId = i::id.InstructionId;
-        val assembly: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?fn.asm_blocks, ?key);
-        if (R.is_ok[*ir.IrAsm, str](assembly) && !add_bytes(?bytes,
-            R.unwrap_ok[*ir.IrAsm, str](assembly).bind_count::usize * $size_of(ir.IrAsmBind))) { ret false; }
-        i = i + 1;
-    }
-    if (!add_bytes(?bytes, fn.asm_blocks.cap * ($size_of(id.InstructionId) + $size_of(ir.IrAsm) + 1))
-        || !add_bytes(?bytes, fn.dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
-        || !add_bytes(?bytes, fn.alloca_dbg_vars.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgVar) + 1))
-        || !add_bytes(?bytes, fn.dbg_expr_ids.cap * ($size_of(id.InstructionId) + $size_of(ir.DbgExprId) + 1))
-        || !add_bytes(?bytes, fn.instr_inline_site.cap * ($size_of(id.InstructionId) + $size_of(u32) + 1))
-        || !add_bytes(?bytes, (fn.inline_site_len::usize + 1) * $size_of(ir.InlineSite))) { ret false; }
-    i = 0;
-    for (i < fn.dbg_expr_len) {
-        if (!add_bytes(?bytes, $size_of(ir.DbgExpr)) || !add_bytes(?bytes, fn.dbg_exprs[i].op_count::usize * $size_of(ir.DbgOp))) { ret false; }
-        i = i + 1;
-    }
-    out.instructions = fn.instr_len;
-    out.bytes = bytes;
-    ret true;
+    ret shape(fn, nil, nil, out);
 }
 
 use std.allocator.page;
 use T: std.allocator.testing;
 use mach.lang.me.ir.builder;
+use semtype: mach.lang.type;
 
 test "mach.lang.me.ir.body:owned_constants_types_and_effect_flags_survive_provider_retirement" {
     var source_home: ir.ModuleHome;
@@ -826,5 +829,78 @@ test "mach.lang.me.ir.body:scratch_refusal_releases_partial_remapping_and_budget
     if (charge(?budget, 2, 0) || charge(?budget, 0, 2)
         || budget.instructions != MAX_INSTRUCTIONS - 1 || budget.bytes != MAX_BYTES - 1) { ret 11; }
     if (!charge(?budget, 1, 1) || budget.instructions != MAX_INSTRUCTIONS || budget.bytes != MAX_BYTES) { ret 12; }
+    ret 0;
+}
+
+# the same program annotated for `-g` and not: an alloca, a debug variable on it, a
+# dbg_value reading it, a return. every cost a decision reads must agree, or `-g`
+# moves an inlining decision and the release image stops being byte-additive (#1944).
+fun annotated_pair(m: *ir.Module, i64t: type.IrTypeId, sig: type.IrTypeId) i32 {
+    var b: builder.Builder = builder.init(m);
+    var k: u32 = 0;
+    for (k < 2) {
+        val added: R.Result[u32, str] = ir.function_add(m, (2 + k)::intern.StrId, sig, 0);
+        if (R.is_err[u32, str](added)) { ret 1; }
+        val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](added)];
+        builder.set_function(?b, fn);
+        val block: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](block)) { ret 2; }
+        builder.set_block(?b, R.unwrap_ok[id.BlockId, str](block));
+        val slot: R.Result[value.Value, str] = builder.emit_alloca(?b, i64t, value.const_int(1, i64t));
+        if (R.is_err[value.Value, str](slot)) { ret 3; }
+        if (k == 1) {
+            var dv: ir.DbgVar;
+            dv.name = 9::intern.StrId;
+            dv.ty   = i64t;
+            if (R.is_err[R.Void, str](ir.record_alloca_dbg_var(fn, R.unwrap_ok[value.Value, str](slot).data.instr, dv))) { ret 4; }
+            if (R.is_err[R.Void, str](builder.emit_dbg_value(?b, R.unwrap_ok[value.Value, str](slot), 9::intern.StrId, i64t, semtype.TYPE_NIL, false, 0))) { ret 5; }
+        }
+        if (R.is_err[R.Void, str](builder.emit_ret_void(?b))) { ret 6; }
+        k = k + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.me.ir.body:debug_annotation_does_not_move_a_bodys_cost" {
+    var home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?home))) { ret 1; }
+    fin { ir.home_dnit(?home); }
+    val made: R.Result[ir.Module, str] = ir.init(?home.alloc, 1);
+    if (R.is_err[ir.Module, str](made)) { ret 2; }
+    var src: ir.Module = R.unwrap_ok[ir.Module, str](made);
+    val vt: R.Result[type.IrTypeId, str] = type.intern_void(?src.types);
+    val it: R.Result[type.IrTypeId, str] = type.intern_int(?src.types, 64);
+    if (R.is_err[type.IrTypeId, str](vt) || R.is_err[type.IrTypeId, str](it)) { ret 3; }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](it);
+    val signature: R.Result[type.IrTypeId, str] = type.intern_fn(?src.types, R.unwrap_ok[type.IrTypeId, str](vt), nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](signature)) { ret 4; }
+    val built: i32 = annotated_pair(?src, i64t, R.unwrap_ok[type.IrTypeId, str](signature));
+    if (built != 0) { ret 10 + built; }
+    val plain: *ir.Function = ?src.functions[0];
+    val annotated: *ir.Function = ?src.functions[1];
+    if (annotated.instr_len == plain.instr_len || annotated.alloca_dbg_vars.cap == 0) { ret 20; }
+    if (live_instructions(plain) != 2 || live_instructions(annotated) != 2 || !candidate(plain) || !candidate(annotated)) { ret 21; }
+    var plain_cost: Budget;
+    var annotated_cost: Budget;
+    if (!growth_cost(plain, ?plain_cost) || !growth_cost(annotated, ?annotated_cost)) { ret 22; }
+    if (plain_cost.instructions != 2 || annotated_cost.instructions != plain_cost.instructions
+        || annotated_cost.bytes != plain_cost.bytes) { ret 23; }
+    var dst_home: ir.ModuleHome;
+    if (O.is_some[str](ir.home_init(?dst_home))) { ret 24; }
+    fin { ir.home_dnit(?dst_home); }
+    val made_dst: R.Result[ir.Module, str] = ir.init(?dst_home.alloc, 5);
+    if (R.is_err[ir.Module, str](made_dst)) { ret 25; }
+    var dst: ir.Module = R.unwrap_ok[ir.Module, str](made_dst);
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 26; }
+    var tgt: target.Target;
+    var c: Copy;
+    if (R.is_err[R.Void, str](copy_init(?c, ?dst, ?src, ?tgt, ?backing))) { ret 27; }
+    fin { copy_dnit(?c); }
+    val plain_measured: R.Result[bool, str] = measure(?c, plain, ?plain_cost);
+    val annotated_measured: R.Result[bool, str] = measure(?c, annotated, ?annotated_cost);
+    if (R.is_err[bool, str](plain_measured) || R.is_err[bool, str](annotated_measured)
+        || !R.unwrap_ok[bool, str](plain_measured) || !R.unwrap_ok[bool, str](annotated_measured)) { ret 28; }
+    if (annotated_cost.instructions != plain_cost.instructions || annotated_cost.bytes != plain_cost.bytes) { ret 29; }
     ret 0;
 }

--- a/src/lang/me/ir/body.mach
+++ b/src/lang/me/ir/body.mach
@@ -224,12 +224,15 @@ fun function_header(c: *Copy, ix: u32) R.Result[u32, str] {
         if (c.dst.functions[at].sig != R.unwrap_ok[type.IrTypeId, str](sig)) { ret R.err[u32, str]("inline body: function identity has incompatible IR signatures"); }
         var origin: intern.StrId = src.body_module;
         if (origin == intern.STR_NIL && (src.flags & ir.FN_FLAG_EXTERN) == 0) { origin = c.src.name; }
-        if (origin != intern.STR_NIL) {
-            if (c.dst.functions[at].body_module != intern.STR_NIL && c.dst.functions[at].body_module != origin) {
-                ret R.err[u32, str]("inline body: function identity has conflicting defining modules");
-            }
-            c.dst.functions[at].body_module = origin;
+        var current: intern.StrId = c.dst.functions[at].body_module;
+        if (current == intern.STR_NIL && (c.dst.functions[at].flags & ir.FN_FLAG_EXTERN) == 0) { current = c.dst.name; }
+        val shared_weak: bool = (src.flags & ir.FN_FLAG_WEAK) != 0 && (c.dst.functions[at].flags & ir.FN_FLAG_WEAK) != 0;
+        if (origin != intern.STR_NIL && current != intern.STR_NIL && current != origin && !shared_weak) {
+            ret R.err[u32, str]("inline body: function identity has conflicting defining modules");
         }
+        # weak specializations retain the first actual provider of their shared linkage
+        if (current == intern.STR_NIL) { current = origin; }
+        c.dst.functions[at].body_module = current;
         c.functions[ix] = at;
         ret R.ok[u32, str](at);
     }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -456,7 +456,7 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
         val res_fn: R.Result[value.Value, fail.Fail] = fn_reference(ctx, link, vty, references_import_function(ctx, sym));
         if (R.is_err[value.Value, fail.Fail](res_fn)) { ret res_fn; }
         stamp_spirv_op(ctx, sym, R.unwrap_ok[value.Value, fail.Fail](res_fn));
-        val res_ci: R.Result[R.Void, fail.Fail] = enqueue_inline_import(ctx, sym, link);
+        val res_ci: R.Result[R.Void, fail.Fail] = stamp_body_provider(ctx, sym, R.unwrap_ok[value.Value, fail.Fail](res_fn));
         if (R.is_err[R.Void, fail.Fail](res_ci)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_ci)); }
         ret res_fn;
     }
@@ -564,50 +564,27 @@ fun references_import_function(ctx: *context.LowerContext, sym: *resolve.Symbol)
     ret (d.flags & decl.DECL_FLAG_EXT) != 0;
 }
 
-fun enqueue_inline_import(ctx: *context.LowerContext, sym: *resolve.Symbol, link: intern.StrId) R.Result[R.Void, fail.Fail] {
-    if (sym.kind != resolve.SYM_IMPORTED) { ret R.ok_void[fail.Fail](); }
+fun stamp_body_provider(ctx: *context.LowerContext, sym: *resolve.Symbol, v: value.Value) R.Result[R.Void, fail.Fail] {
+    if (v.kind != value.VAL_FN || v.data.fn_ix >= ctx.m.function_len) {
+        ret R.err[R.Void, fail.Fail](fail.message("lower: function reference has no IR function identity"));
+    }
     val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
     if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
     val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
-    val origin_ast: *ast.Ast = current.definition.parsed.a;
-    if (origin_ast == nil) { ret R.ok_void[fail.Fail](); }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
-    if (O.is_none[*decl.Decl](opt_d)) { ret R.ok_void[fail.Fail](); }
-    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
-    if (d.kind != decl.DECL_KIND_FUN)             { ret R.ok_void[fail.Fail](); }
-    if ((d.flags & decl.DECL_FLAG_EXT) != 0)      { ret R.ok_void[fail.Fail](); }
-    if (d.data.fun_.body == id.STMT_NIL)          { ret R.ok_void[fail.Fail](); }
-    if (d.data.fun_.generics_len > 0)             { ret R.ok_void[fail.Fail](); }
-    if (fun_decl_is_template(origin_ast, d))      { ret R.ok_void[fail.Fail](); }
-    if (!decl_has_origin_decorator(ctx, origin_ast, d, "inline")) { ret R.ok_void[fail.Fail](); }
-
-    ret context.enqueue_instance(ctx, current.symbol.decl, sym.origin, nil, 0, link, sym.name);
-}
-
-fun fun_decl_is_template(a: *ast.Ast, d: *decl.Decl) bool {
-    var i: u32 = 0;
-    for (i < d.data.fun_.params_len) {
-        val pool_ix: u32 = d.data.fun_.params_start + i;
-        if (pool_ix::usize >= a.typed_name_len) { ret true; }
-        val tn: *decl.TypedName = ?a.typed_names[pool_ix];
-        if (tn.comptime) { ret true; }
-        val opt_t: O.Option[*atype.Type] = ast.get_type(a, tn.ty);
-        if (O.is_some[*atype.Type](opt_t)
-            && O.unwrap[*atype.Type](opt_t).kind == atype.TYPE_KIND_PACK) { ret true; }
-        i = i + 1;
+    val parsed: *ast.Ast = current.definition.parsed.a;
+    val declaration: O.Option[*decl.Decl] = ast.get_decl(parsed, current.symbol.decl);
+    if (O.is_none[*decl.Decl](declaration)) { ret R.err[R.Void, fail.Fail](fail.message("lower: function definition has no current declaration")); }
+    val d: *decl.Decl = O.unwrap[*decl.Decl](declaration);
+    if (d.kind != decl.DECL_KIND_FUN) { ret R.err[R.Void, fail.Fail](fail.message("lower: function reference acquired a non-function declaration")); }
+    if ((d.flags & decl.DECL_FLAG_EXT) != 0 || d.data.fun_.body == id.STMT_NIL) { ret R.ok_void[fail.Fail](); }
+    val origin: intern.StrId = session.module_fqn(ctx.s, current.symbol.origin);
+    if (origin == intern.STR_NIL) { ret R.err[R.Void, fail.Fail](fail.message("lower: function body has no stable module identity")); }
+    val fn: *ir.Function = ?ctx.m.functions[v.data.fn_ix];
+    if (fn.body_module != intern.STR_NIL && fn.body_module != origin) {
+        ret R.err[R.Void, fail.Fail](fail.message("lower: one function linkage names conflicting body providers"));
     }
-    ret false;
-}
-
-fun decl_has_origin_decorator(ctx: *context.LowerContext, a: *ast.Ast, d: *decl.Decl, name: str) bool {
-    val src: str = context.ast_source(ctx, a);
-    var i: u32 = 0;
-    for (i < d.decorators_len) {
-        val dec: *decl.Decorator = ?a.decorators[d.decorators_start + i];
-        if (str_region_equals(src, dec.name.offset, dec.name.len, name)) { ret true; }
-        i = i + 1;
-    }
-    ret false;
+    fn.body_module = origin;
+    ret R.ok_void[fail.Fail]();
 }
 
 fun names_function(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -232,7 +232,7 @@ fun inline_one_in_fn(m: *ir.Module, recursive: *bool, counts: *u32, facts: *Inli
                     val callee_ix: u32 = callee_index(inst);
                     if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
                         val callee: *ir.Function = ?m.functions[callee_ix];
-                        if (should_inline(recursive, counts, facts, dup_count, callee_ix, callee, available)) {
+                        if (should_inline(recursive, counts, facts, dup_count, caller, callee_ix, callee, available)) {
                             var cost: body.Budget;
                             if (!body.growth_cost(callee, ?cost) || !body.charge(budget, cost.instructions, cost.bytes)) {
                                 @exhausted = true; ii = ii + 1; cnt;
@@ -259,11 +259,13 @@ fun callee_index(call: *instruction.Instruction) u32 {
     ret 0xFFFFFFFF;
 }
 
-fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, callee_ix: u32, callee: *ir.Function, available: *body.Available) bool {
+fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, caller: *ir.Function, callee_ix: u32, callee: *ir.Function, available: *body.Available) bool {
     if ((callee.flags & ir.FN_FLAG_EXTERN) != 0 && !body.contains(available, callee_ix)) { ret false; }
     if ((callee.flags & ir.FN_FLAG_SCALAR) != 0)             { ret false; }
     if ((callee.flags & ir.FN_FLAG_NOINLINE) != 0)           { ret false; }
     if ((callee.flags & ir.FN_FLAG_NAKED) != 0)              { ret false; }
+    # constant-time validation runs per #[oblivious] function, so its instructions stay inside one
+    if ((callee.flags & ir.FN_FLAG_OBLIVIOUS) != 0 && (caller.flags & ir.FN_FLAG_OBLIVIOUS) == 0) { ret false; }
     if (recursive[callee_ix])                                { ret false; }
     if (callee.block_count == 0)                             { ret false; }
     if ((callee.flags & ir.FN_FLAG_INLINE) != 0)             { ret true; }
@@ -2841,4 +2843,126 @@ test "mach.lang.me.pass.inline.stamp_inline_metadata:carries_alloca_debug_metada
 
     if (!found) { ret 4; }
     ret bad;
+}
+
+# a callee of `adds` chained adds plus its return, called once from each of `callers`
+# functions carrying `caller_flags`; the callee index is returned and every caller follows it
+fun t_fanned_callee(m: *ir.Module, callee_flags: u32, adds: u32, callers: u32, caller_flags: *u32) R.Result[u32, str] {
+    val ri: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](ri)) { ret R.err[u32, str](R.unwrap_err[type.IrTypeId, str](ri)); }
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ri);
+    var pi: type.IrTypeId = i64t;
+    val rs: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, ?pi, 1, false);
+    if (R.is_err[type.IrTypeId, str](rs)) { ret R.err[u32, str](R.unwrap_err[type.IrTypeId, str](rs)); }
+    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs);
+    val rs0: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, i64t, nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](rs0)) { ret R.err[u32, str](R.unwrap_err[type.IrTypeId, str](rs0)); }
+    val sig0: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs0);
+
+    val r_callee: R.Result[u32, str] = ir.function_add(m, intern.STR_NIL, sig, callee_flags);
+    if (R.is_err[u32, str](r_callee)) { ret r_callee; }
+    val callee_ix: u32 = R.unwrap_ok[u32, str](r_callee);
+    var bld: builder.Builder = builder.init(m);
+    builder.set_function(?bld, ?m.functions[callee_ix]);
+    val rcb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+    if (R.is_err[id.BlockId, str](rcb)) { ret R.err[u32, str](R.unwrap_err[id.BlockId, str](rcb)); }
+    builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rcb));
+    var acc: value.Value = value.param(0, i64t);
+    var k: u32 = 0;
+    for (k < adds) {
+        val r_add: R.Result[value.Value, str] = builder.emit_add(?bld, acc, value.const_int((k + 1)::u64, i64t));
+        if (R.is_err[value.Value, str](r_add)) { ret R.err[u32, str](R.unwrap_err[value.Value, str](r_add)); }
+        acc = R.unwrap_ok[value.Value, str](r_add);
+        k = k + 1;
+    }
+    val r_ret: R.Result[R.Void, str] = builder.emit_ret(?bld, acc);
+    if (R.is_err[R.Void, str](r_ret)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](r_ret)); }
+
+    var c: u32 = 0;
+    for (c < callers) {
+        val r_caller: R.Result[u32, str] = ir.function_add(m, intern.STR_NIL, sig0, caller_flags[c]);
+        if (R.is_err[u32, str](r_caller)) { ret r_caller; }
+        builder.set_function(?bld, ?m.functions[R.unwrap_ok[u32, str](r_caller)]);
+        val rlb: R.Result[id.BlockId, str] = builder.new_block(?bld);
+        if (R.is_err[id.BlockId, str](rlb)) { ret R.err[u32, str](R.unwrap_err[id.BlockId, str](rlb)); }
+        builder.set_block(?bld, R.unwrap_ok[id.BlockId, str](rlb));
+        var arg: value.Value = value.const_int(7, i64t);
+        val rcall: R.Result[value.Value, str] = builder.emit_call(?bld, value.fn(callee_ix, sig), ?arg, 1, i64t);
+        if (R.is_err[value.Value, str](rcall)) { ret R.err[u32, str](R.unwrap_err[value.Value, str](rcall)); }
+        val rr: R.Result[R.Void, str] = builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](rcall));
+        if (R.is_err[R.Void, str](rr)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](rr)); }
+        c = c + 1;
+    }
+    ret R.ok[u32, str](callee_ix);
+}
+
+fun t_calls_to(fn: *ir.Function, callee_ix: u32) u32 {
+    var calls: u32 = 0;
+    var i: u32 = 0;
+    for (i < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[i];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, blk.instructions[ii]);
+            if (O.is_some[*instruction.Instruction](oi)) {
+                val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+                if (ins.kind == instruction.OP_CALL && callee_index(ins) == callee_ix) { calls = calls + 1; }
+            }
+            ii = ii + 1;
+        }
+        i = i + 1;
+    }
+    ret calls;
+}
+
+# the size bar is INLINE_INSTR_THRESHOLD live instructions: a two-caller helper one under
+# it loses both calls, one at it keeps both. mutation control: `<` to `<=` in should_inline
+# inlines the 25-instruction body and fails the second half.
+test "mach.lang.me.pass.inline.run:helper_at_the_size_bar_keeps_its_call" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var flags: [2]u32 = [2]u32{ 0, 0 };
+    var adds: u32 = INLINE_INSTR_THRESHOLD - 2;
+    for (adds <= INLINE_INSTR_THRESHOLD - 1) {
+        val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+        if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+        var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+        val built: R.Result[u32, str] = t_fanned_callee(?m, 0, adds, 2, ?flags[0]);
+        if (R.is_err[u32, str](built)) { ir.dnit(?m); ret 2; }
+        val callee_ix: u32 = R.unwrap_ok[u32, str](built);
+        if (body.live_instructions(?m.functions[callee_ix]) != adds + 1) { ir.dnit(?m); ret 3; }
+        val rr: R.Result[bool, str] = run(?m, nil, nil);
+        if (R.is_err[bool, str](rr)) { ir.dnit(?m); ret 4; }
+        val calls: u32 = t_calls_to(?m.functions[callee_ix + 1], callee_ix) + t_calls_to(?m.functions[callee_ix + 2], callee_ix);
+        ir.dnit(?m);
+        var expected: u32 = 2;
+        if (adds + 1 < INLINE_INSTR_THRESHOLD) { expected = 0; }
+        if (calls != expected) { ret 5; }
+        adds = adds + 1;
+    }
+    ret 0;
+}
+
+# an #[oblivious] body is validated for constant time inside its own function; inlining it
+# into a function that is not #[oblivious] would move those instructions out of every
+# validation, so the public caller keeps its call and the oblivious caller loses it.
+# mutation control: dropping the FN_FLAG_OBLIVIOUS line in should_inline inlines both.
+test "mach.lang.me.pass.inline.run:oblivious_callee_inlines_only_into_an_oblivious_caller" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val res_m: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](res_m)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](res_m);
+    var flags: [2]u32 = [2]u32{ 0, ir.FN_FLAG_OBLIVIOUS };
+    val built: R.Result[u32, str] = t_fanned_callee(?m, ir.FN_FLAG_OBLIVIOUS | ir.FN_FLAG_INLINE, 2, 2, ?flags[0]);
+    if (R.is_err[u32, str](built)) { ir.dnit(?m); ret 2; }
+    val callee_ix: u32 = R.unwrap_ok[u32, str](built);
+    val rr: R.Result[bool, str] = run(?m, nil, nil);
+    if (R.is_err[bool, str](rr)) { ir.dnit(?m); ret 3; }
+    val public_calls: u32 = t_calls_to(?m.functions[callee_ix + 1], callee_ix);
+    val oblivious_calls: u32 = t_calls_to(?m.functions[callee_ix + 2], callee_ix);
+    ir.dnit(?m);
+    if (public_calls != 1)    { ret 4; }
+    if (oblivious_calls != 0) { ret 5; }
+    ret 0;
 }

--- a/src/lang/me/pass/inline.mach
+++ b/src/lang/me/pass/inline.mach
@@ -11,6 +11,7 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.body;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
 use mach.lang.me.ir.instruction;
@@ -22,11 +23,9 @@ use mach.lang.source;
 use mach.lang.target;
 use semtype: mach.lang.type;
 
-val INLINE_INSTR_THRESHOLD: u32 = 25;
+val INLINE_INSTR_THRESHOLD: u32 = body.SMALL_INSTRUCTIONS;
 
-val INLINE_BUDGET: u32 = 1024;
-
-val PEEL_BUDGET: u32 = 1024;
+val INLINE_BUDGET: u32 = body.MAX_INSTRUCTIONS;
 
 val INLINE_SMALL_CALLEE_FANOUT_CAP: u32 = 16;
 
@@ -133,6 +132,10 @@ fun build_inline_facts(m: *ir.Module) R.Result[InlineFacts, str] {
 }
 
 pub fun run(m: *ir.Module, tgt: *target.Target, out_report: *InlineBudget) R.Result[bool, str] {
+    ret run_available(m, tgt, nil, out_report);
+}
+
+pub fun run_available(m: *ir.Module, tgt: *target.Target, available: *body.Available, out_report: *InlineBudget) R.Result[bool, str] {
     if (out_report != nil) {
         out_report.inline_exhausted = false;
         out_report.peel_exhausted   = false;
@@ -183,10 +186,10 @@ pub fun run(m: *ir.Module, tgt: *target.Target, out_report: *InlineBudget) R.Res
     for (i < m.function_len) {
         val caller: *ir.Function = ?m.functions[i];
         if ((caller.flags & ir.FN_FLAG_EXTERN) == 0) {
-            var budget: u32 = INLINE_BUDGET;
+            var budget: body.Budget;
             var progress: bool = true;
-            for (progress && budget > 0) {
-                val inlined_r: R.Result[bool, str] = inline_one_in_fn(m, recursive, counts, ?facts, dup_count, caller);
+            for (progress && budget.instructions < INLINE_BUDGET) {
+                val inlined_r: R.Result[bool, str] = inline_one_in_fn(m, recursive, counts, ?facts, dup_count, caller, available, ?budget, ?any_exhausted);
                 if (R.is_err[bool, str](inlined_r)) {
                     A.deallocate[u32](m.alloc, dup_count, m.function_len::usize);
                     inline_facts_free(m, ?facts);
@@ -195,9 +198,9 @@ pub fun run(m: *ir.Module, tgt: *target.Target, out_report: *InlineBudget) R.Res
                     ret inlined_r;
                 }
                 progress = R.unwrap_ok[bool, str](inlined_r);
-                if (progress) { budget = budget - 1; any_inlined = true; }
+                if (progress) { any_inlined = true; }
             }
-            if (budget == 0) { any_exhausted = true; }
+            if (budget.instructions == INLINE_BUDGET) { any_exhausted = true; }
         }
         i = i + 1;
     }
@@ -215,7 +218,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target, out_report: *InlineBudget) R.Res
     ret R.ok[bool, str](any_inlined || R.unwrap_ok[bool, str](peeled_r));
 }
 
-fun inline_one_in_fn(m: *ir.Module, recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, caller: *ir.Function) R.Result[bool, str] {
+fun inline_one_in_fn(m: *ir.Module, recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, caller: *ir.Function, available: *body.Available, budget: *body.Budget, exhausted: *bool) R.Result[bool, str] {
     var i: u32 = 0;
     for (i < caller.block_count) {
         val blk: *ir.Block = ?caller.blocks[i];
@@ -229,7 +232,11 @@ fun inline_one_in_fn(m: *ir.Module, recursive: *bool, counts: *u32, facts: *Inli
                     val callee_ix: u32 = callee_index(inst);
                     if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
                         val callee: *ir.Function = ?m.functions[callee_ix];
-                        if (should_inline(recursive, counts, facts, dup_count, callee_ix, callee)) {
+                        if (should_inline(recursive, counts, facts, dup_count, callee_ix, callee, available)) {
+                            var cost: body.Budget;
+                            if (!body.growth_cost(callee, ?cost) || !body.charge(budget, cost.instructions, cost.bytes)) {
+                                @exhausted = true; ii = ii + 1; cnt;
+                            }
                             val res_inline: R.Result[R.Void, str] =
                                 do_inline(m, counts, caller, i, ii, iid, callee_ix, callee);
                             if (R.is_err[R.Void, str](res_inline)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](res_inline)); }
@@ -252,8 +259,8 @@ fun callee_index(call: *instruction.Instruction) u32 {
     ret 0xFFFFFFFF;
 }
 
-fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, callee_ix: u32, callee: *ir.Function) bool {
-    if ((callee.flags & ir.FN_FLAG_EXTERN) != 0)             { ret false; }
+fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count: *u32, callee_ix: u32, callee: *ir.Function, available: *body.Available) bool {
+    if ((callee.flags & ir.FN_FLAG_EXTERN) != 0 && !body.contains(available, callee_ix)) { ret false; }
     if ((callee.flags & ir.FN_FLAG_SCALAR) != 0)             { ret false; }
     if ((callee.flags & ir.FN_FLAG_NOINLINE) != 0)           { ret false; }
     if ((callee.flags & ir.FN_FLAG_NAKED) != 0)              { ret false; }
@@ -263,7 +270,7 @@ fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count
 
     val single_caller: bool = counts[callee_ix] == 1
         && !facts.address_taken[callee_ix]
-        && !facts.exposed[callee_ix];
+        && !facts.exposed[callee_ix] && !body.contains(available, callee_ix);
     if (single_caller) { ret true; }
 
     if (callee_instr_count(callee) < INLINE_INSTR_THRESHOLD
@@ -272,21 +279,7 @@ fun should_inline(recursive: *bool, counts: *u32, facts: *InlineFacts, dup_count
 }
 
 fun callee_instr_count(callee: *ir.Function) u32 {
-    var total: u32 = 0;
-    var i: u32 = 0;
-    for (i < callee.block_count) {
-        val blk: *ir.Block = ?callee.blocks[i];
-        total = total + blk.phi_count;
-        var k: u32 = 0;
-        for (k < blk.instr_count) {
-            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(callee, blk.instructions[k]);
-            if (O.is_some[*instruction.Instruction](oi) && O.unwrap[*instruction.Instruction](oi).kind != instruction.OP_DBG_VALUE) { total = total + 1; }
-            k = k + 1;
-        }
-        if (blk.terminator != id.INSTR_NIL) { total = total + 1; }
-        i = i + 1;
-    }
-    ret total;
+    ret body.live_instructions(callee);
 }
 
 fun build_call_counts(m: *ir.Module, counts: *u32) {
@@ -324,76 +317,109 @@ fun add_fn_call_counts(m: *ir.Module, fn: *ir.Function, counts: *u32) {
     }
 }
 
-fun mark_recursive(m: *ir.Module, recursive: *bool) R.Result[R.Void, str] {
-    val n: u32 = m.function_len;
-    val res_visited: R.Result[*bool, str] = A.allocate[bool](m.alloc, n::usize);
-    if (R.is_err[*bool, str](res_visited)) {
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](res_visited));
-    }
-    val visited: *bool = R.unwrap_ok[*bool, str](res_visited);
-    val res_queue: R.Result[*u32, str] = A.allocate[u32](m.alloc, n::usize);
-    if (R.is_err[*u32, str](res_queue)) {
-        A.deallocate[bool](m.alloc, visited, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_queue));
-    }
-    val queue: *u32 = R.unwrap_ok[*u32, str](res_queue);
-
-    var i: u32 = 0;
-    for (i < n) {
-        recursive[i] = reaches_self(m, i, visited, queue, n);
-        i = i + 1;
-    }
-
-    A.deallocate[bool](m.alloc, visited, n::usize);
-    A.deallocate[u32](m.alloc, queue, n::usize);
-    ret R.ok_void[str]();
+rec CallVisit {
+    index: u32;
+    low: u32;
+    block: u32;
+    instr: u32;
+    active: bool;
+    self_call: bool;
 }
 
-fun reaches_self(m: *ir.Module, start: u32, visited: *bool, queue: *u32, n: u32) bool {
-    var i: u32 = 0;
-    for (i < n) {
-        visited[i] = false;
-        i = i + 1;
-    }
-
-    var qt: u32 = 0;
-    if (scan_callees(m, start, start, visited, queue, ?qt)) { ret true; }
-    var qh: u32 = 0;
-    for (qh < qt) {
-        val fn_ix: u32 = queue[qh];
-        qh = qh + 1;
-        if (scan_callees(m, fn_ix, start, visited, queue, ?qt)) { ret true; }
-    }
-    ret false;
-}
-
-fun scan_callees(m: *ir.Module, fn_ix: u32, target_ix: u32, visited: *bool, queue: *u32, qt: *u32) bool {
+fun next_callee(m: *ir.Module, fn_ix: u32, visit: *CallVisit) u32 {
     val fn: *ir.Function = ?m.functions[fn_ix];
-    var i: u32 = 0;
-    for (i < fn.block_count) {
-        val blk: *ir.Block = ?fn.blocks[i];
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val opt_inst: O.Option[*instruction.Instruction] = ir.instruction_get(fn, blk.instructions[ii]);
-            if (O.is_some[*instruction.Instruction](opt_inst)) {
-                val inst: *instruction.Instruction = O.unwrap[*instruction.Instruction](opt_inst);
-                if (inst.kind == instruction.OP_CALL && inst.operand_count >= 1) {
-                    val callee_ix: u32 = callee_index(inst);
-                    if (callee_ix != 0xFFFFFFFF && callee_ix < m.function_len) {
-                        if (callee_ix == target_ix) { ret true; }
-                        if (visited[callee_ix] == false) {
-                            visited[callee_ix] = true;
-                            queue[@qt] = callee_ix;
-                            @qt = @qt + 1;
-                        }
-                    }
-                }
-            }
-            ii = ii + 1;
+    for (visit.block < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[visit.block];
+        for (visit.instr < blk.instr_count) {
+            val oi: O.Option[*instruction.Instruction] = ir.instruction_get(fn, blk.instructions[visit.instr]);
+            visit.instr = visit.instr + 1;
+            if (O.is_none[*instruction.Instruction](oi)) { cnt; }
+            val ins: *instruction.Instruction = O.unwrap[*instruction.Instruction](oi);
+            if (ins.kind != instruction.OP_CALL || ins.operand_count == 0) { cnt; }
+            val callee: u32 = callee_index(ins);
+            if (callee < m.function_len) { ret callee; }
         }
+        visit.block = visit.block + 1;
+        visit.instr = 0;
+    }
+    ret 0xFFFFFFFF;
+}
+
+pub fun mark_recursive(m: *ir.Module, recursive: *bool) R.Result[R.Void, str] {
+    val n: u32 = m.function_len;
+    if (n == 0) { ret R.ok_void[str](); }
+    val rv: R.Result[*CallVisit, str] = A.allocate[CallVisit](m.alloc, n::usize);
+    if (R.is_err[*CallVisit, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[*CallVisit, str](rv)); }
+    val visits: *CallVisit = R.unwrap_ok[*CallVisit, str](rv);
+    fin { A.deallocate[CallVisit](m.alloc, visits, n::usize); }
+    val rd: R.Result[*u32, str] = A.allocate[u32](m.alloc, n::usize);
+    if (R.is_err[*u32, str](rd)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rd)); }
+    val dfs: *u32 = R.unwrap_ok[*u32, str](rd);
+    fin { A.deallocate[u32](m.alloc, dfs, n::usize); }
+    val rs: R.Result[*u32, str] = A.allocate[u32](m.alloc, n::usize);
+    if (R.is_err[*u32, str](rs)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rs)); }
+    val stack: *u32 = R.unwrap_ok[*u32, str](rs);
+    fin { A.deallocate[u32](m.alloc, stack, n::usize); }
+
+    var i: u32 = 0;
+    for (i < n) {
+        visits[i] = CallVisit{ index: 0xFFFFFFFF };
+        recursive[i] = false;
         i = i + 1;
     }
-    ret false;
+    var serial: u32 = 0;
+    var stack_len: u32 = 0;
+    var root: u32 = 0;
+    for (root < n) {
+        if (visits[root].index != 0xFFFFFFFF) { root = root + 1; cnt; }
+        visits[root].index = serial;
+        visits[root].low = serial;
+        visits[root].active = true;
+        serial = serial + 1;
+        stack[stack_len] = root;
+        stack_len = stack_len + 1;
+        dfs[0] = root;
+        var depth: u32 = 1;
+        for (depth > 0) {
+            val current: u32 = dfs[depth - 1];
+            val visit: *CallVisit = ?visits[current];
+            val child: u32 = next_callee(m, current, visit);
+            if (child != 0xFFFFFFFF) {
+                if (child == current) { visit.self_call = true; }
+                if (visits[child].index == 0xFFFFFFFF) {
+                    visits[child].index = serial;
+                    visits[child].low = serial;
+                    visits[child].active = true;
+                    serial = serial + 1;
+                    stack[stack_len] = child;
+                    stack_len = stack_len + 1;
+                    dfs[depth] = child;
+                    depth = depth + 1;
+                } or (visits[child].active && visits[child].index < visit.low) {
+                    visit.low = visits[child].index;
+                }
+                cnt;
+            }
+            if (visit.low == visit.index) {
+                val end: u32 = stack_len;
+                var member: u32 = 0xFFFFFFFF;
+                for (member != current) {
+                    stack_len = stack_len - 1;
+                    member = stack[stack_len];
+                    visits[member].active = false;
+                }
+                val cycle: bool = end - stack_len > 1 || visit.self_call;
+                var k: u32 = stack_len;
+                for (k < end) { recursive[stack[k]] = cycle; k = k + 1; }
+            }
+            depth = depth - 1;
+            if (depth > 0 && visit.low < visits[dfs[depth - 1]].low) {
+                visits[dfs[depth - 1]].low = visit.low;
+            }
+        }
+        root = root + 1;
+    }
+    ret R.ok_void[str]();
 }
 
 rec InlineCtx {
@@ -534,11 +560,12 @@ fun peel_all(m: *ir.Module, out_exhausted: *bool) R.Result[bool, str] {
     for (f_ix < m.function_len) {
         val fn: *ir.Function = ?m.functions[f_ix];
         if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && peel_eligible(fn, f_ix)) {
-            var budget: u32 = PEEL_BUDGET;
-            val peeled_r: R.Result[bool, str] = peel_function(m, f_ix, fn, ?budget);
+            var budget: body.Budget;
+            var exhausted: bool = false;
+            val peeled_r: R.Result[bool, str] = peel_function(m, f_ix, fn, ?budget, ?exhausted);
             if (R.is_err[bool, str](peeled_r)) { ret peeled_r; }
             if (R.unwrap_ok[bool, str](peeled_r)) { changed = true; }
-            if (budget == 0 && out_exhausted != nil) { @out_exhausted = true; }
+            if (exhausted && out_exhausted != nil) { @out_exhausted = true; }
         }
         f_ix = f_ix + 1;
     }
@@ -546,6 +573,7 @@ fun peel_all(m: *ir.Module, out_exhausted: *bool) R.Result[bool, str] {
 }
 
 fun peel_eligible(fn: *ir.Function, f_ix: u32) bool {
+    if ((fn.flags & (ir.FN_FLAG_NOINLINE | ir.FN_FLAG_SCALAR | ir.FN_FLAG_NAKED)) != 0) { ret false; }
     if (fn.block_count == 0)                              { ret false; }
     if (callee_instr_count(fn) >= INLINE_INSTR_THRESHOLD) { ret false; }
     ret has_direct_self_call(fn, f_ix);
@@ -611,6 +639,7 @@ fun locate_call(fn: *ir.Function, call_id: id.InstructionId, out_bi: *u32, out_i
 
 fun build_snapshot(m: *ir.Module, fn: *ir.Function, snap: *ir.Function) R.Result[R.Void, str] {
     @snap = ir.function_new(m.alloc, fn.name, fn.sig, fn.flags);
+    snap.body_module = fn.body_module;
 
     var i: u32 = 0;
     for (i < fn.instr_len) {
@@ -647,7 +676,7 @@ fun build_snapshot(m: *ir.Module, fn: *ir.Function, snap: *ir.Function) R.Result
     ret R.ok_void[str]();
 }
 
-fun peel_function(m: *ir.Module, f_ix: u32, fn: *ir.Function, budget: *u32) R.Result[bool, str] {
+fun peel_function(m: *ir.Module, f_ix: u32, fn: *ir.Function, budget: *body.Budget, exhausted: *bool) R.Result[bool, str] {
     var snap: ir.Function;
     val res_snap: R.Result[R.Void, str] = build_snapshot(m, fn, ?snap);
     if (R.is_err[R.Void, str](res_snap)) { ir.function_dnit(m, ?snap); ret R.err[bool, str](R.unwrap_err[R.Void, str](res_snap)); }
@@ -668,20 +697,23 @@ fun peel_function(m: *ir.Module, f_ix: u32, fn: *ir.Function, budget: *u32) R.Re
     var err: R.Result[bool, str] = R.ok[bool, str](true);
     var did_peel: bool = false;
     var level: u32 = 0;
-    for (level < PEEL_LEVELS && cur_n > 0 && @budget > 0) {
+    for (level < PEEL_LEVELS && cur_n > 0 && !@exhausted) {
         if (callee_instr_count(fn) >= INLINE_INSTR_THRESHOLD * (level + 2)) { brk; }
 
         var nxt_n: u32 = 0;
         var k: u32 = 0;
-        for (k < cur_n && @budget > 0) {
+        for (k < cur_n && !@exhausted) {
             val call_id: id.InstructionId = cur[k]::id.InstructionId;
             var bi: u32 = 0;
             var ii: u32 = 0;
             if (locate_call(fn, call_id, ?bi, ?ii)) {
+                var cost: body.Budget;
+                if (!body.growth_cost(?snap, ?cost) || !body.charge(budget, cost.instructions, cost.bytes)) {
+                    @exhausted = true; brk;
+                }
                 val r: R.Result[R.Void, str] =
                     inline_body(m, fn, bi, ii, call_id, ?snap, f_ix, nxt, PEEL_FRONTIER_CAP, ?nxt_n);
                 if (R.is_err[R.Void, str](r)) { err = R.err[bool, str](R.unwrap_err[R.Void, str](r)); brk; }
-                @budget   = @budget - 1;
                 did_peel  = true;
             } or {
                 err = R.err[bool, str]("inline: peel self-call site not found");
@@ -817,6 +849,15 @@ fun clone_instructions(cx: *InlineCtx) R.Result[R.Void, str] {
             ret R.err[R.Void, str](R.unwrap_err[id.InstructionId, str](res_id));
         }
         cx.instr_map[i] = R.unwrap_ok[id.InstructionId, str](res_id)::u32;
+        if ((callee.flags & ir.FN_FLAG_EXTERN) != 0) {
+            val cloned: *instruction.Instruction = ?cx.caller.instrs[cx.instr_map[i]];
+            var oi: u32 = 0;
+            for (oi < cloned.operand_count) {
+                val owned: R.Result[value.Value, str] = body.own_constant(m.alloc, cloned.operands[oi]);
+                if (R.is_err[value.Value, str](owned)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](owned)); }
+                cloned.operands[oi] = R.unwrap_ok[value.Value, str](owned); oi = oi + 1;
+            }
+        }
         i = i + 1;
     }
     ret R.ok_void[str]();
@@ -1160,6 +1201,54 @@ test "mach.lang.me.pass.inline.mark_recursive:direct_self_call" {
     A.deallocate[bool](m.alloc, recursive, 1::usize);
     ir.dnit(?m);
     if (is_recursive == false) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.me.pass.inline.mark_recursive:cycles_exclude_callers_and_completed_components" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val rm: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](rm)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](rm);
+    fin { ir.dnit(?m); }
+    val rv: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
+    if (R.is_err[type.IrTypeId, str](rv)) { ret 1; }
+    val vt: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rv);
+    val rs: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, vt, nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](rs)) { ret 1; }
+    val sig: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](rs);
+    var i: u32 = 0;
+    for (i < 64) {
+        if (R.is_err[u32, str](ir.function_add(?m, intern.STR_NIL, sig, 0))) { ret 1; }
+        i = i + 1;
+    }
+    var b: builder.Builder = builder.init(?m);
+    i = 0;
+    for (i < 64) {
+        builder.set_function(?b, ?m.functions[i]);
+        val rb: R.Result[id.BlockId, str] = builder.new_block(?b);
+        if (R.is_err[id.BlockId, str](rb)) { ret 1; }
+        builder.set_block(?b, R.unwrap_ok[id.BlockId, str](rb));
+        var callee: u32 = 0xFFFFFFFF;
+        if (i < 29) { callee = i + 1; }
+        if (i == 12) { callee = 9; }
+        if (i == 30) { callee = 31; }
+        if (i == 31 || i == 33) { callee = 30; }
+        if (i == 32) { callee = 32; }
+        if (callee != 0xFFFFFFFF) {
+            if (R.is_err[value.Value, str](builder.emit_call(?b, value.fn(callee, sig), nil, 0, vt))) { ret 1; }
+        }
+        if (R.is_err[R.Void, str](builder.emit_ret_void(?b))) { ret 1; }
+        i = i + 1;
+    }
+    var recursive: [64]bool;
+    if (R.is_err[R.Void, str](mark_recursive(?m, ?recursive[0]))) { ret 1; }
+    i = 0;
+    for (i < 64) {
+        val expected: bool = (i >= 9 && i <= 12) || (i >= 30 && i <= 32);
+        if (recursive[i] != expected) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }
 
@@ -1611,6 +1700,19 @@ test "mach.lang.me.pass.inline.run:peels_direct_self_recursion" {
     val rsum: R.Result[value.Value, str] = builder.emit_add(?bld, R.unwrap_ok[value.Value, str](ra), R.unwrap_ok[value.Value, str](rb));
     if (R.is_err[value.Value, str](rsum)) { ir.dnit(?m); ret 1; }
     if (R.is_err[R.Void, str](builder.emit_ret(?bld, R.unwrap_ok[value.Value, str](rsum)))) { ir.dnit(?m); ret 1; }
+
+    val original_instrs: u32 = m.functions[fib_ix].instr_len;
+    var blocked_flags: [3]u32 = [3]u32{ ir.FN_FLAG_NOINLINE, ir.FN_FLAG_SCALAR, ir.FN_FLAG_NAKED };
+    var flag_ix: u32 = 0;
+    for (flag_ix < 3) {
+        m.functions[fib_ix].flags = blocked_flags[flag_ix];
+        val blocked: R.Result[bool, str] = run(?m, nil, nil);
+        if (R.is_err[bool, str](blocked)) { ir.dnit(?m); ret 1; }
+        if (R.unwrap_ok[bool, str](blocked) || m.functions[fib_ix].instr_len != original_instrs
+            || m.functions[fib_ix].block_count != 3) { ir.dnit(?m); ret 1; }
+        flag_ix = flag_ix + 1;
+    }
+    m.functions[fib_ix].flags = 0;
 
     val rr: R.Result[bool, str] = run(?m, nil, nil);
     if (R.is_err[bool, str](rr)) { ir.dnit(?m); ret 1; }

--- a/src/lang/me/pipeline.mach
+++ b/src/lang/me/pipeline.mach
@@ -14,6 +14,7 @@ use R: std.types.result;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
+use mach.lang.me.ir.body;
 use mach.lang.me.scratch;
 use semtype: mach.lang.type;
 use mach.lang.me.ir.builder;
@@ -50,6 +51,7 @@ pub rec FloatReassocOption     { v: bool; }
 
 pub rec PipelineRequest {
     module:            *ir.Module;
+    available:         *body.Available;
     target:            *target.Target;
     level:             OptLevel;
     vectorize_enabled: VectorizeEnabledOption;
@@ -65,10 +67,10 @@ pub fun run(req: *PipelineRequest) R.Result[bool, str] {
     if (req.interner == nil) { ret R.err[bool, str]("pipeline request: interner is required"); }
 
     ret run_impl(req.module, req.target, req.level, req.vectorize_enabled.v,
-                 req.simd_require.v, req.float_reassoc.v, req.interner, req.source_map);
+                 req.simd_require.v, req.float_reassoc.v, req.interner, req.source_map, req.available);
 }
 
-fun run_impl(m: *ir.Module, tgt: *target.Target, level: OptLevel, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner, srcmap: *source.SourceMap) R.Result[bool, str] {
+fun run_impl(m: *ir.Module, tgt: *target.Target, level: OptLevel, vectorize_enabled: bool, simd_require: bool, float_reassoc: bool, itn: *intern.Interner, srcmap: *source.SourceMap, available: *body.Available) R.Result[bool, str] {
     var vc: VerifyCtx;
     vc.tgt       = tgt;
     vc.itn       = itn;
@@ -98,7 +100,7 @@ fun run_impl(m: *ir.Module, tgt: *target.Target, level: OptLevel, vectorize_enab
     if (R.is_err[R.Void, str](res_verify_dce)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](res_verify_dce)); }
 
     if (level == OPT_RELEASE) {
-        val inline_changed_r: R.Result[bool, str] = inline.run(m, tgt, nil);
+        val inline_changed_r: R.Result[bool, str] = inline_available(m, tgt, available);
         if (R.is_err[bool, str](inline_changed_r)) { ret inline_changed_r; }
         if (R.unwrap_ok[bool, str](inline_changed_r)) { changed = true; }
         val res_verify_inline: R.Result[R.Void, str] = verify_stage(m, false, ?vc);
@@ -942,4 +944,11 @@ test "mach.lang.me.pipeline:simple_passes_do_not_retain_function_work_in_ir" {
         repeat = repeat + 1;
     }
     ret 0;
+}
+
+fun inline_available(m: *ir.Module, tgt: *target.Target, available: *body.Available) R.Result[bool, str] {
+    val attached: R.Result[R.Void, str] = body.attach(available, m);
+    if (R.is_err[R.Void, str](attached)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](attached)); }
+    fin { body.detach(available, m); }
+    ret inline.run_available(m, tgt, available, nil);
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -48,6 +48,7 @@ pub val Q_LOWERED_SURFACE: QueryKind = 17;
 pub val Q_EMBED_FILE: QueryKind = 18;
 pub val Q_CODEGEN_FLAGS: QueryKind = 19;
 pub val Q_GATE_TERMINAL: QueryKind = 20;
+pub val Q_INLINE_BODIES: QueryKind = 21;
 
 pub def Revision: u64;
 

--- a/test/census/real-bools.txt
+++ b/test/census/real-bools.txt
@@ -59,6 +59,7 @@ src/lang/manifest.mach:parse_float_reassoc_flag
 src/lang/manifest.mach:parse_profile_default
 src/lang/manifest.mach:parse_vectorize_flag
 src/lang/me/analysis/oblivious.mach:check_module
+src/lang/me/ir/body.mach:measure
 src/lang/me/ir/mutate.mach:erase_marked
 src/lang/me/ir/reachability.mach:prune
 src/lang/me/pass/algebraic.mach:run
@@ -75,6 +76,7 @@ src/lang/me/pass/inline.mach:inline_one_in_fn
 src/lang/me/pass/inline.mach:peel_all
 src/lang/me/pass/inline.mach:peel_function
 src/lang/me/pass/inline.mach:run
+src/lang/me/pass/inline.mach:run_available
 src/lang/me/pass/mem2reg.mach:promote_function
 src/lang/me/pass/mem2reg.mach:run
 src/lang/me/pass/scalarize.mach:expand_gap_ops
@@ -82,6 +84,7 @@ src/lang/me/pass/scalarize.mach:expand_lane_ops
 src/lang/me/pass/scalarize.mach:gap_work
 src/lang/me/pass/scalarize.mach:lane_work
 src/lang/me/pass/scalarize.mach:run
+src/lang/me/pipeline.mach:inline_available
 src/lang/me/pipeline.mach:run
 src/lang/me/pipeline.mach:run_impl
 src/lang/me/transform/licm.mach:licm_function

--- a/test/golden/aarch64-linux/bits/logic_u32.dis
+++ b/test/golden/aarch64-linux/bits/logic_u32.dis
@@ -5,164 +5,382 @@ Disassembly of section .text:
 <corpus.cases.bits.logic_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x30
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
                	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            // =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            // =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	and	w23, w20, w19
-               	mov	x0, x1
-               	mov	w1, w23
+               	eor	w22, w17, w19
+               	and	w0, w19, w20
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	orr	w24, w20, w19
-               	mov	x0, x1
-               	mov	w1, w24
+               	orr	w1, w19, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	eor	w2, w20, w19
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mvn	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	eor	w1, w19, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	w2, w19
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	and	w2, w21, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w19
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	orr	w2, w21, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	eor	w25, w21, w22
-               	mov	x0, x1
-               	mov	w1, w25
+               	mvn	w1, w20
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mvn	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mvn	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	and	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	and	w2, w20, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	orr	w2, w19, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	orr	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	and	w2, w20, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	orr	w2, w19, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	eor	w1, w21, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	orr	w2, w23, w25
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mvn	w2, w24
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w21
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mvn	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mvn	w2, w25
-               	mov	x0, x1
-               	mov	w1, w2
+               	mvn	w1, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x23, x0
-               	mov	w24, #0x0               // =0
-               	cmp	w24, #0x8
-               	b.lo	 <L19>
-               	b	 <L23>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	eor	w25, w20, w24
-               	orr	w0, w19, w24
-               	eor	w1, w22, w24
-               	and	w26, w21, w1
-               	and	w1, w25, w0
-               	mov	x0, x23
+               	and	w1, w19, w21
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	orr	w1, w25, w26
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
 <L21>:
-               	bl	 <L21>
-               	eor	w1, w25, w26
+               	orr	w1, w20, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	and	w1, w19, w22
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	orr	w1, w20, w21
+<L26>:
+               	bl	 <L26>
+               	and	w23, w19, w20
+               	eor	w24, w21, w22
+               	orr	w1, w23, w24
+<L27>:
+               	bl	 <L27>
+               	orr	w1, w19, w20
                	mvn	w2, w1
                	mov	w1, w2
-<L22>:
-               	bl	 <L22>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x8
-               	b.lo	 <L19>
-<L23>:
-               	mov	x0, x23
+<L28>:
+               	bl	 <L28>
+               	mvn	w1, w23
+<L29>:
+               	bl	 <L29>
+               	mvn	w1, w24
+<L30>:
+               	bl	 <L30>
+               	mov	w1, #0x0                // =0
+               	cmp	w1, #0x8
+               	b.lo	 <L31>
+               	b	 <L38>
+<L31>:
+               	eor	w2, w19, w1
+               	orr	w3, w20, w1
+               	eor	w4, w22, w1
+               	and	w5, w21, w4
+               	and	w4, w2, w3
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x3, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	orr	w3, w2, w5
+               	mov	w6, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x3, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	eor	w3, w2, w5
+               	mvn	w2, w3
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	w1, w1, #0x1
+               	mov	x0, x4
+               	cmp	w1, #0x8
+               	b.lo	 <L31>
+<L38>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
                	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/bits/logic_u64.dis
+++ b/test/golden/aarch64-linux/bits/logic_u64.dis
@@ -5,15 +5,11 @@ Disassembly of section .text:
 <corpus.cases.bits.logic_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x30
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
                	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,145 +25,354 @@ Disassembly of section .text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	and	x23, x19, x20
-               	mov	x0, x1
-               	mov	x1, x23
+               	and	x0, x19, x20
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	orr	x24, x19, x20
-               	mov	x0, x1
-               	mov	x1, x24
+               	orr	x0, x19, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	eor	x2, x19, x20
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mvn	x2, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	eor	x0, x19, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	x2, x20
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	and	x2, x21, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mvn	x0, x19
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	orr	x2, x21, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	eor	x25, x21, x22
-               	mov	x0, x1
-               	mov	x1, x25
+               	mvn	x0, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mvn	x2, x21
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mvn	x2, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	and	x0, x21, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	and	x2, x19, x21
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	orr	x2, x20, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	orr	x0, x21, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	and	x2, x19, x22
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	eor	x0, x21, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mvn	x0, x21
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mvn	x0, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	and	x0, x19, x21
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	orr	x0, x20, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	and	x0, x19, x22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	orr	x2, x20, x21
                	mov	x0, x1
                	mov	x1, x2
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	orr	x2, x23, x25
-               	mov	x0, x1
-               	mov	x1, x2
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mvn	x2, x24
-               	mov	x0, x1
-               	mov	x1, x2
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mvn	x2, x23
-               	mov	x0, x1
-               	mov	x1, x2
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mvn	x2, x25
-               	mov	x0, x1
-               	mov	x1, x2
-<L18>:
-               	bl	 <L18>
-               	mov	x23, x0
-               	mov	x24, #0x0               // =0
-               	cmp	x24, #0x8
-               	b.lo	 <L19>
-               	b	 <L23>
-<L19>:
-               	eor	x25, x19, x24
-               	orr	x0, x20, x24
-               	eor	x1, x22, x24
-               	and	x26, x21, x1
-               	and	x1, x25, x0
-               	mov	x0, x23
-<L20>:
-               	bl	 <L20>
-               	orr	x1, x25, x26
-<L21>:
-               	bl	 <L21>
-               	eor	x1, x25, x26
+<L26>:
+               	bl	 <L26>
+               	and	x23, x19, x20
+               	eor	x24, x21, x22
+               	orr	x1, x23, x24
+<L27>:
+               	bl	 <L27>
+               	orr	x1, x19, x20
                	mvn	x2, x1
                	mov	x1, x2
-<L22>:
-               	bl	 <L22>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x8
-               	b.lo	 <L19>
-<L23>:
-               	mov	x0, x23
+<L28>:
+               	bl	 <L28>
+               	mvn	x1, x23
+<L29>:
+               	bl	 <L29>
+               	mvn	x1, x24
+<L30>:
+               	bl	 <L30>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L31>
+               	b	 <L38>
+<L31>:
+               	eor	x2, x19, x1
+               	orr	x3, x20, x1
+               	eor	x4, x22, x1
+               	and	x5, x21, x4
+               	and	x4, x2, x3
+               	mov	x3, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x3, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	orr	x4, x2, x5
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x3, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	eor	x4, x2, x5
+               	mvn	x2, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x8
+               	b.lo	 <L31>
+<L38>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
                	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/bits/shift_i32.dis
+++ b/test/golden/aarch64-linux/bits/shift_i32.dis
@@ -5,196 +5,404 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_i32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            // =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            // =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	mov	x0, x1
-               	mov	w1, w19
+               	eor	w22, w17, w19
+               	sxtw	x0, w20
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w20, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	lsl	w0, w20, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	asr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	asr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtw	x0, w20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	asr	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w20, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	asr	w2, w21, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsl	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w20, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	asr	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsl	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w21, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	asr	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w21, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	asr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	asr	w0, w21, #31
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	asr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w22, #1
+               	sxtw	x2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	asr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	w2, w21, #0
+               	asr	w2, w22, #1
                	mov	x0, x1
                	mov	w1, w2
 <L20>:
                	bl	 <L20>
-               	mov	x1, x0
-               	asr	w2, w21, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w1, w19, #5
 <L21>:
                	bl	 <L21>
-               	mov	x23, x0
-               	mov	w24, #0x0               // =0
-               	cmp	w24, #0x20
-               	b.lo	 <L22>
-               	b	 <L27>
+               	asr	w1, w19, #5
 <L22>:
-               	lsl	w1, w19, w24
-               	mov	x0, x23
+               	bl	 <L22>
+               	lsr	w1, w20, #0
 <L23>:
                	bl	 <L23>
-               	asr	w1, w19, w24
+               	asr	w1, w20, #0
 <L24>:
                	bl	 <L24>
-               	add	w25, w24, w20
-               	lsl	w1, w21, w25
+               	lsl	w1, w20, #1
 <L25>:
                	bl	 <L25>
-               	asr	w1, w22, w25
+               	asr	w1, w20, #1
 <L26>:
                	bl	 <L26>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x20
-               	b.lo	 <L22>
+               	lsl	w1, w20, #31
 <L27>:
-               	mov	w21, #0x1e              // =30
-               	cmp	w21, #0x28
-               	b.lo	 <L28>
-               	b	 <L31>
+               	bl	 <L27>
+               	asr	w1, w20, #31
 <L28>:
-               	add	w22, w21, w20
-               	lsl	w1, w19, w22
-               	mov	x0, x23
+               	bl	 <L28>
+               	lsr	w1, w21, #0
 <L29>:
                	bl	 <L29>
-               	asr	w1, w19, w22
+               	asr	w1, w21, #31
 <L30>:
                	bl	 <L30>
-               	add	w21, w21, #0x1
-               	mov	x23, x0
-               	cmp	w21, #0x28
-               	b.lo	 <L28>
+               	mov	w1, #0x0                // =0
+               	cmp	w1, #0x20
+               	b.lo	 <L31>
+               	b	 <L40>
 <L31>:
-               	mov	x0, x23
+               	lsl	w2, w20, w1
+               	sxtw	x3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	asr	w3, w20, w1
+               	sxtw	x4, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	w3, w1, w19
+               	lsl	w4, w21, w3
+               	sxtw	x3, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	w3, w1, w19
+               	asr	w4, w22, w3
+               	sxtw	x3, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0x20
+               	b.lo	 <L31>
+<L40>:
+               	mov	w1, #0x1e               // =30
+               	cmp	w1, #0x28
+               	b.lo	 <L41>
+               	b	 <L46>
+<L41>:
+               	add	w2, w1, w19
+               	lsl	w3, w20, w2
+               	sxtw	x2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	add	w2, w1, w19
+               	asr	w4, w20, w2
+               	sxtw	x2, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L44>
+<L45>:
+               	add	w1, w1, #0x1
+               	mov	x0, x3
+               	cmp	w1, #0x28
+               	b.lo	 <L41>
+<L46>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/bits/shift_i64.dis
+++ b/test/golden/aarch64-linux/bits/shift_i64.dis
@@ -5,15 +5,10 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,177 +24,373 @@ Disassembly of section .text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x20, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	lsl	x1, x20, #63
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	asr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	asr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	asr	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x20, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	asr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsl	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x20, #63
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	asr	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsl	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x21, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	asr	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x21, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	asr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x21, #63
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	asr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x22, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	asr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	x2, x21, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	asr	x1, x22, #1
 <L20>:
                	bl	 <L20>
-               	mov	x1, x0
-               	asr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x19, #5
 <L21>:
                	bl	 <L21>
-               	mov	x23, x0
-               	mov	x24, #0x0               // =0
-               	cmp	x24, #0x40
-               	b.lo	 <L22>
-               	b	 <L27>
+               	asr	x1, x19, #5
 <L22>:
-               	lsl	x1, x20, x24
-               	mov	x0, x23
+               	bl	 <L22>
+               	lsr	x1, x20, #0
 <L23>:
                	bl	 <L23>
-               	asr	x1, x20, x24
+               	asr	x1, x20, #0
 <L24>:
                	bl	 <L24>
-               	add	x25, x24, x19
-               	lsl	x1, x21, x25
+               	lsl	x1, x20, #1
 <L25>:
                	bl	 <L25>
-               	asr	x1, x22, x25
+               	asr	x1, x20, #1
 <L26>:
                	bl	 <L26>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L22>
+               	lsl	x1, x20, #63
 <L27>:
-               	mov	x21, #0x3c              // =60
-               	cmp	x21, #0x48
-               	b.lo	 <L28>
-               	b	 <L31>
+               	bl	 <L27>
+               	asr	x1, x20, #63
 <L28>:
-               	add	x22, x21, x19
-               	lsl	x1, x20, x22
-               	mov	x0, x23
+               	bl	 <L28>
+               	lsr	x1, x21, #0
 <L29>:
                	bl	 <L29>
-               	asr	x1, x20, x22
+               	asr	x1, x21, #63
 <L30>:
                	bl	 <L30>
-               	add	x21, x21, #0x1
-               	mov	x23, x0
-               	cmp	x21, #0x48
-               	b.lo	 <L28>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x40
+               	b.lo	 <L31>
+               	b	 <L40>
 <L31>:
-               	mov	x0, x23
+               	lsl	x2, x20, x1
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	asr	x2, x20, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	x2, x1, x19
+               	lsl	x4, x21, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x2, x1, x19
+               	asr	x4, x22, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x40
+               	b.lo	 <L31>
+<L40>:
+               	mov	x1, #0x3c               // =60
+               	cmp	x1, #0x48
+               	b.lo	 <L41>
+               	b	 <L46>
+<L41>:
+               	add	x2, x1, x19
+               	lsl	x3, x20, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	add	x3, x1, x19
+               	asr	x4, x20, x3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L44>
+<L45>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x48
+               	b.lo	 <L41>
+<L46>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/bits/shift_u32.dis
+++ b/test/golden/aarch64-linux/bits/shift_u32.dis
@@ -5,190 +5,401 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
+               	mov	w19, w0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	eor	w19, w17, w20
+               	eor	w20, w17, w19
                	mov	w17, #0xaaaa            // =43690
                	movk	w17, #0xaaaa, lsl #16
-               	eor	w21, w17, w20
+               	eor	w21, w17, w19
                	mov	w17, #0x5555            // =21845
                	movk	w17, #0x5555, lsl #16
-               	eor	w22, w17, w20
-               	mov	x0, x1
-               	mov	w1, w19
+               	eor	w22, w17, w19
+               	mov	w0, w20
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w20, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	lsl	w0, w20, #31
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	lsr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	lsr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w0, w20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	lsr	w2, w21, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w20, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	lsl	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsr	w2, w22, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w20, #31
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	lsl	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsr	w2, w20, #5
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w21, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	w2, w19, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w21, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	lsl	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsr	w2, w19, #1
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsl	w0, w22, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	lsl	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsr	w2, w19, #31
-               	mov	x0, x1
-               	mov	w1, w2
+               	lsr	w0, w22, #1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	lsr	w2, w21, #0
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	w2, w21, #31
+               	lsl	w2, w19, #5
                	mov	x0, x1
                	mov	w1, w2
 <L20>:
                	bl	 <L20>
-               	mov	x23, x0
-               	mov	w24, #0x0               // =0
-               	cmp	w24, #0x20
-               	b.lo	 <L21>
-               	b	 <L26>
+               	lsr	w1, w19, #5
 <L21>:
-               	lsl	w1, w19, w24
-               	mov	x0, x23
+               	bl	 <L21>
+               	lsr	w1, w20, #0
 <L22>:
                	bl	 <L22>
-               	lsr	w1, w19, w24
+               	lsr	w1, w20, #0
 <L23>:
                	bl	 <L23>
-               	add	w25, w24, w20
-               	lsl	w1, w21, w25
+               	lsl	w1, w20, #1
 <L24>:
                	bl	 <L24>
-               	lsr	w1, w22, w25
+               	lsr	w1, w20, #1
 <L25>:
                	bl	 <L25>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0x20
-               	b.lo	 <L21>
+               	lsl	w1, w20, #31
 <L26>:
-               	mov	w21, #0x1e              // =30
-               	cmp	w21, #0x28
-               	b.lo	 <L27>
-               	b	 <L30>
+               	bl	 <L26>
+               	lsr	w1, w20, #31
 <L27>:
-               	add	w22, w21, w20
-               	lsl	w1, w19, w22
-               	mov	x0, x23
+               	bl	 <L27>
+               	lsr	w1, w21, #0
 <L28>:
                	bl	 <L28>
-               	lsr	w1, w19, w22
+               	lsr	w1, w21, #31
 <L29>:
                	bl	 <L29>
-               	add	w21, w21, #0x1
-               	mov	x23, x0
-               	cmp	w21, #0x28
-               	b.lo	 <L27>
+               	mov	w1, #0x0                // =0
+               	cmp	w1, #0x20
+               	b.lo	 <L30>
+               	b	 <L39>
 <L30>:
-               	mov	x0, x23
+               	lsl	w2, w20, w1
+               	mov	w3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	lsr	w3, w20, w1
+               	mov	w4, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	add	w3, w1, w19
+               	lsl	w4, w21, w3
+               	mov	w3, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	add	w3, w1, w19
+               	lsr	w4, w22, w3
+               	mov	w3, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0x20
+               	b.lo	 <L30>
+<L39>:
+               	mov	w1, #0x1e               // =30
+               	cmp	w1, #0x28
+               	b.lo	 <L40>
+               	b	 <L45>
+<L40>:
+               	add	w2, w1, w19
+               	lsl	w3, w20, w2
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	add	w2, w1, w19
+               	lsr	w4, w20, w2
+               	mov	w2, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	w1, w1, #0x1
+               	mov	x0, x3
+               	cmp	w1, #0x28
+               	b.lo	 <L40>
+<L45>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/bits/shift_u64.dis
+++ b/test/golden/aarch64-linux/bits/shift_u64.dis
@@ -5,15 +5,10 @@ Disassembly of section .text:
 <corpus.cases.bits.shift_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -29,171 +24,370 @@ Disassembly of section .text:
                	movk	x17, #0x5555, lsl #32
                	movk	x17, #0x5555, lsl #48
                	eor	x22, x17, x19
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x20, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	lsl	x1, x20, #63
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	lsr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	lsr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	lsl	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	lsr	x2, x21, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x20, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	lsl	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	lsr	x2, x22, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x20, #63
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	lsl	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	lsr	x2, x19, #5
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x21, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	lsr	x2, x20, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x21, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	lsl	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	lsr	x2, x20, #1
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x22, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	lsl	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	lsr	x2, x20, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsr	x1, x22, #1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	lsr	x2, x21, #0
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	lsr	x2, x21, #63
-               	mov	x0, x1
-               	mov	x1, x2
+               	lsl	x1, x19, #5
 <L20>:
                	bl	 <L20>
-               	mov	x23, x0
-               	mov	x24, #0x0               // =0
-               	cmp	x24, #0x40
-               	b.lo	 <L21>
-               	b	 <L26>
+               	lsr	x1, x19, #5
 <L21>:
-               	lsl	x1, x20, x24
-               	mov	x0, x23
+               	bl	 <L21>
+               	lsr	x1, x20, #0
 <L22>:
                	bl	 <L22>
-               	lsr	x1, x20, x24
+               	lsr	x1, x20, #0
 <L23>:
                	bl	 <L23>
-               	add	x25, x24, x19
-               	lsl	x1, x21, x25
+               	lsl	x1, x20, #1
 <L24>:
                	bl	 <L24>
-               	lsr	x1, x22, x25
+               	lsr	x1, x20, #1
 <L25>:
                	bl	 <L25>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L21>
+               	lsl	x1, x20, #63
 <L26>:
-               	mov	x21, #0x3c              // =60
-               	cmp	x21, #0x48
-               	b.lo	 <L27>
-               	b	 <L30>
+               	bl	 <L26>
+               	lsr	x1, x20, #63
 <L27>:
-               	add	x22, x21, x19
-               	lsl	x1, x20, x22
-               	mov	x0, x23
+               	bl	 <L27>
+               	lsr	x1, x21, #0
 <L28>:
                	bl	 <L28>
-               	lsr	x1, x20, x22
+               	lsr	x1, x21, #63
 <L29>:
                	bl	 <L29>
-               	add	x21, x21, #0x1
-               	mov	x23, x0
-               	cmp	x21, #0x48
-               	b.lo	 <L27>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x40
+               	b.lo	 <L30>
+               	b	 <L39>
 <L30>:
-               	mov	x0, x23
+               	lsl	x2, x20, x1
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	lsr	x2, x20, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	add	x2, x1, x19
+               	lsl	x4, x21, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	add	x2, x1, x19
+               	lsr	x4, x22, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x40
+               	b.lo	 <L30>
+<L39>:
+               	mov	x1, #0x3c               // =60
+               	cmp	x1, #0x48
+               	b.lo	 <L40>
+               	b	 <L45>
+<L40>:
+               	add	x2, x1, x19
+               	lsl	x3, x20, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	add	x3, x1, x19
+               	lsr	x4, x20, x3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x48
+               	b.lo	 <L40>
+<L45>:
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_chain.dis
+++ b/test/golden/aarch64-linux/call/call_chain.dis
@@ -40,15 +40,8 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.burn>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
-               	stp	x19, x20, [x29, #-0x20]
-               	stp	x21, x22, [x29, #-0x30]
-               	stp	x23, x24, [x29, #-0x40]
-               	stp	x25, x26, [x29, #-0x50]
-               	stp	x27, x28, [x29, #-0x60]
-               	stp	d8, d9, [x29, #-0x70]
-               	stp	d10, d11, [x29, #-0x80]
-               	stp	d12, d13, [x29, #-0x90]
+               	sub	sp, sp, #0x10
+               	stur	x19, [x29, #-0x8]
                	mov	x16, #0x1               // =1
                	eor	x1, x0, x16
                	mov	x16, #0x3               // =3
@@ -115,96 +108,128 @@ Disassembly of section .text:
                	ucvtf	s0, x0
                	fmov	s30, #4.00000000
                	fdiv	s6, s0, s30
-               	mov	x19, x1
-               	mov	x20, x3
-               	mov	x21, x4
-               	mov	x22, x6
-               	mov	x23, x5
-               	mov	x24, x8
-               	mov	x25, x7
-               	mov	x26, x12
-               	mov	x27, x14
-               	mov	x28, x13
-               	mov	x9, x18
-               	stur	x9, [x29, #-0x8]
-               	mov	x9, x15
-               	stur	x9, [x29, #-0x10]
-               	fmov	d8, d1
-               	fmov	d9, d2
-               	fmov	d10, d3
-               	fmov	d11, d4
-               	fmov	d12, d5
-               	fmov	d13, d6
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x6
                	b.lo	 <L0>
                	b	 <L1>
 <L0>:
-               	add	x19, x19, x20
-               	eor	x20, x20, x21
-               	add	x21, x21, x22
-               	eor	x22, x22, x23
-               	add	x23, x23, x24
-               	eor	x24, x24, x25
-               	add	x25, x25, x26
-               	eor	x26, x26, x27
-               	add	x27, x27, x28
-               	ldur	x9, [x29, #-0x8]
-               	eor	x28, x28, x9
-               	ldur	x9, [x29, #-0x8]
-               	ldur	x10, [x29, #-0x10]
-               	add	x2, x9, x10
-               	ldur	x9, [x29, #-0x10]
-               	eor	x3, x9, x19
-               	fadd	d8, d8, d9
-               	fsub	d9, d9, d10
-               	fadd	d10, d10, d8
-               	fadd	s11, s11, s12
-               	fsub	s12, s12, s13
-               	fadd	s13, s13, s11
+               	add	x1, x1, x3
+               	eor	x3, x3, x4
+               	add	x4, x4, x6
+               	eor	x6, x6, x5
+               	add	x5, x5, x8
+               	eor	x8, x8, x7
+               	add	x7, x7, x12
+               	eor	x12, x12, x14
+               	add	x14, x14, x13
+               	eor	x13, x13, x18
+               	add	x18, x18, x15
+               	eor	x15, x15, x1
+               	fadd	d1, d1, d2
+               	fsub	d2, d2, d3
+               	fadd	d3, d3, d1
+               	fadd	s4, s4, s5
+               	fsub	s5, s5, s6
+               	fadd	s6, s6, s4
                	add	x0, x0, #0x1
-               	mov	x9, x2
-               	stur	x9, [x29, #-0x8]
-               	mov	x9, x3
-               	stur	x9, [x29, #-0x10]
                	cmp	x0, #0x6
                	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	eor	x1, x19, x20
-               	eor	x4, x1, x21
-               	eor	x1, x4, x22
-               	eor	x4, x1, x23
-               	eor	x1, x4, x24
+               	eor	x0, x1, x3
+               	eor	x1, x0, x4
+               	eor	x0, x1, x6
+               	eor	x1, x0, x5
+               	eor	x0, x1, x8
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	eor	x1, x25, x26
-               	eor	x4, x1, x27
-               	eor	x1, x4, x28
-               	ldur	x9, [x29, #-0x8]
-               	eor	x4, x1, x9
-               	ldur	x9, [x29, #-0x10]
-               	eor	x1, x4, x9
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	fadd	d0, d8, d9
-               	fadd	d1, d0, d10
-               	fmov	d0, d1
+               	eor	x0, x7, x12
+               	eor	x2, x0, x14
+               	eor	x0, x2, x13
+               	eor	x2, x0, x18
+               	eor	x0, x2, x15
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fadd	s0, s11, s12
-               	fadd	s1, s0, s13
-               	fmov	s0, s1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ldp	d8, d9, [x29, #-0x70]
-               	ldp	d10, d11, [x29, #-0x80]
-               	ldp	d12, d13, [x29, #-0x90]
-               	ldp	x19, x20, [x29, #-0x20]
-               	ldp	x21, x22, [x29, #-0x30]
-               	ldp	x23, x24, [x29, #-0x40]
-               	ldp	x25, x26, [x29, #-0x50]
-               	ldp	x27, x28, [x29, #-0x60]
+               	fadd	d0, d1, d2
+               	fadd	d1, d0, d3
+               	fmov	x0, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fadd	s0, s4, s5
+               	fadd	s1, s0, s6
+               	fmov	w0, s1
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x0, x1
+               	ldur	x19, [x29, #-0x8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -297,106 +322,295 @@ Disassembly of section .text:
                	fdiv	s13, s0, s30
                	mov	x17, #0x0               // =0
                	cmp	x17, x19
-               	b.lo	 <L2>
+               	b.lo	 <L3>
                	mov	x0, x20
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x21
+               	mov	x1, x21
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x9, x0
-               	stur	x9, [x29, #-0x30]
-               	b	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x8, x2, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x1, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x12, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
+               	mov	x9, x1
+               	stur	x9, [x29, #-0x30]
+               	b	 <L5>
+<L3>:
                	sub	x0, x19, #0x1
                	mov	x16, #0x3               // =3
                	mul	x1, x20, x16
                	add	x2, x1, x19
                	mov	x1, x2
                	mov	x2, x21
-<L3>:
-               	bl	 <L3>
+<L4>:
+               	bl	 <L4>
                	mov	x9, x0
                	stur	x9, [x29, #-0x30]
-<L4>:
-               	ldur	x9, [x29, #-0x30]
-               	mov	x0, x9
-               	mov	x1, x22
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x23
+               	ldur	x9, [x29, #-0x30]
+               	mov	x8, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x22, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x26
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x23, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x27
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x28
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x24, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x25, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0x18]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x26, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x27, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x28, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x8]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x10]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x18]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x20]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x8
                	ldur	x9, [x29, #-0x28]
                	mov	x1, x9
-<L16>:
-               	bl	 <L16>
-               	fmov	d0, d8
-<L17>:
-               	bl	 <L17>
-               	fmov	d0, d9
-<L18>:
-               	bl	 <L18>
-               	fmov	d0, d10
-<L19>:
-               	bl	 <L19>
-               	fmov	s0, s11
-<L20>:
-               	bl	 <L20>
-               	fmov	s0, s12
-<L21>:
-               	bl	 <L21>
-               	fmov	s0, s13
-<L22>:
-               	bl	 <L22>
+<L28>:
+               	bl	 <L28>
+               	fmov	x1, d8
+<L29>:
+               	bl	 <L29>
+               	fmov	x1, d9
+<L30>:
+               	bl	 <L30>
+               	fmov	x1, d10
+<L31>:
+               	bl	 <L31>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
+<L33>:
+               	bl	 <L33>
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
                	fadd	d0, d8, d9
                	fsub	d1, d0, d10
-               	fmov	d0, d1
-<L23>:
-               	bl	 <L23>
+               	fmov	x1, d1
+<L35>:
+               	bl	 <L35>
                	fadd	s0, s11, s12
                	fsub	s1, s0, s13
-               	fmov	s0, s1
-<L24>:
-               	bl	 <L24>
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
                	eor	x1, x22, x27
                	ldur	x9, [x29, #-0x28]
                	eor	x2, x1, x9
                	mov	x1, x2
-<L25>:
-               	bl	 <L25>
+<L37>:
+               	bl	 <L37>
                	ldp	d8, d9, [x29, #-0x90]
                	ldp	d10, d11, [x29, #-0xa0]
                	ldp	d12, d13, [x29, #-0xb0]
@@ -451,10 +665,12 @@ Disassembly of section .text:
                	mov	x1, x22
 <L4>:
                	bl	 <L4>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	fmov	s0, s9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	ldp	d8, d9, [x29, #-0x30]
@@ -544,10 +760,12 @@ Disassembly of section .text:
                	mov	x1, x27
 <L4>:
                	bl	 <L4>
-               	fmov	d0, d11
+               	fmov	x1, d11
 <L5>:
                	bl	 <L5>
-               	fmov	s0, s12
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	mov	x1, x20
@@ -565,13 +783,15 @@ Disassembly of section .text:
                	mov	x1, x24
 <L11>:
                	bl	 <L11>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L12>:
                	bl	 <L12>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L13>:
                	bl	 <L13>
-               	fmov	s0, s10
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	eor	x1, x20, x24
@@ -727,10 +947,12 @@ Disassembly of section .text:
                	mov	x1, x9
 <L4>:
                	bl	 <L4>
-               	ldur	d0, [x29, #-0x40]
+               	ldur	x1, [x29, #-0x40]
 <L5>:
                	bl	 <L5>
-               	ldur	s0, [x29, #-0x50]
+               	ldur	w1, [x29, #-0x50]
+               	mov	w5, w1
+               	mov	x1, x5
 <L6>:
                	bl	 <L6>
                	mov	x1, x27
@@ -751,13 +973,15 @@ Disassembly of section .text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	fmov	d0, d13
+               	fmov	x1, d13
 <L12>:
                	bl	 <L12>
-               	fmov	d0, d14
+               	fmov	x1, d14
 <L13>:
                	bl	 <L13>
-               	fmov	s0, s15
+               	fmov	w1, s15
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	ldur	x9, [x29, #-0x18]
@@ -785,19 +1009,23 @@ Disassembly of section .text:
                	mov	x1, x26
 <L22>:
                	bl	 <L22>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L23>:
                	bl	 <L23>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L24>:
                	bl	 <L24>
-               	fmov	d0, d10
+               	fmov	x1, d10
 <L25>:
                	bl	 <L25>
-               	fmov	s0, s11
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L26>:
                	bl	 <L26>
-               	fmov	s0, s12
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
                	bl	 <L27>
                	add	x1, x20, x23
@@ -1032,10 +1260,12 @@ Disassembly of section .text:
                	mov	x1, x9
 <L4>:
                	bl	 <L4>
-               	ldur	d0, [x29, #-0xd8]
+               	ldur	x1, [x29, #-0xd8]
 <L5>:
                	bl	 <L5>
-               	ldur	s0, [x29, #-0xe8]
+               	ldur	w1, [x29, #-0xe8]
+               	mov	w19, w1
+               	mov	x1, x19
 <L6>:
                	bl	 <L6>
                	ldur	x9, [x29, #-0x78]
@@ -1058,13 +1288,15 @@ Disassembly of section .text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	ldur	d0, [x29, #-0xa8]
+               	ldur	x1, [x29, #-0xa8]
 <L12>:
                	bl	 <L12>
-               	ldur	d0, [x29, #-0xb8]
+               	ldur	x1, [x29, #-0xb8]
 <L13>:
                	bl	 <L13>
-               	ldur	s0, [x29, #-0xc8]
+               	ldur	w1, [x29, #-0xc8]
+               	mov	w13, w1
+               	mov	x1, x13
 <L14>:
                	bl	 <L14>
                	ldur	x9, [x29, #-0x78]
@@ -1100,19 +1332,23 @@ Disassembly of section .text:
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	fmov	d0, d12
+               	fmov	x1, d12
 <L23>:
                	bl	 <L23>
-               	fmov	d0, d13
+               	fmov	x1, d13
 <L24>:
                	bl	 <L24>
-               	fmov	d0, d14
+               	fmov	x1, d14
 <L25>:
                	bl	 <L25>
-               	fmov	s0, s15
+               	fmov	w1, s15
+               	mov	w3, w1
+               	mov	x1, x3
 <L26>:
                	bl	 <L26>
-               	ldur	s0, [x29, #-0x70]
+               	ldur	w1, [x29, #-0x70]
+               	mov	w3, w1
+               	mov	x1, x3
 <L27>:
                	bl	 <L27>
                	ldur	x9, [x29, #-0x30]
@@ -1150,16 +1386,20 @@ Disassembly of section .text:
                	mov	x1, x28
 <L37>:
                	bl	 <L37>
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L38>:
                	bl	 <L38>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L39>:
                	bl	 <L39>
-               	fmov	s0, s10
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L40>:
                	bl	 <L40>
-               	fmov	s0, s11
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L41>:
                	bl	 <L41>
                	eor	x1, x20, x24
@@ -1183,20 +1423,17 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1c0
-               	stp	x19, x20, [x29, #-0x140]
-               	stp	x21, x22, [x29, #-0x150]
-               	stp	x23, x24, [x29, #-0x160]
-               	stp	x25, x26, [x29, #-0x170]
-               	stp	x27, x28, [x29, #-0x180]
-               	stp	d8, d9, [x29, #-0x190]
-               	stp	d10, d11, [x29, #-0x1a0]
-               	stp	d12, d13, [x29, #-0x1b0]
-               	stp	d14, d15, [x29, #-0x1c0]
+               	sub	sp, sp, #0x1d0
+               	stp	x19, x20, [x29, #-0x150]
+               	stp	x21, x22, [x29, #-0x160]
+               	stp	x23, x24, [x29, #-0x170]
+               	stp	x25, x26, [x29, #-0x180]
+               	stp	x27, x28, [x29, #-0x190]
+               	stp	d8, d9, [x29, #-0x1a0]
+               	stp	d10, d11, [x29, #-0x1b0]
+               	stp	d12, d13, [x29, #-0x1c0]
+               	stp	d14, d15, [x29, #-0x1d0]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x2, x0
                	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1206,9 +1443,9 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x28]
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1218,35 +1455,39 @@ Disassembly of section .text:
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x1, x16
-               	add	x1, x3, x19
-               	add	x3, x20, x0, lsl #3
-               	str	x1, [x3]
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x10              // =16
                	add	x0, x17, x19
                	add	x1, x20, #0x0
-               	ldr	x3, [x1]
-               	mov	x1, x3
-<L3>:
-               	bl	 <L3>
+               	ldr	x2, [x1]
+               	mov	x1, x2
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+<L2>:
+               	bl	 <L2>
                	mov	x2, x0
                	mov	x17, #0x1               // =1
                	add	x0, x17, x19
                	add	x1, x20, #0x8
                	ldr	x3, [x1]
                	mov	x1, x3
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L5>
-               	b	 <L49>
-<L5>:
+               	b.lo	 <L4>
+               	b	 <L48>
+<L4>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x0, x1, x19
@@ -1265,13 +1506,13 @@ Disassembly of section .text:
                	eor	x28, x0, x16
                	mov	x16, #0x35              // =53
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0x78]
-               	add	x9, x1, #0x3b
                	stur	x9, [x29, #-0x80]
+               	add	x9, x1, #0x3b
+               	stur	x9, [x29, #-0x88]
                	mov	x16, #0x3d              // =61
                	mul	x1, x0, x16
                	add	x9, x1, #0x4
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x90]
                	lsr	x1, x0, #8
                	mov	x16, #0x3ff             // =1023
                	and	x5, x1, x16
@@ -1302,26 +1543,26 @@ Disassembly of section .text:
                	mov	x16, #0xd               // =13
                	mul	x1, x0, x16
                	add	x9, x1, #0x3
-               	stur	x9, [x29, #-0x90]
+               	stur	x9, [x29, #-0x98]
                	mov	x16, #0x5555            // =21845
                	movk	x16, #0x5555, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0xa0]
                	mvn	x1, x0
                	mov	x16, #0x3               // =3
                	mul	x9, x1, x16
-               	stur	x9, [x29, #-0xa0]
-               	add	x9, x0, #0x11
                	stur	x9, [x29, #-0xa8]
+               	add	x9, x0, #0x11
+               	stur	x9, [x29, #-0xb0]
                	mov	x16, #0x13              // =19
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0xb8]
                	mov	x16, #0x5678            // =22136
                	movk	x16, #0x1234, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0xb8]
-               	add	x9, x0, #0x17
                	stur	x9, [x29, #-0xc0]
+               	add	x9, x0, #0x17
+               	stur	x9, [x29, #-0xc8]
                	lsr	x1, x0, #6
                	mov	x16, #0x3ff             // =1023
                	and	x15, x1, x16
@@ -1352,18 +1593,18 @@ Disassembly of section .text:
                	ucvtf	s0, x15
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	stur	s31, [x29, #-0xd0]
+               	stur	s31, [x29, #-0xd8]
                	add	x9, x0, #0x1d
                	stur	x9, [x29, #-0x50]
                	ldur	x10, [x29, #-0x50]
                	mov	x16, #0xb               // =11
                	eor	x9, x10, x16
-               	stur	x9, [x29, #-0xd8]
+               	stur	x9, [x29, #-0xe0]
                	ldur	x9, [x29, #-0x50]
                	mov	x16, #0x5               // =5
                	mul	x0, x9, x16
                	add	x9, x0, #0x2
-               	stur	x9, [x29, #-0xe0]
+               	stur	x9, [x29, #-0xe8]
                	ldur	x9, [x29, #-0x50]
                	mvn	x0, x9
                	add	x9, x0, #0x7
@@ -1384,7 +1625,7 @@ Disassembly of section .text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	stur	d31, [x29, #-0xf0]
+               	stur	d31, [x29, #-0xf8]
                	ldur	x9, [x29, #-0x50]
                	lsr	x0, x9, #14
                	mov	x16, #0x3ff             // =1023
@@ -1392,7 +1633,11 @@ Disassembly of section .text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	stur	d31, [x29, #-0x100]
+               	mov	x16, #0xfef8            // =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	ldur	x9, [x29, #-0x50]
                	lsr	x0, x9, #21
                	mov	x16, #0xff              // =255
@@ -1400,7 +1645,7 @@ Disassembly of section .text:
                	ucvtf	s0, x1
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	mov	x16, #0xfef0            // =65264
+               	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1427,7 +1672,7 @@ Disassembly of section .text:
                	ucvtf	d0, x1
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfed8            // =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1439,7 +1684,7 @@ Disassembly of section .text:
                	ucvtf	s0, x1
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1447,198 +1692,216 @@ Disassembly of section .text:
                	ldur	x9, [x29, #-0x70]
                	mov	x16, #0x3039            // =12345
                	eor	x0, x9, x16
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	mov	x1, x0
                	mov	x0, x21
+<L6>:
+               	bl	 <L6>
+               	ldur	x9, [x29, #-0x58]
+               	mov	x1, x9
 <L7>:
                	bl	 <L7>
-               	ldur	x9, [x29, #-0x58]
+               	ldur	x9, [x29, #-0x60]
                	mov	x1, x9
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	ldur	x9, [x29, #-0x68]
-               	mov	x1, x9
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x1, [x29, x16]
 <L10>:
                	bl	 <L10>
-               	mov	x16, #0xfee0            // =65248
+               	mov	x16, #0xfec8            // =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	d0, [x29, x16]
+               	ldr	w1, [x29, x16]
+               	mov	w9, w1
+               	stur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x78]
+               	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
+               	ldur	x9, [x29, #-0xe0]
+               	mov	x1, x9
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xe8]
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x48]
-               	mov	x1, x9
+               	ldur	x1, [x29, #-0xf8]
 <L17>:
                	bl	 <L17>
-               	ldur	d0, [x29, #-0xf0]
-<L18>:
-               	bl	 <L18>
-               	ldur	d0, [x29, #-0x100]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfef0            // =65264
+               	mov	x16, #0xfef8            // =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0xd8]
+               	ldr	x1, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	mov	w18, w1
+               	mov	x1, x18
+<L19>:
+               	bl	 <L19>
+               	ldur	x9, [x29, #-0xe0]
                	ldur	x10, [x29, #-0x48]
                	eor	x1, x9, x10
+<L20>:
+               	bl	 <L20>
+               	ldur	x9, [x29, #-0x98]
+               	mov	x1, x9
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0x90]
+               	ldur	x9, [x29, #-0xa0]
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0x98]
+               	ldur	x9, [x29, #-0xa8]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0xa0]
+               	ldur	x9, [x29, #-0xb0]
                	mov	x1, x9
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xb8]
+               	ldur	x9, [x29, #-0xc8]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
+               	fmov	x1, d12
 <L28>:
                	bl	 <L28>
-               	fmov	d0, d12
+               	fmov	x1, d13
 <L29>:
                	bl	 <L29>
-               	fmov	d0, d13
+               	fmov	x1, d14
 <L30>:
                	bl	 <L30>
-               	fmov	d0, d14
+               	fmov	w1, s15
+               	mov	w6, w1
+               	mov	x1, x6
 <L31>:
                	bl	 <L31>
-               	fmov	s0, s15
+               	ldur	w1, [x29, #-0xd8]
+               	mov	w6, w1
+               	mov	x1, x6
 <L32>:
                	bl	 <L32>
-               	ldur	s0, [x29, #-0xd0]
-<L33>:
-               	bl	 <L33>
-               	ldur	x9, [x29, #-0x90]
-               	ldur	x10, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0x98]
+               	ldur	x10, [x29, #-0xb0]
                	add	x1, x9, x10
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xc8]
                	add	x5, x1, x9
                	mov	x1, x5
+<L33>:
+               	bl	 <L33>
+               	mov	x1, x23
 <L34>:
                	bl	 <L34>
-               	mov	x1, x23
+               	mov	x1, x24
 <L35>:
                	bl	 <L35>
-               	mov	x1, x24
+               	mov	x1, x25
 <L36>:
                	bl	 <L36>
-               	mov	x1, x25
+               	mov	x1, x26
 <L37>:
                	bl	 <L37>
-               	mov	x1, x26
+               	mov	x1, x27
 <L38>:
                	bl	 <L38>
-               	mov	x1, x27
+               	mov	x1, x28
 <L39>:
                	bl	 <L39>
-               	mov	x1, x28
+               	ldur	x9, [x29, #-0x80]
+               	mov	x1, x9
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x88]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x90]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
+               	fmov	x1, d8
 <L43>:
                	bl	 <L43>
-               	fmov	d0, d8
+               	fmov	x1, d9
 <L44>:
                	bl	 <L44>
-               	fmov	d0, d9
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
-               	fmov	s0, s10
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L46>:
                	bl	 <L46>
-               	fmov	s0, s11
-<L47>:
-               	bl	 <L47>
                	eor	x1, x23, x27
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x90]
                	eor	x2, x1, x9
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L47>:
+               	bl	 <L47>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L5>
-<L49>:
+               	b.lo	 <L4>
+<L48>:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	add	x0, x1, x19
-<L50>:
-               	bl	 <L50>
+<L49>:
+               	bl	 <L49>
                	mov	x1, x0
                	mov	x0, x21
-<L51>:
-               	bl	 <L51>
-               	ldp	d8, d9, [x29, #-0x190]
-               	ldp	d10, d11, [x29, #-0x1a0]
-               	ldp	d12, d13, [x29, #-0x1b0]
-               	ldp	d14, d15, [x29, #-0x1c0]
-               	ldp	x19, x20, [x29, #-0x140]
-               	ldp	x21, x22, [x29, #-0x150]
-               	ldp	x23, x24, [x29, #-0x160]
-               	ldp	x25, x26, [x29, #-0x170]
-               	ldp	x27, x28, [x29, #-0x180]
+<L50>:
+               	bl	 <L50>
+               	ldp	d8, d9, [x29, #-0x1a0]
+               	ldp	d10, d11, [x29, #-0x1b0]
+               	ldp	d12, d13, [x29, #-0x1c0]
+               	ldp	d14, d15, [x29, #-0x1d0]
+               	ldp	x19, x20, [x29, #-0x150]
+               	ldp	x21, x22, [x29, #-0x160]
+               	ldp	x23, x24, [x29, #-0x170]
+               	ldp	x25, x26, [x29, #-0x180]
+               	ldp	x27, x28, [x29, #-0x190]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_float_regs.dis
+++ b/test/golden/aarch64-linux/call/call_float_regs.dis
@@ -44,159 +44,379 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.takef16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xc0
-               	stp	d8, d9, [x29, #-0x90]
-               	stp	d10, d11, [x29, #-0xa0]
-               	stp	d12, d13, [x29, #-0xb0]
-               	stp	d14, d15, [x29, #-0xc0]
-               	fmov	s8, s0
-               	fmov	d9, d1
-               	fmov	s10, s2
-               	fmov	d11, d3
-               	fmov	s12, s4
-               	fmov	d13, d5
-               	fmov	s14, s6
-               	fmov	d15, d7
-               	ldr	d31, [x29, #0x10]
-               	stur	d31, [x29, #-0x10]
-               	ldr	d31, [x29, #0x18]
-               	stur	d31, [x29, #-0x20]
-               	ldr	d31, [x29, #0x20]
-               	stur	d31, [x29, #-0x30]
-               	ldr	d31, [x29, #0x28]
-               	stur	d31, [x29, #-0x40]
+               	sub	sp, sp, #0x80
+               	stp	d8, d9, [x29, #-0x50]
+               	stp	d10, d11, [x29, #-0x60]
+               	stp	d12, d13, [x29, #-0x70]
+               	stp	d14, d15, [x29, #-0x80]
+               	fmov	d8, d1
+               	fmov	d9, d3
+               	fmov	d10, d5
+               	fmov	d11, d7
+               	ldr	d12, [x29, #0x10]
+               	ldr	d13, [x29, #0x18]
+               	ldr	d14, [x29, #0x20]
+               	ldr	d15, [x29, #0x28]
                	ldr	d31, [x29, #0x30]
-               	stur	d31, [x29, #-0x50]
+               	stur	d31, [x29, #-0x10]
                	ldr	d31, [x29, #0x38]
-               	stur	d31, [x29, #-0x60]
+               	stur	d31, [x29, #-0x20]
                	ldr	d31, [x29, #0x40]
-               	stur	d31, [x29, #-0x70]
+               	stur	d31, [x29, #-0x30]
                	ldr	d31, [x29, #0x48]
-               	stur	d31, [x29, #-0x80]
+               	stur	d31, [x29, #-0x40]
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d8
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	fmov	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s12
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d13
+               	fmov	x1, d9
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d15
+               	fmov	w1, s4
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x10]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x20]
+               	fmov	x1, d10
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x30]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x40]
+               	fmov	w1, s6
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x50]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x60]
+               	fmov	x1, d11
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x70]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x80]
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	fmul	s0, s10, s12
-               	fadd	s17, s8, s0
-               	fsub	s0, s17, s14
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	fmul	d0, d11, d13
-               	fadd	d17, d9, d0
-               	fsub	d0, d17, d15
-               	mov	x0, x1
+               	fmov	x1, d13
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fmov	x1, d15
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldur	w1, [x29, #-0x10]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	ldur	x1, [x29, #-0x20]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	ldur	w1, [x29, #-0x30]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	ldur	x1, [x29, #-0x40]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fmul	s16, s2, s4
+               	fadd	s2, s0, s16
+               	fsub	s0, s2, s6
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	fmul	d0, d9, d10
+               	fadd	d2, d8, d0
+               	fsub	d0, d2, d11
+               	fmov	x1, d0
+<L33>:
+               	bl	 <L33>
+               	fsub	s0, s12, s14
                	ldur	s31, [x29, #-0x10]
                	ldur	s30, [x29, #-0x30]
-               	fsub	s0, s31, s30
-               	ldur	s31, [x29, #-0x50]
-               	ldur	s30, [x29, #-0x70]
-               	fmul	s1, s31, s30
-               	fadd	s3, s0, s1
-               	mov	x0, x1
-               	fmov	s0, s3
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
+               	fmul	s2, s31, s30
+               	fadd	s1, s0, s2
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	fsub	d0, d13, d15
                	ldur	d31, [x29, #-0x20]
                	ldur	d30, [x29, #-0x40]
-               	fsub	d0, d31, d30
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x80]
                	fmul	d1, d31, d30
                	fadd	d2, d0, d1
-               	mov	x0, x1
-               	fmov	d0, d2
-<L20>:
-               	bl	 <L20>
-               	ldp	d8, d9, [x29, #-0x90]
-               	ldp	d10, d11, [x29, #-0xa0]
-               	ldp	d12, d13, [x29, #-0xb0]
-               	ldp	d14, d15, [x29, #-0xc0]
+               	fmov	x1, d2
+<L35>:
+               	bl	 <L35>
+               	ldp	d8, d9, [x29, #-0x50]
+               	ldp	d10, d11, [x29, #-0x60]
+               	ldp	d12, d13, [x29, #-0x70]
+               	ldp	d14, d15, [x29, #-0x80]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -233,106 +453,81 @@ Disassembly of section .text:
                	stur	d31, [x29, #-0x70]
                	ldr	d31, [x29, #0x48]
                	stur	d31, [x29, #-0x80]
+               	fmov	w0, s8
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s12
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s13
+               	fmov	s0, s14
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fmov	s0, s15
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s15
+               	ldur	s0, [x29, #-0x10]
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x10]
+               	ldur	s0, [x29, #-0x20]
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x20]
+               	ldur	s0, [x29, #-0x30]
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x30]
+               	ldur	s0, [x29, #-0x40]
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x40]
+               	ldur	s0, [x29, #-0x50]
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x50]
+               	ldur	s0, [x29, #-0x60]
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x60]
+               	ldur	s0, [x29, #-0x70]
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x70]
+               	ldur	s0, [x29, #-0x80]
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x80]
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
                	ldur	s30, [x29, #-0x80]
                	fadd	s0, s8, s30
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
+<L16>:
+               	bl	 <L16>
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s15, s30
-               	mov	x0, x1
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+<L17>:
+               	bl	 <L17>
                	ldur	s30, [x29, #-0x70]
                	fmul	s0, s11, s30
-               	mov	x0, x1
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	ldp	d8, d9, [x29, #-0x90]
                	ldp	d10, d11, [x29, #-0xa0]
                	ldp	d12, d13, [x29, #-0xb0]
@@ -344,36 +539,30 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x390
-               	sub	x16, x29, #0x2d0
+               	sub	sp, sp, #0x250
+               	sub	x16, x29, #0x1c0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x320
-               	stp	d8, d9, [x16]
-               	stp	d10, d11, [x16, #-0x10]
-               	stp	d12, d13, [x16, #-0x20]
-               	stp	d14, d15, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0xa0
+               	sub	x16, x29, #0x210
+               	str	d8, [x16, #0x8]
+               	sub	x1, x29, #0x190
                	add	x2, x1, #0x0
                	add	x3, x2, #0x0
                	mov	x2, #0xa0               // =160
-<L1>:
+<L0>:
                	str	xzr, [x3]
                	add	x3, x3, #0x8
                	sub	x2, x2, #0x8
                	cmp	x2, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x14
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -384,75 +573,78 @@ Disassembly of section .text:
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
                	add	x4, x3, x16
-               	add	x3, x4, x19
+               	add	x3, x4, x0
                	add	x4, x1, x2, lsl #3
                	str	x3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x14
-               	b.lo	 <L2>
+               	b.lo	 <L1>
+<L2>:
+               	sub	x19, x29, #0x50
+               	add	x0, x19, #0x0
+               	add	x2, x0, #0x0
+               	mov	x0, #0x50               // =80
 <L3>:
-               	sub	x19, x29, #0xf0
-               	add	x2, x19, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x50               // =80
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L3>
+               	sub	x20, x29, #0xf0
+               	add	x0, x20, #0x0
+               	add	x2, x0, #0x0
+               	mov	x0, #0xa0               // =160
 <L4>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L4>
-               	sub	x20, x29, #0x190
-               	add	x2, x20, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0xa0               // =160
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x14
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
-               	b.ne	 <L5>
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x14
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
-               	add	x3, x1, x2, lsl #3
-               	ldr	x4, [x3]
+               	add	x2, x1, x0, lsl #3
+               	ldr	x3, [x2]
                	mov	x16, #0xfff             // =4095
-               	and	x3, x4, x16
-               	ucvtf	s0, x3
+               	and	x2, x3, x16
+               	ucvtf	s0, x2
                	mov	w16, #0x45000000        // =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x3, x19, x2, lsl #2
-               	str	s0, [x3]
-               	add	x3, x1, x2, lsl #3
-               	ldr	x4, [x3]
+               	add	x2, x19, x0, lsl #2
+               	str	s0, [x2]
+               	add	x2, x1, x0, lsl #3
+               	ldr	x3, [x2]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xf, lsl #16
-               	and	x3, x4, x16
-               	ucvtf	d0, x3
+               	and	x2, x3, x16
+               	ucvtf	d0, x2
                	mov	x16, #0x4120000000000000 // =4692750811720056832
                	fmov	d30, x16
                	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
                	fdiv	d0, d1, d30
-               	add	x3, x20, x2, lsl #3
-               	str	d0, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x14
-               	b.lo	 <L6>
-<L7>:
-               	mov	x21, x0
+               	add	x2, x20, x0, lsl #3
+               	str	d0, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x14
+               	b.lo	 <L5>
+<L6>:
+               	mov	x21, #0x2325            // =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L8>
-               	b	 <L32>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L12>
+<L7>:
                	mov	x16, #0x3               // =3
                	and	x0, x23, x16
                	ucvtf	s0, x0
@@ -537,12 +729,12 @@ Disassembly of section .text:
                	fmov	d5, d6
                	fmov	s6, s7
                	fmov	d7, d16
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	mov	x1, x0
                	mov	x0, x21
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	mov	x9, x0
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
@@ -554,400 +746,113 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s9, [x24]
-               	add	x0, x19, #0x4
-               	ldr	s10, [x0]
-               	ldr	s11, [x25]
-               	add	x0, x19, #0xc
-               	ldr	s12, [x0]
-               	ldr	s13, [x26]
-               	add	x0, x19, #0x14
-               	ldr	s14, [x0]
-               	ldr	s15, [x27]
-               	add	x0, x19, #0x1c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	ldr	s31, [x28]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x24
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s0, [x24]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	ldr	s2, [x25]
+               	add	x1, x19, #0xc
+               	ldr	s3, [x1]
+               	ldr	s4, [x26]
+               	add	x1, x19, #0x14
+               	ldr	s5, [x1]
+               	ldr	s6, [x27]
+               	add	x1, x19, #0x1c
+               	ldr	s7, [x1]
+               	ldr	s16, [x28]
+               	add	x1, x19, #0x24
+               	ldr	s17, [x1]
                	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x2c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s18, [x9]
+               	add	x1, x19, #0x2c
+               	ldr	s19, [x1]
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x34
-               	ldr	s31, [x0]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s20, [x9]
+               	add	x1, x19, #0x34
+               	ldr	s21, [x1]
                	mov	x16, #0xfe58            // =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	s31, [x9]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-               	add	x0, x19, #0x3c
-               	ldr	s0, [x0]
-               	fadd	s31, s0, s8
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-<L11>:
-               	bl	 <L11>
-               	fmov	s0, s9
-<L12>:
-               	bl	 <L12>
-               	fmov	s0, s10
-<L13>:
-               	bl	 <L13>
-               	fmov	s0, s11
-<L14>:
-               	bl	 <L14>
-               	fmov	s0, s12
-<L15>:
-               	bl	 <L15>
-               	fmov	s0, s13
-<L16>:
-               	bl	 <L16>
-               	fmov	s0, s14
-<L17>:
-               	bl	 <L17>
-               	fmov	s0, s15
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fadd	s0, s9, s30
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fsub	s0, s31, s30
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fmul	s0, s12, s30
-<L30>:
-               	bl	 <L30>
-               	mov	x24, x0
+               	ldr	s22, [x9]
+               	add	x1, x19, #0x3c
+               	ldr	s23, [x1]
+               	fadd	s24, s23, s8
+               	str	d16, [sp]
+               	str	d17, [sp, #0x8]
+               	str	d18, [sp, #0x10]
+               	str	d19, [sp, #0x18]
+               	str	d20, [sp, #0x20]
+               	str	d21, [sp, #0x28]
+               	str	d22, [sp, #0x30]
+               	str	d24, [sp, #0x38]
+<L10>:
+               	bl	 <L10>
+               	mov	x22, x0
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	x1, x24
-<L31>:
-               	bl	 <L31>
+               	mov	x1, x22
+<L11>:
+               	bl	 <L11>
                	add	x23, x23, #0x1
                	mov	x21, x0
-               	mov	x22, x24
                	cmp	x23, #0x3
-               	b.lo	 <L8>
-<L32>:
+               	b.lo	 <L7>
+<L12>:
                	add	x0, x19, #0x4c
-               	ldr	s8, [x0]
+               	ldr	s0, [x0]
                	add	x0, x19, #0x48
-               	ldr	s9, [x0]
+               	ldr	s1, [x0]
                	add	x0, x19, #0x44
-               	ldr	s10, [x0]
+               	ldr	s2, [x0]
                	add	x0, x19, #0x40
-               	ldr	s11, [x0]
+               	ldr	s3, [x0]
                	add	x0, x19, #0x3c
-               	ldr	s12, [x0]
+               	ldr	s4, [x0]
                	add	x0, x19, #0x38
-               	ldr	s13, [x0]
+               	ldr	s5, [x0]
                	add	x0, x19, #0x34
-               	ldr	s14, [x0]
+               	ldr	s6, [x0]
                	add	x0, x19, #0x30
-               	ldr	s15, [x0]
+               	ldr	s7, [x0]
                	add	x0, x19, #0x2c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s16, [x0]
                	add	x0, x19, #0x28
-               	ldr	s31, [x0]
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s17, [x0]
                	add	x0, x19, #0x24
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s18, [x0]
                	add	x0, x19, #0x20
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s19, [x0]
                	add	x0, x19, #0x1c
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s20, [x0]
                	add	x0, x19, #0x18
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s21, [x0]
                	add	x0, x19, #0x14
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
+               	ldr	s22, [x0]
                	add	x0, x19, #0x10
-               	ldr	s31, [x0]
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	s31, [x29, x16]
-<L33>:
-               	bl	 <L33>
-               	fmov	s0, s8
-<L34>:
-               	bl	 <L34>
-               	fmov	s0, s9
-<L35>:
-               	bl	 <L35>
-               	fmov	s0, s10
-<L36>:
-               	bl	 <L36>
-               	fmov	s0, s11
-<L37>:
-               	bl	 <L37>
-               	fmov	s0, s12
-<L38>:
-               	bl	 <L38>
-               	fmov	s0, s13
-<L39>:
-               	bl	 <L39>
-               	fmov	s0, s14
-<L40>:
-               	bl	 <L40>
-               	fmov	s0, s15
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfd80            // =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s0, [x29, x16]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfd40            // =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fadd	s0, s8, s30
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fsub	s0, s15, s30
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfd50            // =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	s30, [x29, x16]
-               	fmul	s0, s11, s30
-<L52>:
-               	bl	 <L52>
+               	ldr	s23, [x0]
+               	str	d16, [sp]
+               	str	d17, [sp, #0x8]
+               	str	d18, [sp, #0x10]
+               	str	d19, [sp, #0x18]
+               	str	d20, [sp, #0x20]
+               	str	d21, [sp, #0x28]
+               	str	d22, [sp, #0x30]
+               	str	d23, [sp, #0x38]
+<L13>:
+               	bl	 <L13>
                	mov	x16, #0xfff             // =4095
                	and	x1, x0, x16
                	ucvtf	s0, x1
@@ -1000,18 +905,15 @@ Disassembly of section .text:
                	str	d21, [sp, #0x28]
                	str	d22, [sp, #0x30]
                	str	d23, [sp, #0x38]
-<L53>:
-               	bl	 <L53>
+<L14>:
+               	bl	 <L14>
                	mov	x1, x0
                	mov	x0, x21
-<L54>:
-               	bl	 <L54>
-               	sub	x16, x29, #0x320
-               	ldp	d8, d9, [x16]
-               	ldp	d10, d11, [x16, #-0x10]
-               	ldp	d12, d13, [x16, #-0x20]
-               	ldp	d14, d15, [x16, #-0x30]
-               	sub	x16, x29, #0x2d0
+<L15>:
+               	bl	 <L15>
+               	sub	x16, x29, #0x210
+               	ldr	d8, [x16, #0x8]
+               	sub	x16, x29, #0x1c0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/call/call_indirect.dis
+++ b/test/golden/aarch64-linux/call/call_indirect.dis
@@ -63,34 +63,66 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_indirect.fold24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_indirect.sum24>:
@@ -167,97 +199,237 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_indirect.wide>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x60
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	d8, d9, [x29, #-0x50]
-               	stp	d10, d11, [x29, #-0x60]
-               	mov	x19, x0
-               	mov	w20, w1
-               	fmov	d8, d0
-               	mov	x21, x2
-               	fmov	s9, s1
-               	mov	x22, x3
-               	mov	w23, w4
-               	fmov	d10, d2
-               	mov	x24, x5
-               	mov	x25, x6
-               	fmov	s11, s3
-               	mov	x26, x7
+               	mov	x8, #0x2325             // =8997
+               	movk	x8, #0x8422, lsl #16
+               	movk	x8, #0x9ce4, lsl #32
+               	movk	x8, #0xcbf2, lsl #48
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x0, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x12, x1, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x8, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	fmov	x0, d0
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	mov	x16, #0x8               // =8
+               	mul	x12, x1, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x8, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w0, w2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w23
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x12, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x12, x16
+               	eor	x12, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	fmov	w0, s1
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x12, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x12, x16
+               	eor	x12, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x3, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	sxtw	x0, w4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldp	d8, d9, [x29, #-0x50]
-               	ldp	d10, d11, [x29, #-0x60]
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fmov	x0, d2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	uxth	w0, w5
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x6, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fmov	w0, s3
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x8, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x7, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x8, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x0, x8
                	ret
 
 <corpus.cases.call.call_indirect.apply>:
@@ -331,183 +503,170 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x230
-               	sub	x16, x29, #0x1d0
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x220
+               	sub	sp, sp, #0x200
+               	stp	x19, x20, [x29, #-0x1a0]
+               	stp	x21, x22, [x29, #-0x1b0]
+               	stp	x23, x24, [x29, #-0x1c0]
+               	stp	x25, x26, [x29, #-0x1d0]
+               	stp	x27, x28, [x29, #-0x1e0]
+               	sub	x16, x29, #0x1f0
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	mov	x19, x0
+               	sub	x20, x29, #0xe0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               // =96
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               // =96
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            // =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-<L3>:
-               	sub	x21, x29, #0x90
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+<L2>:
+               	sub	x21, x29, #0x30
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	str	xzr, [x21, #0x18]
                	str	xzr, [x21, #0x20]
                	str	xzr, [x21, #0x28]
-               	add	x1, x21, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x10
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x18
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x20
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x21, #0x28
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	sub	x22, x29, #0xa0
+               	add	x0, x21, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x10
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x18
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x20
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x21, #0x28
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	sub	x22, x29, #0x40
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
-               	add	x1, x22, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x22, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	sub	x23, x29, #0xb0
+               	add	x0, x22, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x22, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	sub	x23, x29, #0x50
                	str	xzr, [x23]
                	str	xzr, [x23, #0x8]
-               	add	x1, x23, #0x0
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x23, #0x8
-               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x2, x2, #0x0
-               	str	x2, [x1]
-               	add	x1, x19, #0x1
-               	mov	x24, x0
-               	mov	x25, x1
+               	add	x0, x23, #0x0
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x23, #0x8
+               	adrp	x1, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x1, x1, #0x0
+               	str	x1, [x0]
+               	add	x0, x19, #0x1
+               	mov	x24, #0x2325            // =8997
+               	movk	x24, #0x8422, lsl #16
+               	movk	x24, #0x9ce4, lsl #32
+               	movk	x24, #0xcbf2, lsl #48
+               	mov	x25, x0
                	mov	x26, #0x0               // =0
                	cmp	x26, #0xc
-               	b.lo	 <L4>
+               	b.lo	 <L3>
                	b	 <L18>
-<L4>:
-               	add	x27, x20, x26, lsl #3
-               	ldr	x0, [x27]
-               	add	x1, x0, x19
-               	mov	x0, #0x6                // =6
-               	cbnz	x0,  <L5>
+<L3>:
+               	add	x0, x20, x26, lsl #3
+               	ldr	x1, [x0]
+               	add	x2, x1, x19
+               	mov	x1, #0x6                // =6
+               	cbnz	x1,  <L4>
                	brk	#0
-<L5>:
-               	udiv	x16, x1, x0
-               	msub	x28, x16, x0, x1
-               	add	x9, x21, x28, lsl #3
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x3, [x9]
-               	ldr	x1, [x27]
+<L4>:
+               	udiv	x16, x2, x1
+               	msub	x27, x16, x1, x2
+               	add	x1, x21, x27, lsl #3
+               	ldr	x28, [x1]
+               	ldr	x1, [x0]
                	mov	x0, x25
-               	blr	x3
-               	mov	x9, x0
-               	mov	x16, #0xfeb0            // =65200
+               	blr	x28
+               	mov	x28, x0
+               	mov	x9, x24
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x24
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L6>:
-               	bl	 <L6>
-               	mov	x9, x0
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x3, x28, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x3, x16
                	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldr	x5, [x9]
-               	ldr	x1, [x27]
-               	mov	x16, #0xfeb0            // =65200
+               	eor	x3, x9, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x2
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	blr	x5
+               	str	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x0, x21, x27, lsl #3
+               	ldr	x3, [x0]
+               	add	x0, x20, x26, lsl #3
+               	ldr	x1, [x0]
+               	mov	x0, x28
+               	blr	x3
                	mov	x1, x0
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -515,19 +674,8 @@ Disassembly of section .text:
                	mov	x0, x9
 <L7>:
                	bl	 <L7>
-               	mov	x27, x0
-               	add	x0, x28, #0x1
-               	mov	x1, #0x6                // =6
-               	cbnz	x1,  <L8>
-               	brk	#0
-<L8>:
-               	udiv	x16, x0, x1
-               	msub	x2, x16, x1, x0
-               	add	x0, x21, x2, lsl #3
-               	ldr	x28, [x0]
-               	add	x0, x20, x26, lsl #3
-               	ldr	x9, [x0]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x9, x0
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -537,23 +685,44 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	x16, #0xfea0            // =65184
+               	add	x0, x27, #0x1
+               	mov	x1, #0x6                // =6
+               	cbnz	x1,  <L8>
+               	brk	#0
+<L8>:
+               	udiv	x16, x0, x1
+               	msub	x3, x16, x1, x0
+               	add	x0, x21, x3, lsl #3
+               	ldr	x27, [x0]
+               	add	x0, x20, x26, lsl #3
+               	ldr	x9, [x0]
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, x28
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-               	blr	x28
-               	mov	x16, #0xfea0            // =65184
+               	blr	x27
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-               	blr	x28
+               	blr	x27
                	mov	x1, x0
-               	mov	x0, x27
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
 <L9>:
                	bl	 <L9>
                	mov	x27, x0
@@ -576,52 +745,42 @@ Disassembly of section .text:
                	b.eq	 <L12>
                	cmp	x2, #0x4
                	b.eq	 <L11>
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L11>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L12>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L13>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L14>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
                	b	 <L16>
 <L15>:
-               	adrp	x28, 0x0 <corpus.cases.call.call_indirect.gen>
-               	add	x28, x28, #0x0
+               	adrp	x2, 0x0 <corpus.cases.call.call_indirect.gen>
+               	add	x2, x2, #0x0
 <L16>:
                	add	x0, x20, x26, lsl #3
                	ldr	x1, [x0]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	blr	x28
+               	mov	x0, x28
+               	blr	x2
                	mov	x1, x0
                	mov	x0, x27
 <L17>:
                	bl	 <L17>
                	add	x26, x26, #0x1
                	mov	x24, x0
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x25, x9
+               	mov	x25, x28
                	cmp	x26, #0xc
-               	b.lo	 <L4>
+               	b.lo	 <L3>
 <L18>:
                	add	x0, x20, #0x0
                	ldr	x1, [x0]
@@ -672,7 +831,7 @@ Disassembly of section .text:
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x8
                	b.lo	 <L24>
-               	b	 <L32>
+               	b	 <L35>
 <L24>:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
@@ -692,42 +851,42 @@ Disassembly of section .text:
 <L26>:
                	udiv	x16, x1, x2
                	msub	x27, x16, x2, x1
-               	sub	x28, x29, #0xc8
+               	sub	x28, x29, #0x68
                	add	x1, x23, x26, lsl #3
                	ldr	x2, [x1]
                	ldr	x1, [x0]
                	add	x0, x1, x25
-               	sub	x9, x29, #0xe0
-               	mov	x16, #0xfe98            // =65176
+               	sub	x9, x29, #0x80
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	blr	x2
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x2, [x9, #0x8]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -739,56 +898,88 @@ Disassembly of section .text:
                	add	x0, x28, #0x0
                	ldr	x1, [x0]
                	add	x0, x28, #0x8
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	ldr	x2, [x0]
                	add	x0, x28, #0x10
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe88            // =65160
+               	ldr	x3, [x0]
+               	mov	x0, x24
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x9, x0
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x0, x24
-<L27>:
-               	bl	 <L27>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
                	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x9, x0
-               	mov	x16, #0xfe78            // =65144
+               	eor	x4, x9, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
                	add	x9, x22, x27, lsl #3
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -818,17 +1009,17 @@ Disassembly of section .text:
                	sub	x0, x29, #0x110
                	blr	x27
                	mov	x3, x0
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
                	mov	x1, x3
-<L30>:
-               	bl	 <L30>
+<L33>:
+               	bl	 <L33>
                	mov	x27, x0
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfe98            // =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -839,12 +1030,12 @@ Disassembly of section .text:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
                	sub	x9, x29, #0x128
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -852,24 +1043,24 @@ Disassembly of section .text:
                	mov	x8, x9
                	mov	x0, x1
                	blr	x26
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x1, [x9, #0x8]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfe88            // =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -894,27 +1085,27 @@ Disassembly of section .text:
                	blr	x28
                	mov	x1, x0
                	mov	x0, x27
-<L31>:
-               	bl	 <L31>
+<L34>:
+               	bl	 <L34>
                	add	x21, x21, #0x1
                	mov	x24, x0
                	cmp	x21, #0x8
                	b.lo	 <L24>
-<L32>:
+<L35>:
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L33>
-               	b	 <L62>
-<L33>:
+               	b.lo	 <L36>
+               	b	 <L41>
+<L36>:
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
                	add	x22, x1, x19
                	mov	w23, w22
                	mov	x16, #0xfff             // =4095
                	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	ucvtf	d8, x0
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d0, d8, d30
                	mov	w26, w22
                	mov	x16, #0xff              // =255
                	and	x0, x22, x16
@@ -923,196 +1114,116 @@ Disassembly of section .text:
                	mul	x27, x22, x16
                	mov	x16, #0xffff            // =65535
                	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	ucvtf	d10, x0
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d10, d0, d30
+               	fdiv	d2, d10, d30
                	mov	w28, w22
                	mvn	x9, x22
-               	mov	x16, #0xfe68            // =65128
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x16, #0x3ff             // =1023
                	and	x0, x22, x16
-               	ucvtf	s0, x0
+               	ucvtf	s1, x0
                	mov	w16, #0x44000000        // =1140850688
                	fmov	s30, w16
-               	fsub	s11, s0, s30
+               	fsub	s11, s1, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x22
-<L35>:
-               	bl	 <L35>
+               	mov	x0, x22
                	mov	w1, w23
-<L36>:
-               	bl	 <L36>
-               	fmov	d0, d8
+               	mov	x2, x26
+               	fmov	s1, s9
+               	mov	x3, x27
+               	mov	w4, w23
+               	mov	x5, x28
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	fmov	s3, s11
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x7, x9
 <L37>:
                	bl	 <L37>
-               	mov	x1, x26
-<L38>:
-               	bl	 <L38>
-               	fmov	s0, s9
-<L39>:
-               	bl	 <L39>
-               	mov	x1, x27
-<L40>:
-               	bl	 <L40>
-               	mov	w1, w23
-<L41>:
-               	bl	 <L41>
-               	fmov	d0, d10
-<L42>:
-               	bl	 <L42>
-               	mov	x1, x28
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L44>:
-               	bl	 <L44>
-               	fmov	s0, s11
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L46>:
-               	bl	 <L46>
                	mov	x1, x0
                	mov	x0, x24
-<L47>:
-               	bl	 <L47>
-               	mov	x23, x0
-               	mov	w26, w22
-               	mov	x16, #0xfff             // =4095
-               	and	x0, x22, x16
-               	ucvtf	d0, x0
+<L38>:
+               	bl	 <L38>
+               	mov	x9, x0
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
-               	mov	w27, w22
-               	mov	x16, #0xff              // =255
-               	and	x0, x22, x16
-               	ucvtf	s9, x0
-               	mov	x16, #0x3               // =3
-               	mul	x28, x22, x16
-               	mov	x16, #0xffff            // =65535
-               	and	x0, x22, x16
-               	ucvtf	d0, x0
+               	fdiv	d0, d8, d30
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d10, d0, d30
-               	mov	w9, w22
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mvn	x9, x22
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0x3ff             // =1023
-               	and	x0, x22, x16
-               	ucvtf	s0, x0
-               	mov	w16, #0x44000000        // =1140850688
-               	fmov	s30, w16
-               	fsub	s11, s0, s30
-               	eor	x9, x22, x25
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x22
-<L49>:
-               	bl	 <L49>
-               	mov	w1, w26
-<L50>:
-               	bl	 <L50>
-               	fmov	d0, d8
-<L51>:
-               	bl	 <L51>
-               	mov	x1, x27
-<L52>:
-               	bl	 <L52>
-               	fmov	s0, s9
-<L53>:
-               	bl	 <L53>
-               	mov	x1, x28
-<L54>:
-               	bl	 <L54>
-               	mov	w1, w26
-<L55>:
-               	bl	 <L55>
-               	fmov	d0, d10
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe58            // =65112
+               	fdiv	d2, d10, d30
+               	mov	x0, x22
+               	mov	w1, w23
+               	mov	x2, x26
+               	fmov	s1, s9
+               	mov	x3, x27
+               	mov	w4, w23
+               	mov	x5, x28
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe50            // =65104
+               	mov	x6, x9
+               	fmov	s3, s11
+               	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L58>:
-               	bl	 <L58>
-               	fmov	s0, s11
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
+               	mov	x7, x9
+<L39>:
+               	bl	 <L39>
                	mov	x1, x0
-               	mov	x0, x23
-<L61>:
-               	bl	 <L61>
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x24, x0
                	cmp	x21, #0x4
-               	b.lo	 <L33>
-<L62>:
+               	b.lo	 <L36>
+<L41>:
                	mov	x0, x24
-               	sub	x16, x29, #0x220
+               	sub	x16, x29, #0x1f0
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
-               	sub	x16, x29, #0x1d0
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
-               	ldp	x27, x28, [x16, #-0x40]
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	ldp	x21, x22, [x29, #-0x1b0]
+               	ldp	x23, x24, [x29, #-0x1c0]
+               	ldp	x25, x26, [x29, #-0x1d0]
+               	ldp	x27, x28, [x29, #-0x1e0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_int_regs.dis
+++ b/test/golden/aarch64-linux/call/call_int_regs.dis
@@ -20,127 +20,325 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.take16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
-               	stp	x27, x28, [x29, #-0x80]
-               	mov	x19, x0
-               	mov	x20, x1
-               	mov	x21, x2
-               	mov	x22, x3
-               	mov	w23, w4
-               	mov	w24, w5
-               	mov	x25, x6
-               	mov	x26, x7
-               	ldr	x27, [x29, #0x10]
-               	ldr	x28, [x29, #0x18]
-               	ldr	x9, [x29, #0x20]
-               	stur	x9, [x29, #-0x8]
-               	ldr	x9, [x29, #0x28]
-               	stur	x9, [x29, #-0x10]
-               	ldr	x9, [x29, #0x30]
-               	stur	x9, [x29, #-0x18]
-               	ldr	x9, [x29, #0x38]
-               	stur	x9, [x29, #-0x20]
-               	ldr	x9, [x29, #0x40]
-               	stur	x9, [x29, #-0x28]
-               	ldr	x9, [x29, #0x48]
-               	stur	x9, [x29, #-0x30]
+               	sub	sp, sp, #0x30
+               	stp	x19, x20, [x29, #-0x10]
+               	stp	x21, x22, [x29, #-0x20]
+               	stp	x23, x24, [x29, #-0x30]
+               	ldr	x8, [x29, #0x10]
+               	ldr	x12, [x29, #0x18]
+               	ldr	x13, [x29, #0x20]
+               	ldr	x14, [x29, #0x28]
+               	ldr	x15, [x29, #0x30]
+               	ldr	x18, [x29, #0x38]
+               	ldr	x19, [x29, #0x40]
+               	ldr	x20, [x29, #0x48]
+               	uxtb	w21, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x22, #0x0               // =0
+               	cmp	x22, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x23, x22, x16
+               	lsr	x24, x21, x23
+               	mov	x16, #0xff              // =255
+               	and	x23, x24, x16
+               	eor	x24, x0, x23
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x24, x16
+               	add	x22, x22, #0x1
+               	cmp	x22, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	x21, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x22, x1, x16
+               	lsr	x23, x21, x22
+               	mov	x16, #0xff              // =255
+               	and	x22, x23, x16
+               	eor	x23, x0, x22
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x23, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxth	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w23
+               	mov	x16, #0x8               // =8
+               	mul	x21, x2, x16
+               	lsr	x22, x1, x21
+               	mov	x16, #0xff              // =255
+               	and	x21, x22, x16
+               	eor	x22, x0, x21
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x22, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w24
+               	sxth	x1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x21, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x21, x16
+               	eor	x21, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x21, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	mov	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x28
+               	sxtw	x1, w5
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x18]
-               	mov	w1, w9
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x6, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x20]
-               	mov	w1, w9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x28]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x7, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
+               	uxtb	w1, w8
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
-               	ldp	x27, x28, [x29, #-0x80]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxtb	x1, w12
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	uxth	w1, w13
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	x1, w14
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	w1, w15
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sxtw	x1, w18
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x19, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	ldp	x19, x20, [x29, #-0x10]
+               	ldp	x21, x22, [x29, #-0x20]
+               	ldp	x23, x24, [x29, #-0x30]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -154,116 +352,83 @@ Disassembly of section .text:
                	stp	x23, x24, [x29, #-0x60]
                	stp	x25, x26, [x29, #-0x70]
                	stp	x27, x28, [x29, #-0x80]
-               	mov	x19, x0
-               	mov	x20, x1
-               	mov	x21, x2
-               	mov	x22, x3
-               	mov	x23, x4
-               	mov	x24, x5
-               	mov	x25, x6
-               	mov	x26, x7
-               	ldr	x27, [x29, #0x10]
-               	ldr	x28, [x29, #0x18]
-               	ldr	x9, [x29, #0x20]
-               	stur	x9, [x29, #-0x8]
+               	mov	x19, x1
+               	mov	x20, x2
+               	mov	x21, x3
+               	mov	x22, x4
+               	mov	x23, x5
+               	mov	x24, x6
+               	mov	x25, x7
+               	ldr	x26, [x29, #0x10]
+               	ldr	x27, [x29, #0x18]
+               	ldr	x28, [x29, #0x20]
                	ldr	x9, [x29, #0x28]
-               	stur	x9, [x29, #-0x10]
+               	stur	x9, [x29, #-0x8]
                	ldr	x9, [x29, #0x30]
-               	stur	x9, [x29, #-0x18]
+               	stur	x9, [x29, #-0x10]
                	ldr	x9, [x29, #0x38]
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x18]
                	ldr	x9, [x29, #0x40]
-               	stur	x9, [x29, #-0x28]
+               	stur	x9, [x29, #-0x20]
                	ldr	x9, [x29, #0x48]
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x28]
+               	uxtb	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxtb	w1, w19
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	x1, w20
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	sxtb	x1, w21
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxth	w1, w22
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	uxth	w1, w23
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	sxth	x1, w24
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	sxth	x1, w25
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
+               	uxtb	w1, w26
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	sxtb	x1, w27
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x28
+               	uxth	w1, w28
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x8]
-               	mov	x1, x9
+               	sxth	x1, w9
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x10]
-               	mov	x1, x9
+               	uxtb	w1, w9
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x18]
-               	mov	x1, x9
+               	sxtb	x1, w9
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	uxth	w1, w9
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
                	ldur	x9, [x29, #-0x28]
-               	mov	x1, x9
+               	sxth	x1, w9
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
-<L16>:
-               	bl	 <L16>
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
                	ldp	x23, x24, [x29, #-0x60]
@@ -276,1016 +441,783 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x2b0
-               	sub	x16, x29, #0x270
+               	sub	sp, sp, #0x270
+               	sub	x16, x29, #0x1f0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	sub	x20, x29, #0xa0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xa0               // =160
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xa0               // =160
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x14
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x14
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            // =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x14
-               	b.lo	 <L2>
-<L3>:
-               	mov	x21, x0
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x14
+               	b.lo	 <L1>
+<L2>:
+               	mov	x9, #0x2325             // =8997
+               	movk	x9, #0x8422, lsl #16
+               	movk	x9, #0x9ce4, lsl #32
+               	movk	x9, #0xcbf2, lsl #48
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-               	b	 <L41>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L8>
+<L3>:
                	mov	x16, #0x7               // =7
                	mul	x0, x23, x16
                	add	x24, x0, x19
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w28, w1
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xc8]
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xd0]
-               	add	x0, x20, #0x30
-               	ldr	x1, [x0]
-               	add	x9, x1, x24
-               	stur	x9, [x29, #-0xd8]
-               	add	x0, x20, #0x38
-               	ldr	x9, [x0]
-               	stur	x9, [x29, #-0xe0]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xe8]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xf0]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xf8]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0x100]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	add	x9, x1, x24
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x9, [x0]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x25
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x26
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x27
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x28
-<L9>:
-               	bl	 <L9>
-               	ldur	x9, [x29, #-0xc8]
-               	mov	w1, w9
-<L10>:
-               	bl	 <L10>
-               	ldur	x9, [x29, #-0xd0]
-               	mov	w1, w9
-<L11>:
-               	bl	 <L11>
-               	ldur	x9, [x29, #-0xd8]
-               	mov	x1, x9
-<L12>:
-               	bl	 <L12>
-               	ldur	x9, [x29, #-0xe0]
-               	mov	x1, x9
-<L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0xe8]
-               	mov	x1, x9
-<L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0xf0]
-               	mov	x1, x9
-<L15>:
-               	bl	 <L15>
-               	ldur	x9, [x29, #-0xf8]
-               	mov	x1, x9
-<L16>:
-               	bl	 <L16>
-               	ldur	x9, [x29, #-0x100]
-               	mov	x1, x9
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x21
-<L22>:
-               	bl	 <L22>
-               	mov	x25, x0
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w28, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfed8            // =65240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfec8            // =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x30
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x38
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	add	x0, x1, x24
+               	add	x25, x20, #0x0
+               	ldr	x0, [x25]
                	mov	w9, w0
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe98            // =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x1, [x0]
-               	add	x0, x1, x24
-               	mov	w24, w0
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x26
-<L24>:
-               	bl	 <L24>
-               	mov	x1, x27
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x28
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfed8            // =65240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfec8            // =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe98            // =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L38>:
-               	bl	 <L38>
-               	mov	x1, x24
-<L39>:
-               	bl	 <L39>
-               	mov	x24, x0
-               	mov	x0, x25
-               	mov	x1, x24
-<L40>:
-               	bl	 <L40>
-               	add	x23, x23, #0x1
-               	mov	x21, x0
-               	mov	x22, x24
-               	cmp	x23, #0x3
-               	b.lo	 <L4>
-<L41>:
-               	add	x0, x20, #0x0
-               	ldr	x1, [x0]
-               	mov	w19, w1
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w23, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w24, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	add	x0, x20, #0x20
-               	ldr	x1, [x0]
-               	mov	w26, w1
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w27, w1
-               	add	x0, x20, #0x30
-               	ldr	x28, [x0]
-               	add	x0, x20, #0x38
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x9, [x0]
-               	mov	x16, #0xfe38            // =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	mov	x1, x19
-<L43>:
-               	bl	 <L43>
-               	mov	x1, x23
-<L44>:
-               	bl	 <L44>
-               	mov	x1, x24
-<L45>:
-               	bl	 <L45>
-               	mov	x1, x25
-<L46>:
-               	bl	 <L46>
-               	mov	w1, w26
-<L47>:
-               	bl	 <L47>
-               	mov	w1, w27
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x28
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe38            // =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L58>:
-               	bl	 <L58>
-               	mov	w19, w0
-               	add	x0, x20, #0x8
-               	ldr	x1, [x0]
-               	mov	w23, w1
-               	add	x0, x20, #0x10
-               	ldr	x1, [x0]
-               	mov	w24, w1
-               	add	x0, x20, #0x18
-               	ldr	x1, [x0]
-               	mov	w25, w1
-               	mov	w26, w22
-               	add	x0, x20, #0x28
-               	ldr	x1, [x0]
-               	mov	w22, w1
-               	add	x1, x20, #0x30
-               	ldr	x27, [x1]
-               	add	x2, x20, #0x38
-               	ldr	x28, [x2]
-               	add	x3, x20, #0x80
-               	ldr	x4, [x3]
-               	mov	w9, w4
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x4, x20, #0x88
-               	ldr	x5, [x4]
-               	mov	w9, w5
-               	mov	x16, #0xfe28            // =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x5, x20, #0x90
-               	ldr	x6, [x5]
-               	mov	w9, w6
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x6, x20, #0x98
-               	ldr	x7, [x6]
-               	mov	w9, w7
-               	mov	x16, #0xfe18            // =65048
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x7, x20, #0x20
-               	ldr	x8, [x7]
-               	mov	w9, w8
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x8, [x0]
-               	mov	w9, w8
-               	mov	x16, #0xfe08            // =65032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x0, [x1]
-               	mov	w9, w0
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x0, [x2]
-               	mov	w9, w0
-               	mov	x16, #0xfdf8            // =65016
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x40
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfde8            // =65000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdd8            // =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
                	stur	x9, [x29, #-0xa8]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xb0]
-               	add	x0, x20, #0x70
-               	ldr	x1, [x0]
-               	mov	w9, w1
+               	add	x26, x20, #0x8
+               	ldr	x0, [x26]
+               	mov	w9, w0
                	stur	x9, [x29, #-0xb8]
-               	add	x0, x20, #0x78
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xc0]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe30            // =65072
+               	add	x27, x20, #0x10
+               	ldr	x0, [x27]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xc8]
+               	add	x28, x20, #0x18
+               	ldr	x0, [x28]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xd8]
+               	add	x9, x20, #0x20
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe28            // =65064
+               	ldr	x0, [x9]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xe8]
+               	add	x9, x20, #0x28
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe20            // =65056
+               	ldr	x0, [x9]
+               	mov	w9, w0
+               	stur	x9, [x29, #-0xf8]
+               	add	x9, x20, #0x30
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe18            // =65048
+               	ldr	x0, [x9]
+               	add	x9, x0, x24
+               	mov	x16, #0xfef8            // =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x9, x20, #0x38
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe10            // =65040
+               	ldr	x15, [x9]
+               	add	x9, x20, #0x40
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe58            // =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xfe08            // =65032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdf8            // =65016
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfde8            // =65000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfdd8            // =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L71>:
-               	bl	 <L71>
-               	ldur	x9, [x29, #-0xa8]
-               	mov	x1, x9
-<L72>:
-               	bl	 <L72>
+               	ldr	x0, [x9]
+               	mov	w1, w0
+               	add	x9, x20, #0x48
+               	stur	x9, [x29, #-0xb0]
                	ldur	x9, [x29, #-0xb0]
-               	mov	x1, x9
-<L73>:
-               	bl	 <L73>
+               	ldr	x0, [x9]
+               	mov	w2, w0
+               	add	x9, x20, #0x50
+               	stur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xc0]
+               	ldr	x0, [x9]
+               	mov	w3, w0
+               	add	x9, x20, #0x58
+               	stur	x9, [x29, #-0xd0]
+               	ldur	x9, [x29, #-0xd0]
+               	ldr	x0, [x9]
+               	mov	w4, w0
+               	add	x9, x20, #0x60
+               	stur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0xe0]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	add	x9, x20, #0x68
+               	stur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf0]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	add	x9, x20, #0x70
+               	stur	x9, [x29, #-0x100]
+               	ldur	x9, [x29, #-0x100]
+               	ldr	x0, [x9]
+               	add	x7, x0, x24
+               	add	x9, x20, #0x78
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	str	x1, [sp]
+               	str	x2, [sp, #0x8]
+               	str	x3, [sp, #0x10]
+               	str	x4, [sp, #0x18]
+               	str	x5, [sp, #0x20]
+               	str	x6, [sp, #0x28]
+               	str	x7, [sp, #0x30]
+               	str	x0, [sp, #0x38]
+               	ldur	x9, [x29, #-0xa8]
+               	mov	x0, x9
                	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
-<L74>:
-               	bl	 <L74>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
-<L75>:
-               	bl	 <L75>
-               	mov	w9, w0
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdc8            // =64968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdb8            // =64952
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x60
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	mov	x16, #0xfda8            // =64936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x70
-               	ldr	x9, [x0]
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x20, #0x78
-               	ldr	x20, [x0]
-<L76>:
-               	bl	 <L76>
-               	mov	x1, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x1, x23
-<L78>:
-               	bl	 <L78>
-               	mov	x1, x24
-<L79>:
-               	bl	 <L79>
-               	mov	x1, x25
-<L80>:
-               	bl	 <L80>
-               	mov	w1, w26
-<L81>:
-               	bl	 <L81>
-               	mov	w1, w22
-<L82>:
-               	bl	 <L82>
-               	mov	x1, x27
-<L83>:
-               	bl	 <L83>
-               	mov	x1, x28
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdd0            // =64976
+               	ldur	x9, [x29, #-0xc8]
+               	mov	x2, x9
+               	ldur	x9, [x29, #-0xd8]
+               	mov	x3, x9
+               	ldur	x9, [x29, #-0xe8]
+               	mov	w4, w9
+               	ldur	x9, [x29, #-0xf8]
+               	mov	w5, w9
+               	mov	x16, #0xfef8            // =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfdc8            // =64968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfdb8            // =64952
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfda8            // =64936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L91>:
-               	bl	 <L91>
-               	mov	x1, x20
-<L92>:
-               	bl	 <L92>
+               	mov	x6, x9
+               	mov	x7, x15
+<L4>:
+               	bl	 <L4>
                	mov	x1, x0
-               	mov	x0, x21
-<L93>:
-               	bl	 <L93>
-               	sub	x16, x29, #0x270
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L5>:
+               	bl	 <L5>
+               	mov	x9, x0
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x25]
+               	mov	w1, w0
+               	ldr	x0, [x26]
+               	mov	w2, w0
+               	ldr	x0, [x27]
+               	mov	w3, w0
+               	ldr	x0, [x28]
+               	mov	w4, w0
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w7, w0
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w8, w0
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	add	x12, x0, x24
+               	mov	w0, w12
+               	ldur	x9, [x29, #-0xb0]
+               	ldr	x12, [x9]
+               	mov	w13, w12
+               	ldur	x9, [x29, #-0xc0]
+               	ldr	x12, [x9]
+               	mov	w14, w12
+               	ldur	x9, [x29, #-0xd0]
+               	ldr	x12, [x9]
+               	mov	w18, w12
+               	ldur	x9, [x29, #-0xe0]
+               	ldr	x12, [x9]
+               	mov	w25, w12
+               	ldur	x9, [x29, #-0xf0]
+               	ldr	x12, [x9]
+               	mov	w26, w12
+               	ldur	x9, [x29, #-0x100]
+               	ldr	x12, [x9]
+               	mov	w27, w12
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x12, [x9]
+               	add	x28, x12, x24
+               	mov	w12, w28
+               	str	x0, [sp]
+               	str	x13, [sp, #0x8]
+               	str	x14, [sp, #0x10]
+               	str	x18, [sp, #0x18]
+               	str	x25, [sp, #0x20]
+               	str	x26, [sp, #0x28]
+               	str	x27, [sp, #0x30]
+               	str	x12, [sp, #0x38]
+               	mov	x0, x1
+               	mov	x1, x2
+               	mov	x2, x3
+               	mov	x3, x4
+               	mov	x4, x5
+               	mov	x5, x6
+               	mov	x6, x7
+               	mov	x7, x8
+<L6>:
+               	bl	 <L6>
+               	mov	x22, x0
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x22
+<L7>:
+               	bl	 <L7>
+               	add	x23, x23, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x23, #0x3
+               	b.lo	 <L3>
+<L8>:
+               	add	x0, x20, #0x0
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x19, x20, #0x8
+               	ldr	x1, [x19]
+               	mov	w9, w1
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x23, x20, #0x10
+               	ldr	x1, [x23]
+               	mov	w9, w1
+               	mov	x16, #0xfec8            // =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x24, x20, #0x18
+               	ldr	x1, [x24]
+               	mov	w9, w1
+               	mov	x16, #0xfeb8            // =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x25, x20, #0x20
+               	ldr	x1, [x25]
+               	mov	w9, w1
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x26, x20, #0x28
+               	ldr	x1, [x26]
+               	mov	w6, w1
+               	add	x27, x20, #0x30
+               	ldr	x7, [x27]
+               	add	x28, x20, #0x38
+               	ldr	x8, [x28]
+               	add	x9, x20, #0x40
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w13, w1
+               	add	x9, x20, #0x48
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w15, w1
+               	add	x9, x20, #0x50
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w0, w1
+               	add	x9, x20, #0x58
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w2, w1
+               	add	x9, x20, #0x60
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w3, w1
+               	add	x9, x20, #0x68
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	w4, w1
+               	add	x9, x20, #0x70
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	add	x9, x20, #0x78
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9]
+               	str	x13, [sp]
+               	str	x15, [sp, #0x8]
+               	str	x0, [sp, #0x10]
+               	str	x2, [sp, #0x18]
+               	str	x3, [sp, #0x20]
+               	str	x4, [sp, #0x28]
+               	str	x1, [sp, #0x30]
+               	str	x5, [sp, #0x38]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x16, #0xfec8            // =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x2, x9
+               	mov	x16, #0xfeb8            // =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x3, x9
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w4, w9
+               	mov	w5, w6
+               	mov	x6, x7
+               	mov	x7, x8
+<L9>:
+               	bl	 <L9>
+               	mov	w9, w0
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x19]
+               	mov	w19, w0
+               	ldr	x0, [x23]
+               	mov	w23, w0
+               	ldr	x0, [x24]
+               	mov	w24, w0
+               	mov	w9, w22
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x26]
+               	mov	w22, w0
+               	ldr	x9, [x27]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x21, [x28]
+               	add	x0, x20, #0x80
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x1, x20, #0x88
+               	ldr	x2, [x1]
+               	mov	w9, w2
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x2, x20, #0x90
+               	ldr	x3, [x2]
+               	mov	w9, w3
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x3, x20, #0x98
+               	ldr	x4, [x3]
+               	mov	w3, w4
+               	ldr	x4, [x25]
+               	mov	w5, w4
+               	ldr	x4, [x26]
+               	mov	w6, w4
+               	ldr	x4, [x27]
+               	mov	w7, w4
+               	ldr	x4, [x28]
+               	mov	w20, w4
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w12, w4
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w25, w4
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w26, w4
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w27, w4
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w28, w4
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w0, w4
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w1, w4
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	w2, w4
+               	str	x12, [sp]
+               	str	x25, [sp, #0x8]
+               	str	x26, [sp, #0x10]
+               	str	x27, [sp, #0x18]
+               	str	x28, [sp, #0x20]
+               	str	x0, [sp, #0x28]
+               	str	x1, [sp, #0x30]
+               	str	x2, [sp, #0x38]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x2, x9
+               	mov	x4, x5
+               	mov	x5, x6
+               	mov	x6, x7
+               	mov	x7, x20
+<L10>:
+               	bl	 <L10>
+               	mov	w1, w0
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w2, w0
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w3, w0
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w4, w0
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w5, w0
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	w6, w0
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9]
+               	str	x1, [sp]
+               	str	x2, [sp, #0x8]
+               	str	x3, [sp, #0x10]
+               	str	x4, [sp, #0x18]
+               	str	x5, [sp, #0x20]
+               	str	x6, [sp, #0x28]
+               	str	x0, [sp, #0x30]
+               	str	x7, [sp, #0x38]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x1, x19
+               	mov	x2, x23
+               	mov	x3, x24
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w4, w9
+               	mov	w5, w22
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	mov	x7, x21
+<L11>:
+               	bl	 <L11>
+               	mov	x1, x0
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L12>:
+               	bl	 <L12>
+               	sub	x16, x29, #0x1f0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/call/call_mixed.dis
+++ b/test/golden/aarch64-linux/call/call_mixed.dis
@@ -44,263 +44,471 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.mixed>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xb0]
-               	stp	x21, x22, [x29, #-0xc0]
-               	stp	x23, x24, [x29, #-0xd0]
-               	stp	x25, x26, [x29, #-0xe0]
-               	stur	x27, [x29, #-0xe8]
-               	stp	d8, d9, [x29, #-0xf8]
-               	stp	d11, d12, [x29, #-0x108]
-               	stp	d13, d14, [x29, #-0x118]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d15, [x29, x16]
+               	sub	sp, sp, #0xe0
+               	stp	x19, x20, [x29, #-0x90]
+               	stp	x21, x22, [x29, #-0xa0]
+               	stp	x23, x24, [x29, #-0xb0]
+               	stp	d8, d9, [x29, #-0xc0]
+               	stp	d11, d13, [x29, #-0xd0]
+               	stp	d14, d15, [x29, #-0xe0]
                	mov	x19, x0
                	fmov	s8, s0
-               	mov	w20, w1
                	fmov	d9, d1
                	stur	q2, [x29, #-0x30]
-               	mov	x21, x2
                	fmov	s11, s3
-               	mov	x22, x3
                	stur	q4, [x29, #-0x40]
                	fmov	d13, d5
-               	mov	x23, x4
+               	mov	x20, x4
                	fmov	s14, s6
-               	mov	x24, x5
+               	mov	x21, x5
                	fmov	d15, d7
                	ldr	d31, [x29, #0x10]
                	stur	d31, [x29, #-0x50]
-               	mov	x25, x6
+               	mov	x22, x6
                	ldr	d31, [x29, #0x18]
                	stur	d31, [x29, #-0x60]
-               	mov	w26, w7
+               	mov	w23, w7
                	ldr	d31, [x29, #0x20]
                	stur	d31, [x29, #-0x70]
-               	ldr	x27, [x29, #0x28]
+               	ldr	x24, [x29, #0x28]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x19, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w4, s8
+               	mov	w5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	fmov	x1, d9
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x30]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31.s[0]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31.s[1]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s30, v31.s[0]
-               	stur	s30, [x29, #-0x80]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x80]
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s30, v31.s[1]
-               	stur	s30, [x29, #-0x90]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x90]
+               	ldur	q31, [x29, #-0x30]
+               	mov	s3, v31.s[2]
+               	fmov	w1, s3
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x40]
-               	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d13
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
+               	uxth	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d15
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x50]
-               	mov	s12, v31.s[0]
-               	mov	x0, x1
-               	fmov	s0, s12
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31.s[0]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x50]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
 <L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31.s[1]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
 <L22>:
-               	bl	 <L22>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0x60]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
 <L23>:
-               	bl	 <L23>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w26
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31.s[2]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
 <L24>:
-               	bl	 <L24>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	d0, [x29, #-0x70]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
 <L25>:
-               	bl	 <L25>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
+               	ldur	q31, [x29, #-0x40]
+               	mov	s3, v31.s[3]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	mov	x1, x0
-               	mul	x2, x23, x25
-               	add	x3, x19, x2
-               	sub	x2, x3, x27
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	mov	x1, x0
-               	fmul	s0, s11, s14
-               	fadd	s1, s8, s0
-               	ldur	s30, [x29, #-0x60]
-               	fsub	s0, s1, s30
-               	mov	x0, x1
+               	fmov	x1, d13
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	mov	x1, x0
-               	fmul	d0, d13, d15
-               	fadd	d1, d9, d0
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d1, d30
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	bl	 <L29>
-               	mov	x1, x0
-               	sub	x2, x29, #0xc
-               	add	x3, x2, #0x0
-               	ldur	s31, [x29, #-0x80]
-               	str	s31, [x3]
-               	add	x3, x2, #0x4
-               	ldur	s31, [x29, #-0x90]
-               	str	s31, [x3]
-               	add	x3, x2, #0x8
-               	str	s12, [x3]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x20, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	uxtb	w1, w21
+<L33>:
+               	bl	 <L33>
+               	fmov	x1, d15
+<L34>:
+               	bl	 <L34>
+               	ldur	q31, [x29, #-0x50]
+               	mov	s3, v31.s[0]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	ldur	q31, [x29, #-0x50]
+               	mov	s3, v31.s[1]
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	mov	x1, x22
+<L37>:
+               	bl	 <L37>
+               	ldur	w1, [x29, #-0x60]
+               	mov	w2, w1
+               	mov	x1, x2
+<L38>:
+               	bl	 <L38>
+               	sxtw	x1, w23
+<L39>:
+               	bl	 <L39>
+               	ldur	x1, [x29, #-0x70]
+<L40>:
+               	bl	 <L40>
+               	mov	x1, x24
+<L41>:
+               	bl	 <L41>
+               	mul	x1, x20, x22
+               	add	x2, x19, x1
+               	sub	x1, x2, x24
+<L42>:
+               	bl	 <L42>
+               	fmul	s3, s11, s14
+               	fadd	s4, s8, s3
+               	ldur	s30, [x29, #-0x60]
+               	fsub	s3, s4, s30
+               	fmov	w1, s3
+               	mov	w2, w1
+               	mov	x1, x2
+<L43>:
+               	bl	 <L43>
+               	fmul	d1, d13, d15
+               	fadd	d3, d9, d1
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d1, d3, d30
+               	fmov	x1, d1
+<L44>:
+               	bl	 <L44>
+               	sub	x1, x29, #0xc
+               	ldur	q31, [x29, #-0x40]
+               	mov	s1, v31.s[0]
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
+               	ldur	q31, [x29, #-0x40]
+               	mov	s1, v31.s[1]
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	ldur	q31, [x29, #-0x50]
+               	mov	s1, v31.s[0]
+               	add	x2, x1, #0x8
+               	str	s1, [x2]
                	stur	xzr, [x29, #-0x1c]
                	stur	xzr, [x29, #-0x14]
-               	ldr	x3, [x2]
-               	stur	x3, [x29, #-0x1c]
-               	ldr	w3, [x2, #0x8]
-               	stur	w3, [x29, #-0x14]
+               	ldr	x2, [x1]
+               	stur	x2, [x29, #-0x1c]
+               	ldr	w2, [x1, #0x8]
+               	stur	w2, [x29, #-0x14]
                	ldur	q0, [x29, #-0x1c]
                	ldur	q31, [x29, #-0x30]
                	fadd	v31.4s, v31.4s, v0.4s
-               	stur	q31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0xa0]
+               	stur	q31, [x29, #-0x80]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[0]
-               	mov	x0, x1
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0xa0]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[1]
-               	mov	x0, x1
-<L31>:
-               	bl	 <L31>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0xa0]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[2]
-               	mov	x0, x1
-<L32>:
-               	bl	 <L32>
-               	ldp	d8, d9, [x29, #-0xf8]
-               	ldp	d11, d12, [x29, #-0x108]
-               	ldp	d13, d14, [x29, #-0x118]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d15, [x29, x16]
-               	ldp	x19, x20, [x29, #-0xb0]
-               	ldp	x21, x22, [x29, #-0xc0]
-               	ldp	x23, x24, [x29, #-0xd0]
-               	ldp	x25, x26, [x29, #-0xe0]
-               	ldur	x27, [x29, #-0xe8]
+<L47>:
+               	bl	 <L47>
+               	ldp	d8, d9, [x29, #-0xc0]
+               	ldp	d11, d13, [x29, #-0xd0]
+               	ldp	d14, d15, [x29, #-0xe0]
+               	ldp	x19, x20, [x29, #-0x90]
+               	ldp	x21, x22, [x29, #-0xa0]
+               	ldp	x23, x24, [x29, #-0xb0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -320,51 +528,52 @@ Disassembly of section .text:
                	stp	d13, d14, [x16, #-0x10]
                	stur	d15, [x16, #-0x18]
                	mov	x19, x0
+               	sub	x20, x29, #0xd8
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xc0               // =192
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0xc0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xc0               // =192
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x18
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x18
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            // =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x18
-               	b.lo	 <L2>
-<L3>:
-               	mov	x21, x0
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x18
+               	b.lo	 <L1>
+<L2>:
+               	mov	x21, #0x2325            // =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-               	b	 <L12>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L11>
+<L3>:
                	mov	x16, #0xb               // =11
                	mul	x0, x23, x16
                	add	x24, x0, x19
-               	sub	x0, x29, #0xcc
+               	sub	x0, x29, #0xc
                	add	x1, x20, #0x80
                	ldr	x2, [x1]
                	mov	x16, #0xfff             // =4095
@@ -485,8 +694,8 @@ Disassembly of section .text:
                	ldr	x0, [x26]
                	add	x1, x0, x24
                	mov	x0, x1
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	add	x0, x25, #0x4
                	str	s0, [x0]
                	ldr	d31, [x25]
@@ -500,8 +709,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x1
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	fmov	s11, s0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
@@ -523,8 +732,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	x0, x1
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	fmov	s13, s0
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
@@ -551,8 +760,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L8>:
-               	bl	 <L8>
+<L7>:
+               	bl	 <L7>
                	fmov	s15, s0
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
@@ -589,8 +798,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	x0, x1
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -660,19 +869,19 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x6, x9
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L11>:
-               	bl	 <L11>
+<L10>:
+               	bl	 <L10>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L4>
-<L12>:
-               	sub	x0, x29, #0xd8
+               	b.lo	 <L3>
+<L11>:
+               	sub	x0, x29, #0x18
                	mov	x16, #0xfff             // =4095
                	and	x1, x22, x16
                	ucvtf	s0, x1
@@ -810,8 +1019,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L13>:
-               	bl	 <L13>
+<L12>:
+               	bl	 <L12>
                	add	x0, x19, #0x4
                	str	s0, [x0]
                	ldr	d31, [x19]
@@ -825,8 +1034,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x1
-<L14>:
-               	bl	 <L14>
+<L13>:
+               	bl	 <L13>
                	fmov	s11, s0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
@@ -848,8 +1057,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	x0, x1
-<L15>:
-               	bl	 <L15>
+<L14>:
+               	bl	 <L14>
                	fmov	s13, s0
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
@@ -871,8 +1080,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	x0, x1
-<L16>:
-               	bl	 <L16>
+<L15>:
+               	bl	 <L15>
                	fmov	s15, s0
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
@@ -899,8 +1108,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -954,14 +1163,14 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	d7, [x29, x16]
                	mov	x6, x28
-<L18>:
-               	bl	 <L18>
+<L17>:
+               	bl	 <L17>
                	mov	x19, x0
                	add	x0, x20, #0x18
                	ldr	x1, [x0]
                	mov	x0, x1
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	fmov	s11, s0
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
@@ -983,8 +1192,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
                	mov	x0, x1
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	fmov	s13, s0
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
@@ -1006,8 +1215,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x98
                	ldr	x1, [x0]
                	mov	x0, x1
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	fmov	s15, s0
                	add	x0, x20, #0xa8
                	ldr	x1, [x0]
@@ -1034,8 +1243,8 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	ldr	x1, [x0]
                	mov	x0, x1
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	mov	w7, w1
@@ -1087,12 +1296,12 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	d7, [x29, x16]
                	mov	x6, x28
-<L23>:
-               	bl	 <L23>
+<L22>:
+               	bl	 <L22>
                	mov	x1, x0
                	mov	x0, x21
-<L24>:
-               	bl	 <L24>
+<L23>:
+               	bl	 <L23>
                	sub	x16, x29, #0x240
                	ldp	d11, d12, [x16]
                	ldp	d13, d14, [x16, #-0x10]

--- a/test/golden/aarch64-linux/call/call_rec_edge.dis
+++ b/test/golden/aarch64-linux/call/call_rec_edge.dis
@@ -20,41 +20,66 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e9>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x3, x0
+               	sub	sp, sp, #0x20
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
-               	sub	x19, x29, #0x18
-               	sub	x1, x29, #0x10
-               	ldrb	w2, [x1]
-               	sub	x1, x29, #0xf
-               	ldr	x4, [x1]
-               	str	x4, [x19]
-               	mov	x0, x3
-               	mov	x1, x2
+               	sub	x1, x29, #0x18
+               	sub	x2, x29, #0x10
+               	ldrb	w3, [x2]
+               	sub	x2, x29, #0xf
+               	ldr	x4, [x2]
+               	str	x4, [x1]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x8
-               	b.lo	 <L1>
-               	b	 <L3>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, x21
-               	ldrb	w1, [x0]
-               	mov	x0, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L5>
 <L2>:
-               	bl	 <L2>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L1>
+               	add	x3, x1, x2
+               	ldrb	w4, [x3]
+               	uxtb	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -62,32 +87,72 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e12>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	w20, [x1]
-               	mov	x0, x3
+               	ldr	w4, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -95,25 +160,49 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x3, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -121,24 +210,51 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e16f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	d0, [x29, #-0x10]
                	stur	d1, [x29, #-0x8]
-               	sub	x2, x29, #0x10
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x10
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d1, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -146,25 +262,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e16m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	d8, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	d0, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -172,44 +313,68 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e17>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x2, x0
-               	sub	x19, x29, #0x11
+               	sub	sp, sp, #0x20
+               	sub	x2, x29, #0x11
                	ldr	x3, [x1]
                	ldr	x4, [x1, #0x8]
                	ldrb	w5, [x1, #0x10]
-               	str	x3, [x19]
-               	str	x4, [x19, #0x8]
-               	strb	w5, [x19, #0x10]
-               	add	x1, x19, #0x0
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	strb	w5, [x2, #0x10]
+               	add	x1, x2, #0x0
                	ldrb	w3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	uxtb	w1, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x10
-               	b.lo	 <L1>
-               	b	 <L3>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
+               	b	 <L5>
 <L2>:
-               	bl	 <L2>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L1>
+               	add	x3, x2, #0x1
+               	add	x4, x3, x1
+               	ldrb	w3, [x4]
+               	uxtb	w4, w3
+               	mov	x3, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -217,117 +382,129 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x9                // =9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xc                // =12
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x9               // =9
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               // =16
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               // =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x11               // =17
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x10              // =16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x10               // =16
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x10               // =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x11               // =17
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L9>:
                	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x4                // =4
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                // =8
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                // =8
 <L16>:
                	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L17>:
                	bl	 <L17>
+               	mov	x1, #0x8                // =8
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x8                // =8
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x1                // =1
+<L20>:
+               	bl	 <L20>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_edge.take_edge>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x260
-               	sub	x16, x29, #0x1f0
+               	sub	sp, sp, #0x290
+               	sub	x16, x29, #0x220
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x240
+               	sub	x16, x29, #0x270
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	stur	d12, [x16, #-0x18]
-               	mov	x19, x0
+               	mov	x8, x0
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
-               	mov	w20, w3
+               	mov	w19, w3
                	stur	x4, [x29, #-0x20]
                	stur	x5, [x29, #-0x18]
                	fmov	d8, d0
@@ -335,531 +512,413 @@ Disassembly of section .text:
                	stur	x7, [x29, #-0x28]
                	stur	d1, [x29, #-0x40]
                	stur	d2, [x29, #-0x38]
-               	add	x1, x29, #0x10
-               	ldr	x21, [x29, #0x20]
-               	ldr	x2, [x29, #0x28]
-               	add	x9, x29, #0x30
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x4, x29, #0x40
-               	add	x9, x29, #0x50
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x6, [x29, #0x60]
+               	add	x0, x29, #0x10
+               	ldr	x20, [x29, #0x20]
+               	ldr	x1, [x29, #0x28]
+               	add	x2, x29, #0x30
+               	add	x3, x29, #0x40
+               	add	x4, x29, #0x50
+               	ldr	x5, [x29, #0x60]
                	fmov	s9, s3
-               	ldr	x22, [x29, #0x68]
-               	sub	x23, x29, #0x48
-               	sub	x24, x29, #0x50
-               	sub	x25, x29, #0x58
-               	sub	x26, x29, #0x60
-               	sub	x27, x29, #0x68
-               	sub	x28, x29, #0x70
-               	sub	x7, x29, #0x10
-               	ldrb	w9, [x7]
-               	mov	x16, #0xfe70            // =65136
+               	ldr	x21, [x29, #0x68]
+               	sub	x22, x29, #0x49
+               	ldur	x6, [x29, #-0x10]
+               	ldurb	w7, [x29, #-0x8]
+               	str	x6, [x22]
+               	strb	w7, [x22, #0x8]
+               	sub	x23, x29, #0x58
+               	ldur	x6, [x29, #-0x20]
+               	ldur	w7, [x29, #-0x18]
+               	str	x6, [x23]
+               	str	w7, [x23, #0x8]
+               	sub	x24, x29, #0x68
+               	ldur	x6, [x29, #-0x30]
+               	ldur	x7, [x29, #-0x28]
+               	str	x6, [x24]
+               	str	x7, [x24, #0x8]
+               	sub	x6, x29, #0x40
+               	ldr	d10, [x6]
+               	sub	x6, x29, #0x38
+               	ldr	d11, [x6]
+               	add	x6, x0, #0x0
+               	ldr	x25, [x6]
+               	add	x6, x0, #0x8
+               	ldr	d12, [x6]
+               	sub	x26, x29, #0x79
+               	ldr	x0, [x1]
+               	ldr	x6, [x1, #0x8]
+               	ldrb	w7, [x1, #0x10]
+               	str	x0, [x26]
+               	str	x6, [x26, #0x8]
+               	strb	w7, [x26, #0x10]
+               	sub	x27, x29, #0x82
+               	ldr	x0, [x2]
+               	ldrb	w1, [x2, #0x8]
+               	str	x0, [x27]
+               	strb	w1, [x27, #0x8]
+               	sub	x28, x29, #0x90
+               	ldr	x0, [x3]
+               	ldr	w1, [x3, #0x8]
+               	str	x0, [x28]
+               	str	w1, [x28, #0x8]
+               	sub	x9, x29, #0xa0
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0xf
-               	ldr	x12, [x7]
-               	str	x12, [x23]
-               	sub	x7, x29, #0x20
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x1c
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x18
-               	ldr	w9, [x7]
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x30
-               	ldr	x9, [x7]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x28
-               	ldr	x9, [x7]
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x7, x29, #0x40
-               	ldr	d10, [x7]
-               	sub	x7, x29, #0x38
-               	ldr	d11, [x7]
-               	add	x7, x1, #0x0
-               	ldr	x9, [x7]
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x7, x1, #0x8
-               	ldr	d12, [x7]
-               	sub	x9, x29, #0x81
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x1, [x2]
-               	ldr	x5, [x2, #0x8]
-               	ldrb	w3, [x2, #0x10]
-               	mov	x16, #0xfe78            // =65144
+               	ldr	x0, [x4]
+               	ldr	x1, [x4, #0x8]
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfe78            // =65144
+               	str	x0, [x9]
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	str	x5, [x9, #0x8]
-               	mov	x16, #0xfe78            // =65144
+               	str	x1, [x9, #0x8]
+               	sub	x9, x29, #0xb1
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x5]
+               	ldr	x1, [x5, #0x8]
+               	ldrb	w2, [x5, #0x10]
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	strb	w3, [x9, #0x10]
-               	mov	x16, #0xfea8            // =65192
+               	str	x0, [x9]
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrb	w9, [x1]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfea8            // =65192
+               	str	x1, [x9, #0x8]
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1
-               	ldr	x3, [x1]
-               	str	x3, [x24]
-               	add	x1, x4, #0x0
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe38            // =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x1, x4, #0x4
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x1, x4, #0x8
-               	ldr	w9, [x1]
-               	mov	x16, #0xfe28            // =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	x9, [x1]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	x9, [x1]
-               	mov	x16, #0xfe98            // =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0x92
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldr	x1, [x6]
-               	ldr	x9, [x6, #0x8]
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldrb	w9, [x6, #0x10]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	str	x10, [x9, #0x8]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	strb	w10, [x9, #0x10]
+               	strb	w2, [x9, #0x10]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x8
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
-<L1>:
-               	bl	 <L1>
-               	ldr	x1, [x23]
-               	str	x1, [x25]
-               	ldr	x1, [x25]
-               	str	x1, [x27]
-               	mov	x16, #0xfe70            // =65136
+               	sub	x1, x29, #0x10c
+               	ldr	x2, [x22]
+               	ldrb	w5, [x22, #0x8]
+               	str	x2, [x1]
+               	strb	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	str	xzr, [x29, x16]
+               	ldrb	w5, [x1, #0x8]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w5, [x29, x16]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
+<L1>:
+               	bl	 <L1>
+               	mov	w1, w19
 <L2>:
                	bl	 <L2>
-               	mov	x19, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x8
-               	b.lo	 <L3>
-               	b	 <L5>
+               	sub	x1, x29, #0x124
+               	ldr	x2, [x23]
+               	ldr	w5, [x23, #0x8]
+               	str	x2, [x1]
+               	str	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	w5, [x1, #0x8]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w5, [x29, x16]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
 <L3>:
-               	add	x0, x27, x23
-               	ldrb	w1, [x0]
-               	mov	x0, x19
+               	bl	 <L3>
+               	fmov	x1, d8
 <L4>:
                	bl	 <L4>
-               	add	x23, x23, #0x1
-               	mov	x19, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L3>
+               	sub	x1, x29, #0x140
+               	ldr	x2, [x24]
+               	ldr	x5, [x24, #0x8]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x5, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x5
 <L5>:
-               	mov	x0, x19
-               	mov	w1, w20
+               	bl	 <L5>
+               	fmov	x1, d10
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fmov	x1, d11
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x5, x25, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x5, x16
+               	eor	x5, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	fmov	x1, d12
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x1, x20
+<L14>:
+               	bl	 <L14>
+               	sub	x1, x29, #0x151
+               	ldr	x2, [x26]
+               	ldr	x5, [x26, #0x8]
+               	ldrb	w6, [x26, #0x10]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	strb	w6, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x5, [x1, #0x8]
+               	ldrb	w6, [x1, #0x10]
+               	mov	x16, #0xfe97            // =65175
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe9f            // =65183
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	mov	x16, #0xfea7            // =65191
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w6, [x29, x16]
+               	sub	x1, x29, #0x169
+<L15>:
+               	bl	 <L15>
+               	sub	x1, x29, #0x172
+               	ldr	x2, [x27]
+               	ldrb	w5, [x27, #0x8]
+               	str	x2, [x1]
+               	strb	w5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldrb	w5, [x1, #0x8]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w5, [x29, x16]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
+<L16>:
+               	bl	 <L16>
+               	sub	x1, x29, #0x18c
+               	ldr	x2, [x28]
+               	ldr	w5, [x28, #0x8]
+               	str	x2, [x1]
+               	str	w5, [x1, #0x8]
+               	ldr	x2, [x1]
                	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfe60            // =65120
+               	str	xzr, [x29, x16]
+               	ldr	w5, [x1, #0x8]
+               	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfe58            // =65112
+               	str	w5, [x29, x16]
+               	mov	x16, #0xfe68            // =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L9>:
-               	bl	 <L9>
-               	fmov	d0, d8
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfe48            // =65096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L12>:
-               	bl	 <L12>
-               	fmov	d0, d10
-<L13>:
-               	bl	 <L13>
-               	fmov	d0, d11
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L15>:
-               	bl	 <L15>
-               	fmov	d0, d12
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x21
+               	ldr	x5, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x5
 <L17>:
                	bl	 <L17>
-               	sub	x1, x29, #0xe7
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x6, [x9]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x8, [x9, #0x8]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w12, [x9, #0x10]
-               	str	x6, [x1]
-               	str	x8, [x1, #0x8]
-               	strb	w12, [x1, #0x10]
-               	sub	x19, x29, #0xf8
-               	ldr	x6, [x1]
-               	ldr	x8, [x1, #0x8]
-               	ldrb	w12, [x1, #0x10]
-               	str	x6, [x19]
-               	str	x8, [x19, #0x8]
-               	strb	w12, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w6, [x1]
-               	mov	x1, x6
-<L18>:
-               	bl	 <L18>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x10
-               	b.lo	 <L19>
-               	b	 <L21>
-<L19>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w6, [x1]
-               	mov	x0, x20
-               	mov	x1, x6
-<L20>:
-               	bl	 <L20>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L19>
-<L21>:
-               	ldr	x0, [x24]
-               	str	x0, [x26]
-               	ldr	x0, [x26]
-               	str	x0, [x28]
-               	mov	x0, x20
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	mov	x19, x0
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x8
-               	b.lo	 <L23>
-               	b	 <L25>
-<L23>:
-               	add	x0, x28, x20
-               	ldrb	w1, [x0]
-               	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x8
-               	b.lo	 <L23>
-<L25>:
-               	mov	x0, x19
-               	mov	x16, #0xfe38            // =65080
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe28            // =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe98            // =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	sub	x1, x29, #0x109
-               	mov	x16, #0xfe90            // =65168
+               	sub	x1, x29, #0x1a8
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x2, [x9]
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9, #0x8]
+               	str	x2, [x1]
+               	str	x5, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L18>:
+               	bl	 <L18>
+               	sub	x1, x29, #0x1b9
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x2, [x9]
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x3, [x9, #0x8]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w4, [x9, #0x10]
-               	str	x2, [x1]
-               	str	x3, [x1, #0x8]
-               	strb	w4, [x1, #0x10]
-               	sub	x19, x29, #0x11a
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldrb	w4, [x1, #0x10]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	strb	w4, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x10
-               	b.lo	 <L32>
-               	b	 <L34>
-<L32>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L32>
-<L34>:
-               	mov	x0, x20
-               	fmov	s0, s9
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x22
-<L36>:
-               	bl	 <L36>
-               	sub	x1, x29, #0x12b
-               	sub	x2, x29, #0x13c
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x3, [x9]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x4, [x9, #0x8]
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldrb	w5, [x9, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	strb	w5, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldrb	w4, [x1, #0x10]
+               	mov	x16, #0xfe2f            // =65071
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe37            // =65079
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfe3f            // =65087
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w4, [x29, x16]
+               	sub	x1, x29, #0x1d1
+<L19>:
+               	bl	 <L19>
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x1, x21
+<L21>:
+               	bl	 <L21>
+               	sub	x1, x29, #0x1e2
+               	sub	x2, x29, #0x1f3
+               	ldr	x3, [x26]
+               	ldr	x4, [x26, #0x8]
+               	ldrb	w5, [x26, #0x10]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
                	strb	w5, [x2, #0x10]
@@ -875,9 +934,9 @@ Disassembly of section .text:
                	strb	w4, [x2]
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x10
-               	b.lo	 <L37>
-               	b	 <L38>
-<L37>:
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
                	add	x3, x1, #0x1
                	add	x4, x3, x2
                	ldrb	w3, [x4]
@@ -887,103 +946,49 @@ Disassembly of section .text:
                	strb	w3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x10
-               	b.lo	 <L37>
-<L38>:
-               	sub	x2, x29, #0xa3
+               	b.lo	 <L22>
+<L23>:
+               	sub	x2, x29, #0xc2
                	ldr	x3, [x1]
                	ldr	x4, [x1, #0x8]
                	ldrb	w5, [x1, #0x10]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
                	strb	w5, [x2, #0x10]
-               	sub	x19, x29, #0xb4
                	ldr	x1, [x2]
                	ldr	x3, [x2, #0x8]
                	ldrb	w4, [x2, #0x10]
-               	str	x1, [x19]
-               	str	x3, [x19, #0x8]
-               	strb	w4, [x19, #0x10]
-               	add	x1, x19, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x10
-               	b.lo	 <L40>
-               	b	 <L42>
-<L40>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L41>:
-               	bl	 <L41>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L40>
-<L42>:
-               	sub	x0, x29, #0xc5
-               	mov	x16, #0xfe78            // =65144
+               	stur	x1, [x29, #-0xda]
+               	stur	x3, [x29, #-0xd2]
+               	sturb	w4, [x29, #-0xca]
+               	sub	x1, x29, #0xda
+<L24>:
+               	bl	 <L24>
+               	sub	x1, x29, #0xeb
+               	ldr	x2, [x26]
+               	ldr	x3, [x26, #0x8]
+               	ldrb	w4, [x26, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	strb	w4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldrb	w4, [x1, #0x10]
+               	mov	x16, #0xfefd            // =65277
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x2, [x9, #0x8]
-               	mov	x16, #0xfe78            // =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldrb	w3, [x9, #0x10]
-               	str	x1, [x0]
-               	str	x2, [x0, #0x8]
-               	strb	w3, [x0, #0x10]
-               	sub	x19, x29, #0xd6
-               	ldr	x1, [x0]
-               	ldr	x2, [x0, #0x8]
-               	ldrb	w3, [x0, #0x10]
-               	str	x1, [x19]
-               	str	x2, [x19, #0x8]
-               	strb	w3, [x19, #0x10]
-               	add	x0, x19, #0x0
-               	ldrb	w1, [x0]
-               	mov	x0, x20
-<L43>:
-               	bl	 <L43>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x10
-               	b.lo	 <L44>
-               	b	 <L46>
-<L44>:
-               	add	x0, x19, #0x1
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L45>:
-               	bl	 <L45>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x10
-               	b.lo	 <L44>
-<L46>:
-               	mov	x0, x20
-               	sub	x16, x29, #0x240
+               	str	x2, [x29, x16]
+               	stur	x3, [x29, #-0xfb]
+               	sturb	w4, [x29, #-0xf3]
+               	sub	x1, x29, #0x103
+<L25>:
+               	bl	 <L25>
+               	sub	x16, x29, #0x270
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
                	ldur	d12, [x16, #-0x18]
-               	sub	x16, x29, #0x1f0
+               	sub	x16, x29, #0x220
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]
@@ -1191,51 +1196,95 @@ Disassembly of section .text:
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x9                // =9
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x9               // =9
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, #0xc                // =12
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, #0x10               // =16
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               // =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, #0x10               // =16
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x10              // =16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x11               // =17
+               	mov	x1, #0x10               // =16
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x10               // =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x11               // =17
 <L8>:
                	bl	 <L8>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L9>:
                	bl	 <L9>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x4                // =4
 <L10>:
                	bl	 <L10>
                	mov	x1, #0x8                // =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L13>:
                	bl	 <L13>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L14>:
                	bl	 <L14>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x1                // =1
 <L15>:
                	bl	 <L15>
                	mov	x1, #0x8                // =8
@@ -1244,24 +1293,30 @@ Disassembly of section .text:
                	mov	x1, #0x8                // =8
 <L17>:
                	bl	 <L17>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x8                // =8
 <L18>:
                	bl	 <L18>
-               	sub	x20, x29, #0x60
+               	mov	x1, #0x8                // =8
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x1                // =1
+<L20>:
+               	bl	 <L20>
+               	sub	x20, x29, #0x88
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               // =96
-<L19>:
+<L21>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L19>
+               	b.ne	 <L21>
                	mov	x1, #0x0                // =0
                	cmp	x1, #0xc
-               	b.lo	 <L20>
-               	b	 <L21>
-<L20>:
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1277,15 +1332,15 @@ Disassembly of section .text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L20>
-<L21>:
+               	b.lo	 <L22>
+<L23>:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L22>
-               	b	 <L33>
-<L22>:
+               	b.lo	 <L24>
+               	b	 <L35>
+<L24>:
                	mov	x16, #0x11              // =17
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -1294,7 +1349,7 @@ Disassembly of section .text:
                	add	x0, x2, x1
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
-               	sub	x2, x29, #0x69
+               	sub	x2, x29, #0x9
                	str	xzr, [x2]
                	strb	wzr, [x2, #0x8]
                	mov	w4, w3
@@ -1302,9 +1357,9 @@ Disassembly of section .text:
                	strb	w4, [x5]
                	mov	x4, #0x0                // =0
                	cmp	x4, #0x8
-               	b.lo	 <L23>
-               	b	 <L24>
-<L23>:
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
                	mov	x16, #0x8               // =8
                	mul	x5, x4, x16
                	lsr	x6, x3, x5
@@ -1316,9 +1371,9 @@ Disassembly of section .text:
                	strb	w7, [x6]
                	add	x4, x4, #0x1
                	cmp	x4, #0x8
-               	b.lo	 <L23>
-<L24>:
-               	sub	x3, x29, #0x72
+               	b.lo	 <L25>
+<L26>:
+               	sub	x3, x29, #0x12
                	ldr	x4, [x2]
                	ldrb	w5, [x2, #0x8]
                	str	x4, [x3]
@@ -1328,7 +1383,7 @@ Disassembly of section .text:
                	mov	w5, w4
                	add	x2, x20, #0x18
                	ldr	x4, [x2]
-               	sub	x2, x29, #0x90
+               	sub	x2, x29, #0x94
                	mov	w6, w4
                	add	x7, x2, #0x0
                	str	w6, [x7]
@@ -1405,9 +1460,9 @@ Disassembly of section .text:
                	strb	w14, [x13]
                	mov	x13, #0x0               // =0
                	cmp	x13, #0x10
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
                	mov	x16, #0x4               // =4
                	mul	x14, x13, x16
                	lsr	x15, x12, x14
@@ -1419,8 +1474,8 @@ Disassembly of section .text:
                	strb	w18, [x15]
                	add	x13, x13, #0x1
                	cmp	x13, #0x10
-               	b.lo	 <L25>
-<L26>:
+               	b.lo	 <L27>
+<L28>:
                	sub	x12, x29, #0x122
                	ldr	x13, [x7]
                	ldr	x14, [x7, #0x8]
@@ -1438,9 +1493,9 @@ Disassembly of section .text:
                	strb	w14, [x15]
                	mov	x14, #0x0               // =0
                	cmp	x14, #0x8
-               	b.lo	 <L27>
-               	b	 <L28>
-<L27>:
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
                	mov	x16, #0x8               // =8
                	mul	x15, x14, x16
                	lsr	x18, x13, x15
@@ -1452,8 +1507,8 @@ Disassembly of section .text:
                	strb	w24, [x18]
                	add	x14, x14, #0x1
                	cmp	x14, #0x8
-               	b.lo	 <L27>
-<L28>:
+               	b.lo	 <L29>
+<L30>:
                	sub	x13, x29, #0x156
                	ldr	x14, [x7]
                	ldrb	w15, [x7, #0x8]
@@ -1495,9 +1550,9 @@ Disassembly of section .text:
                	strb	w25, [x24]
                	mov	x24, #0x0               // =0
                	cmp	x24, #0x10
-               	b.lo	 <L29>
-               	b	 <L30>
-<L29>:
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
                	mov	x16, #0x4               // =4
                	mul	x25, x24, x16
                	lsr	x26, x18, x25
@@ -1509,8 +1564,8 @@ Disassembly of section .text:
                	strb	w27, [x26]
                	add	x24, x24, #0x1
                	cmp	x24, #0x10
-               	b.lo	 <L29>
-<L30>:
+               	b.lo	 <L31>
+<L32>:
                	sub	x18, x29, #0x1c2
                	ldr	x24, [x15]
                	ldr	x25, [x15, #0x8]
@@ -1628,19 +1683,19 @@ Disassembly of section .text:
                	mov	x5, x26
                	mov	x6, x27
                	mov	x7, x28
-<L31>:
-               	bl	 <L31>
+<L33>:
+               	bl	 <L33>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L32>:
-               	bl	 <L32>
+<L34>:
+               	bl	 <L34>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L22>
-<L33>:
-               	sub	x0, x29, #0x7b
+               	b.lo	 <L24>
+<L35>:
+               	sub	x0, x29, #0x1b
                	str	xzr, [x0]
                	strb	wzr, [x0, #0x8]
                	mov	w1, w22
@@ -1648,9 +1703,9 @@ Disassembly of section .text:
                	strb	w1, [x2]
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x8
-               	b.lo	 <L34>
-               	b	 <L35>
-<L34>:
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
                	mov	x16, #0x8               // =8
                	mul	x2, x1, x16
                	lsr	x3, x22, x2
@@ -1662,15 +1717,15 @@ Disassembly of section .text:
                	strb	w4, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L34>
-<L35>:
-               	sub	x1, x29, #0x84
+               	b.lo	 <L36>
+<L37>:
+               	sub	x1, x29, #0x24
                	ldr	x2, [x0]
                	ldrb	w3, [x0, #0x8]
                	str	x2, [x1]
                	strb	w3, [x1, #0x8]
                	mov	w3, w22
-               	sub	x0, x29, #0x9c
+               	sub	x0, x29, #0xa0
                	mov	w2, w22
                	add	x4, x0, #0x0
                	str	w2, [x4]
@@ -1736,9 +1791,9 @@ Disassembly of section .text:
                	strb	w12, [x8]
                	mov	x8, #0x0                // =0
                	cmp	x8, #0x10
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
                	mov	x16, #0x4               // =4
                	mul	x12, x8, x16
                	lsr	x13, x22, x12
@@ -1750,8 +1805,8 @@ Disassembly of section .text:
                	strb	w14, [x13]
                	add	x8, x8, #0x1
                	cmp	x8, #0x10
-               	b.lo	 <L36>
-<L37>:
+               	b.lo	 <L38>
+<L39>:
                	sub	x8, x29, #0x144
                	ldr	x12, [x6]
                	ldr	x13, [x6, #0x8]
@@ -1769,9 +1824,9 @@ Disassembly of section .text:
                	strb	w13, [x14]
                	mov	x13, #0x0               // =0
                	cmp	x13, #0x8
-               	b.lo	 <L38>
-               	b	 <L39>
-<L38>:
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
                	mov	x16, #0x8               // =8
                	mul	x14, x13, x16
                	lsr	x15, x12, x14
@@ -1783,8 +1838,8 @@ Disassembly of section .text:
                	strb	w18, [x15]
                	add	x13, x13, #0x1
                	cmp	x13, #0x8
-               	b.lo	 <L38>
-<L39>:
+               	b.lo	 <L40>
+<L41>:
                	sub	x12, x29, #0x168
                	ldr	x13, [x6]
                	ldrb	w14, [x6, #0x8]
@@ -1826,9 +1881,9 @@ Disassembly of section .text:
                	strb	w19, [x18]
                	mov	x18, #0x0               // =0
                	cmp	x18, #0x10
-               	b.lo	 <L40>
-               	b	 <L41>
-<L40>:
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
                	mov	x16, #0x4               // =4
                	mul	x19, x18, x16
                	lsr	x23, x15, x19
@@ -1840,8 +1895,8 @@ Disassembly of section .text:
                	strb	w24, [x23]
                	add	x18, x18, #0x1
                	cmp	x18, #0x10
-               	b.lo	 <L40>
-<L41>:
+               	b.lo	 <L42>
+<L43>:
                	sub	x15, x29, #0x22a
                	ldr	x18, [x14]
                	ldr	x19, [x14, #0x8]
@@ -1959,12 +2014,12 @@ Disassembly of section .text:
                	mov	x5, x23
                	mov	x6, x24
                	mov	x7, x25
-<L42>:
-               	bl	 <L42>
+<L44>:
+               	bl	 <L44>
                	mov	x1, x0
                	mov	x0, x21
-<L43>:
-               	bl	 <L43>
+<L45>:
+               	bl	 <L45>
                	sub	x16, x29, #0x280
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]

--- a/test/golden/aarch64-linux/call/call_rec_large.dis
+++ b/test/golden/aarch64-linux/call/call_rec_large.dis
@@ -18,187 +18,369 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	d8, d9, [x29, #-0x30]
-               	mov	x1, x0
+               	sub	sp, sp, #0x20
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	sub	x2, x29, #0x18
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	ldr	d8, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d9, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x18
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x10
+               	ldr	d1, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d2, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	d8, d9, [x29, #-0x30]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	fmov	x1, d2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24m>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	d8, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	d8, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x14
-               	ldr	w20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	d0, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w4, [x2]
+               	add	x2, x1, #0x14
+               	ldr	w1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	fmov	x2, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldur	d8, [x29, #-0x18]
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w2, w4
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x5, [x2]
+               	add	x2, x1, #0x18
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x5, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l32n>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	add	x4, x3, #0x0
-               	ldr	x5, [x4]
-               	add	x4, x3, #0x8
-               	ldr	x19, [x4]
+               	sub	sp, sp, #0x10
+               	stur	x19, [x29, #-0x8]
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldr	x4, [x3]
+               	add	x3, x2, #0x8
+               	ldr	x2, [x3]
                	add	x3, x1, #0x10
                	add	x1, x3, #0x0
-               	ldr	x20, [x1]
+               	ldr	x5, [x1]
                	add	x1, x3, #0x8
-               	ldr	x21, [x1]
-               	mov	x0, x2
-               	mov	x1, x5
+               	ldr	x19, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
+               	mov	x1, x5
+<L4>:
+               	bl	 <L4>
+               	mov	x1, x19
+<L5>:
+               	bl	 <L5>
+               	ldur	x19, [x29, #-0x8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -285,33 +467,21 @@ Disassembly of section .text:
                	mov	x1, x4
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	w1, w19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	w1, w20
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x21
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x22
 <L6>:
                	bl	 <L6>
@@ -416,33 +586,41 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.take_large>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1a0
-               	stp	x19, x20, [x29, #-0x120]
-               	stp	x21, x22, [x29, #-0x130]
-               	stp	x23, x24, [x29, #-0x140]
-               	stp	x25, x26, [x29, #-0x150]
-               	stp	x27, x28, [x29, #-0x160]
-               	stp	d8, d9, [x29, #-0x170]
-               	stp	d10, d11, [x29, #-0x180]
-               	stp	d12, d13, [x29, #-0x190]
-               	stp	d14, d15, [x29, #-0x1a0]
-               	mov	x19, x0
+               	sub	sp, sp, #0x320
+               	sub	x16, x29, #0x2a0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x2f0
+               	stp	d8, d9, [x16]
+               	stp	d10, d11, [x16, #-0x10]
+               	stp	d12, d13, [x16, #-0x20]
+               	stp	d14, d15, [x16, #-0x30]
+               	mov	x9, x0
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	mov	w20, w3
+               	mov	w19, w3
                	fmov	d8, d3
-               	ldr	x3, [x29, #0x10]
-               	ldr	x8, [x29, #0x18]
+               	ldr	x0, [x29, #0x10]
+               	ldr	x3, [x29, #0x18]
                	ldr	x12, [x29, #0x20]
                	fmov	s9, s4
-               	ldr	x21, [x29, #0x28]
-               	add	x13, x1, #0x0
-               	ldr	x22, [x13]
-               	add	x13, x1, #0x8
-               	ldr	x23, [x13]
-               	add	x13, x1, #0x10
-               	ldr	x24, [x13]
+               	ldr	x20, [x29, #0x28]
+               	sub	x21, x29, #0x30
+               	ldr	x13, [x1]
+               	ldr	x14, [x1, #0x8]
+               	ldr	x15, [x1, #0x10]
+               	str	x13, [x21]
+               	str	x14, [x21, #0x8]
+               	str	x15, [x21, #0x10]
                	sub	x1, x29, #0x18
                	ldr	d10, [x1]
                	sub	x1, x29, #0x10
@@ -450,372 +628,1021 @@ Disassembly of section .text:
                	sub	x1, x29, #0x8
                	ldr	d12, [x1]
                	add	x1, x2, #0x0
-               	ldr	x25, [x1]
+               	ldr	x22, [x1]
                	add	x1, x2, #0x8
                	ldr	d13, [x1]
                	add	x1, x2, #0x10
-               	ldr	w26, [x1]
+               	ldr	w23, [x1]
                	add	x1, x2, #0x14
-               	ldr	w27, [x1]
-               	add	x1, x4, #0x0
-               	ldr	x28, [x1]
-               	add	x1, x4, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb8]
-               	add	x1, x4, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc0]
-               	add	x1, x4, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc8]
+               	ldr	w24, [x1]
+               	sub	x25, x29, #0x50
+               	ldr	x1, [x4]
+               	ldr	x2, [x4, #0x8]
+               	ldr	x13, [x4, #0x10]
+               	ldr	x14, [x4, #0x18]
+               	str	x1, [x25]
+               	str	x2, [x25, #0x8]
+               	str	x13, [x25, #0x10]
+               	str	x14, [x25, #0x18]
                	add	x1, x5, #0x0
-               	add	x14, x1, #0x0
-               	ldr	x9, [x14]
-               	stur	x9, [x29, #-0x100]
-               	add	x14, x1, #0x8
-               	ldr	x9, [x14]
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	add	x2, x1, #0x0
+               	ldr	x26, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x27, [x2]
                	add	x1, x5, #0x10
-               	add	x5, x1, #0x0
-               	ldr	x9, [x5]
-               	mov	x16, #0xfef0            // =65264
+               	add	x2, x1, #0x0
+               	ldr	x28, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x9, [x2]
+               	mov	x16, #0xfd78            // =64888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	add	x5, x1, #0x8
-               	ldr	x9, [x5]
-               	stur	x9, [x29, #-0x20]
                	add	x1, x6, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd0]
+               	mov	x16, #0xfdc8            // =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x28]
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x30]
+               	mov	x16, #0xfdb8            // =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x38]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x40]
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x6, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x48]
+               	mov	x16, #0xfd98            // =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x8
                	ldr	d14, [x1]
                	add	x1, x7, #0x10
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x50]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x14
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x58]
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x18
                	ldr	d15, [x1]
                	add	x1, x7, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x60]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x1, x7, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe0]
-               	add	x1, x3, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x68]
-               	add	x1, x3, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x70]
-               	add	x1, x3, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe8]
-               	add	x1, x8, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x78]
-               	add	x1, x8, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x80]
-               	add	x1, x8, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x88]
-               	add	x1, x8, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf0]
-               	add	x1, x12, #0x0
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x90]
-               	add	x1, x12, #0x8
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x98]
-               	add	x1, x12, #0x10
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa0]
-               	add	x1, x12, #0x18
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa8]
-               	add	x1, x12, #0x20
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb0]
-               	add	x1, x12, #0x28
-               	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf8]
+               	mov	x16, #0xfd90            // =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x9, x29, #0x68
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x1, [x0]
+               	ldr	x8, [x0, #0x8]
+               	ldr	x9, [x0, #0x10]
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x1, [x9]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x8, [x9, #0x8]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x10]
+               	sub	x9, x29, #0x88
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x0, [x3]
+               	ldr	x1, [x3, #0x8]
+               	ldr	x9, [x3, #0x10]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x9, [x3, #0x18]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x1, [x9, #0x8]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x10]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x18]
+               	add	x0, x12, #0x0
+               	ldr	x9, [x0]
+               	mov	x16, #0xfd88            // =64904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x8
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x10
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x18
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x20
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x12, #0x28
+               	ldr	x9, [x0]
+               	mov	x16, #0xfd80            // =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x9, x0
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	sub	x1, x29, #0xa0
+               	ldr	x0, [x21]
+               	ldr	x9, [x21, #0x8]
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	x9, [x21, #0x10]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	str	x0, [x1]
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x1, #0x8]
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x1, #0x10]
+               	ldr	x0, [x1]
+               	ldr	x21, [x1, #0x8]
+               	ldr	x9, [x1, #0x10]
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	stur	x0, [x29, #-0xb8]
+               	stur	x21, [x29, #-0xb0]
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	stur	x9, [x29, #-0xa8]
+               	sub	x1, x29, #0xb8
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
 <L1>:
                	bl	 <L1>
-               	mov	x1, x22
+               	fmov	x9, d10
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x1, x21, x16
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x0, x16
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x0, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x24
+               	fmov	x9, d11
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fmov	d0, d10
+               	mov	x16, #0x8               // =8
+               	mul	x0, x21, x16
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              // =255
+               	and	x0, x1, x16
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	fmov	d0, d11
+               	fmov	x9, d12
+               	mov	x16, #0xfdf0            // =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfdf8            // =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfde8            // =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	fmov	d0, d12
+               	mov	x16, #0x8               // =8
+               	mul	x0, x21, x16
+               	mov	x16, #0xfdf0            // =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              // =255
+               	and	x0, x1, x16
+               	mov	x16, #0xfde8            // =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x21, x21, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xfde8            // =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x21, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	mov	x16, #0xfde8            // =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	fmov	d0, d13
+               	mov	x16, #0x8               // =8
+               	mul	x21, x1, x16
+               	lsr	x0, x22, x21
+               	mov	x16, #0xff              // =255
+               	and	x21, x0, x16
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x21
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x0, x16
+               	add	x1, x1, #0x1
+               	mov	x9, x21
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	w1, w26
+               	fmov	x9, d13
+               	mov	x16, #0xfdd8            // =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w1, w27
+               	mov	x16, #0x8               // =8
+               	mul	x22, x21, x16
+               	mov	x16, #0xfdd8            // =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x22
+               	mov	x16, #0xff              // =255
+               	and	x22, x0, x16
+               	eor	x0, x1, x22
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x0, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w1, w20
+               	mov	w0, w23
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x28
+               	mov	x16, #0x8               // =8
+               	mul	x22, x21, x16
+               	lsr	x23, x0, x22
+               	mov	x16, #0xff              // =255
+               	and	x22, x23, x16
+               	eor	x23, x1, x22
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x23, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0xb8]
-               	mov	x1, x9
+               	mov	w0, w24
+               	mov	x21, #0x0               // =0
+               	cmp	x21, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x22, x21, x16
+               	lsr	x23, x0, x22
+               	mov	x16, #0xff              // =255
+               	and	x22, x23, x16
+               	eor	x23, x1, x22
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x23, x16
+               	add	x21, x21, #0x1
+               	cmp	x21, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldur	x9, [x29, #-0xc8]
-               	mov	x1, x9
+               	mov	w21, w19
+               	mov	x0, x1
+               	mov	x1, x21
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x100]
-               	mov	x1, x9
+               	sub	x1, x29, #0xd8
+               	ldr	x19, [x25]
+               	ldr	x21, [x25, #0x8]
+               	ldr	x22, [x25, #0x10]
+               	ldr	x23, [x25, #0x18]
+               	str	x19, [x1]
+               	str	x21, [x1, #0x8]
+               	str	x22, [x1, #0x10]
+               	str	x23, [x1, #0x18]
+               	ldr	x19, [x1]
+               	ldr	x21, [x1, #0x8]
+               	ldr	x22, [x1, #0x10]
+               	ldr	x23, [x1, #0x18]
+               	stur	x19, [x29, #-0xf8]
+               	stur	x21, [x29, #-0xf0]
+               	stur	x22, [x29, #-0xe8]
+               	stur	x23, [x29, #-0xe0]
+               	sub	x1, x29, #0xf8
 <L17>:
                	bl	 <L17>
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x19, x1, x16
+               	lsr	x21, x26, x19
+               	mov	x16, #0xff              // =255
+               	and	x19, x21, x16
+               	eor	x21, x0, x19
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x21, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x20]
-               	mov	x1, x9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x19, x1, x16
+               	lsr	x21, x27, x19
+               	mov	x16, #0xff              // =255
+               	and	x19, x21, x16
+               	eor	x21, x0, x19
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x21, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
 <L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0xd0]
-               	mov	x1, x9
+               	mov	x1, x28
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0x28]
+               	mov	x16, #0xfd78            // =64888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0x30]
-               	mov	x1, x9
+               	fmov	x1, d8
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0x38]
+               	mov	x16, #0xfdc8            // =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0x40]
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfdb8            // =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0x48]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L28>:
                	bl	 <L28>
-               	fmov	d0, d14
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L29>:
                	bl	 <L29>
-               	ldur	x9, [x29, #-0x50]
-               	mov	w1, w9
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L30>:
                	bl	 <L30>
-               	ldur	x9, [x29, #-0x58]
-               	mov	w1, w9
+               	mov	x16, #0xfd98            // =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L31>:
                	bl	 <L31>
-               	fmov	d0, d15
+               	fmov	x1, d14
 <L32>:
                	bl	 <L32>
-               	ldur	x9, [x29, #-0x60]
-               	mov	x1, x9
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w1, w9
 <L33>:
                	bl	 <L33>
-               	ldur	x9, [x29, #-0xe0]
-               	mov	x1, x9
+               	mov	x16, #0xfe88            // =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w1, w9
 <L34>:
                	bl	 <L34>
-               	ldur	x9, [x29, #-0x68]
-               	mov	x1, x9
+               	fmov	x1, d15
 <L35>:
                	bl	 <L35>
-               	ldur	x9, [x29, #-0x70]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	ldur	x9, [x29, #-0xe8]
+               	mov	x16, #0xfd90            // =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L37>:
                	bl	 <L37>
-               	ldur	x9, [x29, #-0x78]
-               	mov	x1, x9
+               	sub	x1, x29, #0x110
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9, #0x8]
+               	mov	x16, #0xfe78            // =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x18, [x9, #0x10]
+               	str	x4, [x1]
+               	str	x7, [x1, #0x8]
+               	str	x18, [x1, #0x10]
+               	ldr	x4, [x1]
+               	ldr	x7, [x1, #0x8]
+               	ldr	x18, [x1, #0x10]
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x7, [x29, x16]
+               	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x18, [x29, x16]
+               	sub	x1, x29, #0x128
 <L38>:
                	bl	 <L38>
-               	ldur	x9, [x29, #-0x80]
-               	mov	x1, x9
+               	sub	x1, x29, #0x148
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x7, [x9, #0x8]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x18, [x9, #0x10]
+               	mov	x16, #0xfdd0            // =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x19, [x9, #0x18]
+               	str	x4, [x1]
+               	str	x7, [x1, #0x8]
+               	str	x18, [x1, #0x10]
+               	str	x19, [x1, #0x18]
+               	ldr	x4, [x1]
+               	ldr	x7, [x1, #0x8]
+               	ldr	x8, [x1, #0x10]
+               	ldr	x18, [x1, #0x18]
+               	mov	x16, #0xfe98            // =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x7, [x29, x16]
+               	mov	x16, #0xfea8            // =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x18, [x29, x16]
+               	sub	x1, x29, #0x168
 <L39>:
                	bl	 <L39>
-               	ldur	x9, [x29, #-0x88]
+               	mov	x16, #0xfd88            // =64904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0xf0]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x90]
+               	mov	x16, #0xfe48            // =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0x98]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L43>:
                	bl	 <L43>
-               	ldur	x9, [x29, #-0xa0]
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L44>:
                	bl	 <L44>
-               	ldur	x9, [x29, #-0xa8]
+               	mov	x16, #0xfd80            // =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L45>:
                	bl	 <L45>
-               	ldur	x9, [x29, #-0xb0]
-               	mov	x1, x9
+               	fmov	w1, s9
+               	mov	w3, w1
+               	mov	x1, x3
 <L46>:
                	bl	 <L46>
-               	ldur	x9, [x29, #-0xf8]
-               	mov	x1, x9
+               	mov	x1, x20
 <L47>:
                	bl	 <L47>
-               	fmov	s0, s9
-<L48>:
-               	bl	 <L48>
-               	mov	x1, x21
-<L49>:
-               	bl	 <L49>
-               	ldur	x9, [x29, #-0xd0]
+               	mov	x16, #0xfdc8            // =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1
-               	ldur	x9, [x29, #-0xd8]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	eor	x19, x9, x16
+<L48>:
+               	bl	 <L48>
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L49>:
+               	bl	 <L49>
+               	mov	x16, #0xfdb8            // =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L50>:
                	bl	 <L50>
-               	ldur	x9, [x29, #-0x28]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L51>:
                	bl	 <L51>
-               	ldur	x9, [x29, #-0x30]
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L52>:
                	bl	 <L52>
-               	ldur	x9, [x29, #-0x38]
-               	mov	x1, x9
+               	mov	x1, x19
 <L53>:
                	bl	 <L53>
-               	ldur	x9, [x29, #-0x40]
+               	mov	x16, #0xfdc8            // =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L54>:
                	bl	 <L54>
-               	mov	x1, x19
+               	mov	x16, #0xfdc0            // =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L55>:
                	bl	 <L55>
-               	ldur	x9, [x29, #-0xd0]
+               	mov	x16, #0xfdb8            // =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	ldur	x9, [x29, #-0x28]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L57>:
                	bl	 <L57>
-               	ldur	x9, [x29, #-0x30]
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L58>:
                	bl	 <L58>
-               	ldur	x9, [x29, #-0x38]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L59>:
                	bl	 <L59>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
-<L60>:
-               	bl	 <L60>
-               	ldur	x9, [x29, #-0xd8]
-               	mov	x1, x9
-<L61>:
-               	bl	 <L61>
-               	ldp	d8, d9, [x29, #-0x170]
-               	ldp	d10, d11, [x29, #-0x180]
-               	ldp	d12, d13, [x29, #-0x190]
-               	ldp	d14, d15, [x29, #-0x1a0]
-               	ldp	x19, x20, [x29, #-0x120]
-               	ldp	x21, x22, [x29, #-0x130]
-               	ldp	x23, x24, [x29, #-0x140]
-               	ldp	x25, x26, [x29, #-0x150]
-               	ldp	x27, x28, [x29, #-0x160]
+               	sub	x16, x29, #0x2f0
+               	ldp	d8, d9, [x16]
+               	ldp	d10, d11, [x16, #-0x10]
+               	ldp	d12, d13, [x16, #-0x20]
+               	ldp	d14, d15, [x16, #-0x30]
+               	sub	x16, x29, #0x2a0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -1091,6 +1918,11 @@ Disassembly of section .text:
                	sub	x16, x29, #0x640
                	str	d8, [x16, #0x8]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x18               // =24
 <L0>:
                	bl	 <L0>
                	mov	x1, #0x18               // =24
@@ -1099,19 +1931,19 @@ Disassembly of section .text:
                	mov	x1, #0x18               // =24
 <L2>:
                	bl	 <L2>
-               	mov	x1, #0x18               // =24
+               	mov	x1, #0x20               // =32
 <L3>:
                	bl	 <L3>
                	mov	x1, #0x20               // =32
 <L4>:
                	bl	 <L4>
-               	mov	x1, #0x20               // =32
+               	mov	x1, #0x30               // =48
 <L5>:
                	bl	 <L5>
                	mov	x1, #0x30               // =48
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x30               // =48
+               	mov	x1, #0x8                // =8
 <L7>:
                	bl	 <L7>
                	mov	x1, #0x8                // =8
@@ -1120,45 +1952,42 @@ Disassembly of section .text:
                	mov	x1, #0x8                // =8
 <L9>:
                	bl	 <L9>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x10               // =16
 <L10>:
                	bl	 <L10>
                	mov	x1, #0x10               // =16
 <L11>:
                	bl	 <L11>
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x14               // =20
 <L12>:
                	bl	 <L12>
-               	mov	x1, #0x14               // =20
+               	mov	x1, #0x10               // =16
 <L13>:
                	bl	 <L13>
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x28               // =40
 <L14>:
                	bl	 <L14>
-               	mov	x1, #0x28               // =40
+               	mov	x1, #0x18               // =24
 <L15>:
                	bl	 <L15>
-               	mov	x1, #0x18               // =24
+               	mov	x1, #0x28               // =40
 <L16>:
                	bl	 <L16>
-               	mov	x1, #0x28               // =40
-<L17>:
-               	bl	 <L17>
-               	sub	x20, x29, #0x60
+               	sub	x20, x29, #0x90
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               // =96
-<L18>:
+<L17>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L18>
+               	b.ne	 <L17>
                	mov	x1, #0x0                // =0
                	cmp	x1, #0xc
-               	b.lo	 <L19>
-               	b	 <L20>
-<L19>:
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -1174,15 +2003,15 @@ Disassembly of section .text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L19>
-<L20>:
+               	b.lo	 <L18>
+<L19>:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L21>
-               	b	 <L25>
-<L21>:
+               	b.lo	 <L20>
+               	b	 <L24>
+<L20>:
                	mov	x16, #0x13              // =19
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -1191,7 +2020,7 @@ Disassembly of section .text:
                	add	x24, x2, x1
                	add	x0, x20, #0x8
                	ldr	x2, [x0]
-               	sub	x25, x29, #0x78
+               	sub	x25, x29, #0x18
                	add	x0, x25, #0x0
                	str	x2, [x0]
                	mov	x16, #0x3               // =3
@@ -1414,8 +2243,8 @@ Disassembly of section .text:
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	mov	x0, x2
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1840,19 +2669,19 @@ Disassembly of section .text:
                	fmov	d3, d8
                	mov	x6, x15
                	mov	x7, x18
-<L23>:
-               	bl	 <L23>
+<L22>:
+               	bl	 <L22>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L24>:
-               	bl	 <L24>
+<L23>:
+               	bl	 <L23>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L21>
-<L25>:
-               	sub	x19, x29, #0x90
+               	b.lo	 <L20>
+<L24>:
+               	sub	x19, x29, #0x30
                	add	x0, x19, #0x0
                	str	x22, [x0]
                	mov	x16, #0x3               // =3
@@ -1983,8 +2812,8 @@ Disassembly of section .text:
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	mov	x0, x22
-<L26>:
-               	bl	 <L26>
+<L25>:
+               	bl	 <L25>
                	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -2339,12 +3168,12 @@ Disassembly of section .text:
                	fmov	d3, d8
                	mov	x6, x12
                	mov	x7, x13
-<L27>:
-               	bl	 <L27>
+<L26>:
+               	bl	 <L26>
                	mov	x1, x0
                	mov	x0, x21
-<L28>:
-               	bl	 <L28>
+<L27>:
+               	bl	 <L27>
                	sub	x16, x29, #0x640
                	ldr	d8, [x16, #0x8]
                	sub	x16, x29, #0x5f0

--- a/test/golden/aarch64-linux/call/call_rec_small.dis
+++ b/test/golden/aarch64-linux/call/call_rec_small.dis
@@ -21,14 +21,28 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x2, x0
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -36,24 +50,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r2>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
+               	ldrb	w2, [x1]
                	sub	x1, x29, #0x7
-               	ldrb	w19, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrb	w3, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -61,31 +101,71 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r4>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldrb	w3, [x1]
+               	ldrb	w2, [x1]
                	sub	x1, x29, #0x7
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x6
-               	ldrh	w20, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
+               	ldrh	w4, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxth	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -93,31 +173,71 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldr	w3, [x1]
+               	ldr	w2, [x1]
                	sub	x1, x29, #0x4
-               	ldrh	w19, [x1]
+               	ldrh	w3, [x1]
                	sub	x1, x29, #0x2
-               	ldrb	w20, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
+               	ldrb	w4, [x1]
+               	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxth	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxtb	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -125,266 +245,358 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                // =2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               // =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               // =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                // =2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x8               // =8
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                // =2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x6                // =6
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               // =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x1, #0x4                // =4
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x1                // =1
+<L15>:
+               	bl	 <L15>
+               	mov	x1, #0x1                // =1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, #0x2                // =2
+<L17>:
+               	bl	 <L17>
+               	mov	x1, #0x4                // =4
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x6                // =6
+<L19>:
+               	bl	 <L19>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_rec_small.take_small>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xf0
-               	stp	x19, x20, [x29, #-0xa0]
-               	stp	x21, x22, [x29, #-0xb0]
-               	stp	x23, x24, [x29, #-0xc0]
-               	stp	x25, x26, [x29, #-0xd0]
-               	stp	x27, x28, [x29, #-0xe0]
-               	stp	d8, d9, [x29, #-0xf0]
-               	mov	x19, x0
+               	sub	sp, sp, #0x120
+               	stp	x19, x20, [x29, #-0xd0]
+               	stp	x21, x22, [x29, #-0xe0]
+               	stp	x23, x24, [x29, #-0xf0]
+               	stp	x25, x26, [x29, #-0x100]
+               	stp	x27, x28, [x29, #-0x110]
+               	stp	d8, d9, [x29, #-0x120]
+               	mov	x8, x0
                	stur	x1, [x29, #-0x8]
-               	mov	w20, w2
+               	mov	w19, w2
                	stur	x3, [x29, #-0x10]
                	fmov	d8, d0
                	stur	x4, [x29, #-0x18]
-               	mov	x21, x5
+               	mov	x20, x5
                	stur	x6, [x29, #-0x20]
                	stur	x7, [x29, #-0x28]
-               	add	x1, x29, #0x10
-               	add	x2, x29, #0x18
-               	add	x3, x29, #0x20
+               	add	x0, x29, #0x10
+               	add	x1, x29, #0x18
+               	add	x2, x29, #0x20
                	fmov	s9, s1
-               	ldr	x22, [x29, #0x28]
-               	sub	x4, x29, #0x8
-               	ldrb	w23, [x4]
-               	sub	x4, x29, #0x10
-               	ldrb	w24, [x4]
-               	sub	x4, x29, #0xf
-               	ldrb	w25, [x4]
-               	sub	x4, x29, #0x18
-               	ldrb	w26, [x4]
-               	sub	x4, x29, #0x17
-               	ldrb	w27, [x4]
-               	sub	x4, x29, #0x16
-               	ldrh	w28, [x4]
-               	sub	x4, x29, #0x20
-               	ldr	w9, [x4]
-               	stur	x9, [x29, #-0x30]
-               	sub	x4, x29, #0x1c
-               	ldrh	w9, [x4]
-               	stur	x9, [x29, #-0x38]
-               	sub	x4, x29, #0x1a
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x40]
-               	sub	x4, x29, #0x28
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x48]
-               	add	x4, x1, #0x0
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x50]
-               	add	x4, x1, #0x1
-               	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x58]
-               	add	x1, x2, #0x0
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x60]
-               	add	x1, x2, #0x1
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x68]
-               	add	x1, x2, #0x2
-               	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x70]
-               	add	x1, x3, #0x0
-               	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x78]
-               	add	x1, x3, #0x4
-               	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x80]
-               	add	x1, x3, #0x6
-               	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x88]
+               	ldr	x21, [x29, #0x28]
+               	sub	x3, x29, #0x8
+               	ldrb	w22, [x3]
+               	sub	x23, x29, #0x2a
+               	ldurh	w3, [x29, #-0x10]
+               	strh	w3, [x23]
+               	sub	x24, x29, #0x2e
+               	ldur	w3, [x29, #-0x18]
+               	str	w3, [x24]
+               	sub	x25, x29, #0x38
+               	ldur	x3, [x29, #-0x20]
+               	str	x3, [x25]
+               	sub	x3, x29, #0x28
+               	ldrb	w26, [x3]
+               	sub	x27, x29, #0x3a
+               	ldrh	w3, [x0]
+               	strh	w3, [x27]
+               	sub	x28, x29, #0x3e
+               	ldr	w0, [x1]
+               	str	w0, [x28]
+               	sub	x9, x29, #0x48
+               	stur	x9, [x29, #-0xc0]
+               	ldr	x0, [x2]
+               	ldur	x9, [x29, #-0xc0]
+               	str	x0, [x9]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x8
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxtb	w1, w22
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	w1, w20
+               	mov	w1, w19
 <L3>:
                	bl	 <L3>
-               	mov	x1, x24
+               	sub	x1, x29, #0x4a
+               	ldrh	w2, [x23]
+               	strh	w2, [x1]
+               	stur	xzr, [x29, #-0x58]
+               	ldrh	w2, [x1]
+               	sturh	w2, [x29, #-0x58]
+               	ldur	x1, [x29, #-0x58]
 <L4>:
                	bl	 <L4>
-               	mov	x1, x25
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	fmov	d0, d8
+               	sub	x1, x29, #0x5c
+               	ldr	w2, [x24]
+               	str	w2, [x1]
+               	stur	xzr, [x29, #-0x68]
+               	ldr	w2, [x1]
+               	stur	w2, [x29, #-0x68]
+               	ldur	x1, [x29, #-0x68]
 <L6>:
                	bl	 <L6>
-               	mov	x1, x26
+               	mov	x1, x20
 <L7>:
                	bl	 <L7>
-               	mov	x1, x27
+               	sub	x1, x29, #0x70
+               	ldr	x2, [x25]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L8>:
                	bl	 <L8>
-               	mov	x1, x28
+               	uxtb	w1, w26
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	ldur	x9, [x29, #-0x30]
-               	mov	w1, w9
+               	sub	x1, x29, #0x72
+               	ldrh	w2, [x27]
+               	strh	w2, [x1]
+               	stur	xzr, [x29, #-0x80]
+               	ldrh	w2, [x1]
+               	sturh	w2, [x29, #-0x80]
+               	ldur	x1, [x29, #-0x80]
 <L11>:
                	bl	 <L11>
-               	ldur	x9, [x29, #-0x38]
-               	mov	x1, x9
+               	sub	x1, x29, #0x84
+               	ldr	w2, [x28]
+               	str	w2, [x1]
+               	stur	xzr, [x29, #-0x90]
+               	ldr	w2, [x1]
+               	stur	w2, [x29, #-0x90]
+               	ldur	x1, [x29, #-0x90]
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
+               	sub	x1, x29, #0x98
+               	ldur	x9, [x29, #-0xc0]
+               	ldr	x2, [x9]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0x48]
-               	mov	x1, x9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x50]
-               	mov	x1, x9
+               	mov	x1, x21
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x58]
-               	mov	x1, x9
+               	sub	x1, x29, #0xa0
+               	sub	x2, x29, #0xa8
+               	ldr	x3, [x25]
+               	str	x3, [x2]
+               	ldr	x3, [x2]
+               	str	x3, [x1]
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	add	w4, w3, #0x1
+               	str	w4, [x2]
+               	add	x2, x1, #0x4
+               	ldrh	w3, [x2]
+               	add	w4, w3, #0x2
+               	strh	w4, [x2]
+               	add	x2, x1, #0x6
+               	ldrb	w3, [x2]
+               	add	w4, w3, #0x3
+               	strb	w4, [x2]
+               	sub	x2, x29, #0xb0
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	ldr	x1, [x2]
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x60]
-               	mov	x1, x9
+               	sub	x1, x29, #0xb8
+               	ldr	x2, [x25]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
-               	ldur	x9, [x29, #-0x68]
-               	mov	x1, x9
-<L18>:
-               	bl	 <L18>
-               	ldur	x9, [x29, #-0x70]
-               	mov	x1, x9
-<L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x78]
-               	mov	w1, w9
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0x80]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	fmov	s0, s9
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x22
-<L24>:
-               	bl	 <L24>
-               	ldur	x9, [x29, #-0x30]
-               	add	w1, w9, #0x1
-               	ldur	x9, [x29, #-0x38]
-               	add	w19, w9, #0x2
-               	ldur	x9, [x29, #-0x40]
-               	add	w20, w9, #0x3
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x19
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x20
-<L27>:
-               	bl	 <L27>
-               	ldur	x9, [x29, #-0x30]
-               	mov	w1, w9
-<L28>:
-               	bl	 <L28>
-               	ldur	x9, [x29, #-0x38]
-               	mov	x1, x9
-<L29>:
-               	bl	 <L29>
-               	ldur	x9, [x29, #-0x40]
-               	mov	x1, x9
-<L30>:
-               	bl	 <L30>
-               	ldp	d8, d9, [x29, #-0xf0]
-               	ldp	x19, x20, [x29, #-0xa0]
-               	ldp	x21, x22, [x29, #-0xb0]
-               	ldp	x23, x24, [x29, #-0xc0]
-               	ldp	x25, x26, [x29, #-0xd0]
-               	ldp	x27, x28, [x29, #-0xe0]
+               	ldp	d8, d9, [x29, #-0x120]
+               	ldp	x19, x20, [x29, #-0xd0]
+               	ldp	x21, x22, [x29, #-0xe0]
+               	ldp	x23, x24, [x29, #-0xf0]
+               	ldp	x25, x26, [x29, #-0x100]
+               	ldp	x27, x28, [x29, #-0x110]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -473,71 +685,185 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x130
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	mov	x16, #0xfef8            // =65272
+               	sub	sp, sp, #0x140
+               	stp	x19, x20, [x29, #-0x100]
+               	stp	x21, x22, [x29, #-0x110]
+               	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x23, [x29, x16]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, #0x2                // =2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               // =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               // =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, #0x2                // =2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x8               // =8
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, #0x2                // =2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, #0x6                // =6
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x2               // =2
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	sub	x20, x29, #0x60
+               	mov	x1, #0x4                // =4
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x1                // =1
+<L15>:
+               	bl	 <L15>
+               	mov	x1, #0x1                // =1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, #0x2                // =2
+<L17>:
+               	bl	 <L17>
+               	mov	x1, #0x4                // =4
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x6                // =6
+<L19>:
+               	bl	 <L19>
+               	sub	x20, x29, #0x68
                	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               // =96
-<L14>:
+<L20>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L14>
+               	b.ne	 <L20>
                	mov	x1, #0x0                // =0
                	cmp	x1, #0xc
-               	b.lo	 <L15>
-               	b	 <L16>
-<L15>:
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -553,15 +879,15 @@ Disassembly of section .text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0xc
-               	b.lo	 <L15>
-<L16>:
+               	b.lo	 <L21>
+<L22>:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x3
-               	b.lo	 <L17>
-               	b	 <L20>
-<L17>:
+               	b.lo	 <L23>
+               	b	 <L26>
+<L23>:
                	mov	x16, #0xd               // =13
                	mul	x0, x23, x16
                	add	x1, x0, x19
@@ -570,7 +896,7 @@ Disassembly of section .text:
                	add	x0, x2, x1
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
-               	sub	x2, x29, #0x61
+               	sub	x2, x29, #0x1
                	mov	w4, w3
                	add	x3, x2, #0x0
                	strb	w4, [x3]
@@ -579,7 +905,7 @@ Disassembly of section .text:
                	mov	w3, w4
                	add	x4, x20, #0x18
                	ldr	x5, [x4]
-               	sub	x4, x29, #0x64
+               	sub	x4, x29, #0x6a
                	mov	w6, w5
                	add	x7, x4, #0x0
                	strb	w6, [x7]
@@ -594,7 +920,7 @@ Disassembly of section .text:
                	ucvtf	d0, x5
                	add	x5, x20, #0x28
                	ldr	x6, [x5]
-               	sub	x5, x29, #0x6a
+               	sub	x5, x29, #0x70
                	mov	w7, w6
                	add	x8, x5, #0x0
                	strb	w7, [x8]
@@ -611,7 +937,7 @@ Disassembly of section .text:
                	add	x6, x20, #0x38
                	ldr	x8, [x6]
                	add	x6, x8, x1
-               	sub	x1, x29, #0x78
+               	sub	x1, x29, #0x7c
                	mov	w8, w6
                	add	x12, x1, #0x0
                	str	w8, [x12]
@@ -625,13 +951,13 @@ Disassembly of section .text:
                	strb	w6, [x8]
                	add	x6, x20, #0x40
                	ldr	x8, [x6]
-               	sub	x6, x29, #0x81
+               	sub	x6, x29, #0x85
                	mov	w12, w8
                	add	x8, x6, #0x0
                	strb	w12, [x8]
                	add	x8, x20, #0x48
                	ldr	x12, [x8]
-               	sub	x8, x29, #0x84
+               	sub	x8, x29, #0x88
                	mov	w13, w12
                	add	x14, x8, #0x0
                	strb	w13, [x14]
@@ -641,7 +967,7 @@ Disassembly of section .text:
                	strb	w12, [x13]
                	add	x12, x20, #0x50
                	ldr	x13, [x12]
-               	sub	x12, x29, #0x8a
+               	sub	x12, x29, #0x8e
                	mov	w14, w13
                	add	x15, x12, #0x0
                	strb	w14, [x15]
@@ -655,7 +981,7 @@ Disassembly of section .text:
                	strh	w13, [x14]
                	add	x13, x20, #0x58
                	ldr	x14, [x13]
-               	sub	x13, x29, #0x98
+               	sub	x13, x29, #0x9c
                	mov	w15, w14
                	add	x18, x13, #0x0
                	str	w15, [x18]
@@ -674,23 +1000,23 @@ Disassembly of section .text:
                	ucvtf	s1, x14
                	add	x14, x20, #0x8
                	ldr	x15, [x14]
-               	stur	xzr, [x29, #-0xa0]
-               	ldrb	w14, [x2]
-               	sturb	w14, [x29, #-0xa0]
-               	ldur	x2, [x29, #-0xa0]
                	stur	xzr, [x29, #-0xa8]
-               	ldrh	w14, [x4]
-               	sturh	w14, [x29, #-0xa8]
-               	ldur	x4, [x29, #-0xa8]
+               	ldrb	w14, [x2]
+               	sturb	w14, [x29, #-0xa8]
+               	ldur	x2, [x29, #-0xa8]
                	stur	xzr, [x29, #-0xb0]
-               	ldr	w14, [x5]
-               	stur	w14, [x29, #-0xb0]
-               	ldur	x5, [x29, #-0xb0]
-               	ldr	x14, [x1]
+               	ldrh	w14, [x4]
+               	sturh	w14, [x29, #-0xb0]
+               	ldur	x4, [x29, #-0xb0]
                	stur	xzr, [x29, #-0xb8]
+               	ldr	w14, [x5]
+               	stur	w14, [x29, #-0xb8]
+               	ldur	x5, [x29, #-0xb8]
+               	ldr	x14, [x1]
+               	stur	xzr, [x29, #-0xc0]
                	ldrb	w1, [x6]
-               	sturb	w1, [x29, #-0xb8]
-               	ldur	x18, [x29, #-0xb8]
+               	sturb	w1, [x29, #-0xc0]
+               	ldur	x18, [x29, #-0xc0]
                	ldrh	w1, [x8]
                	strh	w1, [sp]
                	ldr	w1, [x12]
@@ -705,24 +1031,24 @@ Disassembly of section .text:
                	mov	x5, x7
                	mov	x6, x14
                	mov	x7, x18
-<L18>:
-               	bl	 <L18>
+<L24>:
+               	bl	 <L24>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L19>:
-               	bl	 <L19>
+<L25>:
+               	bl	 <L25>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
-               	b.lo	 <L17>
-<L20>:
-               	sub	x0, x29, #0x62
+               	b.lo	 <L23>
+<L26>:
+               	sub	x0, x29, #0x2
                	mov	w1, w22
                	add	x2, x0, #0x0
                	strb	w1, [x2]
                	mov	w2, w22
-               	sub	x1, x29, #0x66
+               	sub	x1, x29, #0x6c
                	mov	w3, w22
                	add	x4, x1, #0x0
                	strb	w3, [x4]
@@ -733,7 +1059,7 @@ Disassembly of section .text:
                	mov	x16, #0x3ff             // =1023
                	and	x3, x22, x16
                	ucvtf	d0, x3
-               	sub	x3, x29, #0x6e
+               	sub	x3, x29, #0x74
                	mov	w4, w22
                	add	x5, x3, #0x0
                	strb	w4, [x5]
@@ -747,7 +1073,7 @@ Disassembly of section .text:
                	strh	w5, [x4]
                	add	x4, x20, #0x30
                	ldr	x5, [x4]
-               	sub	x4, x29, #0x80
+               	sub	x4, x29, #0x84
                	mov	w6, w22
                	add	x7, x4, #0x0
                	str	w6, [x7]
@@ -761,13 +1087,13 @@ Disassembly of section .text:
                	strb	w7, [x6]
                	add	x6, x20, #0x40
                	ldr	x7, [x6]
-               	sub	x6, x29, #0x82
+               	sub	x6, x29, #0x86
                	mov	w8, w7
                	add	x7, x6, #0x0
                	strb	w8, [x7]
                	add	x7, x20, #0x48
                	ldr	x8, [x7]
-               	sub	x7, x29, #0x86
+               	sub	x7, x29, #0x8a
                	mov	w12, w8
                	add	x13, x7, #0x0
                	strb	w12, [x13]
@@ -777,7 +1103,7 @@ Disassembly of section .text:
                	strb	w8, [x12]
                	add	x8, x20, #0x50
                	ldr	x12, [x8]
-               	sub	x8, x29, #0x8e
+               	sub	x8, x29, #0x92
                	mov	w13, w12
                	add	x14, x8, #0x0
                	strb	w13, [x14]
@@ -791,7 +1117,7 @@ Disassembly of section .text:
                	strh	w12, [x13]
                	add	x12, x20, #0x58
                	ldr	x13, [x12]
-               	sub	x12, x29, #0xc0
+               	sub	x12, x29, #0xc8
                	mov	w14, w13
                	add	x15, x12, #0x0
                	str	w14, [x15]
@@ -810,23 +1136,23 @@ Disassembly of section .text:
                	ucvtf	s1, x13
                	add	x13, x20, #0x10
                	ldr	x14, [x13]
-               	stur	xzr, [x29, #-0xc8]
-               	ldrb	w13, [x0]
-               	sturb	w13, [x29, #-0xc8]
-               	ldur	x13, [x29, #-0xc8]
                	stur	xzr, [x29, #-0xd0]
-               	ldrh	w0, [x1]
-               	sturh	w0, [x29, #-0xd0]
-               	ldur	x15, [x29, #-0xd0]
+               	ldrb	w13, [x0]
+               	sturb	w13, [x29, #-0xd0]
+               	ldur	x13, [x29, #-0xd0]
                	stur	xzr, [x29, #-0xd8]
-               	ldr	w0, [x3]
-               	stur	w0, [x29, #-0xd8]
-               	ldur	x18, [x29, #-0xd8]
-               	ldr	x19, [x4]
+               	ldrh	w0, [x1]
+               	sturh	w0, [x29, #-0xd8]
+               	ldur	x15, [x29, #-0xd8]
                	stur	xzr, [x29, #-0xe0]
+               	ldr	w0, [x3]
+               	stur	w0, [x29, #-0xe0]
+               	ldur	x18, [x29, #-0xe0]
+               	ldr	x19, [x4]
+               	stur	xzr, [x29, #-0xe8]
                	ldrb	w0, [x6]
-               	sturb	w0, [x29, #-0xe0]
-               	ldur	x20, [x29, #-0xe0]
+               	sturb	w0, [x29, #-0xe8]
+               	ldur	x20, [x29, #-0xe8]
                	ldrh	w0, [x7]
                	strh	w0, [sp]
                	ldr	w0, [x8]
@@ -840,15 +1166,15 @@ Disassembly of section .text:
                	mov	x4, x18
                	mov	x6, x19
                	mov	x7, x20
-<L21>:
-               	bl	 <L21>
+<L27>:
+               	bl	 <L27>
                	mov	x1, x0
                	mov	x0, x21
-<L22>:
-               	bl	 <L22>
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	mov	x16, #0xfef8            // =65272
+<L28>:
+               	bl	 <L28>
+               	ldp	x19, x20, [x29, #-0x100]
+               	ldp	x21, x22, [x29, #-0x110]
+               	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/call/call_recursive.dis
+++ b/test/golden/aarch64-linux/call/call_recursive.dis
@@ -20,10 +20,9 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.descend>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x70
+               	sub	sp, sp, #0x60
                	stp	x19, x20, [x29, #-0x50]
                	stp	x21, x22, [x29, #-0x60]
-               	stur	x23, [x29, #-0x68]
                	mov	x19, x0
                	sub	x20, x29, #0x40
                	str	xzr, [x20]
@@ -63,31 +62,76 @@ Disassembly of section .text:
                	bl	 <L3>
                	mov	x22, x0
 <L4>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x8
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x22
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x22
-               	mov	x1, x21
+               	add	x0, x0, #0x1
+               	mov	x22, x1
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x19
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x21, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x19, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x50]
                	ldp	x21, x22, [x29, #-0x60]
-               	ldur	x23, [x29, #-0x68]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -97,7 +141,7 @@ Disassembly of section .text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x30]
-               	stp	x21, x22, [x29, #-0x40]
+               	stur	x21, [x29, #-0x38]
                	mov	x19, x0
                	sub	x20, x29, #0x20
                	str	xzr, [x20]
@@ -134,28 +178,60 @@ Disassembly of section .text:
                	bl	 <L3>
                	mov	x21, x0
 <L4>:
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x4
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x4
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x21
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L5>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x16, #0x2               // =2
-               	mul	x1, x19, x16
-               	mov	x0, x21
+               	add	x0, x0, #0x1
+               	mov	x21, x1
+               	cmp	x0, #0x4
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
+               	mov	x16, #0x2               // =2
+               	mul	x0, x19, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x0, x21
                	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
+               	ldur	x21, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -163,10 +239,9 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.pong>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x60
+               	sub	sp, sp, #0x50
                	stp	x19, x20, [x29, #-0x40]
                	stp	x21, x22, [x29, #-0x50]
-               	stur	x23, [x29, #-0x58]
                	mov	x19, x0
                	sub	x20, x29, #0x30
                	str	xzr, [x20]
@@ -203,34 +278,79 @@ Disassembly of section .text:
                	bl	 <L3>
                	mov	x22, x0
 <L4>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x6
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x6
                	b.lo	 <L5>
-               	b	 <L7>
+               	b	 <L8>
 <L5>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	add	x1, x20, x0, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x22
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x6
-               	b.lo	 <L5>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x22
-               	mov	x1, x21
+               	add	x0, x0, #0x1
+               	mov	x22, x1
+               	cmp	x0, #0x6
+               	b.lo	 <L5>
 <L8>:
-               	bl	 <L8>
-               	mov	x16, #0x3               // =3
-               	mul	x1, x19, x16
-               	add	x2, x1, #0x1
-               	mov	x1, x2
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x21, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	mov	x16, #0x3               // =3
+               	mul	x0, x19, x16
+               	add	x1, x0, #0x1
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
-               	ldur	x23, [x29, #-0x58]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -238,243 +358,90 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.tree>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	x27, x28, [x29, #-0x50]
+               	stur	x21, [x29, #-0x18]
                	mov	x19, x0
                	mov	x16, #0x79b1            // =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x3, x1, x16
-               	add	x20, x3, x19
-               	mov	x0, x2
-               	mov	x1, x20
+               	mul	x0, x1, x16
+               	add	x20, x0, x19
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x3, x20, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x3, x16
+               	eor	x3, x2, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x0               // =0
                	cmp	x17, x19
-               	b.lo	 <L1>
-               	mov	x21, x0
-               	b	 <L41>
-<L1>:
-               	sub	x22, x19, #0x1
-               	add	x1, x20, #0x1
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x23, x2, x22
-               	mov	x1, x23
+               	b.lo	 <L2>
+               	mov	x21, x2
+               	b	 <L7>
 <L2>:
-               	bl	 <L2>
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x22
-               	b.lo	 <L3>
-               	mov	x24, x0
-               	b	 <L19>
+               	sub	x0, x19, #0x1
+               	add	x1, x20, #0x1
 <L3>:
-               	sub	x25, x22, #0x1
-               	add	x1, x23, #0x1
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x26, x2, x25
-               	mov	x1, x26
+               	bl	 <L3>
+               	mov	x2, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x2, x0
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x25
-               	b.lo	 <L5>
-               	mov	x27, x2
-               	b	 <L9>
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x3, x20, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x3, x16
+               	eor	x3, x2, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	sub	x28, x25, #0x1
-               	add	x1, x26, #0x1
-               	mov	x0, x28
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x26
-<L7>:
-               	bl	 <L7>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x26, x16
-               	mov	x0, x28
-<L8>:
-               	bl	 <L8>
-               	mov	x27, x0
-<L9>:
-               	mov	x0, x27
-               	mov	x1, x26
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x23
-<L11>:
-               	bl	 <L11>
-               	sub	x25, x22, #0x1
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x23, x16
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x22, x2, x25
-               	mov	x1, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x2, x0
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x25
-               	b.lo	 <L13>
-               	mov	x26, x2
-               	b	 <L17>
-<L13>:
-               	sub	x27, x25, #0x1
-               	add	x1, x22, #0x1
-               	mov	x0, x27
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x22
-<L15>:
-               	bl	 <L15>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x22, x16
-               	mov	x0, x27
-<L16>:
-               	bl	 <L16>
-               	mov	x26, x0
-<L17>:
-               	mov	x0, x26
-               	mov	x1, x22
-<L18>:
-               	bl	 <L18>
-               	mov	x24, x0
-<L19>:
-               	mov	x0, x24
-               	mov	x1, x23
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x20
-<L21>:
-               	bl	 <L21>
-               	sub	x22, x19, #0x1
+               	sub	x0, x19, #0x1
                	mov	x16, #0xaaaa            // =43690
                	movk	x16, #0xaaaa, lsl #16
                	eor	x1, x20, x16
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x19, x2, x22
-               	mov	x1, x19
-<L22>:
-               	bl	 <L22>
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x22
-               	b.lo	 <L23>
-               	mov	x23, x0
-               	b	 <L39>
-<L23>:
-               	sub	x24, x22, #0x1
-               	add	x1, x19, #0x1
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x25, x2, x24
-               	mov	x1, x25
-<L24>:
-               	bl	 <L24>
-               	mov	x2, x0
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x24
-               	b.lo	 <L25>
-               	mov	x26, x2
-               	b	 <L29>
-<L25>:
-               	sub	x27, x24, #0x1
-               	add	x1, x25, #0x1
-               	mov	x0, x27
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x25
-<L27>:
-               	bl	 <L27>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x25, x16
-               	mov	x0, x27
-<L28>:
-               	bl	 <L28>
-               	mov	x26, x0
-<L29>:
-               	mov	x0, x26
-               	mov	x1, x25
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x19
-<L31>:
-               	bl	 <L31>
-               	sub	x24, x22, #0x1
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x19, x16
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x22, x2, x24
-               	mov	x1, x22
-<L32>:
-               	bl	 <L32>
-               	mov	x2, x0
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x24
-               	b.lo	 <L33>
-               	mov	x25, x2
-               	b	 <L37>
-<L33>:
-               	sub	x26, x24, #0x1
-               	add	x1, x22, #0x1
-               	mov	x0, x26
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x22
-<L35>:
-               	bl	 <L35>
-               	mov	x2, x0
-               	mov	x16, #0xaaaa            // =43690
-               	movk	x16, #0xaaaa, lsl #16
-               	eor	x1, x22, x16
-               	mov	x0, x26
-<L36>:
-               	bl	 <L36>
-               	mov	x25, x0
-<L37>:
-               	mov	x0, x25
-               	mov	x1, x22
-<L38>:
-               	bl	 <L38>
-               	mov	x23, x0
-<L39>:
-               	mov	x0, x23
-               	mov	x1, x19
-<L40>:
-               	bl	 <L40>
+<L6>:
+               	bl	 <L6>
                	mov	x21, x0
-<L41>:
+<L7>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x2, x20, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x21, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x21, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	x0, x21
-               	mov	x1, x20
-<L42>:
-               	bl	 <L42>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	ldp	x27, x28, [x29, #-0x50]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -482,70 +449,78 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.tail>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
-               	stp	x19, x20, [x29, #-0x30]
-               	stp	x21, x22, [x29, #-0x40]
-               	stur	x23, [x29, #-0x48]
-               	mov	x19, x0
-               	mov	x20, x1
-               	sub	x21, x29, #0x20
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, #0x4
+               	sub	sp, sp, #0x30
+               	stur	x19, [x29, #-0x28]
+               	sub	x3, x29, #0x20
+               	str	xzr, [x3]
+               	str	xzr, [x3, #0x8]
+               	str	xzr, [x3, #0x10]
+               	str	xzr, [x3, #0x18]
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x4
                	b.lo	 <L0>
                	b	 <L1>
 <L0>:
                	mov	x16, #0x1b3             // =435
                	movk	x16, #0x100, lsl #32
-               	mul	x1, x0, x16
-               	add	x3, x1, x19
-               	eor	x1, x20, x3
-               	add	x3, x21, x0, lsl #3
-               	str	x1, [x3]
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x4
+               	mul	x5, x4, x16
+               	add	x6, x5, x0
+               	eor	x5, x1, x6
+               	add	x6, x3, x4, lsl #3
+               	str	x5, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x4
                	b.lo	 <L0>
 <L1>:
-               	mov	x22, #0x0               // =0
-               	mov	x23, x2
-               	cmp	x22, #0x4
+               	mov	x4, #0x0                // =0
+               	mov	x19, x2
+               	cmp	x4, #0x4
                	b.lo	 <L2>
-               	b	 <L4>
+               	b	 <L5>
 <L2>:
-               	add	x0, x21, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	add	x2, x3, x4, lsl #3
+               	ldr	x5, [x2]
+               	mov	x2, x19
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x23, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L2>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	cmp	x19, #0x0
-               	b.eq	 <L6>
-               	sub	x0, x19, #0x1
-               	mov	x16, #0x5               // =5
-               	mul	x1, x20, x16
-               	add	x2, x1, #0x3
-               	mov	x1, x2
-               	mov	x2, x23
+               	add	x4, x4, #0x1
+               	mov	x19, x2
+               	cmp	x4, #0x4
+               	b.lo	 <L2>
 <L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
-               	ldur	x23, [x29, #-0x48]
+               	cmp	x0, #0x0
+               	b.eq	 <L7>
+               	sub	x2, x0, #0x1
+               	mov	x16, #0x5               // =5
+               	mul	x0, x1, x16
+               	add	x1, x0, #0x3
+               	mov	x0, x2
+               	mov	x2, x19
+<L6>:
+               	bl	 <L6>
+               	ldur	x19, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
-<L6>:
-               	mov	x0, x23
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldp	x21, x22, [x29, #-0x40]
-               	ldur	x23, [x29, #-0x48]
+<L7>:
+               	mov	x0, x19
+               	ldur	x19, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -642,16 +617,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
+               	sub	sp, sp, #0x80
                	stp	x19, x20, [x29, #-0x60]
                	stp	x21, x22, [x29, #-0x70]
                	stp	x23, x24, [x29, #-0x80]
-               	stur	x25, [x29, #-0x88]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x2, x0
-               	sub	x20, x29, #0x30
+               	sub	x20, x29, #0x48
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -660,9 +631,9 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x28]
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -672,93 +643,142 @@ Disassembly of section .text:
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x1, x16
-               	add	x1, x3, x19
-               	add	x3, x20, x0, lsl #3
-               	str	x1, [x3]
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L0>
+<L1>:
                	mov	x17, #0x28              // =40
                	add	x0, x17, x19
                	add	x1, x20, #0x0
-               	ldr	x3, [x1]
-               	mov	x1, x3
-<L3>:
-               	bl	 <L3>
+               	ldr	x2, [x1]
+               	mov	x1, x2
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+<L2>:
+               	bl	 <L2>
                	mov	x2, x0
                	mov	x17, #0x21              // =33
                	add	x21, x17, x19
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
                	mov	x0, x21
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x2, x0
                	add	x0, x20, #0x10
                	ldr	x1, [x0]
                	mov	x0, x21
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	mov	x2, x0
                	add	x0, x20, #0x18
                	ldr	x1, [x0]
                	add	x3, x1, x19
                	mov	x0, #0x8                // =8
                	mov	x1, x3
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	mov	x2, x0
                	mov	x17, #0x30              // =48
                	add	x0, x17, x19
                	add	x1, x20, #0x20
                	ldr	x3, [x1]
                	mov	x1, x3
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	mov	x17, #0x18              // =24
                	add	x21, x17, x19
                	mov	x22, x0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x4
-               	b.lo	 <L8>
-               	b	 <L13>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L15>
+<L7>:
                	add	x0, x20, x23, lsl #3
                	ldr	x1, [x0]
                	add	x2, x1, x19
-               	sub	x24, x29, #0x48
+               	sub	x24, x29, #0x18
                	mov	x8, x24
                	mov	x0, x21
                	mov	x1, x2
-<L9>:
-               	bl	 <L9>
+<L8>:
+               	bl	 <L8>
                	add	x0, x24, #0x0
                	ldr	x1, [x0]
                	add	x0, x24, #0x8
-               	ldr	x25, [x0]
+               	ldr	x2, [x0]
                	add	x0, x24, #0x10
-               	ldr	x24, [x0]
+               	ldr	x3, [x0]
                	mov	x0, x22
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x25
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L13>
+<L14>:
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x4
-               	b.lo	 <L8>
-<L13>:
+               	b.lo	 <L7>
+<L15>:
                	mov	x0, x22
                	ldp	x19, x20, [x29, #-0x60]
                	ldp	x21, x22, [x29, #-0x70]
                	ldp	x23, x24, [x29, #-0x80]
-               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_ret_large.dis
+++ b/test/golden/aarch64-linux/call/call_ret_large.dis
@@ -18,206 +18,386 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_ret_large.fold20>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	w4, [x3]
-               	add	x3, x1, #0x4
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x8
-               	ldr	w20, [x3]
-               	add	x3, x1, #0xc
-               	ldr	w21, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w22, [x3]
-               	mov	x0, x2
-               	mov	w1, w4
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	add	x2, x1, #0x4
+               	ldr	w4, [x2]
+               	add	x2, x1, #0x8
+               	ldr	w5, [x2]
+               	add	x2, x1, #0xc
+               	ldr	w6, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w1, [x2]
+               	mov	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x7, x3, x16
+               	lsr	x8, x2, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w2, w4
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w21
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x7, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x7, x16
+               	eor	x7, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	w2, w5
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w2, w6
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold24>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	x19, x20, [x29, #-0x10]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold24f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	d8, d9, [x29, #-0x30]
-               	mov	x1, x0
+               	sub	sp, sp, #0x20
                	stur	d0, [x29, #-0x18]
                	stur	d1, [x29, #-0x10]
                	stur	d2, [x29, #-0x8]
-               	sub	x2, x29, #0x18
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	ldr	d8, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d9, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x18
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x10
+               	ldr	d1, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d2, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	d8, d9, [x29, #-0x30]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	fmov	x1, d2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_ret_large.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	x19, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	x4, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x5, [x2]
+               	add	x2, x1, #0x18
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x6, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x5, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.call.call_ret_large.fold40m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
                	stur	x21, [x29, #-0x18]
-               	stp	d8, d9, [x29, #-0x28]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	x4, [x3]
-               	add	x3, x1, #0x8
-               	ldr	d8, [x3]
-               	add	x3, x1, #0x10
-               	ldr	w19, [x3]
-               	add	x3, x1, #0x14
-               	ldr	w20, [x3]
-               	add	x3, x1, #0x18
-               	ldr	d9, [x3]
-               	add	x3, x1, #0x20
-               	ldr	x21, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	stur	d8, [x29, #-0x20]
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x1, #0x8
+               	ldr	d0, [x2]
+               	add	x2, x1, #0x10
+               	ldr	w19, [x2]
+               	add	x2, x1, #0x14
+               	ldr	w20, [x2]
+               	add	x2, x1, #0x18
+               	ldr	d8, [x2]
+               	add	x2, x1, #0x20
+               	ldr	x21, [x2]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	fmov	x1, d0
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w19
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	mov	w1, w20
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	fmov	x1, d8
 <L5>:
                	bl	 <L5>
-               	ldp	d8, d9, [x29, #-0x28]
+               	mov	x1, x21
+<L6>:
+               	bl	 <L6>
+               	ldur	d8, [x29, #-0x20]
                	ldp	x19, x20, [x29, #-0x10]
                	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
@@ -283,47 +463,55 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold_nest>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldr	w4, [x3]
-               	add	x3, x1, #0x8
-               	add	x5, x3, #0x0
-               	ldr	x19, [x5]
-               	add	x5, x3, #0x8
-               	ldr	x20, [x5]
-               	add	x5, x3, #0x10
-               	ldr	x21, [x5]
-               	add	x3, x1, #0x20
-               	add	x1, x3, #0x0
-               	ldr	x22, [x1]
-               	add	x1, x3, #0x8
-               	ldr	x23, [x1]
-               	mov	x0, x2
-               	mov	w1, w4
+               	sub	sp, sp, #0x70
+               	stp	x19, x20, [x29, #-0x70]
+               	sub	x19, x29, #0x30
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	ldr	x6, [x1, #0x20]
+               	ldr	x7, [x1, #0x28]
+               	str	x2, [x19]
+               	str	x3, [x19, #0x8]
+               	str	x4, [x19, #0x10]
+               	str	x5, [x19, #0x18]
+               	str	x6, [x19, #0x20]
+               	str	x7, [x19, #0x28]
+               	add	x1, x19, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x19
+               	add	x1, x19, #0x8
+               	sub	x2, x29, #0x48
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	stur	x1, [x29, #-0x60]
+               	stur	x3, [x29, #-0x58]
+               	stur	x4, [x29, #-0x50]
+               	sub	x1, x29, #0x60
 <L1>:
                	bl	 <L1>
-               	mov	x1, x20
+               	add	x20, x19, #0x20
+               	add	x1, x20, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x21
+               	add	x1, x20, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x22
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x23
-<L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	ldp	x19, x20, [x29, #-0x70]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -809,32 +997,36 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.take_two>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x50
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	stp	x27, x28, [x29, #-0x50]
-               	mov	x3, x0
+               	sub	sp, sp, #0x90
+               	stp	x19, x20, [x29, #-0x60]
+               	stp	x21, x22, [x29, #-0x70]
+               	stp	x23, x24, [x29, #-0x80]
+               	stur	x25, [x29, #-0x88]
                	mov	x19, x2
-               	add	x2, x3, #0x0
+               	add	x2, x0, #0x0
+               	ldr	x3, [x2]
+               	add	x2, x0, #0x8
                	ldr	x20, [x2]
-               	add	x2, x3, #0x8
+               	add	x2, x0, #0x10
                	ldr	x21, [x2]
-               	add	x2, x3, #0x10
+               	add	x2, x0, #0x18
                	ldr	x22, [x2]
-               	add	x2, x3, #0x18
+               	add	x2, x0, #0x20
                	ldr	x23, [x2]
-               	add	x2, x3, #0x20
+               	add	x2, x0, #0x28
                	ldr	x24, [x2]
-               	add	x2, x3, #0x28
-               	ldr	x25, [x2]
-               	add	x2, x1, #0x0
-               	ldr	x26, [x2]
-               	add	x2, x1, #0x8
-               	ldr	x27, [x2]
-               	add	x2, x1, #0x10
-               	ldr	x28, [x2]
+               	sub	x25, x29, #0x18
+               	ldr	x0, [x1]
+               	ldr	x2, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	str	x0, [x25]
+               	str	x2, [x25, #0x8]
+               	str	x4, [x25, #0x10]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x3
 <L0>:
                	bl	 <L0>
                	mov	x1, x20
@@ -852,26 +1044,29 @@ Disassembly of section .text:
                	mov	x1, x24
 <L5>:
                	bl	 <L5>
-               	mov	x1, x25
+               	sub	x1, x29, #0x30
+               	ldr	x2, [x25]
+               	ldr	x3, [x25, #0x8]
+               	ldr	x4, [x25, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	str	x4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	stur	x2, [x29, #-0x48]
+               	stur	x3, [x29, #-0x40]
+               	stur	x4, [x29, #-0x38]
+               	sub	x1, x29, #0x48
 <L6>:
                	bl	 <L6>
-               	mov	x1, x26
+               	mov	x1, x19
 <L7>:
                	bl	 <L7>
-               	mov	x1, x27
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x28
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x19
-<L10>:
-               	bl	 <L10>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	ldp	x27, x28, [x29, #-0x50]
+               	ldp	x19, x20, [x29, #-0x60]
+               	ldp	x21, x22, [x29, #-0x70]
+               	ldp	x23, x24, [x29, #-0x80]
+               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -879,46 +1074,48 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x6f0
-               	sub	x16, x29, #0x6a0
+               	sub	sp, sp, #0x900
+               	sub	x16, x29, #0x8b0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x6f0
-               	stp	d8, d9, [x16]
+               	sub	x16, x29, #0x900
+               	str	d8, [x16, #0x8]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x14               // =20
 <L0>:
                	bl	 <L0>
-               	mov	x1, #0x14               // =20
+               	mov	x1, #0x18               // =24
 <L1>:
                	bl	 <L1>
                	mov	x1, #0x18               // =24
 <L2>:
                	bl	 <L2>
-               	mov	x1, #0x18               // =24
+               	mov	x1, #0x20               // =32
 <L3>:
                	bl	 <L3>
-               	mov	x1, #0x20               // =32
+               	mov	x1, #0x28               // =40
 <L4>:
                	bl	 <L4>
-               	mov	x1, #0x28               // =40
+               	mov	x1, #0x30               // =48
 <L5>:
                	bl	 <L5>
                	mov	x1, #0x30               // =48
 <L6>:
                	bl	 <L6>
-               	mov	x1, #0x30               // =48
+               	mov	x1, #0x8                // =8
 <L7>:
                	bl	 <L7>
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x20               // =32
 <L8>:
                	bl	 <L8>
-               	mov	x1, #0x20               // =32
-<L9>:
-               	bl	 <L9>
-               	sub	x20, x29, #0x1f0
+               	sub	x20, x29, #0x358
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -929,9 +1126,9 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x38]
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x8
-               	b.lo	 <L10>
-               	b	 <L11>
-<L10>:
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
@@ -947,54 +1144,154 @@ Disassembly of section .text:
                	str	x2, [x3]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L10>
-<L11>:
+               	b.lo	 <L9>
+<L10>:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x8
-               	b.lo	 <L12>
-               	b	 <L41>
-<L12>:
+               	b.lo	 <L11>
+               	b	 <L47>
+<L11>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	mov	w1, w23
-               	lsr	x0, x23, #8
-               	mov	w24, w0
-               	lsr	x0, x23, #16
-               	mov	w25, w0
-               	lsr	x0, x23, #24
-               	mov	w26, w0
-               	lsr	x0, x23, #32
-               	mov	w27, w0
+               	mov	w0, w23
+               	lsr	x1, x23, #8
+               	mov	w2, w1
+               	lsr	x1, x23, #16
+               	mov	w3, w1
+               	lsr	x1, x23, #24
+               	mov	w4, w1
+               	lsr	x1, x23, #32
+               	mov	w5, w1
+               	mov	w1, w0
                	mov	x0, x21
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x1, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	w1, w24
+               	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	w1, w25
+               	mov	x16, #0x8               // =8
+               	mul	x6, x2, x16
+               	lsr	x7, x1, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x0, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w26
+               	mov	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	w1, w27
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x6, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x6, x16
+               	eor	x6, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	mvn	x24, x23
-               	mov	x16, #0x3               // =3
-               	mul	x1, x23, x16
-               	add	x25, x1, #0x1
-               	mov	x1, x23
+               	mov	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x25
+               	mov	w1, w5
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sub	x1, x29, #0x440
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	mvn	x2, x23
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x3               // =3
+               	mul	x2, x23, x16
+               	add	x3, x2, #0x1
+               	add	x2, x1, #0x10
+               	str	x3, [x2]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	mov	x16, #0xfba8            // =64424
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfbb0            // =64432
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfbb8            // =64440
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x458
+<L22>:
+               	bl	 <L22>
                	mov	x16, #0xffff            // =65535
                	and	x1, x23, x16
                	ucvtf	d0, x1
@@ -1005,44 +1302,116 @@ Disassembly of section .text:
                	ucvtf	d0, x1
                	mov	x16, #0x40a0000000000000 // =4656722014701092864
                	fmov	d30, x16
-               	fsub	d8, d0, d30
+               	fsub	d2, d0, d30
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x3, lsl #16
                	and	x1, x23, x16
                	ucvtf	d0, x1
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
-               	fmov	d0, d1
-<L21>:
-               	bl	 <L21>
-               	fmov	d0, d8
-<L22>:
-               	bl	 <L22>
-               	fmov	d0, d9
+               	fdiv	d3, d0, d30
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	bl	 <L23>
-               	add	x24, x23, #0x1
-               	mov	x16, #0x5               // =5
-               	mul	x25, x23, x16
-               	mvn	x26, x23
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
-               	mov	x1, x24
+               	fmov	x1, d2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
 <L25>:
-               	bl	 <L25>
-               	mov	x1, x25
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	bl	 <L26>
-               	mov	x1, x26
+               	fmov	x1, d3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
 <L27>:
-               	bl	 <L27>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	sub	x1, x29, #0x5e0
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	add	x2, x23, #0x1
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x5               // =5
+               	mul	x2, x23, x16
+               	add	x3, x1, #0x10
+               	str	x2, [x3]
+               	mvn	x2, x23
+               	add	x3, x1, #0x18
+               	str	x2, [x3]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	mov	x16, #0xfa00            // =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfa10            // =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	mov	x16, #0xfa18            // =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	sub	x1, x29, #0x600
+<L29>:
+               	bl	 <L29>
                	mov	x16, #0x1fff            // =8191
                	and	x1, x23, x16
                	ucvtf	d0, x1
                	fmov	d30, #2.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
                	mov	w24, w23
                	lsr	x1, x23, #16
                	mov	w25, w1
@@ -1052,27 +1421,42 @@ Disassembly of section .text:
                	ucvtf	d0, x1
                	mov	x16, #0x4040000000000000 // =4629700416936869888
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
+               	fdiv	d8, d0, d30
                	mov	x16, #0x7               // =7
                	mul	x26, x23, x16
-               	mov	x1, x23
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d8
-<L29>:
-               	bl	 <L29>
-               	mov	w1, w24
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	w1, w25
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	fmov	d0, d9
+               	fmov	x1, d1
 <L32>:
                	bl	 <L32>
-               	mov	x1, x26
+               	mov	w1, w24
 <L33>:
                	bl	 <L33>
+               	mov	w1, w25
+<L34>:
+               	bl	 <L34>
+               	fmov	x1, d8
+<L35>:
+               	bl	 <L35>
+               	mov	x1, x26
+<L36>:
+               	bl	 <L36>
                	add	x24, x23, #0x1
                	add	x25, x23, #0x2
                	mov	x16, #0x9               // =9
@@ -1082,28 +1466,28 @@ Disassembly of section .text:
                	movk	x16, #0xaaaa, lsl #16
                	eor	x28, x23, x16
                	mov	x1, x23
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x24
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x25
-<L36>:
-               	bl	 <L36>
-               	mov	x1, x26
 <L37>:
                	bl	 <L37>
-               	mov	x1, x27
+               	mov	x1, x24
 <L38>:
                	bl	 <L38>
-               	mov	x1, x28
+               	mov	x1, x25
 <L39>:
                	bl	 <L39>
-               	sub	x1, x29, #0x610
+               	mov	x1, x26
+<L40>:
+               	bl	 <L40>
+               	mov	x1, x27
+<L41>:
+               	bl	 <L41>
+               	mov	x1, x28
+<L42>:
+               	bl	 <L42>
+               	sub	x1, x29, #0x7f8
                	mov	w2, w23
                	add	x3, x1, #0x0
                	str	w2, [x3]
-               	sub	x2, x29, #0x628
+               	sub	x2, x29, #0x810
                	add	x3, x2, #0x0
                	str	x23, [x3]
                	mvn	x3, x23
@@ -1121,7 +1505,7 @@ Disassembly of section .text:
                	str	x4, [x3]
                	str	x5, [x3, #0x8]
                	str	x6, [x3, #0x10]
-               	sub	x2, x29, #0x638
+               	sub	x2, x29, #0x820
                	mov	x16, #0xb               // =11
                	mul	x3, x23, x16
                	add	x4, x2, #0x0
@@ -1134,89 +1518,154 @@ Disassembly of section .text:
                	ldr	x5, [x2, #0x8]
                	str	x4, [x3]
                	str	x5, [x3, #0x8]
+               	sub	x23, x29, #0x850
                	ldr	x2, [x1]
                	ldr	x3, [x1, #0x8]
                	ldr	x4, [x1, #0x10]
                	ldr	x5, [x1, #0x18]
                	ldr	x6, [x1, #0x20]
                	ldr	x7, [x1, #0x28]
-               	mov	x16, #0xf998            // =63896
+               	str	x2, [x23]
+               	str	x3, [x23, #0x8]
+               	str	x4, [x23, #0x10]
+               	str	x5, [x23, #0x18]
+               	str	x6, [x23, #0x20]
+               	str	x7, [x23, #0x28]
+               	add	x1, x23, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L43>:
+               	bl	 <L43>
+               	add	x1, x23, #0x8
+               	sub	x2, x29, #0x868
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	mov	x16, #0xf780            // =63360
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x2, [x29, x16]
-               	mov	x16, #0xf9a0            // =63904
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf788            // =63368
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xf9a8            // =63912
+               	mov	x16, #0xf790            // =63376
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xf9b0            // =63920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x5, [x29, x16]
-               	mov	x16, #0xf9b8            // =63928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x6, [x29, x16]
-               	mov	x16, #0xf9c0            // =63936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x7, [x29, x16]
-               	sub	x1, x29, #0x668
-<L40>:
-               	bl	 <L40>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x8
-               	b.lo	 <L12>
-<L41>:
-               	add	x0, x19, #0x1
-               	mvn	x1, x0
-               	mov	x16, #0x3               // =3
-               	mul	x2, x0, x16
-               	add	x3, x2, #0x1
-               	mov	x22, #0x0               // =0
-               	mov	x23, x0
-               	mov	x24, x1
-               	mov	x25, x3
-               	cmp	x22, #0x8
-               	b.lo	 <L42>
-               	b	 <L46>
-<L42>:
-               	add	x0, x20, x22, lsl #3
-               	ldr	x1, [x0]
-               	add	x26, x23, x1
-               	eor	x27, x24, x1
-               	add	x28, x25, x23
-               	mov	x0, x21
-               	mov	x1, x26
-<L43>:
-               	bl	 <L43>
-               	mov	x1, x27
+               	sub	x1, x29, #0x880
 <L44>:
                	bl	 <L44>
-               	mov	x1, x28
+               	add	x24, x23, #0x20
+               	add	x1, x24, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
+               	add	x1, x24, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	add	x22, x22, #0x1
                	mov	x21, x0
-               	mov	x23, x26
-               	mov	x24, x27
-               	mov	x25, x28
                	cmp	x22, #0x8
-               	b.lo	 <L42>
-<L46>:
-               	sub	x22, x29, #0x30
-               	add	x0, x19, #0x2
+               	b.lo	 <L11>
+<L47>:
+               	sub	x22, x29, #0x18
+               	add	x0, x19, #0x1
                	sub	x1, x29, #0x220
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	mvn	x2, x0
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x16, #0x3               // =3
+               	mul	x2, x0, x16
+               	add	x0, x2, #0x1
+               	add	x2, x1, #0x10
+               	str	x0, [x2]
+               	ldr	x0, [x1]
+               	ldr	x2, [x1, #0x8]
+               	ldr	x3, [x1, #0x10]
+               	str	x0, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	mov	x23, #0x0               // =0
+               	cmp	x23, #0x8
+               	b.lo	 <L48>
+               	b	 <L50>
+<L48>:
+               	add	x0, x22, #0x0
+               	ldr	x1, [x0]
+               	add	x0, x22, #0x8
+               	ldr	x2, [x0]
+               	add	x0, x22, #0x10
+               	ldr	x3, [x0]
+               	add	x0, x20, x23, lsl #3
+               	ldr	x4, [x0]
+               	sub	x0, x29, #0x238
+               	add	x5, x1, x4
+               	add	x6, x0, #0x0
+               	str	x5, [x6]
+               	eor	x5, x2, x4
+               	add	x2, x0, #0x8
+               	str	x5, [x2]
+               	add	x2, x3, x1
+               	add	x1, x0, #0x10
+               	str	x2, [x1]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	str	x1, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	sub	x0, x29, #0x250
+               	ldr	x1, [x22]
+               	ldr	x2, [x22, #0x8]
+               	ldr	x3, [x22, #0x10]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	str	x3, [x0, #0x10]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	mov	x16, #0xfd98            // =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfda0            // =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfda8            // =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	sub	x1, x29, #0x268
+               	mov	x0, x21
+<L49>:
+               	bl	 <L49>
+               	add	x23, x23, #0x1
+               	mov	x21, x0
+               	cmp	x23, #0x8
+               	b.lo	 <L48>
+<L50>:
+               	sub	x22, x29, #0x48
+               	add	x0, x19, #0x2
+               	sub	x1, x29, #0x298
                	add	x2, x1, #0x0
                	str	x0, [x2]
                	add	x2, x0, #0x1
@@ -1251,10 +1700,10 @@ Disassembly of section .text:
                	str	x6, [x22, #0x28]
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x8
-               	b.lo	 <L47>
-               	b	 <L55>
-<L47>:
-               	sub	x0, x29, #0x60
+               	b.lo	 <L51>
+               	b	 <L59>
+<L51>:
+               	sub	x0, x29, #0x78
                	ldr	x1, [x22]
                	ldr	x2, [x22, #0x8]
                	ldr	x3, [x22, #0x10]
@@ -1269,24 +1718,24 @@ Disassembly of section .text:
                	str	x6, [x0, #0x28]
                	add	x1, x20, x23, lsl #3
                	ldr	x2, [x1]
-               	sub	x24, x29, #0x90
+               	sub	x24, x29, #0xa8
                	ldr	x1, [x0]
                	ldr	x3, [x0, #0x8]
                	ldr	x4, [x0, #0x10]
                	ldr	x5, [x0, #0x18]
                	ldr	x6, [x0, #0x20]
                	ldr	x7, [x0, #0x28]
-               	stur	x1, [x29, #-0xc0]
-               	stur	x3, [x29, #-0xb8]
-               	stur	x4, [x29, #-0xb0]
-               	stur	x5, [x29, #-0xa8]
-               	stur	x6, [x29, #-0xa0]
-               	stur	x7, [x29, #-0x98]
-               	sub	x0, x29, #0xc0
+               	stur	x1, [x29, #-0xd8]
+               	stur	x3, [x29, #-0xd0]
+               	stur	x4, [x29, #-0xc8]
+               	stur	x5, [x29, #-0xc0]
+               	stur	x6, [x29, #-0xb8]
+               	stur	x7, [x29, #-0xb0]
+               	sub	x0, x29, #0xd8
                	mov	x8, x24
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L52>:
+               	bl	 <L52>
                	ldr	x0, [x24]
                	ldr	x1, [x24, #0x8]
                	ldr	x2, [x24, #0x10]
@@ -1312,47 +1761,47 @@ Disassembly of section .text:
                	add	x0, x22, #0x28
                	ldr	x28, [x0]
                	mov	x0, x21
-<L49>:
-               	bl	 <L49>
-               	mov	x1, x24
-<L50>:
-               	bl	 <L50>
-               	mov	x1, x25
-<L51>:
-               	bl	 <L51>
-               	mov	x1, x26
-<L52>:
-               	bl	 <L52>
-               	mov	x1, x27
 <L53>:
                	bl	 <L53>
-               	mov	x1, x28
+               	mov	x1, x24
 <L54>:
                	bl	 <L54>
+               	mov	x1, x25
+<L55>:
+               	bl	 <L55>
+               	mov	x1, x26
+<L56>:
+               	bl	 <L56>
+               	mov	x1, x27
+<L57>:
+               	bl	 <L57>
+               	mov	x1, x28
+<L58>:
+               	bl	 <L58>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x8
-               	b.lo	 <L47>
-<L55>:
-               	sub	x22, x29, #0x180
+               	b.lo	 <L51>
+<L59>:
+               	sub	x22, x29, #0x198
                	add	x0, x22, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0xc0               // =192
-<L56>:
+<L60>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L56>
+               	b.ne	 <L60>
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x6
-               	b.lo	 <L57>
-               	b	 <L58>
-<L57>:
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0x240
+               	sub	x2, x29, #0x2b8
                	add	x3, x2, #0x0
                	str	x1, [x3]
                	add	x3, x1, #0x1
@@ -1378,43 +1827,59 @@ Disassembly of section .text:
                	str	x6, [x3, #0x18]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L57>
-<L58>:
+               	b.lo	 <L61>
+<L62>:
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x6
-               	b.lo	 <L59>
-               	b	 <L64>
-<L59>:
+               	b.lo	 <L63>
+               	b	 <L65>
+<L63>:
                	mov	x16, #0x20              // =32
                	mul	x0, x23, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldr	x2, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x24, [x0]
-               	add	x0, x1, #0x10
-               	ldr	x25, [x0]
-               	add	x0, x1, #0x18
-               	ldr	x26, [x0]
+               	sub	x0, x29, #0x1b8
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	ldr	x5, [x1, #0x18]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	str	x4, [x0, #0x10]
+               	str	x5, [x0, #0x18]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	ldr	x4, [x0, #0x18]
+               	mov	x16, #0xfe28            // =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfe38            // =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x1d8
                	mov	x0, x21
-               	mov	x1, x2
-<L60>:
-               	bl	 <L60>
-               	mov	x1, x24
-<L61>:
-               	bl	 <L61>
-               	mov	x1, x25
-<L62>:
-               	bl	 <L62>
-               	mov	x1, x26
-<L63>:
-               	bl	 <L63>
+<L64>:
+               	bl	 <L64>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x6
-               	b.lo	 <L59>
-<L64>:
-               	sub	x0, x29, #0x1b0
+               	b.lo	 <L63>
+<L65>:
+               	sub	x0, x29, #0x208
                	str	xzr, [x0]
                	str	xzr, [x0, #0x8]
                	str	xzr, [x0, #0x10]
@@ -1432,7 +1897,7 @@ Disassembly of section .text:
                	add	x4, x3, #0x1
                	add	x3, x20, #0x0
                	ldr	x5, [x3]
-               	sub	x3, x29, #0x2b8
+               	sub	x3, x29, #0x370
                	add	x6, x1, x5
                	add	x7, x3, #0x0
                	str	x6, [x7]
@@ -1449,7 +1914,7 @@ Disassembly of section .text:
                	str	x2, [x1]
                	str	x4, [x1, #0x8]
                	str	x5, [x1, #0x10]
-               	sub	x1, x29, #0x2c8
+               	sub	x1, x29, #0x380
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
                	add	x2, x1, #0x0
@@ -1463,7 +1928,7 @@ Disassembly of section .text:
                	ldr	x4, [x1, #0x8]
                	str	x3, [x2]
                	str	x4, [x2, #0x8]
-               	sub	x1, x29, #0x2f8
+               	sub	x1, x29, #0x3b0
                	ldr	x2, [x0]
                	ldr	x3, [x0, #0x8]
                	ldr	x4, [x0, #0x10]
@@ -1476,56 +1941,76 @@ Disassembly of section .text:
                	str	x5, [x1, #0x18]
                	str	x6, [x1, #0x20]
                	str	x7, [x1, #0x28]
+               	sub	x22, x29, #0x488
                	ldr	x0, [x1]
                	ldr	x2, [x1, #0x8]
                	ldr	x3, [x1, #0x10]
                	ldr	x4, [x1, #0x18]
                	ldr	x5, [x1, #0x20]
                	ldr	x6, [x1, #0x28]
-               	mov	x16, #0xfcd8            // =64728
+               	str	x0, [x22]
+               	str	x2, [x22, #0x8]
+               	str	x3, [x22, #0x10]
+               	str	x4, [x22, #0x18]
+               	str	x5, [x22, #0x20]
+               	str	x6, [x22, #0x28]
+               	add	x0, x22, #0x0
+               	ldr	w1, [x0]
+               	mov	w2, w1
+               	mov	x0, x21
+               	mov	x1, x2
+<L66>:
+               	bl	 <L66>
+               	add	x1, x22, #0x8
+               	sub	x2, x29, #0x4a0
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	ldr	x5, [x1, #0x10]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	str	x5, [x2, #0x10]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	ldr	x4, [x2, #0x10]
+               	mov	x16, #0xfb48            // =64328
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x2, [x29, x16]
-               	mov	x16, #0xfce8            // =64744
+               	str	x1, [x29, x16]
+               	mov	x16, #0xfb50            // =64336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfcf0            // =64752
+               	mov	x16, #0xfb58            // =64344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfcf8            // =64760
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x5, [x29, x16]
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x6, [x29, x16]
-               	sub	x1, x29, #0x328
-               	mov	x0, x21
-<L65>:
-               	bl	 <L65>
+               	sub	x1, x29, #0x4b8
+<L67>:
+               	bl	 <L67>
+               	add	x21, x22, #0x20
+               	add	x1, x21, #0x0
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L68>:
+               	bl	 <L68>
+               	add	x1, x21, #0x8
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L69>:
+               	bl	 <L69>
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L66>
-               	b	 <L99>
-<L66>:
+               	b.lo	 <L70>
+               	b	 <L96>
+<L70>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	sub	x0, x29, #0x258
+               	sub	x0, x29, #0x2d0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1536,30 +2021,30 @@ Disassembly of section .text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x24, x29, #0x288
+               	sub	x24, x29, #0x300
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	mov	x16, #0xfd60            // =64864
+               	mov	x16, #0xfce8            // =64744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfd68            // =64872
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfd70            // =64880
+               	mov	x16, #0xfcf8            // =64760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	sub	x0, x29, #0x2a0
+               	sub	x0, x29, #0x318
                	mov	x8, x24
-<L67>:
-               	bl	 <L67>
-               	sub	x0, x29, #0x358
+<L71>:
+               	bl	 <L71>
+               	sub	x0, x29, #0x3e0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1580,124 +2065,107 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x370
+               	sub	x25, x29, #0x3f8
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfc60            // =64608
+               	mov	x16, #0xfbd8            // =64472
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfc68            // =64616
+               	mov	x16, #0xfbe0            // =64480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfc70            // =64624
+               	mov	x16, #0xfbe8            // =64488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfc78            // =64632
+               	mov	x16, #0xfbf0            // =64496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfc80            // =64640
+               	mov	x16, #0xfbf8            // =64504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfc88            // =64648
+               	mov	x16, #0xfc00            // =64512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x3a0
+               	sub	x0, x29, #0x428
                	mov	x8, x25
-<L68>:
-               	bl	 <L68>
+<L72>:
+               	bl	 <L72>
                	add	x0, x24, #0x0
-               	ldr	x26, [x0]
+               	ldr	x1, [x0]
                	add	x0, x24, #0x8
-               	ldr	x27, [x0]
+               	ldr	x26, [x0]
                	add	x0, x24, #0x10
-               	ldr	x28, [x0]
+               	ldr	x27, [x0]
                	add	x0, x24, #0x18
-               	ldr	x9, [x0]
-               	mov	x16, #0xf990            // =63888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	ldr	x28, [x0]
                	add	x0, x24, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xf988            // =63880
+               	mov	x16, #0xf770            // =63344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x24, #0x28
                	ldr	x24, [x0]
-               	add	x0, x25, #0x0
-               	ldr	x9, [x0]
-               	mov	x16, #0xf980            // =63872
+               	sub	x9, x29, #0x4d0
+               	mov	x16, #0xf778            // =63352
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	add	x0, x25, #0x8
-               	ldr	x9, [x0]
-               	mov	x16, #0xf978            // =63864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	add	x0, x25, #0x10
-               	ldr	x25, [x0]
-<L69>:
-               	bl	 <L69>
-               	mov	x1, x26
-<L70>:
-               	bl	 <L70>
-               	mov	x1, x27
-<L71>:
-               	bl	 <L71>
-               	mov	x1, x28
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xf990            // =63888
+               	ldr	x0, [x25]
+               	ldr	x4, [x25, #0x8]
+               	ldr	x5, [x25, #0x10]
+               	mov	x16, #0xf778            // =63352
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	str	x0, [x9]
+               	mov	x16, #0xf778            // =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x4, [x9, #0x8]
+               	mov	x16, #0xf778            // =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x5, [x9, #0x10]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L73>:
                	bl	 <L73>
-               	mov	x16, #0xf988            // =63880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, x26
 <L74>:
                	bl	 <L74>
-               	mov	x1, x24
+               	mov	x1, x27
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xf980            // =63872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, x28
 <L76>:
                	bl	 <L76>
-               	mov	x16, #0xf978            // =63864
+               	mov	x16, #0xf770            // =63344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1705,18 +2173,61 @@ Disassembly of section .text:
                	mov	x1, x9
 <L77>:
                	bl	 <L77>
-               	mov	x1, x25
+               	mov	x1, x24
 <L78>:
                	bl	 <L78>
-               	mov	x1, x23
+               	sub	x1, x29, #0x4e8
+               	mov	x16, #0xf778            // =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x2, [x9]
+               	mov	x16, #0xf778            // =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x4, [x9, #0x8]
+               	mov	x16, #0xf778            // =63352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x5, [x9, #0x10]
+               	str	x2, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	mov	x16, #0xfb00            // =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xfb08            // =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	mov	x16, #0xfb10            // =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x1, x29, #0x500
 <L79>:
                	bl	 <L79>
-               	mov	x1, x0
-               	mov	x0, x21
+               	mov	x1, x23
 <L80>:
                	bl	 <L80>
+               	mov	x1, x0
+               	mov	x0, x21
+<L81>:
+               	bl	 <L81>
                	mov	x24, x0
-               	sub	x0, x29, #0x3d0
+               	sub	x0, x29, #0x530
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1737,70 +2248,70 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x3e8
+               	sub	x25, x29, #0x548
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfbe8            // =64488
+               	mov	x16, #0xfa88            // =64136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfbf0            // =64496
+               	mov	x16, #0xfa90            // =64144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfbf8            // =64504
+               	mov	x16, #0xfa98            // =64152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfc00            // =64512
+               	mov	x16, #0xfaa0            // =64160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfc08            // =64520
+               	mov	x16, #0xfaa8            // =64168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfc10            // =64528
+               	mov	x16, #0xfab0            // =64176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x418
+               	sub	x0, x29, #0x578
                	mov	x8, x25
-<L81>:
-               	bl	 <L81>
-               	sub	x26, x29, #0x448
+<L82>:
+               	bl	 <L82>
+               	sub	x26, x29, #0x5a8
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
-               	mov	x16, #0xfba0            // =64416
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfba8            // =64424
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfbb0            // =64432
+               	mov	x16, #0xfa50            // =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	sub	x0, x29, #0x460
+               	sub	x0, x29, #0x5c0
                	mov	x8, x26
-<L82>:
-               	bl	 <L82>
+<L83>:
+               	bl	 <L83>
                	add	x0, x26, #0x0
                	ldr	x1, [x0]
                	add	x0, x26, #0x8
@@ -1811,7 +2322,7 @@ Disassembly of section .text:
                	ldr	x28, [x0]
                	add	x0, x26, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xf970            // =63856
+               	mov	x16, #0xf768            // =63336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1819,30 +2330,30 @@ Disassembly of section .text:
                	add	x0, x26, #0x28
                	ldr	x26, [x0]
                	mov	x0, x24
-<L83>:
-               	bl	 <L83>
-               	mov	x1, x25
 <L84>:
                	bl	 <L84>
-               	mov	x1, x27
+               	mov	x1, x25
 <L85>:
                	bl	 <L85>
-               	mov	x1, x28
+               	mov	x1, x27
 <L86>:
                	bl	 <L86>
-               	mov	x16, #0xf970            // =63856
+               	mov	x1, x28
+<L87>:
+               	bl	 <L87>
+               	mov	x16, #0xf768            // =63336
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
-<L87>:
-               	bl	 <L87>
-               	mov	x1, x26
 <L88>:
                	bl	 <L88>
+               	mov	x1, x26
+<L89>:
+               	bl	 <L89>
                	mov	x24, x0
-               	sub	x0, x29, #0x478
+               	sub	x0, x29, #0x618
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1853,87 +2364,94 @@ Disassembly of section .text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x25, x29, #0x4a8
+               	sub	x25, x29, #0x648
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	mov	x16, #0xfb40            // =64320
+               	mov	x16, #0xf9a0            // =63904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfb48            // =64328
+               	mov	x16, #0xf9a8            // =63912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfb50            // =64336
+               	mov	x16, #0xf9b0            // =63920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	sub	x0, x29, #0x4c0
+               	sub	x0, x29, #0x660
                	mov	x8, x25
-<L89>:
-               	bl	 <L89>
-               	sub	x26, x29, #0x4d8
+<L90>:
+               	bl	 <L90>
+               	sub	x26, x29, #0x678
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
                	ldr	x3, [x25, #0x18]
                	ldr	x4, [x25, #0x20]
                	ldr	x5, [x25, #0x28]
-               	mov	x16, #0xfaf8            // =64248
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfb00            // =64256
+               	mov	x16, #0xf960            // =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfb08            // =64264
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfb10            // =64272
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfb18            // =64280
+               	mov	x16, #0xf978            // =63864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfb20            // =64288
+               	mov	x16, #0xf980            // =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	sub	x0, x29, #0x508
+               	sub	x0, x29, #0x6a8
                	mov	x8, x26
-<L90>:
-               	bl	 <L90>
-               	add	x0, x26, #0x0
-               	ldr	x1, [x0]
-               	add	x0, x26, #0x8
-               	ldr	x25, [x0]
-               	add	x0, x26, #0x10
-               	ldr	x26, [x0]
-               	mov	x0, x24
 <L91>:
                	bl	 <L91>
-               	mov	x1, x25
+               	ldr	x0, [x26]
+               	ldr	x1, [x26, #0x8]
+               	ldr	x2, [x26, #0x10]
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf950            // =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x6c0
+               	mov	x0, x24
 <L92>:
                	bl	 <L92>
-               	mov	x1, x26
-<L93>:
-               	bl	 <L93>
                	mov	x24, x0
-               	sub	x0, x29, #0x538
+               	sub	x0, x29, #0x6f0
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1954,117 +2472,136 @@ Disassembly of section .text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x568
+               	sub	x25, x29, #0x720
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
                	ldr	x4, [x0, #0x18]
                	ldr	x5, [x0, #0x20]
                	ldr	x6, [x0, #0x28]
-               	mov	x16, #0xfa68            // =64104
+               	mov	x16, #0xf8b0            // =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfa70            // =64112
+               	mov	x16, #0xf8b8            // =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfa78            // =64120
+               	mov	x16, #0xf8c0            // =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfa80            // =64128
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfa88            // =64136
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	mov	x16, #0xfa90            // =64144
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x6, [x29, x16]
-               	sub	x0, x29, #0x598
+               	sub	x0, x29, #0x750
                	mov	x8, x25
                	mov	x1, x23
-<L94>:
-               	bl	 <L94>
-               	sub	x26, x29, #0x5b0
+<L93>:
+               	bl	 <L93>
+               	sub	x26, x29, #0x768
                	ldr	x0, [x25]
                	ldr	x1, [x25, #0x8]
                	ldr	x2, [x25, #0x10]
                	ldr	x3, [x25, #0x18]
                	ldr	x4, [x25, #0x20]
                	ldr	x5, [x25, #0x28]
-               	mov	x16, #0xfa20            // =64032
+               	mov	x16, #0xf868            // =63592
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xfa28            // =64040
+               	mov	x16, #0xf870            // =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
-               	mov	x16, #0xfa30            // =64048
+               	mov	x16, #0xf878            // =63608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x2, [x29, x16]
-               	mov	x16, #0xfa38            // =64056
+               	mov	x16, #0xf880            // =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x3, [x29, x16]
-               	mov	x16, #0xfa40            // =64064
+               	mov	x16, #0xf888            // =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x4, [x29, x16]
-               	mov	x16, #0xfa48            // =64072
+               	mov	x16, #0xf890            // =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x5, [x29, x16]
-               	sub	x0, x29, #0x5e0
+               	sub	x0, x29, #0x798
                	mov	x8, x26
-<L95>:
-               	bl	 <L95>
+<L94>:
+               	bl	 <L94>
                	add	x0, x26, #0x0
                	ldr	x1, [x0]
                	add	x0, x26, #0x8
                	ldr	x2, [x0]
                	add	x0, x26, #0x10
                	ldr	x3, [x0]
+               	sub	x0, x29, #0x7b0
                	add	x4, x1, x23
-               	eor	x25, x2, x23
-               	add	x23, x3, x1
+               	add	x5, x0, #0x0
+               	str	x4, [x5]
+               	eor	x4, x2, x23
+               	add	x2, x0, #0x8
+               	str	x4, [x2]
+               	add	x2, x3, x1
+               	add	x1, x0, #0x10
+               	str	x2, [x1]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	mov	x16, #0xf838            // =63544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf840            // =63552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	mov	x16, #0xf848            // =63560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x3, [x29, x16]
+               	sub	x1, x29, #0x7c8
                	mov	x0, x24
-               	mov	x1, x4
-<L96>:
-               	bl	 <L96>
-               	mov	x1, x25
-<L97>:
-               	bl	 <L97>
-               	mov	x1, x23
-<L98>:
-               	bl	 <L98>
+<L95>:
+               	bl	 <L95>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L66>
-<L99>:
+               	b.lo	 <L70>
+<L96>:
                	mov	x0, x21
-               	sub	x16, x29, #0x6f0
-               	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x6a0
+               	sub	x16, x29, #0x900
+               	ldr	d8, [x16, #0x8]
+               	sub	x16, x29, #0x8b0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/call/call_ret_small.dis
+++ b/test/golden/aarch64-linux/call/call_ret_small.dis
@@ -228,24 +228,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
                	sub	x1, x29, #0x8
-               	ldr	w3, [x1]
+               	ldr	w2, [x1]
                	sub	x1, x29, #0x4
-               	ldr	w19, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
+               	ldr	w3, [x1]
+               	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -253,24 +279,53 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold8f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	s0, [x29, #-0x8]
                	stur	s1, [x29, #-0x4]
-               	sub	x2, x29, #0x8
-               	ldr	s0, [x2]
-               	sub	x2, x29, #0x4
-               	ldr	s8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x8
+               	ldr	s0, [x1]
+               	sub	x1, x29, #0x4
+               	ldr	s1, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -278,32 +333,72 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold12>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	w20, [x1]
-               	mov	x0, x3
+               	ldr	w4, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -311,25 +406,49 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x3, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -337,24 +456,51 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold16f>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x1, x0
+               	sub	sp, sp, #0x10
                	stur	d0, [x29, #-0x10]
                	stur	d1, [x29, #-0x8]
-               	sub	x2, x29, #0x10
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x8
-               	ldr	d8, [x2]
-               	mov	x0, x1
+               	sub	x1, x29, #0x10
+               	ldr	d0, [x1]
+               	sub	x1, x29, #0x8
+               	ldr	d1, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -362,25 +508,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold16m>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	d8, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	x2, [x1]
                	sub	x1, x29, #0x8
-               	ldr	d8, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	d0, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	d8, [x29, #-0x18]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -388,24 +559,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold16n>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x18]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldr	d0, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x19, [x1]
-               	mov	x0, x3
+               	ldr	x2, [x1]
+               	fmov	x1, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	ldur	x19, [x29, #-0x18]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -413,70 +610,66 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.layout>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x1                // =1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x2                // =2
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x2                // =2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x4                // =4
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x8                // =8
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xc                // =12
+               	mov	x1, #0x8                // =8
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0xc                // =12
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               // =16
 <L7>:
                	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               // =16
 <L8>:
                	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x10               // =16
 <L9>:
                	bl	 <L9>
+               	mov	x1, #0x10               // =16
+<L10>:
+               	bl	 <L10>
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.call.call_ret_small.regain>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xc0
-               	stp	x19, x20, [x29, #-0x60]
-               	stp	x21, x22, [x29, #-0x70]
-               	stp	x23, x24, [x29, #-0x80]
-               	stp	x25, x26, [x29, #-0x90]
-               	stp	d8, d9, [x29, #-0xa0]
-               	stp	d10, d11, [x29, #-0xb0]
-               	stur	d12, [x29, #-0xb8]
+               	sub	sp, sp, #0x130
+               	stp	x19, x20, [x29, #-0x110]
+               	stp	x21, x22, [x29, #-0x120]
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x23, [x29, x16]
                	stur	x0, [x29, #-0x10]
                	stur	x1, [x29, #-0x8]
                	stur	d0, [x29, #-0x20]
@@ -488,80 +681,102 @@ Disassembly of section .text:
                	stur	x6, [x29, #-0x48]
                	stur	s2, [x29, #-0x50]
                	stur	s3, [x29, #-0x4c]
-               	sub	x1, x29, #0x10
-               	ldr	x19, [x1]
-               	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	sub	x1, x29, #0x20
-               	ldr	d8, [x1]
-               	sub	x1, x29, #0x18
-               	ldr	d9, [x1]
-               	sub	x1, x29, #0x30
-               	ldr	x21, [x1]
-               	sub	x1, x29, #0x28
-               	ldr	d10, [x1]
-               	sub	x1, x29, #0x40
-               	ldr	w22, [x1]
-               	sub	x1, x29, #0x3c
-               	ldr	w23, [x1]
-               	sub	x1, x29, #0x38
-               	ldr	w24, [x1]
-               	sub	x1, x29, #0x48
-               	ldr	w25, [x1]
-               	sub	x1, x29, #0x44
-               	ldr	w26, [x1]
-               	sub	x1, x29, #0x50
-               	ldr	s11, [x1]
-               	sub	x1, x29, #0x4c
-               	ldr	s12, [x1]
+               	sub	x0, x29, #0x60
+               	ldur	x1, [x29, #-0x10]
+               	ldur	x2, [x29, #-0x8]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	sub	x19, x29, #0x70
+               	ldur	x1, [x29, #-0x20]
+               	ldur	x2, [x29, #-0x18]
+               	str	x1, [x19]
+               	str	x2, [x19, #0x8]
+               	sub	x20, x29, #0x80
+               	ldur	x1, [x29, #-0x30]
+               	ldur	x2, [x29, #-0x28]
+               	str	x1, [x20]
+               	str	x2, [x20, #0x8]
+               	sub	x21, x29, #0x8c
+               	ldur	x1, [x29, #-0x40]
+               	ldur	w2, [x29, #-0x38]
+               	str	x1, [x21]
+               	str	w2, [x21, #0x8]
+               	sub	x22, x29, #0x94
+               	ldur	x1, [x29, #-0x48]
+               	str	x1, [x22]
+               	sub	x23, x29, #0x9c
+               	ldur	x1, [x29, #-0x50]
+               	str	x1, [x23]
+               	sub	x1, x29, #0xb0
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x2
+               	mov	x2, x3
 <L0>:
                	bl	 <L0>
-               	mov	x1, x19
+               	sub	x1, x29, #0xc0
+               	ldr	x2, [x19]
+               	ldr	x3, [x19, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x20
+               	sub	x1, x29, #0xd0
+               	ldr	x2, [x20]
+               	ldr	x3, [x20, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L2>:
                	bl	 <L2>
-               	fmov	d0, d8
+               	sub	x1, x29, #0xdc
+               	ldr	x2, [x21]
+               	ldr	w3, [x21, #0x8]
+               	str	x2, [x1]
+               	str	w3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	stur	xzr, [x29, #-0xe8]
+               	ldr	w3, [x1, #0x8]
+               	stur	w3, [x29, #-0xe8]
+               	ldur	x3, [x29, #-0xe8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L3>:
                	bl	 <L3>
-               	fmov	d0, d9
+               	sub	x1, x29, #0xf0
+               	ldr	x2, [x22]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x21
+               	sub	x1, x29, #0xf8
+               	ldr	x2, [x23]
+               	str	x2, [x1]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
 <L5>:
                	bl	 <L5>
-               	fmov	d0, d10
-<L6>:
-               	bl	 <L6>
-               	mov	w1, w22
-<L7>:
-               	bl	 <L7>
-               	mov	w1, w23
-<L8>:
-               	bl	 <L8>
-               	mov	w1, w24
-<L9>:
-               	bl	 <L9>
-               	mov	w1, w25
-<L10>:
-               	bl	 <L10>
-               	mov	w1, w26
-<L11>:
-               	bl	 <L11>
-               	fmov	s0, s11
-<L12>:
-               	bl	 <L12>
-               	fmov	s0, s12
-<L13>:
-               	bl	 <L13>
-               	ldp	d8, d9, [x29, #-0xa0]
-               	ldp	d10, d11, [x29, #-0xb0]
-               	ldur	d12, [x29, #-0xb8]
-               	ldp	x19, x20, [x29, #-0x60]
-               	ldp	x21, x22, [x29, #-0x70]
-               	ldp	x23, x24, [x29, #-0x80]
-               	ldp	x25, x26, [x29, #-0x90]
+               	ldp	x19, x20, [x29, #-0x110]
+               	ldp	x21, x22, [x29, #-0x120]
+               	mov	x16, #0xfed8            // =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x23, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -569,25 +784,37 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1a0
-               	stp	x19, x20, [x29, #-0x130]
-               	stp	x21, x22, [x29, #-0x140]
-               	stp	x23, x24, [x29, #-0x150]
-               	stp	x25, x26, [x29, #-0x160]
-               	stp	x27, x28, [x29, #-0x170]
-               	stp	d8, d9, [x29, #-0x180]
-               	stp	d10, d11, [x29, #-0x190]
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d12, [x29, x16]
+               	sub	sp, sp, #0x2d0
+               	sub	x16, x29, #0x290
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stur	x27, [x16, #-0x38]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, #0x1                // =1
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
                	mov	x1, #0x2                // =2
 <L2>:
                	bl	 <L2>
@@ -615,7 +842,7 @@ Disassembly of section .text:
                	mov	x1, #0x10               // =16
 <L10>:
                	bl	 <L10>
-               	sub	x20, x29, #0xe8
+               	sub	x20, x29, #0x130
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -650,98 +877,143 @@ Disassembly of section .text:
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x8
                	b.lo	 <L13>
-               	b	 <L32>
+               	b	 <L27>
 <L13>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	mov	w1, w23
+               	mov	w0, w23
+               	uxtb	w1, w0
                	mov	x0, x21
 <L14>:
                	bl	 <L14>
                	mov	w1, w23
+               	uxth	w2, w1
+               	mov	x1, x2
 <L15>:
                	bl	 <L15>
                	mov	w1, w23
+               	mov	w2, w1
+               	mov	x1, x2
 <L16>:
                	bl	 <L16>
-               	mov	w1, w23
+               	sub	x1, x29, #0x184
+               	mov	w2, w23
+               	add	x3, x1, #0x0
+               	str	w2, [x3]
                	lsr	x2, x23, #32
-               	mov	w24, w2
+               	mov	w3, w2
+               	add	x2, x1, #0x4
+               	str	w3, [x2]
+               	ldr	x2, [x1]
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
-               	mov	w1, w24
-<L18>:
-               	bl	 <L18>
+               	sub	x1, x29, #0x238
                	mov	x16, #0xfff             // =4095
-               	and	x1, x23, x16
-               	ucvtf	s0, x1
+               	and	x2, x23, x16
+               	ucvtf	s0, x2
                	fmov	s30, #8.00000000
                	fdiv	s1, s0, s30
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
                	mov	x16, #0xff              // =255
-               	and	x1, x23, x16
-               	ucvtf	s0, x1
+               	and	x2, x23, x16
+               	ucvtf	s0, x2
                	mov	w16, #0x43000000        // =1124073472
                	fmov	s30, w16
-               	fsub	s8, s0, s30
-               	fmov	s0, s1
+               	fsub	s1, s0, s30
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
+<L18>:
+               	bl	 <L18>
+               	sub	x1, x29, #0x244
+               	mov	w2, w23
+               	add	x3, x1, #0x0
+               	str	w2, [x3]
+               	lsr	x2, x23, #16
+               	mov	w3, w2
+               	add	x2, x1, #0x4
+               	str	w3, [x2]
+               	lsr	x2, x23, #32
+               	mov	w3, w2
+               	add	x2, x1, #0x8
+               	str	w3, [x2]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	w3, [x1, #0x8]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w3, [x29, x16]
+               	mov	x16, #0xfdb0            // =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x3, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x3
 <L19>:
                	bl	 <L19>
-               	fmov	s0, s8
+               	sub	x1, x29, #0x260
+               	add	x2, x1, #0x0
+               	str	x23, [x2]
+               	mvn	x2, x23
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
 <L20>:
                	bl	 <L20>
-               	mov	w1, w23
-               	lsr	x2, x23, #16
-               	mov	w24, w2
-               	lsr	x2, x23, #32
-               	mov	w25, w2
-<L21>:
-               	bl	 <L21>
-               	mov	w1, w24
-<L22>:
-               	bl	 <L22>
-               	mov	w1, w25
-<L23>:
-               	bl	 <L23>
-               	mvn	x24, x23
-               	mov	x1, x23
-<L24>:
-               	bl	 <L24>
-               	mov	x1, x24
-<L25>:
-               	bl	 <L25>
+               	sub	x1, x29, #0x270
                	mov	x16, #0xffff            // =65535
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	fmov	d30, #8.00000000
                	fdiv	d1, d0, d30
+               	add	x2, x1, #0x0
+               	str	d1, [x2]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x3, lsl #16
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d8, d0, d30
-               	fmov	d0, d1
-<L26>:
-               	bl	 <L26>
-               	fmov	d0, d8
-<L27>:
-               	bl	 <L27>
+               	fdiv	d1, d0, d30
+               	add	x2, x1, #0x8
+               	str	d1, [x2]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
+<L21>:
+               	bl	 <L21>
+               	sub	x1, x29, #0x280
                	mov	x16, #0x3               // =3
-               	mul	x1, x23, x16
-               	add	x2, x1, #0x1
+               	mul	x2, x23, x16
+               	add	x3, x2, #0x1
+               	add	x2, x1, #0x0
+               	str	x3, [x2]
                	mov	x16, #0x7fff            // =32767
-               	and	x1, x23, x16
-               	ucvtf	d0, x1
+               	and	x2, x23, x16
+               	ucvtf	d0, x2
                	fmov	d30, #4.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x2, x1, #0x8
+               	str	d1, [x2]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d8
-<L29>:
-               	bl	 <L29>
+               	mov	x2, x3
+<L22>:
+               	bl	 <L22>
                	mov	x16, #0x1fff            // =8191
                	and	x1, x23, x16
                	ucvtf	d0, x1
@@ -749,47 +1021,78 @@ Disassembly of section .text:
                	fdiv	d1, d0, d30
                	mov	x16, #0x5678            // =22136
                	movk	x16, #0x1234, lsl #16
-               	eor	x24, x23, x16
-               	fmov	d0, d1
-<L30>:
-               	bl	 <L30>
-               	mov	x1, x24
-<L31>:
-               	bl	 <L31>
+               	eor	x1, x23, x16
+               	fmov	x2, d1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
+<L26>:
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x8
                	b.lo	 <L13>
-<L32>:
+<L27>:
                	sub	x22, x29, #0x48
                	add	x0, x22, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x48               // =72
-<L33>:
+<L28>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L33>
+               	b.ne	 <L28>
                	sub	x23, x29, #0xa8
                	add	x0, x23, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x60               // =96
-<L34>:
+<L29>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L34>
+               	b.ne	 <L29>
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x6
-               	b.lo	 <L35>
-               	b	 <L36>
-<L35>:
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0xf4
+               	sub	x2, x29, #0xdc
                	mov	w3, w1
                	add	x4, x2, #0x0
                	str	w3, [x4]
@@ -813,7 +1116,7 @@ Disassembly of section .text:
                	mov	x16, #0x3               // =3
                	mul	x1, x2, x16
                	add	x2, x1, x19
-               	sub	x1, x29, #0x108
+               	sub	x1, x29, #0x140
                	mov	x16, #0x3               // =3
                	mul	x3, x2, x16
                	add	x4, x3, #0x1
@@ -835,181 +1138,245 @@ Disassembly of section .text:
                	str	x4, [x3, #0x8]
                	add	x0, x0, #0x1
                	cmp	x0, #0x6
-               	b.lo	 <L35>
-<L36>:
+               	b.lo	 <L30>
+<L31>:
                	mov	x24, #0x0               // =0
                	cmp	x24, #0x6
-               	b.lo	 <L37>
-               	b	 <L43>
-<L37>:
+               	b.lo	 <L32>
+               	b	 <L35>
+<L32>:
                	mov	x16, #0xc               // =12
                	mul	x0, x24, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldr	w2, [x0]
-               	add	x0, x1, #0x4
-               	ldr	w25, [x0]
-               	add	x0, x1, #0x8
-               	ldr	w26, [x0]
+               	sub	x0, x29, #0xb4
+               	ldr	x2, [x1]
+               	ldr	w3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	w3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	stur	xzr, [x29, #-0xc0]
+               	ldr	w2, [x0, #0x8]
+               	stur	w2, [x29, #-0xc0]
+               	ldur	x2, [x29, #-0xc0]
                	mov	x0, x21
-               	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	mov	w1, w25
-<L39>:
-               	bl	 <L39>
-               	mov	w1, w26
-<L40>:
-               	bl	 <L40>
+<L33>:
+               	bl	 <L33>
                	mov	x16, #0x10              // =16
                	mul	x1, x24, x16
                	add	x2, x23, x1
-               	add	x1, x2, #0x0
-               	ldr	x3, [x1]
-               	add	x1, x2, #0x8
-               	ldr	d8, [x1]
-               	mov	x1, x3
-<L41>:
-               	bl	 <L41>
-               	fmov	d0, d8
-<L42>:
-               	bl	 <L42>
+               	sub	x1, x29, #0xd0
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L34>:
+               	bl	 <L34>
                	add	x24, x24, #0x1
                	mov	x21, x0
                	cmp	x24, #0x6
-               	b.lo	 <L37>
-<L43>:
+               	b.lo	 <L32>
+<L35>:
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L44>
-               	b	 <L60>
-<L44>:
+               	b.lo	 <L36>
+               	b	 <L44>
+<L36>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
-               	add	x23, x1, x19
-               	mvn	x24, x23
+               	add	x0, x1, x19
+               	sub	x1, x29, #0xf0
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	mvn	x2, x0
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	sub	x2, x29, #0x150
                	mov	x16, #0xffff            // =65535
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x3, x0, x16
+               	ucvtf	d0, x3
                	fmov	d30, #8.00000000
-               	fdiv	d8, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x3, x2, #0x0
+               	str	d1, [x3]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x3, lsl #16
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x3, x0, x16
+               	ucvtf	d0, x3
                	mov	x16, #0x4050000000000000 // =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d9, d0, d30
+               	fdiv	d1, d0, d30
+               	add	x3, x2, #0x8
+               	str	d1, [x3]
+               	sub	x3, x29, #0x160
                	mov	x16, #0x3               // =3
-               	mul	x0, x23, x16
-               	add	x25, x0, #0x1
+               	mul	x4, x0, x16
+               	add	x5, x4, #0x1
+               	add	x4, x3, #0x0
+               	str	x5, [x4]
                	mov	x16, #0x7fff            // =32767
-               	and	x0, x23, x16
-               	ucvtf	d0, x0
+               	and	x4, x0, x16
+               	ucvtf	d0, x4
                	fmov	d30, #4.00000000
-               	fdiv	d10, d0, d30
-               	mov	w26, w23
-               	lsr	x0, x23, #16
-               	mov	w27, w0
-               	lsr	x0, x23, #32
-               	mov	w28, w0
-               	mov	w9, w23
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	lsr	x0, x23, #32
-               	mov	w9, w0
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	fdiv	d1, d0, d30
+               	add	x4, x3, #0x8
+               	str	d1, [x4]
+               	sub	x4, x29, #0x16c
+               	mov	w5, w0
+               	add	x6, x4, #0x0
+               	str	w5, [x6]
+               	lsr	x5, x0, #16
+               	mov	w6, w5
+               	add	x5, x4, #0x4
+               	str	w6, [x5]
+               	lsr	x5, x0, #32
+               	mov	w6, w5
+               	add	x5, x4, #0x8
+               	str	w6, [x5]
+               	sub	x5, x29, #0x174
+               	mov	w6, w0
+               	add	x7, x5, #0x0
+               	str	w6, [x7]
+               	lsr	x6, x0, #32
+               	mov	w7, w6
+               	add	x6, x5, #0x4
+               	str	w7, [x6]
+               	sub	x6, x29, #0x17c
                	mov	x16, #0xfff             // =4095
-               	and	x0, x23, x16
-               	ucvtf	s0, x0
+               	and	x7, x0, x16
+               	ucvtf	s0, x7
                	fmov	s30, #8.00000000
-               	fdiv	s11, s0, s30
+               	fdiv	s1, s0, s30
+               	add	x7, x6, #0x0
+               	str	s1, [x7]
                	mov	x16, #0xff              // =255
-               	and	x0, x23, x16
-               	ucvtf	s0, x0
+               	and	x7, x0, x16
+               	ucvtf	s0, x7
                	mov	w16, #0x43000000        // =1124073472
                	fmov	s30, w16
-               	fsub	s12, s0, s30
-<L45>:
-               	bl	 <L45>
-               	mov	x1, x23
-<L46>:
-               	bl	 <L46>
-               	mov	x1, x24
-<L47>:
-               	bl	 <L47>
-               	fmov	d0, d8
-<L48>:
-               	bl	 <L48>
-               	fmov	d0, d9
-<L49>:
-               	bl	 <L49>
-               	mov	x1, x25
-<L50>:
-               	bl	 <L50>
-               	fmov	d0, d10
-<L51>:
-               	bl	 <L51>
-               	mov	w1, w26
-<L52>:
-               	bl	 <L52>
-               	mov	w1, w27
-<L53>:
-               	bl	 <L53>
-               	mov	w1, w28
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfef0            // =65264
+               	fsub	s1, s0, s30
+               	add	x0, x6, #0x4
+               	str	s1, [x0]
+               	sub	x0, x29, #0x198
+               	ldr	x7, [x1]
+               	ldr	x8, [x1, #0x8]
+               	str	x7, [x0]
+               	str	x8, [x0, #0x8]
+               	sub	x23, x29, #0x1a8
+               	ldr	x1, [x2]
+               	ldr	x7, [x2, #0x8]
+               	str	x1, [x23]
+               	str	x7, [x23, #0x8]
+               	sub	x24, x29, #0x1b8
+               	ldr	x1, [x3]
+               	ldr	x2, [x3, #0x8]
+               	str	x1, [x24]
+               	str	x2, [x24, #0x8]
+               	sub	x25, x29, #0x1c4
+               	ldr	x1, [x4]
+               	ldr	w2, [x4, #0x8]
+               	str	x1, [x25]
+               	str	w2, [x25, #0x8]
+               	sub	x26, x29, #0x1cc
+               	ldr	x1, [x5]
+               	str	x1, [x26]
+               	sub	x27, x29, #0x1d4
+               	ldr	x1, [x6]
+               	str	x1, [x27]
+               	sub	x1, x29, #0x1e8
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x2
+               	mov	x2, x3
+<L37>:
+               	bl	 <L37>
+               	sub	x1, x29, #0x1f8
+               	ldr	x2, [x23]
+               	ldr	x3, [x23, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	d0, [x1]
+               	ldr	d1, [x1, #0x8]
+<L38>:
+               	bl	 <L38>
+               	sub	x1, x29, #0x208
+               	ldr	x2, [x24]
+               	ldr	x3, [x24, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x1, x2
+               	mov	x2, x3
+<L39>:
+               	bl	 <L39>
+               	sub	x1, x29, #0x214
+               	ldr	x2, [x25]
+               	ldr	w3, [x25, #0x8]
+               	str	x2, [x1]
+               	str	w3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfee8            // =65256
+               	str	xzr, [x29, x16]
+               	ldr	w3, [x1, #0x8]
+               	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L56>:
-               	bl	 <L56>
-               	fmov	s0, s11
-<L57>:
-               	bl	 <L57>
-               	fmov	s0, s12
-<L58>:
-               	bl	 <L58>
+               	str	w3, [x29, x16]
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x3, [x29, x16]
+               	mov	x1, x2
+               	mov	x2, x3
+<L40>:
+               	bl	 <L40>
+               	sub	x1, x29, #0x228
+               	ldr	x2, [x26]
+               	str	x2, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L41>:
+               	bl	 <L41>
+               	sub	x1, x29, #0x230
+               	ldr	x2, [x27]
+               	str	x2, [x1]
+               	ldr	s0, [x1]
+               	ldr	s1, [x1, #0x4]
+<L42>:
+               	bl	 <L42>
                	mov	x1, x0
                	mov	x0, x21
-<L59>:
-               	bl	 <L59>
+<L43>:
+               	bl	 <L43>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L44>
-<L60>:
+               	b.lo	 <L36>
+<L44>:
                	mov	x0, x21
-               	ldp	d8, d9, [x29, #-0x180]
-               	ldp	d10, d11, [x29, #-0x190]
-               	mov	x16, #0xfe68            // =65128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d12, [x29, x16]
-               	ldp	x19, x20, [x29, #-0x130]
-               	ldp	x21, x22, [x29, #-0x140]
-               	ldp	x23, x24, [x29, #-0x150]
-               	ldp	x25, x26, [x29, #-0x160]
-               	ldp	x27, x28, [x29, #-0x170]
+               	sub	x16, x29, #0x290
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldur	x27, [x16, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/call/call_variadic.dis
+++ b/test/golden/aarch64-linux/call/call_variadic.dis
@@ -20,70 +20,99 @@ Disassembly of section .text:
 <corpus.cases.call.call_variadic.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x150
-               	stp	x19, x20, [x29, #-0xd0]
-               	stp	x21, x22, [x29, #-0xe0]
-               	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
-               	stp	x27, x28, [x29, #-0x110]
-               	stp	d8, d9, [x29, #-0x120]
-               	stp	d10, d11, [x29, #-0x130]
-               	stp	d12, d13, [x29, #-0x140]
-               	mov	x16, #0xfeb8            // =65208
+               	sub	sp, sp, #0x130
+               	stp	x19, x20, [x29, #-0xb0]
+               	stp	x21, x22, [x29, #-0xc0]
+               	stp	x23, x24, [x29, #-0xd0]
+               	stp	x25, x26, [x29, #-0xe0]
+               	stp	x27, x28, [x29, #-0xf0]
+               	stp	d8, d9, [x29, #-0x100]
+               	stp	d10, d11, [x29, #-0x110]
+               	stp	d12, d13, [x29, #-0x120]
+               	mov	x16, #0xfed8            // =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d14, [x29, x16]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               // =96
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               // =96
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x2, x1, x16
+               	mul	x1, x0, x16
                	mov	x16, #0x814f            // =33103
                	movk	x16, #0xf767, lsl #16
                	movk	x16, #0x7b7e, lsl #32
                	movk	x16, #0x1405, lsl #48
-               	add	x3, x2, x16
-               	add	x2, x3, x19
-               	add	x3, x20, x1, lsl #3
-               	str	x2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0xc
-               	b.lo	 <L2>
+               	add	x2, x1, x16
+               	add	x1, x2, x19
+               	add	x2, x20, x0, lsl #3
+               	str	x1, [x2]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0xc
+               	b.lo	 <L1>
+<L2>:
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	mov	x1, #0x0                // =0
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, #0x0                // =0
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x0, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
                	mov	x21, x0
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L7>
-               	b	 <L77>
-<L7>:
+               	b.lo	 <L9>
+               	b	 <L92>
+<L9>:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
@@ -91,12 +120,11 @@ Disassembly of section .text:
                	mov	w25, w23
                	mov	w26, w23
                	lsr	x0, x23, #7
-               	mov	w27, w0
+               	mov	w1, w0
                	lsr	x0, x23, #3
-               	mov	w28, w0
+               	mov	w27, w0
                	lsr	x0, x23, #11
-               	mov	w9, w0
-               	stur	x9, [x29, #-0x68]
+               	mov	w28, w0
                	mov	x16, #0xfff             // =4095
                	and	x0, x23, x16
                	ucvtf	s0, x0
@@ -139,223 +167,379 @@ Disassembly of section .text:
                	mov	x16, #0x3               // =3
                	mul	x9, x23, x16
                	stur	x9, [x29, #-0x70]
-               	uxtb	w1, w24
-               	mov	x0, x21
-<L8>:
-               	bl	 <L8>
-               	sxth	x1, w25
-<L9>:
-               	bl	 <L9>
-               	mov	w1, w26
+               	uxtb	w0, w24
+               	mov	x3, x21
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	uxtb	w1, w27
+               	sxth	x0, w25
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	uxth	w1, w28
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldur	x9, [x29, #-0x68]
-               	sxtw	x1, w9
+               	mov	w0, w26
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x0, x16
+               	lsr	x5, x23, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	uxtb	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	uxth	w1, w27
+               	mov	x0, x3
+<L20>:
+               	bl	 <L20>
+               	sxtw	x1, w28
+<L21>:
+               	bl	 <L21>
                	ldur	x9, [x29, #-0x70]
                	mov	x1, x9
-<L15>:
-               	bl	 <L15>
+<L22>:
+               	bl	 <L22>
                	mov	x1, #0x8                // =8
-<L16>:
-               	bl	 <L16>
+<L23>:
+               	bl	 <L23>
                	add	x1, x20, #0x0
                	ldr	x2, [x1]
                	add	x1, x2, x23
                	add	x2, x20, #0x8
-               	ldr	x27, [x2]
+               	ldr	x3, [x2]
                	add	x2, x20, #0x10
-               	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x78]
+               	ldr	x4, [x2]
                	add	x2, x20, #0x18
-               	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x80]
+               	ldr	x5, [x2]
                	add	x2, x20, #0x20
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x68]
                	add	x2, x20, #0x28
-               	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x90]
+               	ldr	x28, [x2]
                	add	x2, x20, #0x30
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0x78]
                	add	x2, x20, #0x38
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xa0]
+               	stur	x9, [x29, #-0x80]
                	add	x2, x20, #0x40
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xa8]
+               	stur	x9, [x29, #-0x88]
                	add	x2, x20, #0x48
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0x90]
                	add	x2, x20, #0x50
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xb8]
+               	stur	x9, [x29, #-0x98]
                	add	x2, x20, #0x58
                	ldr	x9, [x2]
-               	stur	x9, [x29, #-0xc0]
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x27
-<L18>:
-               	bl	 <L18>
-               	ldur	x9, [x29, #-0x78]
-               	mov	x1, x9
-<L19>:
-               	bl	 <L19>
-               	ldur	x9, [x29, #-0x80]
-               	mov	x1, x9
-<L20>:
-               	bl	 <L20>
-               	ldur	x9, [x29, #-0x88]
-               	mov	x1, x9
-<L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x90]
-               	mov	x1, x9
-<L22>:
-               	bl	 <L22>
-               	ldur	x9, [x29, #-0x98]
-               	mov	x1, x9
-<L23>:
-               	bl	 <L23>
-               	ldur	x9, [x29, #-0xa0]
-               	mov	x1, x9
+               	stur	x9, [x29, #-0xa0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
 <L24>:
-               	bl	 <L24>
-               	ldur	x9, [x29, #-0xa8]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x18, x2, x16
+               	lsr	x6, x1, x18
+               	mov	x16, #0xff              // =255
+               	and	x18, x6, x16
+               	eor	x6, x0, x18
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
 <L25>:
-               	bl	 <L25>
-               	ldur	x9, [x29, #-0xb0]
-               	mov	x1, x9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	ldur	x9, [x29, #-0xb8]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x6, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x6, x16
+               	eor	x6, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	ldur	x9, [x29, #-0xc0]
-               	mov	x1, x9
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	mov	x1, #0xc                // =12
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	bl	 <L29>
-               	fmov	s0, s8
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	fmov	d0, d12
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x5, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	fmov	s0, s9
+               	ldur	x9, [x29, #-0x68]
+               	mov	x1, x9
 <L32>:
                	bl	 <L32>
-               	fmov	d0, d13
+               	mov	x1, x28
 <L33>:
                	bl	 <L33>
-               	mov	x1, #0x4                // =4
+               	ldur	x9, [x29, #-0x78]
+               	mov	x1, x9
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0x5               // =5
-               	mul	x27, x23, x16
-               	mov	x1, x23
+               	ldur	x9, [x29, #-0x80]
+               	mov	x1, x9
 <L35>:
                	bl	 <L35>
-               	fmov	s0, s8
+               	ldur	x9, [x29, #-0x88]
+               	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	mov	w1, w26
+               	ldur	x9, [x29, #-0x90]
+               	mov	x1, x9
 <L37>:
                	bl	 <L37>
-               	fmov	d0, d12
+               	ldur	x9, [x29, #-0x98]
+               	mov	x1, x9
 <L38>:
                	bl	 <L38>
-               	sxth	x1, w25
+               	ldur	x9, [x29, #-0xa0]
+               	mov	x1, x9
 <L39>:
                	bl	 <L39>
-               	mov	x1, x27
+               	mov	x1, #0xc                // =12
 <L40>:
                	bl	 <L40>
-               	mov	x1, #0x6                // =6
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
 <L41>:
-               	bl	 <L41>
-               	mov	x16, #0x7               // =7
-               	mul	x27, x23, x16
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L41>
 <L42>:
-               	bl	 <L42>
-               	uxtb	w1, w24
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	fmov	x1, d12
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
 <L43>:
-               	bl	 <L43>
-               	mov	w1, w26
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
 <L44>:
-               	bl	 <L44>
-               	add	x1, x27, x23
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
-               	uxth	w1, w28
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	fmov	x1, d13
 <L46>:
                	bl	 <L46>
                	mov	x1, #0x4                // =4
 <L47>:
                	bl	 <L47>
-               	mov	x1, x23
+               	mov	x16, #0x5               // =5
+               	mul	x28, x23, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
+               	b	 <L49>
 <L48>:
-               	bl	 <L48>
-               	fmov	s0, s10
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
 <L49>:
-               	bl	 <L49>
-               	add	x1, x23, x23
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L50>:
                	bl	 <L50>
-               	fmov	d0, d14
+               	mov	w1, w26
 <L51>:
                	bl	 <L51>
-               	mov	x1, #0x3                // =3
+               	fmov	x1, d12
 <L52>:
                	bl	 <L52>
-               	uxtb	w1, w24
+               	sxth	x1, w25
 <L53>:
                	bl	 <L53>
-               	sxth	x1, w25
+               	mov	x1, x28
 <L54>:
                	bl	 <L54>
-               	mov	w1, w26
+               	mov	x1, #0x6                // =6
 <L55>:
                	bl	 <L55>
-               	mov	x1, x23
+               	mov	x16, #0x7               // =7
+               	mul	x28, x23, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
 <L56>:
-               	bl	 <L56>
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x23, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
 <L57>:
-               	bl	 <L57>
                	uxtb	w1, w24
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L58>:
                	bl	 <L58>
-               	sxth	x1, w25
+               	mov	w1, w26
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L59>:
                	bl	 <L59>
-               	mov	w1, w26
+               	add	x1, x28, x23
 <L60>:
                	bl	 <L60>
-               	mov	x1, x23
+               	uxth	w1, w27
+               	add	x2, x1, x23
+               	mov	x1, x2
 <L61>:
                	bl	 <L61>
                	mov	x1, #0x4                // =4
@@ -364,74 +548,125 @@ Disassembly of section .text:
                	mov	x1, x23
 <L63>:
                	bl	 <L63>
-               	fmov	s0, s8
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L64>:
                	bl	 <L64>
-               	fmov	d0, d12
+               	add	x1, x23, x23
 <L65>:
                	bl	 <L65>
-               	mov	x1, #0x3                // =3
+               	fmov	x1, d14
 <L66>:
                	bl	 <L66>
-               	mov	x16, #0x7               // =7
-               	mul	x25, x23, x16
-               	mov	x16, #0x3               // =3
-               	mul	x27, x23, x16
-               	mov	x1, x27
+               	mov	x1, #0x3                // =3
 <L67>:
                	bl	 <L67>
                	uxtb	w1, w24
-               	add	x2, x1, x27
-               	mov	x1, x2
 <L68>:
                	bl	 <L68>
-               	mov	w1, w26
-               	add	x2, x1, x27
-               	mov	x1, x2
+               	sxth	x1, w25
 <L69>:
                	bl	 <L69>
-               	add	x1, x25, x27
+               	mov	w1, w26
 <L70>:
                	bl	 <L70>
-               	uxth	w1, w28
-               	add	x2, x1, x27
-               	mov	x1, x2
+               	mov	x1, x23
 <L71>:
                	bl	 <L71>
                	mov	x1, #0x4                // =4
 <L72>:
                	bl	 <L72>
-               	mov	x1, x23
+               	uxtb	w1, w24
 <L73>:
                	bl	 <L73>
-               	mov	x1, #0x1                // =1
+               	sxth	x1, w25
 <L74>:
                	bl	 <L74>
-               	fmov	s0, s11
+               	mov	w1, w26
 <L75>:
                	bl	 <L75>
-               	mov	x1, #0x1                // =1
+               	mov	x1, x23
 <L76>:
                	bl	 <L76>
+               	mov	x1, #0x4                // =4
+<L77>:
+               	bl	 <L77>
+               	mov	x1, x23
+<L78>:
+               	bl	 <L78>
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
+               	fmov	x1, d12
+<L80>:
+               	bl	 <L80>
+               	mov	x1, #0x3                // =3
+<L81>:
+               	bl	 <L81>
+               	mov	x16, #0x7               // =7
+               	mul	x25, x23, x16
+               	mov	x16, #0x3               // =3
+               	mul	x28, x23, x16
+               	mov	x1, x28
+<L82>:
+               	bl	 <L82>
+               	uxtb	w1, w24
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L83>:
+               	bl	 <L83>
+               	mov	w1, w26
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L84>:
+               	bl	 <L84>
+               	add	x1, x25, x28
+<L85>:
+               	bl	 <L85>
+               	uxth	w1, w27
+               	add	x2, x1, x28
+               	mov	x1, x2
+<L86>:
+               	bl	 <L86>
+               	mov	x1, #0x4                // =4
+<L87>:
+               	bl	 <L87>
+               	mov	x1, x23
+<L88>:
+               	bl	 <L88>
+               	mov	x1, #0x1                // =1
+<L89>:
+               	bl	 <L89>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L90>:
+               	bl	 <L90>
+               	mov	x1, #0x1                // =1
+<L91>:
+               	bl	 <L91>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L7>
-<L77>:
+               	b.lo	 <L9>
+<L92>:
                	mov	x0, x21
-               	ldp	d8, d9, [x29, #-0x120]
-               	ldp	d10, d11, [x29, #-0x130]
-               	ldp	d12, d13, [x29, #-0x140]
-               	mov	x16, #0xfeb8            // =65208
+               	ldp	d8, d9, [x29, #-0x100]
+               	ldp	d10, d11, [x29, #-0x110]
+               	ldp	d12, d13, [x29, #-0x120]
+               	mov	x16, #0xfed8            // =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d14, [x29, x16]
-               	ldp	x19, x20, [x29, #-0xd0]
-               	ldp	x21, x22, [x29, #-0xe0]
-               	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
-               	ldp	x27, x28, [x29, #-0x110]
+               	ldp	x19, x20, [x29, #-0xb0]
+               	ldp	x21, x22, [x29, #-0xc0]
+               	ldp	x23, x24, [x29, #-0xd0]
+               	ldp	x25, x26, [x29, #-0xe0]
+               	ldp	x27, x28, [x29, #-0xf0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -640,30 +875,25 @@ Disassembly of section .text:
                	sub	sp, sp, #0x20
                	stp	d8, d9, [x29, #-0x10]
                	stur	d10, [x29, #-0x18]
-               	mov	x1, x0
                	fmov	d8, d1
                	fmov	s9, s2
                	fmov	d10, d3
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
+               	fmov	x1, d8
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	fmov	x1, d10
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x4                // =4
 <L4>:
                	bl	 <L4>
@@ -689,35 +919,23 @@ Disassembly of section .text:
                	mov	x0, x5
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	w2, w19
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	w1, w19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	sxth	x2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	sxth	x1, w20
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, x21
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x6                // =6
 <L6>:
                	bl	 <L6>
@@ -799,24 +1017,17 @@ Disassembly of section .text:
                	mov	x1, x19
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x20, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	add	x1, x20, x19
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x3                // =3
 <L4>:
                	bl	 <L4>
@@ -897,10 +1108,12 @@ Disassembly of section .text:
                	fmov	d9, d1
 <L0>:
                	bl	 <L0>
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
                	mov	x1, #0x3                // =3
@@ -973,12 +1186,11 @@ Disassembly of section .text:
 <corpus.cases.call.call_variadic.fold_pack$pack$f32>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	mov	x1, x0
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x1                // =1
 <L1>:
                	bl	 <L1>
@@ -1037,10 +1249,12 @@ Disassembly of section .text:
                	fmov	d9, d1
 <L0>:
                	bl	 <L0>
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
                	mov	x1, #0x3                // =3
@@ -1062,18 +1276,14 @@ Disassembly of section .text:
                	mov	x0, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
+               	fmov	x1, d9
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
                	mov	x1, #0x3                // =3
 <L3>:
                	bl	 <L3>

--- a/test/golden/aarch64-linux/cmp/branch_nest.dis
+++ b/test/golden/aarch64-linux/cmp/branch_nest.dis
@@ -3,158 +3,180 @@ cmp/branch_nest.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.branch_nest.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	w2, #0x0                // =0
+               	cmp	w2, #0x14
+               	b.lo	 <L0>
+               	b	 <L43>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	mov	x19, x0
-               	mov	w21, #0x0               // =0
-               	cmp	w21, #0x14
-               	b.lo	 <L1>
-               	b	 <L42>
+               	add	w3, w2, w1
+               	cmp	w3, #0x4
+               	b.lo	 <L31>
+               	cmp	w3, #0x8
+               	b.lo	 <L23>
+               	cmp	w3, #0xc
+               	b.lo	 <L15>
+               	cmp	w3, #0x10
+               	b.lo	 <L7>
+               	cmp	w3, #0x10
+               	b.eq	 <L5>
+               	cmp	w3, #0x11
+               	b.eq	 <L3>
+               	cmp	w3, #0x12
+               	b.eq	 <L1>
+               	mov	w4, #0x1f7              // =503
+               	b	 <L2>
 <L1>:
-               	add	w22, w21, w20
-               	cmp	w22, #0x4
-               	b.lo	 <L32>
-               	cmp	w22, #0x8
-               	b.lo	 <L24>
-               	cmp	w22, #0xc
-               	b.lo	 <L16>
-               	cmp	w22, #0x10
-               	b.lo	 <L8>
-               	cmp	w22, #0x10
-               	b.eq	 <L6>
-               	cmp	w22, #0x11
-               	b.eq	 <L4>
-               	cmp	w22, #0x12
-               	b.eq	 <L2>
-               	mov	w0, #0x1f7              // =503
-               	b	 <L3>
+               	mov	w4, #0x1f6              // =502
 <L2>:
-               	mov	w0, #0x1f6              // =502
+               	b	 <L4>
 <L3>:
-               	b	 <L5>
+               	mov	w4, #0x1f5              // =501
 <L4>:
-               	mov	w0, #0x1f5              // =501
+               	b	 <L6>
 <L5>:
-               	b	 <L7>
+               	mov	w4, #0x1f4              // =500
 <L6>:
-               	mov	w0, #0x1f4              // =500
-<L7>:
-               	b	 <L15>
-<L8>:
-               	cmp	w22, #0xe
-               	b.lo	 <L11>
-               	cmp	w22, #0xe
-               	b.eq	 <L9>
-               	mov	w1, #0x193              // =403
-               	b	 <L10>
-<L9>:
-               	mov	w1, #0x192              // =402
-<L10>:
                	b	 <L14>
-<L11>:
-               	cmp	w22, #0xc
-               	b.eq	 <L12>
-               	mov	w2, #0x191              // =401
+<L7>:
+               	cmp	w3, #0xe
+               	b.lo	 <L10>
+               	cmp	w3, #0xe
+               	b.eq	 <L8>
+               	mov	w5, #0x193              // =403
+               	b	 <L9>
+<L8>:
+               	mov	w5, #0x192              // =402
+<L9>:
                	b	 <L13>
+<L10>:
+               	cmp	w3, #0xc
+               	b.eq	 <L11>
+               	mov	w6, #0x191              // =401
+               	b	 <L12>
+<L11>:
+               	mov	w6, #0x190              // =400
 <L12>:
-               	mov	w2, #0x190              // =400
+               	mov	x5, x6
 <L13>:
-               	mov	x1, x2
+               	mov	x4, x5
 <L14>:
-               	mov	x0, x1
-<L15>:
-               	b	 <L23>
-<L16>:
-               	cmp	w22, #0x8
-               	b.eq	 <L21>
-               	cmp	w22, #0x9
-               	b.eq	 <L19>
-               	cmp	w22, #0xa
-               	b.eq	 <L17>
-               	mov	w1, #0x12f              // =303
-               	b	 <L18>
-<L17>:
-               	mov	w1, #0x12e              // =302
-<L18>:
-               	b	 <L20>
-<L19>:
-               	mov	w1, #0x12d              // =301
-<L20>:
                	b	 <L22>
+<L15>:
+               	cmp	w3, #0x8
+               	b.eq	 <L20>
+               	cmp	w3, #0x9
+               	b.eq	 <L18>
+               	cmp	w3, #0xa
+               	b.eq	 <L16>
+               	mov	w5, #0x12f              // =303
+               	b	 <L17>
+<L16>:
+               	mov	w5, #0x12e              // =302
+<L17>:
+               	b	 <L19>
+<L18>:
+               	mov	w5, #0x12d              // =301
+<L19>:
+               	b	 <L21>
+<L20>:
+               	mov	w5, #0x12c              // =300
 <L21>:
-               	mov	w1, #0x12c              // =300
+               	mov	x4, x5
 <L22>:
-               	mov	x0, x1
-<L23>:
-               	b	 <L31>
-<L24>:
-               	cmp	w22, #0x6
-               	b.lo	 <L27>
-               	cmp	w22, #0x6
-               	b.eq	 <L25>
-               	mov	w1, #0xcb               // =203
-               	b	 <L26>
-<L25>:
-               	mov	w1, #0xca               // =202
-<L26>:
                	b	 <L30>
-<L27>:
-               	cmp	w22, #0x4
-               	b.eq	 <L28>
-               	mov	w2, #0xc9               // =201
+<L23>:
+               	cmp	w3, #0x6
+               	b.lo	 <L26>
+               	cmp	w3, #0x6
+               	b.eq	 <L24>
+               	mov	w5, #0xcb               // =203
+               	b	 <L25>
+<L24>:
+               	mov	w5, #0xca               // =202
+<L25>:
                	b	 <L29>
+<L26>:
+               	cmp	w3, #0x4
+               	b.eq	 <L27>
+               	mov	w6, #0xc9               // =201
+               	b	 <L28>
+<L27>:
+               	mov	w6, #0xc8               // =200
 <L28>:
-               	mov	w2, #0xc8               // =200
+               	mov	x5, x6
 <L29>:
-               	mov	x1, x2
+               	mov	x4, x5
 <L30>:
-               	mov	x0, x1
-<L31>:
-               	mov	x1, x0
-               	b	 <L39>
-<L32>:
-               	cmp	w22, #0x0
-               	b.eq	 <L37>
-               	cmp	w22, #0x1
-               	b.eq	 <L35>
-               	cmp	w22, #0x2
-               	b.eq	 <L33>
-               	mov	w0, #0x67               // =103
-               	b	 <L34>
-<L33>:
-               	mov	w0, #0x66               // =102
-<L34>:
-               	b	 <L36>
-<L35>:
-               	mov	w0, #0x65               // =101
-<L36>:
                	b	 <L38>
+<L31>:
+               	cmp	w3, #0x0
+               	b.eq	 <L36>
+               	cmp	w3, #0x1
+               	b.eq	 <L34>
+               	cmp	w3, #0x2
+               	b.eq	 <L32>
+               	mov	w5, #0x67               // =103
+               	b	 <L33>
+<L32>:
+               	mov	w5, #0x66               // =102
+<L33>:
+               	b	 <L35>
+<L34>:
+               	mov	w5, #0x65               // =101
+<L35>:
+               	b	 <L37>
+<L36>:
+               	mov	w5, #0x64               // =100
 <L37>:
-               	mov	w0, #0x64               // =100
+               	mov	x4, x5
 <L38>:
-               	mov	x1, x0
+               	mov	w5, w4
+               	mov	x4, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
 <L39>:
-               	mov	x0, x19
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L39>
 <L40>:
-               	bl	 <L40>
-               	mov	w1, w22
+               	mov	w5, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
 <L41>:
-               	bl	 <L41>
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x14
-               	b.lo	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L41>
 <L42>:
-               	mov	x0, x19
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w2, w2, #0x1
+               	mov	x0, x4
+               	cmp	w2, #0x14
+               	b.lo	 <L0>
+<L43>:
                	ret

--- a/test/golden/aarch64-linux/cmp/cmp_i32.dis
+++ b/test/golden/aarch64-linux/cmp/cmp_i32.dis
@@ -5,125 +5,219 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_i32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xb0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
-               	stur	x25, [x29, #-0xa8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x70
+               	mov	w1, w0
+               	sub	x0, x29, #0x1c
+               	sub	x2, x29, #0x38
+               	add	x3, x2, #0x0
+               	str	wzr, [x3]
+               	add	x3, x2, #0x4
+               	str	wzr, [x3]
+               	add	x3, x2, #0x8
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0xc
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x10
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x3]
+               	add	x3, x2, #0x14
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x18
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	w6, [x2, #0x18]
+               	str	x3, [x0]
+               	str	x4, [x0, #0x8]
+               	str	x5, [x0, #0x10]
+               	str	w6, [x0, #0x18]
+               	sub	x2, x29, #0x54
+               	sub	x3, x29, #0x70
+               	add	x4, x3, #0x0
+               	str	wzr, [x4]
+               	add	x4, x3, #0x4
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x8
+               	str	wzr, [x4]
+               	add	x4, x3, #0xc
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x4]
+               	add	x4, x3, #0x10
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x14
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x18
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	w7, [x3, #0x18]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	w7, [x2, #0x18]
+               	mov	x3, #0x2325             // =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x19, x29, #0x1c
-               	sub	x1, x29, #0x38
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	str	wzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	str	x4, [x19, #0x10]
-               	str	w5, [x19, #0x18]
-               	sub	x21, x29, #0x54
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	str	wzr, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	w5, [x21, #0x18]
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x7
+               	add	x5, x0, x4, lsl #2
+               	ldr	w6, [x5]
+               	add	w5, w6, w1
+               	add	x6, x2, x4, lsl #2
+               	ldr	w7, [x6]
+               	cmp	w5, w7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x19, x23, lsl #2
-               	ldr	w1, [x0]
-               	add	w24, w1, w20
-               	add	x0, x21, x23, lsl #2
-               	ldr	w25, [x0]
-               	cmp	w24, w25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	w24, w25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	w24, w25
-               	cset	w1, lt
-<L4>:
-               	bl	 <L4>
-               	cmp	w25, w24
-               	cset	w1, lt
-<L5>:
-               	bl	 <L5>
-               	cmp	w24, w25
-               	cset	w1, le
-<L6>:
-               	bl	 <L6>
-               	cmp	w25, w24
-               	cset	w1, le
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	w5, w7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	w5, w7
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	w7, w5
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
-               	ldur	x25, [x29, #-0xa8]
+               	cmp	w5, w7
+               	cset	w8, le
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	w7, w5
+               	cset	w8, le
+               	uxtb	w5, w8
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/cmp/cmp_i64.dis
+++ b/test/golden/aarch64-linux/cmp/cmp_i64.dis
@@ -5,156 +5,242 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	stp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x25, [x29, x16]
-               	mov	x19, x0
+               	sub	sp, sp, #0xe0
+               	sub	x1, x29, #0x38
+               	sub	x2, x29, #0x70
+               	add	x3, x2, #0x0
+               	str	xzr, [x3]
+               	add	x3, x2, #0x8
+               	str	xzr, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x18
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x20
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x28
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x30
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	x6, [x2, #0x18]
+               	ldr	x7, [x2, #0x20]
+               	ldr	x8, [x2, #0x28]
+               	ldr	x12, [x2, #0x30]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	str	x6, [x1, #0x18]
+               	str	x7, [x1, #0x20]
+               	str	x8, [x1, #0x28]
+               	str	x12, [x1, #0x30]
+               	sub	x2, x29, #0xa8
+               	sub	x3, x29, #0xe0
+               	add	x4, x3, #0x0
+               	str	xzr, [x4]
+               	add	x4, x3, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x10
+               	str	xzr, [x4]
+               	add	x4, x3, #0x18
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x4]
+               	add	x4, x3, #0x20
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x28
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x30
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	x7, [x3, #0x18]
+               	ldr	x8, [x3, #0x20]
+               	ldr	x12, [x3, #0x28]
+               	ldr	x13, [x3, #0x30]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	x7, [x2, #0x18]
+               	str	x8, [x2, #0x20]
+               	str	x12, [x2, #0x28]
+               	str	x13, [x2, #0x30]
+               	mov	x3, #0x2325             // =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x38
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	add	x2, x1, #0x10
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x20]
-               	str	x3, [x20, #0x8]
-               	str	x4, [x20, #0x10]
-               	str	x5, [x20, #0x18]
-               	str	x6, [x20, #0x20]
-               	str	x7, [x20, #0x28]
-               	str	x8, [x20, #0x30]
-               	sub	x21, x29, #0xa8
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x10
-               	str	xzr, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	x5, [x21, #0x18]
-               	str	x6, [x21, #0x20]
-               	str	x7, [x21, #0x28]
-               	str	x8, [x21, #0x30]
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x7
+               	add	x5, x1, x4, lsl #3
+               	ldr	x6, [x5]
+               	add	x5, x6, x0
+               	add	x6, x2, x4, lsl #3
+               	ldr	x7, [x6]
+               	cmp	x5, x7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	add	x24, x1, x19
-               	add	x0, x21, x23, lsl #3
-               	ldr	x25, [x0]
-               	cmp	x24, x25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	x24, x25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	x24, x25
-               	cset	w1, lt
-<L4>:
-               	bl	 <L4>
-               	cmp	x25, x24
-               	cset	w1, lt
-<L5>:
-               	bl	 <L5>
-               	cmp	x24, x25
-               	cset	w1, le
-<L6>:
-               	bl	 <L6>
-               	cmp	x25, x24
-               	cset	w1, le
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	x5, x7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	x5, x7
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	x7, x5
+               	cset	w8, lt
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	ldp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x25, [x29, x16]
+               	cmp	x5, x7
+               	cset	w8, le
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	x7, x5
+               	cset	w8, le
+               	uxtb	w5, w8
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/cmp/cmp_u32.dis
+++ b/test/golden/aarch64-linux/cmp/cmp_u32.dis
@@ -5,125 +5,219 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_u32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xb0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
-               	stur	x25, [x29, #-0xa8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x70
+               	mov	w1, w0
+               	sub	x0, x29, #0x1c
+               	sub	x2, x29, #0x38
+               	add	x3, x2, #0x0
+               	str	wzr, [x3]
+               	add	x3, x2, #0x4
+               	str	wzr, [x3]
+               	add	x3, x2, #0x8
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0xc
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x10
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x3]
+               	add	x3, x2, #0x14
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x3]
+               	add	x3, x2, #0x18
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	w6, [x2, #0x18]
+               	str	x3, [x0]
+               	str	x4, [x0, #0x8]
+               	str	x5, [x0, #0x10]
+               	str	w6, [x0, #0x18]
+               	sub	x2, x29, #0x54
+               	sub	x3, x29, #0x70
+               	add	x4, x3, #0x0
+               	str	wzr, [x4]
+               	add	x4, x3, #0x4
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x8
+               	str	wzr, [x4]
+               	add	x4, x3, #0xc
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x4]
+               	add	x4, x3, #0x10
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0x7fff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x14
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x4]
+               	add	x4, x3, #0x18
+               	mov	w17, #-0x80000000       // =-2147483648
+               	str	w17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	w7, [x3, #0x18]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	w7, [x2, #0x18]
+               	mov	x3, #0x2325             // =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x19, x29, #0x1c
-               	sub	x1, x29, #0x38
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	str	wzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x19]
-               	str	x3, [x19, #0x8]
-               	str	x4, [x19, #0x10]
-               	str	w5, [x19, #0x18]
-               	sub	x21, x29, #0x54
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	wzr, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	str	wzr, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	add	x2, x1, #0x10
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0x7fff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x14
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x18
-               	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	w5, [x1, #0x18]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	w5, [x21, #0x18]
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x7
+               	add	x5, x0, x4, lsl #2
+               	ldr	w6, [x5]
+               	add	w5, w6, w1
+               	add	x6, x2, x4, lsl #2
+               	ldr	w7, [x6]
+               	cmp	w5, w7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x19, x23, lsl #2
-               	ldr	w1, [x0]
-               	add	w24, w1, w20
-               	add	x0, x21, x23, lsl #2
-               	ldr	w25, [x0]
-               	cmp	w24, w25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	w24, w25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	w24, w25
-               	cset	w1, lo
-<L4>:
-               	bl	 <L4>
-               	cmp	w25, w24
-               	cset	w1, lo
-<L5>:
-               	bl	 <L5>
-               	cmp	w24, w25
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	cmp	w25, w24
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	w5, w7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	w5, w7
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	w7, w5
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
-               	ldur	x25, [x29, #-0xa8]
+               	cmp	w5, w7
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	w7, w5
+               	cset	w8, ls
+               	uxtb	w5, w8
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/cmp/cmp_u64.dis
+++ b/test/golden/aarch64-linux/cmp/cmp_u64.dis
@@ -5,156 +5,242 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_u64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x120
-               	stp	x19, x20, [x29, #-0xf0]
-               	stp	x21, x22, [x29, #-0x100]
-               	stp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x25, [x29, x16]
-               	mov	x19, x0
+               	sub	sp, sp, #0xe0
+               	sub	x1, x29, #0x38
+               	sub	x2, x29, #0x70
+               	add	x3, x2, #0x0
+               	str	xzr, [x3]
+               	add	x3, x2, #0x8
+               	str	xzr, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x18
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x20
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x28
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x3]
+               	add	x3, x2, #0x30
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x3]
+               	ldr	x3, [x2]
+               	ldr	x4, [x2, #0x8]
+               	ldr	x5, [x2, #0x10]
+               	ldr	x6, [x2, #0x18]
+               	ldr	x7, [x2, #0x20]
+               	ldr	x8, [x2, #0x28]
+               	ldr	x12, [x2, #0x30]
+               	str	x3, [x1]
+               	str	x4, [x1, #0x8]
+               	str	x5, [x1, #0x10]
+               	str	x6, [x1, #0x18]
+               	str	x7, [x1, #0x20]
+               	str	x8, [x1, #0x28]
+               	str	x12, [x1, #0x30]
+               	sub	x2, x29, #0xa8
+               	sub	x3, x29, #0xe0
+               	add	x4, x3, #0x0
+               	str	xzr, [x4]
+               	add	x4, x3, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x10
+               	str	xzr, [x4]
+               	add	x4, x3, #0x18
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x4]
+               	add	x4, x3, #0x20
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x28
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x4]
+               	add	x4, x3, #0x30
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x4]
+               	ldr	x4, [x3]
+               	ldr	x5, [x3, #0x8]
+               	ldr	x6, [x3, #0x10]
+               	ldr	x7, [x3, #0x18]
+               	ldr	x8, [x3, #0x20]
+               	ldr	x12, [x3, #0x28]
+               	ldr	x13, [x3, #0x30]
+               	str	x4, [x2]
+               	str	x5, [x2, #0x8]
+               	str	x6, [x2, #0x10]
+               	str	x7, [x2, #0x18]
+               	str	x8, [x2, #0x20]
+               	str	x12, [x2, #0x28]
+               	str	x13, [x2, #0x30]
+               	mov	x3, #0x2325             // =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+               	b	 <L13>
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x38
-               	sub	x1, x29, #0x70
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	add	x2, x1, #0x10
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x20]
-               	str	x3, [x20, #0x8]
-               	str	x4, [x20, #0x10]
-               	str	x5, [x20, #0x18]
-               	str	x6, [x20, #0x20]
-               	str	x7, [x20, #0x28]
-               	str	x8, [x20, #0x30]
-               	sub	x21, x29, #0xa8
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
-               	str	xzr, [x2]
-               	add	x2, x1, #0x8
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x10
-               	str	xzr, [x2]
-               	add	x2, x1, #0x18
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x20
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x28
-               	mov	x17, #0xffff            // =65535
-               	movk	x17, #0xffff, lsl #16
-               	movk	x17, #0xffff, lsl #32
-               	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x30
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	x2, [x1]
-               	ldr	x3, [x1, #0x8]
-               	ldr	x4, [x1, #0x10]
-               	ldr	x5, [x1, #0x18]
-               	ldr	x6, [x1, #0x20]
-               	ldr	x7, [x1, #0x28]
-               	ldr	x8, [x1, #0x30]
-               	str	x2, [x21]
-               	str	x3, [x21, #0x8]
-               	str	x4, [x21, #0x10]
-               	str	x5, [x21, #0x18]
-               	str	x6, [x21, #0x20]
-               	str	x7, [x21, #0x28]
-               	str	x8, [x21, #0x30]
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x7
+               	add	x5, x1, x4, lsl #3
+               	ldr	x6, [x5]
+               	add	x5, x6, x0
+               	add	x6, x2, x4, lsl #3
+               	ldr	x7, [x6]
+               	cmp	x5, x7
+               	cset	w6, eq
+               	uxtb	w8, w6
+               	mov	x6, x3
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
                	b.lo	 <L1>
-               	b	 <L8>
+               	b	 <L2>
 <L1>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	add	x24, x1, x19
-               	add	x0, x21, x23, lsl #3
-               	ldr	x25, [x0]
-               	cmp	x24, x25
-               	cset	w1, eq
-               	mov	x0, x22
-<L2>:
-               	bl	 <L2>
-               	cmp	x24, x25
-               	cset	w1, ne
-<L3>:
-               	bl	 <L3>
-               	cmp	x24, x25
-               	cset	w1, lo
-<L4>:
-               	bl	 <L4>
-               	cmp	x25, x24
-               	cset	w1, lo
-<L5>:
-               	bl	 <L5>
-               	cmp	x24, x25
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	cmp	x25, x24
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x7
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x8, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
                	b.lo	 <L1>
+<L2>:
+               	cmp	x5, x7
+               	cset	w8, ne
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	cmp	x5, x7
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	cmp	x7, x5
+               	cset	w8, lo
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	mov	x0, x22
-               	ldp	x19, x20, [x29, #-0xf0]
-               	ldp	x21, x22, [x29, #-0x100]
-               	ldp	x23, x24, [x29, #-0x110]
-               	mov	x16, #0xfee8            // =65256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x25, [x29, x16]
+               	cmp	x5, x7
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x8, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x6, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x14, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	cmp	x7, x5
+               	cset	w8, ls
+               	uxtb	w5, w8
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x4, x4, #0x1
+               	mov	x3, x6
+               	cmp	x4, #0x7
+               	b.lo	 <L0>
+<L13>:
+               	mov	x0, x3
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/cmp/loop_shapes.dis
+++ b/test/golden/aarch64-linux/cmp/loop_shapes.dis
@@ -3,139 +3,208 @@ cmp/loop_shapes.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.loop_shapes.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	mov	x19, x0
-               	mov	w21, #0x0               // =0
-               	mov	x22, x20
-               	cmp	w21, #0x10
-               	b.lo	 <L1>
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	w2, #0x0                // =0
+               	mov	x3, x1
+               	cmp	w2, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w16, #0x3               // =3
-               	mul	w0, w21, w16
-               	add	w1, w22, w0
-               	add	w22, w1, #0x1
-               	mov	x0, x19
-               	mov	w1, w22
-<L2>:
-               	bl	 <L2>
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x10
+               	mul	w4, w2, w16
+               	add	w5, w3, w4
+               	add	w4, w5, #0x1
+               	mov	w5, w4
+               	mov	x6, x0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	w2, w2, #0x1
+               	mov	x0, x6
+               	mov	x3, x4
+               	cmp	w2, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	w17, #0x62              // =98
-               	add	w0, w17, w20
-               	mov	x21, x0
+               	add	w2, w17, w1
                	mov	w17, #0x0               // =0
-               	cmp	w17, w21
+               	cmp	w17, w2
                	b.lo	 <L4>
-               	b	 <L6>
+               	b	 <L7>
 <L4>:
-               	sub	w21, w21, #0x7
-               	mov	x0, x19
-               	mov	w1, w21
+               	sub	w3, w2, #0x7
+               	mov	w4, w3
+               	mov	x5, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x19, x0
-               	mov	w17, #0x0               // =0
-               	cmp	w17, w21
-               	b.lo	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	mov	w21, #0x0               // =0
-               	cmp	w21, #0x6
-               	b.lo	 <L7>
-               	b	 <L13>
+               	mov	x0, x5
+               	mov	x2, x3
+               	mov	w17, #0x0               // =0
+               	cmp	w17, w2
+               	b.lo	 <L4>
 <L7>:
-               	mov	w16, #0x6               // =6
-               	mul	w22, w21, w16
-               	mov	x23, x19
-               	mov	w24, #0x0               // =0
-               	cmp	w24, #0x6
+               	mov	w2, #0x0                // =0
+               	cmp	w2, #0x6
                	b.lo	 <L8>
-               	b	 <L12>
+               	b	 <L15>
 <L8>:
-               	cmp	w24, #0x3
-               	b.eq	 <L10>
-               	add	w0, w22, w24
-               	add	w1, w0, w20
-               	mov	x0, x23
+               	mov	w16, #0x6               // =6
+               	mul	w3, w2, w16
+               	mov	x4, x0
+               	mov	w5, #0x0                // =0
+               	cmp	w5, #0x6
+               	b.lo	 <L9>
+               	b	 <L14>
 <L9>:
-               	bl	 <L9>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
+               	cmp	w5, #0x3
+               	b.eq	 <L12>
+               	add	w6, w3, w5
+               	add	w7, w6, w1
+               	mov	w6, w7
+               	mov	x7, x4
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
                	b	 <L11>
 <L10>:
-               	add	w24, w24, #0x1
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	cmp	w24, #0x6
-               	b.lo	 <L8>
+               	add	w5, w5, #0x1
+               	mov	x4, x7
+               	b	 <L13>
 <L12>:
-               	add	w21, w21, #0x1
-               	mov	x19, x23
-               	cmp	w21, #0x6
-               	b.lo	 <L7>
+               	add	w5, w5, #0x1
 <L13>:
-               	mov	w17, #0x9               // =9
-               	add	w21, w17, w20
-               	mov	x22, x20
-               	mov	w16, #0x4240            // =16960
-               	movk	w16, #0xf, lsl #16
-               	cmp	w22, w16
-               	b.lo	 <L14>
-               	b	 <L16>
+               	cmp	w5, #0x6
+               	b.lo	 <L9>
 <L14>:
-               	mov	x0, x19
-               	mov	w1, w22
+               	add	w2, w2, #0x1
+               	mov	x0, x4
+               	cmp	w2, #0x6
+               	b.lo	 <L8>
 <L15>:
-               	bl	 <L15>
-               	cmp	w22, w21
-               	b.eq	 <L17>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
+               	mov	w17, #0x9               // =9
+               	add	w2, w17, w1
+               	mov	x3, x1
                	mov	w16, #0x4240            // =16960
                	movk	w16, #0xf, lsl #16
-               	cmp	w22, w16
-               	b.lo	 <L14>
+               	cmp	w3, w16
+               	b.lo	 <L16>
+               	b	 <L19>
 <L16>:
+               	mov	w4, w3
+               	mov	x5, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L17>
                	b	 <L18>
 <L17>:
-               	mov	x19, x0
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	mov	w17, #0x1               // =1
-               	add	w0, w17, w20
-               	mov	x20, x0
-               	mov	w21, #0x1               // =1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x14
-               	b.lo	 <L19>
-               	b	 <L21>
+               	cmp	w3, w2
+               	b.eq	 <L20>
+               	add	w3, w3, #0x1
+               	mov	x0, x5
+               	mov	w16, #0x4240            // =16960
+               	movk	w16, #0xf, lsl #16
+               	cmp	w3, w16
+               	b.lo	 <L16>
 <L19>:
-               	add	w23, w20, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	mov	x20, x21
-               	mov	x21, x23
-               	cmp	w22, #0x14
-               	b.lo	 <L19>
+               	mov	x0, x5
 <L21>:
-               	mov	x0, x19
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w17, #0x1               // =1
+               	add	w2, w17, w1
+               	mov	w1, #0x1                // =1
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x14
+               	b.lo	 <L22>
+               	b	 <L25>
+<L22>:
+               	add	w4, w2, w1
+               	mov	w5, w4
+               	mov	x6, x0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	add	w3, w3, #0x1
+               	mov	x0, x6
+               	mov	x2, x1
+               	mov	x1, x4
+               	cmp	w3, #0x14
+               	b.lo	 <L22>
+<L25>:
                	ret

--- a/test/golden/aarch64-linux/cmp/short_circuit.dis
+++ b/test/golden/aarch64-linux/cmp/short_circuit.dis
@@ -47,61 +47,147 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.cmp.short_circuit.fold_state>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x20, x20, #0x0
-               	mov	x21, x0
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x4
-               	b.lo	 <L1>
-               	b	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	add	x0, x19, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x4
+               	b.lo	 <L2>
+               	b	 <L7>
 <L2>:
-               	bl	 <L2>
-               	add	x1, x20, x22, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x4, x1, x3, lsl #3
+               	ldr	x5, [x4]
+               	mov	x4, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x0, x21
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x5, x2, x3, lsl #3
+               	ldr	x6, [x5]
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x5, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x3, x3, #0x1
+               	mov	x0, x4
+               	cmp	x3, #0x4
+               	b.lo	 <L2>
+<L7>:
                	ret
 
 <corpus.cases.cmp.short_circuit.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
+               	mov	w19, w0
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x4
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L0>
+<L1>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x1, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x1, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x1, [x0]
+               	add	x2, x1, #0x1
+               	str	x2, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	str	x0, [x1]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x0               // =0
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	bl	 <L3>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -110,17 +196,17 @@ Disassembly of section .text:
                	add	x2, x2, #0x0
                	mov	x3, #0x0                // =0
                	cmp	x3, #0x4
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
                	add	x4, x1, x3, lsl #3
                	str	xzr, [x4]
                	add	x4, x2, x3, lsl #3
                	str	xzr, [x4]
                	add	x3, x3, #0x1
                	cmp	x3, #0x4
-               	b.lo	 <L1>
-<L2>:
+               	b.lo	 <L4>
+<L5>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
                	add	x2, x1, #0x1
@@ -136,74 +222,65 @@ Disassembly of section .text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x1, [x2]
-               	mov	x1, #0x0                // =0
-<L3>:
-               	bl	 <L3>
+               	mov	w17, #0x1               // =1
+               	eor	w1, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L4>:
-               	bl	 <L4>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L5>
-               	b	 <L8>
-<L5>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w1
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
                	bl	 <L7>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L5>
-<L8>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
                	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x1, x1, #0x0
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x4
-               	b.lo	 <L9>
-               	b	 <L10>
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x4
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	add	x4, x1, x3, lsl #3
+               	str	xzr, [x4]
+               	add	x4, x2, x3, lsl #3
+               	str	xzr, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x4
+               	b.lo	 <L8>
 <L9>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L9>
-<L10>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               // =1
-               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
                	add	x2, x1, #0x1
@@ -219,137 +296,56 @@ Disassembly of section .text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x1, [x2]
-               	uxtb	w17, w0
-               	cmp	w17, #0x1
-               	cset	w1, eq
-               	mov	x0, x22
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1               // =1
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
                	bl	 <L11>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x4
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L13>
-               	b	 <L16>
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L12>
 <L13>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L14>:
-               	bl	 <L14>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L15>:
-               	bl	 <L15>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L13>
-<L16>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x4
-               	b.lo	 <L17>
-               	b	 <L18>
-<L17>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L17>
-<L18>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x0, x22
-               	mov	x1, #0x1                // =1
-<L19>:
-               	bl	 <L19>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L20>:
-               	bl	 <L20>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L21>
-               	b	 <L24>
-<L21>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L22>:
-               	bl	 <L22>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L21>
-<L24>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x4
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L25>
-<L26>:
                	mov	x0, #0x0                // =0
                	mov	x1, #0x0                // =0
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L28>
+               	cbnz	w1,  <L15>
                	mov	w17, #0x1               // =1
-               	eor	w0, w17, w20
+               	eor	w0, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -368,43 +364,33 @@ Disassembly of section .text:
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w2, eq
-               	b	 <L29>
-<L28>:
+               	b	 <L16>
+<L15>:
                	mov	x2, x1
-<L29>:
-               	mov	x0, x22
-               	mov	x1, x2
-<L30>:
-               	bl	 <L30>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L31>:
-               	bl	 <L31>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L32>
-               	b	 <L35>
-<L32>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L33>:
-               	bl	 <L33>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L34>:
-               	bl	 <L34>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L32>
-<L35>:
+<L16>:
+               	uxtb	w0, w2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	mov	x0, x20
+<L19>:
+               	bl	 <L19>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -413,25 +399,25 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x4
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L36>
-<L37>:
+               	b.lo	 <L20>
+<L21>:
                	mov	x0, #0x0                // =0
                	mov	x1, #0x0                // =0
-<L38>:
-               	bl	 <L38>
+<L22>:
+               	bl	 <L22>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L39>
+               	cbnz	w1,  <L23>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -448,33 +434,32 @@ Disassembly of section .text:
                	add	x2, x2, #0x0
                	str	x0, [x2]
                	mov	x0, #0x1                // =1
-               	b	 <L40>
-<L39>:
+               	b	 <L24>
+<L23>:
                	mov	x0, x1
-<L40>:
-               	cbnz	w0,  <L41>
-               	mov	x1, x0
-               	b	 <L44>
-<L41>:
+<L24>:
+               	cbnz	w0,  <L25>
+               	b	 <L28>
+<L25>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	uxtb	w17, w20
+               	str	x1, [x2]
+               	uxtb	w17, w19
                	cmp	w17, #0x1
-               	cset	w0, eq
-               	cbnz	w0,  <L42>
+               	cset	w1, eq
+               	cbnz	w1,  <L26>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -491,44 +476,35 @@ Disassembly of section .text:
                	add	x3, x3, #0x0
                	str	x2, [x3]
                	mov	x2, #0x1                // =1
-               	b	 <L43>
-<L42>:
-               	mov	x2, x0
-<L43>:
-               	mov	x1, x2
-<L44>:
-               	mov	x0, x22
-<L45>:
-               	bl	 <L45>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L46>:
-               	bl	 <L46>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L47>
-               	b	 <L50>
-<L47>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L48>:
-               	bl	 <L48>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L49>:
-               	bl	 <L49>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L47>
-<L50>:
+               	b	 <L27>
+<L26>:
+               	mov	x2, x1
+<L27>:
+               	mov	x0, x2
+<L28>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, x20
+<L31>:
+               	bl	 <L31>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -537,25 +513,25 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x4
-               	b.lo	 <L51>
-               	b	 <L52>
-<L51>:
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L51>
-<L52>:
+               	b.lo	 <L32>
+<L33>:
                	mov	x0, #0x0                // =0
                	mov	x1, #0x1                // =1
-<L53>:
-               	bl	 <L53>
+<L34>:
+               	bl	 <L34>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L54>
+               	cbnz	w1,  <L35>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -572,31 +548,30 @@ Disassembly of section .text:
                	add	x2, x2, #0x0
                	str	x0, [x2]
                	mov	x0, #0x1                // =1
-               	b	 <L55>
-<L54>:
+               	b	 <L36>
+<L35>:
                	mov	x0, x1
-<L55>:
-               	cbnz	w0,  <L56>
-               	mov	x1, x0
-               	b	 <L57>
-<L56>:
+<L36>:
+               	cbnz	w0,  <L37>
+               	b	 <L38>
+<L37>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
+               	str	x1, [x2]
                	mov	w17, #0x1               // =1
-               	eor	w0, w17, w20
+               	eor	w1, w17, w19
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x2, [x16]
                	add	x3, x2, #0x1
@@ -612,43 +587,34 @@ Disassembly of section .text:
                	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x3, x3, #0x0
                	str	x2, [x3]
-               	uxtb	w17, w0
+               	uxtb	w17, w1
                	cmp	w17, #0x1
                	cset	w2, eq
-               	mov	x1, x2
-<L57>:
-               	mov	x0, x22
-<L58>:
-               	bl	 <L58>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
-<L59>:
-               	bl	 <L59>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L60>
-               	b	 <L63>
-<L60>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x22
-<L61>:
-               	bl	 <L61>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L62>:
-               	bl	 <L62>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L60>
-<L63>:
+               	mov	x0, x2
+<L38>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	mov	x0, x20
+<L41>:
+               	bl	 <L41>
+               	mov	x20, x0
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -657,25 +623,25 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x4
-               	b.lo	 <L64>
-               	b	 <L65>
-<L64>:
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L64>
-<L65>:
+               	b.lo	 <L42>
+<L43>:
                	mov	x0, #0x0                // =0
                	mov	x1, #0x0                // =0
-<L66>:
-               	bl	 <L66>
+<L44>:
+               	bl	 <L44>
                	uxtb	w17, w0
                	cmp	w17, #0x1
                	cset	w1, eq
-               	cbnz	w1,  <L67>
+               	cbnz	w1,  <L45>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -691,70 +657,56 @@ Disassembly of section .text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x0, [x2]
-               	uxtb	w17, w20
+               	uxtb	w17, w19
                	cmp	w17, #0x1
                	cset	w0, eq
-               	b	 <L68>
-<L67>:
+               	b	 <L46>
+<L45>:
                	mov	x0, x1
-<L68>:
-               	cbnz	w0,  <L69>
-               	mov	x1, x0
-               	b	 <L70>
-<L69>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
-               	add	x3, x2, #0x1
-               	str	x3, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	mov	x1, #0x1                // =1
-<L70>:
-               	mov	x0, x22
-<L71>:
-               	bl	 <L71>
+<L46>:
+               	cbnz	w0,  <L47>
+               	b	 <L48>
+<L47>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L72>:
-               	bl	 <L72>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x20, x20, #0x0
-               	mov	x21, x0
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x4
-               	b.lo	 <L73>
-               	b	 <L76>
-<L73>:
-               	add	x0, x19, x22, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x21
-<L74>:
-               	bl	 <L74>
-               	add	x1, x20, x22, lsl #3
+               	add	x2, x1, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
                	ldr	x2, [x1]
-               	mov	x1, x2
-<L75>:
-               	bl	 <L75>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x4
-               	b.lo	 <L73>
-<L76>:
-               	mov	x0, x21
+               	add	x3, x2, #0x1
+               	str	x3, [x1]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x1, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x1, [x2]
+               	mov	x0, #0x1                // =1
+<L48>:
+               	uxtb	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	mov	x0, x20
+<L51>:
+               	bl	 <L51>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/comptime/ct_runtime_agree.dis
+++ b/test/golden/aarch64-linux/comptime/ct_runtime_agree.dis
@@ -31,133 +31,194 @@ Disassembly of section .text:
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xa0
+               	sub	sp, sp, #0x80
                	stp	x19, x20, [x29, #-0x40]
                	stp	x21, x22, [x29, #-0x50]
                	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
-               	stur	x27, [x29, #-0x78]
-               	stp	d8, d9, [x29, #-0x88]
-               	stp	d10, d11, [x29, #-0x98]
+               	stp	d8, d9, [x29, #-0x70]
+               	stp	d10, d11, [x29, #-0x80]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x17, #0x5678            // =22136
                	movk	x17, #0x1234, lsl #16
-               	add	x20, x17, x19
+               	add	x0, x17, x19
                	mov	x16, #0x3               // =3
-               	mul	x2, x20, x16
-               	add	x21, x2, #0x7
-               	lsl	x2, x21, #13
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x7
+               	lsl	x1, x2, #13
                	mov	x16, #0xf0f             // =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf, lsl #32
-               	eor	x22, x2, x16
-               	lsr	x2, x22, #7
-               	eor	x23, x22, x2
+               	eor	x3, x1, x16
+               	lsr	x1, x3, #7
+               	eor	x20, x3, x1
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
-               	and	x24, x23, x16
+               	and	x21, x20, x16
                	mov	x16, #0x79b1            // =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x25, x24, x16
-               	lsr	x26, x25, #17
-               	add	x27, x26, x24
-               	mov	x0, x1
-               	mov	x1, #0x5678             // =22136
-               	movk	x1, #0x1234, lsl #16
+               	mul	x22, x21, x16
+               	lsr	x23, x22, #17
+               	add	x24, x23, x21
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	mov	x17, #0x5678            // =22136
+               	movk	x17, #0x1234, lsl #16
+               	lsr	x6, x17, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x36f              // =879
-               	movk	x1, #0x369d, lsl #16
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0xef0f             // =61199
-               	movk	x1, #0xaf62, lsl #16
-               	movk	x1, #0x6dc, lsl #32
+               	mov	x16, #0x8               // =8
+               	mul	x4, x0, x16
+               	mov	x17, #0x36f             // =879
+               	movk	x17, #0x369d, lsl #16
+               	lsr	x5, x17, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x4, x0, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xef0f            // =61199
+               	movk	x17, #0xaf62, lsl #16
+               	movk	x17, #0x6dc, lsl #32
+               	lsr	x4, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x4, x3, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x4, x16
+               	eor	x4, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x0, x1
                	mov	x1, #0x2ad1             // =10961
                	movk	x1, #0x163c, lsl #16
                	movk	x1, #0x6d1, lsl #32
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
+<L12>:
+               	bl	 <L12>
+               	mov	x1, x20
+<L13>:
+               	bl	 <L13>
                	mov	x1, #0x2ad1             // =10961
                	movk	x1, #0x163c, lsl #16
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
+<L14>:
+               	bl	 <L14>
+               	mov	x1, x21
+<L15>:
+               	bl	 <L15>
                	mov	x1, #0x6381             // =25473
                	movk	x1, #0xbd, lsl #16
                	movk	x1, #0xf3ec, lsl #32
                	movk	x1, #0xdbd, lsl #48
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
+<L16>:
+               	bl	 <L16>
+               	mov	x1, x22
+<L17>:
+               	bl	 <L17>
                	mov	x1, #0x5e               // =94
                	movk	x1, #0xf9f6, lsl #16
                	movk	x1, #0x6de, lsl #32
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x26
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
+<L18>:
+               	bl	 <L18>
+               	mov	x1, x23
+<L19>:
+               	bl	 <L19>
                	mov	x1, #0x2b2f             // =11055
                	movk	x1, #0x1032, lsl #16
                	movk	x1, #0x6df, lsl #32
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x27
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L20>:
+               	bl	 <L20>
+               	mov	x1, x24
+<L21>:
+               	bl	 <L21>
                	ucvtf	d0, x19
                	fmov	d31, #1.00000000
                	fadd	d1, d31, d0
@@ -172,50 +233,42 @@ Disassembly of section .text:
                	fdiv	d10, d9, d30
                	fmul	d0, d10, d10
                	fadd	d11, d0, d8
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d9
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d10
+               	mov	x1, #0x5555             // =21845
+               	movk	x1, #0x5555, lsl #16
+               	movk	x1, #0x5555, lsl #32
+               	movk	x1, #0x3fd5, lsl #48
 <L22>:
                	bl	 <L22>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	d0, [x16]
+               	fmov	x1, d8
 <L23>:
                	bl	 <L23>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	mov	x1, #0x5550             // =21840
+               	movk	x1, #0x5555, lsl #16
+               	movk	x1, #0x5555, lsl #32
+               	movk	x1, #0x3fd5, lsl #48
 <L24>:
                	bl	 <L24>
-               	mov	x1, x0
+               	fmov	x1, d9
+<L25>:
+               	bl	 <L25>
+               	mov	x1, #0x9360             // =37728
+               	movk	x1, #0x364d, lsl #16
+               	movk	x1, #0x64d9, lsl #32
+               	movk	x1, #0x3fd3, lsl #48
+<L26>:
+               	bl	 <L26>
+               	fmov	x1, d10
+<L27>:
+               	bl	 <L27>
+               	mov	x1, #0x4baf             // =19375
+               	movk	x1, #0x373e, lsl #16
+               	movk	x1, #0x35d5, lsl #32
+               	movk	x1, #0x3fdb, lsl #48
+<L28>:
+               	bl	 <L28>
+               	fmov	x1, d11
+<L29>:
+               	bl	 <L29>
                	ucvtf	s0, x19
                	fmov	s31, #1.00000000
                	fadd	s1, s31, s0
@@ -230,320 +283,461 @@ Disassembly of section .text:
                	fdiv	s10, s9, s30
                	fmul	s0, s10, s10
                	fadd	s11, s0, s8
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L25>:
-               	bl	 <L25>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
-<L26>:
-               	bl	 <L26>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L27>:
-               	bl	 <L27>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s9
-<L28>:
-               	bl	 <L28>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
-<L29>:
-               	bl	 <L29>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	w16, #0xaaab            // =43691
+               	movk	w16, #0x3eaa, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
-               	mov	x1, x0
-               	mov	x0, x1
-               	adrp	x16, 0x0 <corpus.cases.comptime.ct_runtime_agree.apply_rt>
-               	ldr	s0, [x16]
+               	fmov	w1, s8
+               	mov	w2, w1
+               	mov	x1, x2
 <L31>:
                	bl	 <L31>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s11
+               	mov	w16, #0xaab0            // =43696
+               	movk	w16, #0x3eaa, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
 <L32>:
                	bl	 <L32>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x79b1             // =31153
-               	movk	x1, #0x9e37, lsl #16
+               	fmov	w1, s9
+               	mov	w2, w1
+               	mov	x1, x2
 <L33>:
                	bl	 <L33>
-               	mov	x1, x0
-               	mov	x0, x1
+               	mov	w16, #0x26ce            // =9934
+               	movk	w16, #0x3e9b, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	mov	w16, #0xaead            // =44717
+               	movk	w16, #0x3ed9, lsl #16
+               	mov	w1, w16
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
+<L37>:
+               	bl	 <L37>
+               	mov	x1, #0x79b1             // =31153
+               	movk	x1, #0x9e37, lsl #16
+<L38>:
+               	bl	 <L38>
                	mov	x1, #0x14a2             // =5282
                	movk	x1, #0x4491, lsl #16
                	movk	x1, #0x1, lsl #32
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x0
-               	mov	x0, x1
+<L39>:
+               	bl	 <L39>
                	mov	x1, #0x4775             // =18293
                	movk	x1, #0x1715, lsl #16
                	movk	x1, #0x5, lsl #32
-<L35>:
-               	bl	 <L35>
-               	mov	x1, x0
-               	mov	x0, x1
+<L40>:
+               	bl	 <L40>
                	mov	x1, #0x662a             // =26154
                	movk	x1, #0x5255, lsl #16
                	movk	x1, #0xc, lsl #32
-<L36>:
-               	bl	 <L36>
-               	mov	x1, x0
-               	mov	x0, x1
+<L41>:
+               	bl	 <L41>
                	mov	x1, #0xda45             // =55877
                	movk	x1, #0x7ae2, lsl #16
                	movk	x1, #0x1f, lsl #32
-<L37>:
-               	bl	 <L37>
-               	mov	x1, x0
-               	mov	x0, x1
+<L42>:
+               	bl	 <L42>
                	mov	x1, #0x28ca             // =10442
                	movk	x1, #0x9544, lsl #16
                	movk	x1, #0x39, lsl #32
-<L38>:
-               	bl	 <L38>
-               	sub	x20, x29, #0x30
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	mov	x17, #0x1               // =1
-               	add	x1, x17, x19
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	mov	x17, #0x3               // =3
-               	add	x1, x17, x19
-               	add	x2, x20, #0x8
-               	str	x1, [x2]
-               	mov	x17, #0x7               // =7
-               	add	x1, x17, x19
-               	add	x2, x20, #0x10
-               	str	x1, [x2]
-               	mov	x17, #0xf               // =15
-               	add	x1, x17, x19
-               	add	x2, x20, #0x18
-               	str	x1, [x2]
-               	mov	x17, #0x1f              // =31
-               	add	x1, x17, x19
-               	add	x2, x20, #0x20
-               	str	x1, [x2]
-               	mov	x17, #0x3f              // =63
-               	add	x1, x17, x19
-               	add	x2, x20, #0x28
-               	str	x1, [x2]
-               	mov	x21, x0
-               	mov	x22, #0x0               // =0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x6
-               	b.lo	 <L39>
-               	b	 <L41>
-<L39>:
-               	add	x0, x20, x23, lsl #3
-               	ldr	x1, [x0]
-               	mov	x16, #0x79b1            // =31153
-               	movk	x16, #0x9e37, lsl #16
-               	mul	x0, x1, x16
-               	eor	x22, x22, x0
-               	mov	x0, x21
-               	mov	x1, x22
-<L40>:
-               	bl	 <L40>
-               	add	x23, x23, #0x1
-               	mov	x21, x0
-               	cmp	x23, #0x6
-               	b.lo	 <L39>
-<L41>:
-               	mov	x0, x21
-               	mov	x1, #0xb                // =11
-<L42>:
-               	bl	 <L42>
-               	mov	x20, x0
-               	cmp	x27, x25
-               	b.lo	 <L44>
-               	mov	x0, x20
-               	mov	x1, #0x16               // =22
 <L43>:
                	bl	 <L43>
-               	mov	x21, x0
-               	b	 <L46>
+               	sub	x1, x29, #0x30
+               	str	xzr, [x1]
+               	str	xzr, [x1, #0x8]
+               	str	xzr, [x1, #0x10]
+               	str	xzr, [x1, #0x18]
+               	str	xzr, [x1, #0x20]
+               	str	xzr, [x1, #0x28]
+               	mov	x17, #0x1               // =1
+               	add	x2, x17, x19
+               	add	x3, x1, #0x0
+               	str	x2, [x3]
+               	mov	x17, #0x3               // =3
+               	add	x2, x17, x19
+               	add	x3, x1, #0x8
+               	str	x2, [x3]
+               	mov	x17, #0x7               // =7
+               	add	x2, x17, x19
+               	add	x3, x1, #0x10
+               	str	x2, [x3]
+               	mov	x17, #0xf               // =15
+               	add	x2, x17, x19
+               	add	x3, x1, #0x18
+               	str	x2, [x3]
+               	mov	x17, #0x1f              // =31
+               	add	x2, x17, x19
+               	add	x3, x1, #0x20
+               	str	x2, [x3]
+               	mov	x17, #0x3f              // =63
+               	add	x2, x17, x19
+               	add	x3, x1, #0x28
+               	str	x2, [x3]
+               	mov	x2, #0x0                // =0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x6
+               	b.lo	 <L44>
+               	b	 <L47>
 <L44>:
-               	mov	x0, x20
-               	mov	x1, #0xb                // =11
+               	add	x4, x1, x3, lsl #3
+               	ldr	x5, [x4]
+               	mov	x16, #0x79b1            // =31153
+               	movk	x16, #0x9e37, lsl #16
+               	mul	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x4, x0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L45>
+               	b	 <L46>
 <L45>:
-               	bl	 <L45>
-               	mov	x21, x0
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L45>
 <L46>:
-               	mov	x0, x21
-               	mov	x1, #0x21               // =33
+               	add	x3, x3, #0x1
+               	mov	x0, x4
+               	mov	x2, x5
+               	cmp	x3, #0x6
+               	b.lo	 <L44>
 <L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-               	mov	x17, #0xffff            // =65535
-               	cmp	x17, x24
-               	b.lo	 <L49>
-               	mov	x0, x20
-               	mov	x1, #0x2c               // =44
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
+               	b	 <L49>
 <L48>:
-               	bl	 <L48>
-               	mov	x21, x0
-               	b	 <L51>
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xb               // =11
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L48>
 <L49>:
-               	mov	x0, x20
-               	mov	x1, #0x21               // =33
+               	cmp	x24, x22
+               	b.lo	 <L52>
+               	mov	x1, x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L50>
+               	b	 <L51>
 <L50>:
-               	bl	 <L50>
-               	mov	x21, x0
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x16              // =22
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L50>
 <L51>:
+               	b	 <L55>
+<L52>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L53>
+               	b	 <L54>
+<L53>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	mov	x17, #0xb               // =11
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L53>
+<L54>:
+               	mov	x1, x0
+<L55>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x21              // =33
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L56>
+<L57>:
+               	mov	x17, #0xffff            // =65535
+               	cmp	x17, x21
+               	b.lo	 <L60>
+               	mov	x0, x1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L58>
+               	b	 <L59>
+<L58>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x2c              // =44
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L58>
+<L59>:
+               	b	 <L63>
+<L60>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	mov	x17, #0x21              // =33
+               	lsr	x4, x17, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L61>
+<L62>:
+               	mov	x0, x1
+<L63>:
                	mov	w20, w19
                	mov	w17, #0x1               // =1
                	add	w19, w17, w20
-               	lsr	x0, x27, #29
-               	eor	x1, x27, x0
-               	mov	x16, #0x1b3             // =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x2, x1, x16
-               	mov	x0, x21
-               	mov	x1, x2
-<L52>:
-               	bl	 <L52>
-               	uxtb	w17, w20
-               	cmp	w17, #0x0
-               	b.eq	 <L55>
-               	uxtb	w17, w20
-               	cmp	w17, #0x1
-               	b.eq	 <L53>
-               	mov	x1, #0x0                // =0
-               	b	 <L54>
-<L53>:
-               	lsl	x2, x27, #17
-               	lsr	x3, x27, #47
-               	orr	x4, x2, x3
-               	mov	x16, #0x3039            // =12345
-               	add	x1, x4, x16
-<L54>:
-               	b	 <L56>
-<L55>:
-               	lsr	x2, x27, #29
-               	eor	x3, x27, x2
-               	mov	x16, #0x1b3             // =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x1, x3, x16
-<L56>:
-               	bl	 <L56>
-               	lsl	x1, x27, #17
-               	lsr	x2, x27, #47
-               	orr	x3, x1, x2
-               	mov	x16, #0x3039            // =12345
-               	add	x1, x3, x16
-<L57>:
-               	bl	 <L57>
-               	uxtb	w17, w19
-               	cmp	w17, #0x0
-               	b.eq	 <L60>
-               	uxtb	w17, w19
-               	cmp	w17, #0x1
-               	b.eq	 <L58>
-               	mov	x1, #0x0                // =0
-               	b	 <L59>
-<L58>:
-               	lsl	x2, x27, #17
-               	lsr	x3, x27, #47
-               	orr	x4, x2, x3
-               	mov	x16, #0x3039            // =12345
-               	add	x1, x4, x16
-<L59>:
-               	b	 <L61>
-<L60>:
-               	lsr	x2, x27, #29
-               	eor	x3, x27, x2
-               	mov	x16, #0x1b3             // =435
-               	movk	x16, #0x100, lsl #32
-               	mul	x1, x3, x16
-<L61>:
-               	bl	 <L61>
                	lsr	x1, x24, #29
                	eor	x2, x24, x1
                	mov	x16, #0x1b3             // =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x2, x16
-<L62>:
-               	bl	 <L62>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L64>
+               	b	 <L65>
+<L64>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L64>
+<L65>:
                	uxtb	w17, w20
                	cmp	w17, #0x0
-               	b.eq	 <L65>
+               	b.eq	 <L68>
                	uxtb	w17, w20
                	cmp	w17, #0x1
-               	b.eq	 <L63>
+               	b.eq	 <L66>
                	mov	x1, #0x0                // =0
-               	b	 <L64>
-<L63>:
+               	b	 <L67>
+<L66>:
                	lsl	x2, x24, #17
                	lsr	x3, x24, #47
                	orr	x4, x2, x3
                	mov	x16, #0x3039            // =12345
                	add	x1, x4, x16
-<L64>:
-               	b	 <L66>
-<L65>:
+<L67>:
+               	b	 <L69>
+<L68>:
                	lsr	x2, x24, #29
                	eor	x3, x24, x2
                	mov	x16, #0x1b3             // =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x3, x16
-<L66>:
-               	bl	 <L66>
+<L69>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L70>
+               	b	 <L71>
+<L70>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L70>
+<L71>:
                	lsl	x1, x24, #17
                	lsr	x2, x24, #47
                	orr	x3, x1, x2
                	mov	x16, #0x3039            // =12345
                	add	x1, x3, x16
-<L67>:
-               	bl	 <L67>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L72>
+<L73>:
                	uxtb	w17, w19
                	cmp	w17, #0x0
-               	b.eq	 <L70>
+               	b.eq	 <L76>
                	uxtb	w17, w19
                	cmp	w17, #0x1
-               	b.eq	 <L68>
+               	b.eq	 <L74>
                	mov	x1, #0x0                // =0
-               	b	 <L69>
-<L68>:
+               	b	 <L75>
+<L74>:
                	lsl	x2, x24, #17
                	lsr	x3, x24, #47
                	orr	x4, x2, x3
                	mov	x16, #0x3039            // =12345
                	add	x1, x4, x16
-<L69>:
-               	b	 <L71>
-<L70>:
+<L75>:
+               	b	 <L77>
+<L76>:
                	lsr	x2, x24, #29
                	eor	x3, x24, x2
                	mov	x16, #0x1b3             // =435
                	movk	x16, #0x100, lsl #32
                	mul	x1, x3, x16
-<L71>:
-               	bl	 <L71>
-               	ldp	d8, d9, [x29, #-0x88]
-               	ldp	d10, d11, [x29, #-0x98]
+<L77>:
+               	bl	 <L77>
+               	lsr	x1, x21, #29
+               	eor	x2, x21, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x2, x16
+<L78>:
+               	bl	 <L78>
+               	uxtb	w17, w20
+               	cmp	w17, #0x0
+               	b.eq	 <L81>
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	b.eq	 <L79>
+               	mov	x1, #0x0                // =0
+               	b	 <L80>
+<L79>:
+               	lsl	x2, x21, #17
+               	lsr	x3, x21, #47
+               	orr	x4, x2, x3
+               	mov	x16, #0x3039            // =12345
+               	add	x1, x4, x16
+<L80>:
+               	b	 <L82>
+<L81>:
+               	lsr	x2, x21, #29
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+<L82>:
+               	bl	 <L82>
+               	lsl	x1, x21, #17
+               	lsr	x2, x21, #47
+               	orr	x3, x1, x2
+               	mov	x16, #0x3039            // =12345
+               	add	x1, x3, x16
+<L83>:
+               	bl	 <L83>
+               	uxtb	w17, w19
+               	cmp	w17, #0x0
+               	b.eq	 <L86>
+               	uxtb	w17, w19
+               	cmp	w17, #0x1
+               	b.eq	 <L84>
+               	mov	x1, #0x0                // =0
+               	b	 <L85>
+<L84>:
+               	lsl	x2, x21, #17
+               	lsr	x3, x21, #47
+               	orr	x4, x2, x3
+               	mov	x16, #0x3039            // =12345
+               	add	x1, x4, x16
+<L85>:
+               	b	 <L87>
+<L86>:
+               	lsr	x2, x21, #29
+               	eor	x3, x21, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+<L87>:
+               	bl	 <L87>
+               	ldp	d8, d9, [x29, #-0x70]
+               	ldp	d10, d11, [x29, #-0x80]
                	ldp	x19, x20, [x29, #-0x40]
                	ldp	x21, x22, [x29, #-0x50]
                	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
-               	ldur	x27, [x29, #-0x78]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/convert/bitcast.dis
+++ b/test/golden/aarch64-linux/convert/bitcast.dis
@@ -3,88 +3,220 @@ convert/bitcast.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.bitcast.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	d8, [x29, #-0x18]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0xfdb             // =4059
                	movk	w16, #0xc049, lsl #16
-               	eor	w3, w2, w16
-               	fmov	s8, w3
-               	fmov	w20, s8
-               	mov	x0, x1
-               	mov	w1, w3
+               	eor	w2, w1, w16
+               	fmov	s0, w2
+               	fmov	w1, s0
+               	mov	w3, w2
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w3, s0
+               	mov	w4, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+               	mov	w3, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0x2d18            // =11544
                	movk	x16, #0x5444, lsl #16
                	movk	x16, #0x21fb, lsl #32
                	movk	x16, #0x4009, lsl #48
-               	eor	x2, x19, x16
-               	fmov	d8, x2
-               	fmov	x19, d8
-               	mov	x0, x1
-               	mov	x1, x2
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	eor	x1, x0, x16
+               	fmov	d0, x1
+               	fmov	x0, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fmov	x1, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xfdb             // =4059
                	movk	w16, #0x4049, lsl #16
-               	mov	w2, w16
-               	fmov	s8, w2
-               	mov	x0, x1
-               	mov	w1, w2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x2, #0x5769             // =22377
-               	movk	x2, #0x8b14, lsl #16
-               	movk	x2, #0xbf0a, lsl #32
-               	movk	x2, #0x4005, lsl #48
-               	fmov	d8, x2
-               	mov	x0, x1
-               	mov	x1, x2
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L10>:
-               	bl	 <L10>
-               	ldur	d8, [x29, #-0x18]
-               	ldp	x19, x20, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w0, w16
+               	fmov	s0, w0
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, #0x5769             // =22377
+               	movk	x0, #0x8b14, lsl #16
+               	movk	x0, #0xbf0a, lsl #32
+               	movk	x0, #0x4005, lsl #48
+               	fmov	d0, x0
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fmov	x0, d0
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/convert/ext_sign.dis
+++ b/test/golden/aarch64-linux/convert/ext_sign.dis
@@ -3,118 +3,301 @@ convert/ext_sign.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.ext_sign.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0x80              // =128
-               	orr	w20, w2, w16
-               	mvn	w21, w20
-               	mov	w2, w19
+               	orr	w2, w1, w16
+               	mvn	w1, w2
+               	mov	w3, w0
                	mov	w16, #0x8000            // =32768
-               	orr	w22, w2, w16
-               	mvn	w23, w22
-               	mov	w2, w19
+               	orr	w4, w3, w16
+               	mvn	w3, w4
+               	mov	w5, w0
                	mov	w16, #-0x80000000       // =-2147483648
-               	orr	w19, w2, w16
-               	mvn	w24, w19
-               	sxtb	w2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	orr	w0, w5, w16
+               	mvn	w5, w0
+               	sxtb	w6, w2
+               	sxth	x7, w6
+               	mov	x6, #0x2325             // =8997
+               	movk	x6, #0x8422, lsl #16
+               	movk	x6, #0x9ce4, lsl #32
+               	movk	x6, #0xcbf2, lsl #48
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	sxtb	w2, w21
-               	mov	x0, x1
-               	mov	x1, x2
+               	sxtb	w7, w1
+               	sxth	x8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	sxtb	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	sxtb	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtb	w7, w2
+               	sxtw	x8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	sxtb	x25, w20
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	sxtb	x20, w21
-               	mov	x0, x1
-               	mov	x1, x20
+               	sxtb	w7, w1
+               	sxtw	x8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	sxth	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	sxth	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	sxtb	x7, w2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sxth	x21, w22
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	sxth	x22, w23
-               	mov	x0, x1
-               	mov	x1, x22
+               	sxtb	x7, w1
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	sxtw	x23, w19
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	sxtw	x19, w24
-               	mov	x0, x1
-               	mov	x1, x19
+               	sxth	w7, w4
+               	sxtw	x8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	add	x2, x25, x21
-               	add	x3, x2, x23
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	add	x2, x20, x22
-               	add	x3, x2, x19
-               	mov	x0, x1
-               	mov	x1, x3
+               	sxth	w7, w3
+               	sxtw	x8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	sxth	x7, w4
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxth	x7, w3
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	sxtw	x7, w0
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxtw	x7, w5
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sxtb	x7, w2
+               	sxth	x2, w4
+               	add	x4, x7, x2
+               	sxtw	x2, w0
+               	add	x0, x4, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x7, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x7, x16
+               	eor	x7, x6, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sxtb	x0, w1
+               	sxth	x1, w3
+               	add	x2, x0, x1
+               	sxtw	x0, w5
+               	add	x1, x2, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x6, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x6
                	ret

--- a/test/golden/aarch64-linux/convert/ext_zero.dis
+++ b/test/golden/aarch64-linux/convert/ext_zero.dis
@@ -3,122 +3,305 @@ convert/ext_zero.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.ext_zero.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
+               	mov	w1, w0
                	mov	w16, #0x80              // =128
-               	orr	w20, w2, w16
+               	orr	w2, w1, w16
                	mov	w17, #0xff              // =255
-               	sub	w21, w17, w20
-               	mov	w2, w19
+               	sub	w1, w17, w2
+               	mov	w3, w0
                	mov	w16, #0x8000            // =32768
-               	orr	w22, w2, w16
+               	orr	w4, w3, w16
                	mov	w17, #0xffff            // =65535
-               	sub	w23, w17, w22
-               	mov	w2, w19
+               	sub	w3, w17, w4
+               	mov	w5, w0
                	mov	w16, #-0x80000000       // =-2147483648
-               	orr	w19, w2, w16
+               	orr	w0, w5, w16
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w24, w17, w19
-               	uxtb	w2, w20
-               	mov	x0, x1
-               	mov	x1, x2
+               	sub	w5, w17, w0
+               	uxtb	w6, w2
+               	uxth	w7, w6
+               	mov	x6, #0x2325             // =8997
+               	movk	x6, #0x8422, lsl #16
+               	movk	x6, #0x9ce4, lsl #32
+               	movk	x6, #0xcbf2, lsl #48
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	uxtb	w2, w21
-               	mov	x0, x1
-               	mov	x1, x2
+               	uxtb	w7, w1
+               	uxth	w8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	uxtb	w2, w20
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	uxtb	w2, w21
-               	mov	x0, x1
-               	mov	w1, w2
+               	uxtb	w7, w2
+               	mov	w8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	uxtb	w25, w20
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	uxtb	w20, w21
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w7, w1
+               	mov	w8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	uxth	w2, w22
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	uxth	w2, w23
-               	mov	x0, x1
-               	mov	w1, w2
+               	uxtb	w7, w2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	uxth	w21, w22
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	uxth	w22, w23
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w7, w1
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	w23, w19
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mov	w19, w24
-               	mov	x0, x1
-               	mov	x1, x19
+               	uxth	w7, w4
+               	mov	w8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	add	x2, x25, x21
-               	add	x3, x2, x23
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	add	x2, x20, x22
-               	add	x3, x2, x19
-               	mov	x0, x1
-               	mov	x1, x3
+               	uxth	w7, w3
+               	mov	w8, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x8, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	uxth	w7, w4
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	uxth	w7, w3
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w7, w0
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	w7, w5
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	uxtb	w7, w2
+               	uxth	w2, w4
+               	add	x4, x7, x2
+               	mov	w2, w0
+               	add	x0, x4, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x7, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x7, x16
+               	eor	x7, x6, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	uxtb	w0, w1
+               	uxth	w1, w3
+               	add	x2, x0, x1
+               	mov	w0, w5
+               	add	x1, x2, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x6, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x6
                	ret

--- a/test/golden/aarch64-linux/convert/f2f.dis
+++ b/test/golden/aarch64-linux/convert/f2f.dis
@@ -4,84 +4,223 @@ Disassembly of section .text:
 
 <corpus.cases.convert.f2f.checksum>:
 <L0>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	stp	d10, d11, [x29, #-0x28]
-               	mov	x19, x0
+               	ucvtf	d0, x0
+               	ucvtf	s1, x0
+               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
+               	ldr	d31, [x16]
+               	fadd	d2, d31, d0
+               	fcvt	s3, d2
+               	fcvt	d4, s3
+               	fmov	x0, d2
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ucvtf	d8, x19
-               	ucvtf	s9, x19
-               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
-               	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s10, d0
-               	fcvt	d11, s10
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	fmov	w0, s3
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
-               	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s10, d0
-               	fcvt	d11, s10
-               	mov	x0, x1
+               	fmov	x0, d4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d11
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d8
-               	fcvt	s8, d0
-               	mov	x0, x1
+               	fadd	d2, d31, d0
+               	fcvt	s3, d2
+               	fcvt	d4, s3
+               	fmov	x0, d2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s8
+               	fmov	w0, s3
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	fmov	x0, d4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
+               	ldr	d31, [x16]
+               	fadd	d2, d31, d0
+               	fcvt	s0, d2
+               	fmov	x0, d2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+<L16>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2f.checksum>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s9
-               	fcvt	d8, s0
+               	fadd	s0, s31, s1
+               	fcvt	d1, s0
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	fmov	x0, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+<L20>:
                	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, d8
-<L11>:
-               	bl	 <L11>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldp	d10, d11, [x29, #-0x28]
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/convert/f2i.dis
+++ b/test/golden/aarch64-linux/convert/f2i.dis
@@ -3,111 +3,322 @@ convert/f2i.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.f2i.fold_pos>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stp	d8, d9, [x29, #-0x10]
-               	mov	x1, x0
-               	fmov	s8, s0
-               	fmov	d9, d1
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	w1, s0
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	fcvtzu	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, s0
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	fcvtzu	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	fcvtzs	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	w1, s0
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	fcvtzu	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, s0
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	fcvtzu	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	w1, s0
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	x1, s0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	fcvtzs	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldp	d8, d9, [x29, #-0x10]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	fcvtzu	w1, d1
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fcvtzu	w1, d1
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fcvtzu	w1, d1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fcvtzu	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	fcvtzs	w1, d1
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	fcvtzs	w1, d1
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcvtzs	w1, d1
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	fcvtzs	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.convert.f2i.fold_neg>:
@@ -115,54 +326,42 @@ Disassembly of section .text:
                	mov	x29, sp
                	sub	sp, sp, #0x10
                	stp	d8, d9, [x29, #-0x10]
-               	mov	x1, x0
                	fmov	s8, s0
                	fmov	d9, d1
-               	fcvtzs	w2, s8
-               	mov	x0, x1
+               	fcvtzs	w1, s8
+               	sxtb	x2, w1
                	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
+               	fcvtzs	w1, s8
+               	sxth	x2, w1
                	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	fcvtzs	w2, s8
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, s8
+               	sxtw	x2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	fcvtzs	x2, s8
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	x1, s8
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
+               	fcvtzs	w1, d9
+               	sxtb	x2, w1
                	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
+               	fcvtzs	w1, d9
+               	sxth	x2, w1
                	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	fcvtzs	w2, d9
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzs	w1, d9
+               	sxtw	x2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	fcvtzs	x2, d9
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzs	x1, d9
 <L7>:
                	bl	 <L7>
                	ldp	d8, d9, [x29, #-0x10]
@@ -173,69 +372,337 @@ Disassembly of section .text:
 <corpus.cases.convert.f2i.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	stp	d10, d11, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
+               	sub	sp, sp, #0x20
+               	stp	d8, d9, [x29, #-0x10]
+               	stp	d10, d11, [x29, #-0x20]
+               	ucvtf	s8, x0
+               	ucvtf	d9, x0
                	mov	w16, #0x42230000        // =1109590016
                	fmov	s31, w16
-               	fadd	s10, s31, s8
+               	fadd	s0, s31, s8
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
-               	fadd	d11, d31, d9
-               	fcvtzu	w1, s10
+               	fadd	d1, d31, d9
+               	fcvtzu	w0, s0
+               	uxtb	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	fcvtzu	w1, s10
+               	fcvtzu	w1, s0
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	fcvtzu	w1, s10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	fcvtzu	x1, s10
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	fcvtzs	w1, s10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	fcvtzs	w1, s10
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	fcvtzs	w1, s10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	fcvtzs	x1, s10
+               	fcvtzs	w1, s0
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	fcvtzu	w1, d11
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	fcvtzu	w1, d11
+               	fcvtzs	w1, s0
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	fcvtzu	w1, d11
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	fcvtzu	x1, d11
+               	fcvtzs	w1, s0
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	fcvtzs	w1, d11
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	fcvtzs	w1, d11
+               	fcvtzs	x1, s0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	fcvtzs	w1, d11
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	fcvtzs	x1, d11
+               	fcvtzu	w1, d1
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	fcvtzu	w1, d1
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	fcvtzu	w1, d1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	fcvtzu	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	fcvtzs	w1, d1
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	fcvtzs	w1, d1
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcvtzs	w1, d1
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	fcvtzs	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	w16, #0x42230000        // =1109590016
                	fmov	s31, w16
                	fneg	s0, s31
@@ -244,59 +711,80 @@ Disassembly of section .text:
                	ldr	d31, [x16]
                	fsub	d11, d31, d9
                	fcvtzs	w1, s10
-<L17>:
-               	bl	 <L17>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
                	fcvtzs	w1, s10
-<L18>:
-               	bl	 <L18>
+               	sxth	x2, w1
+               	mov	x1, x2
+<L33>:
+               	bl	 <L33>
                	fcvtzs	w1, s10
-<L19>:
-               	bl	 <L19>
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
                	fcvtzs	x1, s10
-<L20>:
-               	bl	 <L20>
+<L35>:
+               	bl	 <L35>
                	fcvtzs	w1, d11
-<L21>:
-               	bl	 <L21>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
                	fcvtzs	w1, d11
-<L22>:
-               	bl	 <L22>
+               	sxth	x2, w1
+               	mov	x1, x2
+<L37>:
+               	bl	 <L37>
                	fcvtzs	w1, d11
-<L23>:
-               	bl	 <L23>
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L38>:
+               	bl	 <L38>
                	fcvtzs	x1, d11
-<L24>:
-               	bl	 <L24>
+<L39>:
+               	bl	 <L39>
                	mov	w16, #0x42fe0000        // =1123942400
                	fmov	s31, w16
                	fadd	s0, s31, s8
                	fcvtzs	w1, s0
-<L25>:
-               	bl	 <L25>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
                	mov	w16, #0x437f0000        // =1132396544
                	fmov	s31, w16
                	fadd	s0, s31, s8
                	fcvtzu	w1, s0
-<L26>:
-               	bl	 <L26>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L41>:
+               	bl	 <L41>
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
                	fadd	d8, d31, d9
                	fcvtzu	w1, d8
-<L27>:
-               	bl	 <L27>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L42>:
+               	bl	 <L42>
                	fcvtzs	w1, d8
-<L28>:
-               	bl	 <L28>
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L43>:
+               	bl	 <L43>
                	adrp	x16, 0x0 <corpus.cases.convert.f2i.fold_pos>
                	ldr	d31, [x16]
                	fsub	d0, d31, d9
                	fcvtzs	w1, d0
-<L29>:
-               	bl	 <L29>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldp	d10, d11, [x29, #-0x28]
-               	ldur	x19, [x29, #-0x8]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L44>:
+               	bl	 <L44>
+               	ldp	d8, d9, [x29, #-0x10]
+               	ldp	d10, d11, [x29, #-0x20]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/convert/f2u_high.dis
+++ b/test/golden/aarch64-linux/convert/f2u_high.dis
@@ -3,186 +3,550 @@ convert/f2u_high.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.f2u_high.f32_u32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	w2, s0
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	w2, d0
-               	mov	x0, x1
-               	mov	w1, w2
+               	fcvtzu	w1, d0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f32_u64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	x2, s0
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	x1, s0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	mov	x1, x0
-               	fcvtzu	x2, d0
-               	mov	x0, x1
-               	mov	x1, x2
+               	fcvtzu	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+<L1>:
                	ret
 
 <corpus.cases.convert.f2u_high.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stur	x19, [x29, #-0x8]
-               	stp	d8, d9, [x29, #-0x18]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
+               	ucvtf	s0, x0
+               	ucvtf	d1, x0
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
+               	fadd	s2, s31, s0
+               	fcvtzu	w0, s2
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
                	mov	w16, #0x4f000000        // =1325400064
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L3>:
-               	bl	 <L3>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0x4f400000        // =1329594368
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L4>:
-               	bl	 <L4>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	w1, s0
-<L5>:
-               	bl	 <L5>
+               	fadd	s2, s31, s0
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L6>:
-               	bl	 <L6>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x16, #0x41e0000000000000 // =4746794007248502784
                	fmov	d31, x16
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L7>:
-               	bl	 <L7>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L8>:
-               	bl	 <L8>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L9>:
-               	bl	 <L9>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
-               	fcvtzu	w1, d0
-<L10>:
-               	bl	 <L10>
+               	fadd	d2, d31, d1
+               	fcvtzu	w1, d2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w16, #0x5e800000        // =1585446912
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L11>:
-               	bl	 <L11>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
                	mov	w16, #0x5f000000        // =1593835520
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L12>:
-               	bl	 <L12>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L13>:
-               	bl	 <L13>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	w16, #0x5f400000        // =1598029824
                	fmov	s31, w16
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L14>:
-               	bl	 <L14>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	s31, [x16]
-               	fadd	s0, s31, s8
-               	fcvtzu	x1, s0
-<L15>:
-               	bl	 <L15>
+               	fadd	s2, s31, s0
+               	fcvtzu	x1, s2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L16>:
-               	bl	 <L16>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	x16, #0x43e0000000000000 // =4890909195324358656
                	fmov	d31, x16
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L17>:
-               	bl	 <L17>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L32>
+<L33>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L18>:
-               	bl	 <L18>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L34>
+<L35>:
                	mov	x16, #0x43e8000000000000 // =4893160995138043904
                	fmov	d31, x16
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L19>:
-               	bl	 <L19>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L36>
+<L37>:
                	adrp	x16, 0x0 <corpus.cases.convert.f2u_high.f32_u32>
                	ldr	d31, [x16]
-               	fadd	d0, d31, d9
+               	fadd	d0, d31, d1
                	fcvtzu	x1, d0
-<L20>:
-               	bl	 <L20>
-               	ldp	d8, d9, [x29, #-0x18]
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L38>
+<L39>:
                	ret

--- a/test/golden/aarch64-linux/convert/i2f.dis
+++ b/test/golden/aarch64-linux/convert/i2f.dis
@@ -5,211 +5,727 @@ Disassembly of section .text:
 <corpus.cases.convert.i2f.fold_from>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stp	x25, x26, [x29, #-0x40]
-               	mov	x8, x0
-               	mov	x19, x1
-               	mov	x20, x2
-               	mov	w21, w3
-               	mov	x22, x4
-               	mov	x23, x5
-               	mov	x24, x6
-               	mov	w25, w7
-               	ldr	x26, [x29, #0x10]
-               	uxtb	w16, w19
+               	ldr	x8, [x29, #0x10]
+               	uxtb	w16, w1
                	ucvtf	s0, w16
-               	mov	x0, x8
+               	fmov	w12, s0
+               	mov	w13, w12
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	uxtb	w16, w19
-               	ucvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x14, x12, x16
+               	lsr	x15, x13, x14
+               	mov	x16, #0xff              // =255
+               	and	x14, x15, x16
+               	eor	x15, x0, x14
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x15, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	uxth	w16, w20
-               	ucvtf	s0, w16
-               	mov	x0, x1
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	uxth	w16, w20
+               	uxtb	w16, w1
                	ucvtf	d0, w16
-               	mov	x0, x1
+               	fmov	x1, d0
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x1, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ucvtf	s0, w21
-               	mov	x0, x1
+               	uxth	w16, w2
+               	ucvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w12, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ucvtf	d0, w21
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x13, x1, x16
+               	lsr	x14, x12, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ucvtf	s0, x22
-               	mov	x0, x1
+               	uxth	w16, w2
+               	ucvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ucvtf	d0, x22
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x12, x2, x16
+               	lsr	x13, x1, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x0, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	sxtb	w16, w23
-               	scvtf	s0, w16
-               	mov	x0, x1
+               	ucvtf	s0, w3
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sxtb	w16, w23
-               	scvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x12, x1, x16
+               	lsr	x13, x2, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x0, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	sxth	w16, w24
-               	scvtf	s0, w16
-               	mov	x0, x1
+               	ucvtf	d0, w3
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	sxth	w16, w24
-               	scvtf	d0, w16
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x12, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x12, x16
+               	eor	x12, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x12, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	scvtf	s0, w25
-               	mov	x0, x1
+               	ucvtf	s0, x4
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	scvtf	d0, w25
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x12, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x12, x16
+               	eor	x12, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x12, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	scvtf	s0, x26
-               	mov	x0, x1
+               	ucvtf	d0, x4
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	scvtf	d0, x26
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldp	x25, x26, [x29, #-0x40]
-               	mov	sp, x29
+               	sxtb	w16, w5
+               	scvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sxtb	w16, w5
+               	scvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	sxth	w16, w6
+               	scvtf	s0, w16
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	w16, w6
+               	scvtf	d0, w16
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	scvtf	s0, w7
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	scvtf	d0, w7
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	scvtf	s0, x8
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	scvtf	d0, x8
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.convert.i2f.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
+               	mov	w1, w0
                	mov	w16, #0x80              // =128
-               	orr	w20, w1, w16
-               	mov	w1, w19
+               	orr	w2, w1, w16
+               	mov	w1, w0
                	mov	w16, #0x8000            // =32768
-               	orr	w21, w1, w16
-               	mov	w1, w19
+               	orr	w3, w1, w16
+               	mov	w1, w0
                	mov	w16, #-0x80000000       // =-2147483648
-               	orr	w22, w1, w16
+               	orr	w4, w1, w16
                	mov	x16, #-0x8000000000000000 // =-9223372036854775808
-               	orr	x23, x19, x16
-               	uxtb	w16, w20
+               	orr	x1, x0, x16
+               	uxtb	w16, w2
                	ucvtf	s0, w16
+               	fmov	w5, s0
+               	mov	w6, w5
+               	mov	x5, #0x2325             // =8997
+               	movk	x5, #0x8422, lsl #16
+               	movk	x5, #0x9ce4, lsl #32
+               	movk	x5, #0xcbf2, lsl #48
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	uxtb	w16, w20
+               	uxtb	w16, w2
                	ucvtf	d0, w16
+               	fmov	x6, d0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	uxth	w16, w21
-               	ucvtf	s0, w16
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	uxth	w16, w21
-               	ucvtf	d0, w16
+               	uxth	w16, w3
+               	ucvtf	s0, w16
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ucvtf	s0, w22
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ucvtf	d0, w22
+               	uxth	w16, w3
+               	ucvtf	d0, w16
+               	fmov	x6, d0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ucvtf	s0, x23
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ucvtf	d0, x23
+               	ucvtf	s0, w4
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	sxtb	w16, w20
-               	scvtf	s0, w16
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	sxtb	w16, w20
-               	scvtf	d0, w16
+               	ucvtf	d0, w4
+               	fmov	x6, d0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	sxth	w16, w21
-               	scvtf	s0, w16
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	sxth	w16, w21
-               	scvtf	d0, w16
+               	ucvtf	s0, x1
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	scvtf	s0, w22
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	scvtf	d0, w22
+               	ucvtf	d0, x1
+               	fmov	x6, d0
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	scvtf	s0, x23
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	scvtf	d0, x23
+               	sxtb	w16, w2
+               	scvtf	s0, w16
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mov	x16, #0x1               // =1
-               	orr	x20, x19, x16
-               	mov	x17, #0x0               // =0
-               	sub	x19, x17, x20
-               	ucvtf	s0, x20
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ucvtf	d0, x20
+               	sxtb	w16, w2
+               	scvtf	d0, w16
+               	fmov	x2, d0
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
 <L18>:
-               	bl	 <L18>
-               	scvtf	s0, x19
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x2, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L18>
 <L19>:
-               	bl	 <L19>
-               	scvtf	d0, x19
+               	sxth	w16, w3
+               	scvtf	s0, w16
+               	fmov	w2, s0
+               	mov	w6, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x2, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	sxth	w16, w3
+               	scvtf	d0, w16
+               	fmov	x2, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x3, x16
+               	lsr	x7, x2, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x5, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	scvtf	s0, w4
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x2, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x5, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	scvtf	d0, w4
+               	fmov	x2, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x6, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x6, x16
+               	eor	x6, x5, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	scvtf	s0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x6, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x6, x16
+               	eor	x6, x5, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	scvtf	d0, x1
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x5, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	x16, #0x1               // =1
+               	orr	x19, x0, x16
+               	mov	x17, #0x0               // =0
+               	sub	x20, x17, x19
+               	ucvtf	s0, x19
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, x5
+<L32>:
+               	bl	 <L32>
+               	ucvtf	d0, x19
+               	fmov	x1, d0
+<L33>:
+               	bl	 <L33>
+               	scvtf	s0, x20
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L34>:
+               	bl	 <L34>
+               	scvtf	d0, x20
+               	fmov	x1, d0
+<L35>:
+               	bl	 <L35>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/convert/trunc.dis
+++ b/test/golden/aarch64-linux/convert/trunc.dis
@@ -3,86 +3,187 @@ convert/trunc.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.trunc.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	x16, #0xdef0            // =57072
                	movk	x16, #0x9abc, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	eor	x2, x19, x16
+               	eor	x1, x0, x16
                	mov	x16, #0x1               // =1
-               	orr	x3, x2, x16
-               	mov	w19, w3
-               	mov	w20, w3
-               	mov	w21, w3
-               	mov	x0, x1
-               	mov	w1, w19
+               	orr	x0, x1, x16
+               	mov	w1, w0
+               	mov	w2, w0
+               	mov	w3, w0
+               	mov	w0, w1
+               	mov	x4, #0x2325             // =8997
+               	movk	x4, #0x8422, lsl #16
+               	movk	x4, #0x9ce4, lsl #32
+               	movk	x4, #0xcbf2, lsl #48
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxth	w0, w2
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+               	uxtb	w0, w3
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0x5555            // =21845
                	movk	w16, #0x5555, lsl #16
-               	eor	w2, w19, w16
-               	mov	w22, w2
-               	mov	w23, w2
-               	mov	x0, x1
-               	mov	x1, x22
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	w16, #0x5555            // =21845
-               	eor	w2, w20, w16
-               	mov	w24, w2
-               	mov	x0, x1
-               	mov	x1, x24
+               	eor	w0, w1, w16
+               	mov	w5, w0
+               	mov	w6, w0
+               	uxth	w0, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	w2, w19
-               	uxth	w3, w20
-               	add	x4, x2, x3
-               	uxtb	w2, w21
-               	add	x3, x4, x2
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x4, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	uxth	w2, w22
-               	uxtb	w3, w23
-               	add	x4, x2, x3
-               	uxtb	w2, w24
-               	add	x3, x4, x2
-               	mov	x0, x1
-               	mov	x1, x3
+               	uxtb	w0, w6
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x0, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x4, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	w16, #0x5555            // =21845
+               	eor	w0, w2, w16
+               	mov	w7, w0
+               	uxtb	w0, w7
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x0, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x4, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w0, w1
+               	uxth	w1, w2
+               	add	x2, x0, x1
+               	uxtb	w0, w3
+               	add	x1, x2, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	uxth	w0, w5
+               	uxtb	w1, w6
+               	add	x2, x0, x1
+               	uxtb	w0, w7
+               	add	x1, x2, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x4
                	ret

--- a/test/golden/aarch64-linux/float/arith_f32.dis
+++ b/test/golden/aarch64-linux/float/arith_f32.dis
@@ -8,30 +8,54 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.arith_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.arith_f32.checksum>:
@@ -39,1142 +63,915 @@ Disassembly of section .text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	d8, d9, [x29, #-0x30]
-               	stp	d10, d11, [x29, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	w21, w19
+               	stur	x21, [x29, #-0x18]
+               	stp	d8, d9, [x29, #-0x28]
+               	stp	d10, d11, [x29, #-0x38]
+               	mov	w19, w0
                	mov	w17, #0x3f800000        // =1065353216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s8, w0
                	fmov	s31, #1.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #0.25000000
                	fmul	s10, s31, s8
                	fadd	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	fsub	s0, s9, s10
 <L1>:
                	bl	 <L1>
-               	mov	x19, x0
-               	b	 <L4>
+               	fsub	s0, s10, s9
 <L2>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L2>
+               	fmul	s0, s9, s10
 <L3>:
                	bl	 <L3>
-               	mov	x19, x0
+               	fdiv	s0, s9, s10
 <L4>:
-               	fsub	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x19
+               	bl	 <L4>
+               	fdiv	s0, s10, s9
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
-<L6>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L7>:
-               	bl	 <L7>
-               	mov	x20, x0
-<L8>:
-               	fsub	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
-<L9>:
-               	bl	 <L9>
-               	mov	x19, x0
-               	b	 <L12>
-<L10>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L11>:
-               	bl	 <L11>
-               	mov	x19, x0
-<L12>:
-               	fmul	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x19
-<L13>:
-               	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
-<L14>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L15>:
-               	bl	 <L15>
-               	mov	x20, x0
-<L16>:
-               	fdiv	s0, s9, s10
-               	mov	x0, x20
-<L17>:
-               	bl	 <L17>
-               	fdiv	s0, s10, s9
-<L18>:
-               	bl	 <L18>
                	fneg	s0, s9
-<L19>:
-               	bl	 <L19>
+<L6>:
+               	bl	 <L6>
                	fmov	s31, wzr
                	fsub	s10, s31, s9
                	fmov	s0, s10
-<L20>:
-               	bl	 <L20>
+<L7>:
+               	bl	 <L7>
                	fsub	s0, s9, s9
-<L21>:
-               	bl	 <L21>
+<L8>:
+               	bl	 <L8>
                	fadd	s0, s10, s9
-<L22>:
-               	bl	 <L22>
+<L9>:
+               	bl	 <L9>
                	fmov	s31, #3.00000000
                	fmul	s9, s31, s8
                	fdiv	s10, s8, s9
                	fmov	s0, s10
-<L23>:
-               	bl	 <L23>
+<L10>:
+               	bl	 <L10>
                	fmul	s0, s10, s9
-<L24>:
-               	bl	 <L24>
+<L11>:
+               	bl	 <L11>
                	fsub	s0, s8, s10
                	fsub	s1, s0, s10
                	fsub	s0, s1, s10
-<L25>:
-               	bl	 <L25>
+<L12>:
+               	bl	 <L12>
                	mov	w16, #0x42440000        // =1111752704
                	fmov	s30, w16
                	fdiv	s0, s8, s30
-<L26>:
-               	bl	 <L26>
+<L13>:
+               	bl	 <L13>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s30, [x16]
                	fdiv	s0, s8, s30
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s31, [x16]
                	fdiv	s0, s31, s9
-<L28>:
-               	bl	 <L28>
+<L15>:
+               	bl	 <L15>
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
                	fadd	s11, s9, s8
                	fmov	s0, s11
-<L29>:
-               	bl	 <L29>
+<L16>:
+               	bl	 <L16>
                	fadd	s0, s11, s8
-<L30>:
-               	bl	 <L30>
+<L17>:
+               	bl	 <L17>
                	fadd	s0, s8, s8
                	fadd	s1, s9, s0
                	fmov	s0, s1
-<L31>:
-               	bl	 <L31>
+<L18>:
+               	bl	 <L18>
                	fsub	s0, s9, s8
-<L32>:
-               	bl	 <L32>
+<L19>:
+               	bl	 <L19>
                	fsub	s0, s11, s9
-<L33>:
-               	bl	 <L33>
+<L20>:
+               	bl	 <L20>
                	fmov	s31, wzr
                	fmul	s0, s31, s8
-               	mov	x19, x0
+               	mov	x20, x0
                	fmov	d9, d0
-               	mov	w20, #0x0               // =0
-               	cmp	w20, #0x18
-               	b.lo	 <L34>
-               	b	 <L39>
-<L34>:
+               	mov	w21, #0x0               // =0
+               	cmp	w21, #0x18
+               	b.lo	 <L21>
+               	b	 <L23>
+<L21>:
                	fadd	s0, s9, s10
                	fmov	s30, #1.50000000
-               	fmul	s11, s0, s30
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L36>
-               	mov	x0, x19
-               	fmov	s0, s11
-<L35>:
-               	bl	 <L35>
-               	mov	x22, x0
-               	b	 <L38>
-<L36>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L37>:
-               	bl	 <L37>
-               	mov	x22, x0
-<L38>:
-               	add	w20, w20, #0x1
-               	mov	x19, x22
-               	fmov	d9, d11
-               	cmp	w20, #0x18
-               	b.lo	 <L34>
-<L39>:
+               	fmul	s9, s0, s30
+               	mov	x0, x20
+               	fmov	s0, s9
+<L22>:
+               	bl	 <L22>
+               	add	w21, w21, #0x1
+               	mov	x20, x0
+               	cmp	w21, #0x18
+               	b.lo	 <L21>
+<L23>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s9, w0
-               	fcmp	s9, s9
-               	cset	w0, ne
-               	cbnz	w0,  <L41>
-               	mov	x0, x19
+               	mov	x0, x20
                	fmov	s0, s9
-<L40>:
-               	bl	 <L40>
-               	mov	x20, x0
-               	b	 <L43>
-<L41>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L42>:
-               	bl	 <L42>
-               	mov	x20, x0
-<L43>:
+<L24>:
+               	bl	 <L24>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L45>
-               	mov	x0, x20
-<L44>:
-               	bl	 <L44>
-               	mov	x19, x0
-               	b	 <L47>
-<L45>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L46>:
-               	bl	 <L46>
-               	mov	x19, x0
-<L47>:
+<L25>:
+               	bl	 <L25>
                	fadd	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L49>
-               	mov	x0, x19
-<L48>:
-               	bl	 <L48>
-               	mov	x20, x0
-               	b	 <L51>
-<L49>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L50>:
-               	bl	 <L50>
-               	mov	x20, x0
-<L51>:
+<L26>:
+               	bl	 <L26>
                	fmov	s30, #2.00000000
                	fmul	s10, s9, s30
-               	mov	x0, x20
                	fmov	s0, s10
-<L52>:
-               	bl	 <L52>
+<L27>:
+               	bl	 <L27>
                	fmov	s31, wzr
                	fsub	s0, s31, s10
-<L53>:
-               	bl	 <L53>
+<L28>:
+               	bl	 <L28>
                	fmul	s0, s9, s9
-<L54>:
-               	bl	 <L54>
+<L29>:
+               	bl	 <L29>
                	fsub	s0, s9, s9
-<L55>:
-               	bl	 <L55>
+<L30>:
+               	bl	 <L30>
                	mov	w17, #0x800000          // =8388608
-               	add	w1, w17, w21
+               	add	w1, w17, w19
                	fmov	s9, w1
                	mov	w17, #0x1               // =1
-               	add	w1, w17, w21
+               	add	w1, w17, w19
                	fmov	s10, w1
                	fmov	s30, #0.50000000
                	fmul	s0, s9, s30
-<L56>:
-               	bl	 <L56>
+<L31>:
+               	bl	 <L31>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-<L57>:
-               	bl	 <L57>
+<L32>:
+               	bl	 <L32>
                	fsub	s0, s9, s10
-<L58>:
-               	bl	 <L58>
+<L33>:
+               	bl	 <L33>
                	fmul	s0, s9, s8
-<L59>:
-               	bl	 <L59>
+<L34>:
+               	bl	 <L34>
                	fadd	s0, s10, s10
-<L60>:
-               	bl	 <L60>
+<L35>:
+               	bl	 <L35>
                	fmov	s30, #0.50000000
                	fmul	s0, s10, s30
-<L61>:
-               	bl	 <L61>
+<L36>:
+               	bl	 <L36>
                	fmov	s30, #0.75000000
                	fmul	s0, s10, s30
-<L62>:
-               	bl	 <L62>
+<L37>:
+               	bl	 <L37>
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s30, w16
                	fmul	s0, s10, s30
-<L63>:
-               	bl	 <L63>
+<L38>:
+               	bl	 <L38>
                	fdiv	s0, s10, s9
-<L64>:
-               	bl	 <L64>
-               	mov	x19, x0
+<L39>:
+               	bl	 <L39>
                	fmov	s31, #5.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #3.00000000
                	fmul	s10, s31, s8
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L67>
+               	cset	w1, eq
+               	cbnz	w1,  <L42>
                	fmov	s30, #2.00000000
                	fmul	s0, s9, s30
                	fcmp	s9, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L65>
-               	b	 <L66>
-<L65>:
+               	cset	w2, eq
+               	cbnz	w2,  <L40>
+               	b	 <L41>
+<L40>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w1, ne
-<L66>:
-               	b	 <L68>
-<L67>:
-               	mov	x1, x0
-<L68>:
-               	cbnz	w1,  <L81>
+               	cset	w2, ne
+<L41>:
+               	b	 <L43>
+<L42>:
+               	mov	x2, x1
+<L43>:
+               	cbnz	w2,  <L56>
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L69>
+               	cset	w1, mi
+               	cbnz	w1,  <L44>
                	fmov	d0, d9
-               	b	 <L70>
-<L69>:
+               	b	 <L45>
+<L44>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
-<L70>:
+<L45>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L71>
+               	cset	w2, mi
+               	cbnz	w2,  <L46>
                	fmov	d1, d10
-               	b	 <L72>
-<L71>:
+               	b	 <L47>
+<L46>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L72>:
+<L47>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L73>:
+<L48>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L80>
+               	cset	w2, ls
+               	cbnz	w2,  <L55>
                	fmov	d4, d0
                	fmov	d5, d3
-<L74>:
+<L49>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L77>
-               	cbnz	w0,  <L75>
+               	cset	w2, ls
+               	cbnz	w2,  <L52>
+               	cbnz	w1,  <L50>
                	fmov	d6, d4
-               	b	 <L76>
-<L75>:
+               	b	 <L51>
+<L50>:
                	fneg	s6, s4
-<L76>:
-               	b	 <L82>
-<L77>:
+<L51>:
+               	b	 <L57>
+<L52>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cset	w2, ls
+               	cbnz	w2,  <L53>
                	fmov	d7, d4
-               	b	 <L79>
-<L78>:
+               	b	 <L54>
+<L53>:
                	fsub	s7, s4, s5
-<L79>:
+<L54>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L74>
-<L80>:
+               	b	 <L49>
+<L55>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L73>
-<L81>:
+               	b	 <L48>
+<L56>:
                	fdiv	s0, s9, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s9, s1
-<L82>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L84>
-               	mov	x0, x19
+<L57>:
                	fmov	s0, s6
-<L83>:
-               	bl	 <L83>
-               	mov	x20, x0
-               	b	 <L86>
-<L84>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-<L86>:
+<L58>:
+               	bl	 <L58>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L89>
+               	cset	w1, eq
+               	cbnz	w1,  <L61>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L87>
-               	b	 <L88>
-<L87>:
+               	cset	w2, eq
+               	cbnz	w2,  <L59>
+               	b	 <L60>
+<L59>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L88>:
-               	b	 <L90>
-<L89>:
-               	mov	x1, x0
-<L90>:
-               	cbnz	w1,  <L103>
+               	cset	w2, ne
+<L60>:
+               	b	 <L62>
+<L61>:
+               	mov	x2, x1
+<L62>:
+               	cbnz	w2,  <L75>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L91>
+               	cset	w1, mi
+               	cbnz	w1,  <L63>
                	fmov	d1, d0
-               	b	 <L92>
-<L91>:
+               	b	 <L64>
+<L63>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L92>:
+<L64>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L93>
+               	cset	w2, mi
+               	cbnz	w2,  <L65>
                	fmov	d2, d10
-               	b	 <L94>
-<L93>:
+               	b	 <L66>
+<L65>:
                	fmov	s31, wzr
                	fsub	s2, s31, s10
-<L94>:
+<L66>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L95>:
+<L67>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L102>
+               	cset	w2, ls
+               	cbnz	w2,  <L74>
                	fmov	d5, d1
                	fmov	d6, d4
-<L96>:
+<L68>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L99>
-               	cbnz	w0,  <L97>
+               	cset	w2, ls
+               	cbnz	w2,  <L71>
+               	cbnz	w1,  <L69>
                	fmov	d7, d5
-               	b	 <L98>
-<L97>:
+               	b	 <L70>
+<L69>:
                	fneg	s7, s5
-<L98>:
-               	b	 <L104>
-<L99>:
+<L70>:
+               	b	 <L76>
+<L71>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L100>
+               	cset	w2, ls
+               	cbnz	w2,  <L72>
                	fmov	d16, d5
-               	b	 <L101>
-<L100>:
+               	b	 <L73>
+<L72>:
                	fsub	s16, s5, s6
-<L101>:
+<L73>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L96>
-<L102>:
+               	b	 <L68>
+<L74>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L95>
-<L103>:
+               	b	 <L67>
+<L75>:
                	fdiv	s1, s0, s10
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L104>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x20
+<L76>:
                	fmov	s0, s7
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L107>:
-               	bl	 <L107>
-               	mov	x19, x0
-<L108>:
+<L77>:
+               	bl	 <L77>
                	fmov	s31, wzr
                	fsub	s0, s31, s10
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L111>
+               	cset	w1, eq
+               	cbnz	w1,  <L80>
                	fmov	s30, #2.00000000
                	fmul	s1, s9, s30
                	fcmp	s9, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L109>
-               	b	 <L110>
-<L109>:
+               	cset	w2, eq
+               	cbnz	w2,  <L78>
+               	b	 <L79>
+<L78>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w1, ne
-<L110>:
-               	b	 <L112>
-<L111>:
-               	mov	x1, x0
-<L112>:
-               	cbnz	w1,  <L125>
+               	cset	w2, ne
+<L79>:
+               	b	 <L81>
+<L80>:
+               	mov	x2, x1
+<L81>:
+               	cbnz	w2,  <L94>
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L113>
+               	cset	w1, mi
+               	cbnz	w1,  <L82>
                	fmov	d1, d9
-               	b	 <L114>
-<L113>:
+               	b	 <L83>
+<L82>:
                	fmov	s31, wzr
                	fsub	s1, s31, s9
-<L114>:
+<L83>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L115>
+               	cset	w2, mi
+               	cbnz	w2,  <L84>
                	fmov	d2, d0
-               	b	 <L116>
-<L115>:
+               	b	 <L85>
+<L84>:
                	fmov	s31, wzr
                	fsub	s2, s31, s0
-<L116>:
+<L85>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L117>:
+<L86>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L124>
+               	cset	w2, ls
+               	cbnz	w2,  <L93>
                	fmov	d5, d1
                	fmov	d6, d4
-<L118>:
+<L87>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L121>
-               	cbnz	w0,  <L119>
+               	cset	w2, ls
+               	cbnz	w2,  <L90>
+               	cbnz	w1,  <L88>
                	fmov	d7, d5
-               	b	 <L120>
-<L119>:
+               	b	 <L89>
+<L88>:
                	fneg	s7, s5
-<L120>:
-               	b	 <L126>
-<L121>:
+<L89>:
+               	b	 <L95>
+<L90>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L122>
+               	cset	w2, ls
+               	cbnz	w2,  <L91>
                	fmov	d16, d5
-               	b	 <L123>
-<L122>:
+               	b	 <L92>
+<L91>:
                	fsub	s16, s5, s6
-<L123>:
+<L92>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L118>
-<L124>:
+               	b	 <L87>
+<L93>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L117>
-<L125>:
+               	b	 <L86>
+<L94>:
                	fdiv	s1, s9, s0
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s0
                	fsub	s7, s9, s2
-<L126>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x19
+<L95>:
                	fmov	s0, s7
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L96>:
+               	bl	 <L96>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s31, wzr
                	fsub	s1, s31, s10
                	fmov	s30, wzr
                	fcmp	s1, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L133>
+               	cset	w1, eq
+               	cbnz	w1,  <L99>
                	fmov	s30, #2.00000000
                	fmul	s2, s0, s30
                	fcmp	s0, s2
-               	cset	w1, eq
-               	cbnz	w1,  <L131>
-               	b	 <L132>
-<L131>:
+               	cset	w2, eq
+               	cbnz	w2,  <L97>
+               	b	 <L98>
+<L97>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L132>:
-               	b	 <L134>
-<L133>:
-               	mov	x1, x0
-<L134>:
-               	cbnz	w1,  <L147>
+               	cset	w2, ne
+<L98>:
+               	b	 <L100>
+<L99>:
+               	mov	x2, x1
+<L100>:
+               	cbnz	w2,  <L113>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L135>
+               	cset	w1, mi
+               	cbnz	w1,  <L101>
                	fmov	d2, d0
-               	b	 <L136>
-<L135>:
+               	b	 <L102>
+<L101>:
                	fmov	s31, wzr
                	fsub	s2, s31, s0
-<L136>:
+<L102>:
                	fmov	s30, wzr
                	fcmp	s1, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L137>
+               	cset	w2, mi
+               	cbnz	w2,  <L103>
                	fmov	d3, d1
-               	b	 <L138>
-<L137>:
+               	b	 <L104>
+<L103>:
                	fmov	s31, wzr
                	fsub	s3, s31, s1
-<L138>:
+<L104>:
                	fmov	s30, #2.00000000
                	fdiv	s4, s2, s30
                	fmov	d5, d3
-<L139>:
+<L105>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L146>
+               	cset	w2, ls
+               	cbnz	w2,  <L112>
                	fmov	d6, d2
                	fmov	d7, d5
-<L140>:
+<L106>:
                	fcmp	s3, s7
-               	cset	w1, ls
-               	cbnz	w1,  <L143>
-               	cbnz	w0,  <L141>
+               	cset	w2, ls
+               	cbnz	w2,  <L109>
+               	cbnz	w1,  <L107>
                	fmov	d16, d6
-               	b	 <L142>
-<L141>:
+               	b	 <L108>
+<L107>:
                	fneg	s16, s6
-<L142>:
-               	b	 <L148>
-<L143>:
+<L108>:
+               	b	 <L114>
+<L109>:
                	fcmp	s7, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L144>
+               	cset	w2, ls
+               	cbnz	w2,  <L110>
                	fmov	d17, d6
-               	b	 <L145>
-<L144>:
+               	b	 <L111>
+<L110>:
                	fsub	s17, s6, s7
-<L145>:
+<L111>:
                	fmov	s30, #2.00000000
                	fdiv	s7, s7, s30
                	fmov	d6, d17
-               	b	 <L140>
-<L146>:
+               	b	 <L106>
+<L112>:
                	fmov	s30, #2.00000000
                	fmul	s5, s5, s30
-               	b	 <L139>
-<L147>:
+               	b	 <L105>
+<L113>:
                	fdiv	s2, s0, s1
-               	fcvtzs	x0, s2
-               	scvtf	s2, x0
+               	fcvtzs	x1, s2
+               	scvtf	s2, x1
                	fmul	s3, s2, s1
                	fsub	s16, s0, s3
-<L148>:
-               	fcmp	s16, s16
-               	cset	w0, ne
-               	cbnz	w0,  <L150>
-               	mov	x0, x20
+<L114>:
                	fmov	s0, s16
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-               	b	 <L152>
-<L150>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L151>:
-               	bl	 <L151>
-               	mov	x19, x0
-<L152>:
+<L115>:
+               	bl	 <L115>
                	fmov	s31, #7.00000000
                	fmul	s0, s31, s8
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L155>
+               	cset	w1, eq
+               	cbnz	w1,  <L118>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L153>
-               	b	 <L154>
-<L153>:
+               	cset	w2, eq
+               	cbnz	w2,  <L116>
+               	b	 <L117>
+<L116>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L154>:
-               	b	 <L156>
-<L155>:
-               	mov	x1, x0
-<L156>:
-               	cbnz	w1,  <L169>
+               	cset	w2, ne
+<L117>:
+               	b	 <L119>
+<L118>:
+               	mov	x2, x1
+<L119>:
+               	cbnz	w2,  <L132>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L157>
+               	cset	w1, mi
+               	cbnz	w1,  <L120>
                	fmov	d1, d0
-               	b	 <L158>
-<L157>:
+               	b	 <L121>
+<L120>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L158>:
+<L121>:
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L159>
+               	cset	w2, mi
+               	cbnz	w2,  <L122>
                	fmov	s2, #0.50000000
-               	b	 <L160>
-<L159>:
+               	b	 <L123>
+<L122>:
                	fmov	s31, wzr
                	fmov	s30, #0.50000000
                	fsub	s2, s31, s30
-<L160>:
+<L123>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L161>:
+<L124>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L168>
+               	cset	w2, ls
+               	cbnz	w2,  <L131>
                	fmov	d5, d1
                	fmov	d6, d4
-<L162>:
+<L125>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L165>
-               	cbnz	w0,  <L163>
+               	cset	w2, ls
+               	cbnz	w2,  <L128>
+               	cbnz	w1,  <L126>
                	fmov	d7, d5
-               	b	 <L164>
-<L163>:
+               	b	 <L127>
+<L126>:
                	fneg	s7, s5
-<L164>:
-               	b	 <L170>
-<L165>:
+<L127>:
+               	b	 <L133>
+<L128>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L166>
+               	cset	w2, ls
+               	cbnz	w2,  <L129>
                	fmov	d16, d5
-               	b	 <L167>
-<L166>:
+               	b	 <L130>
+<L129>:
                	fsub	s16, s5, s6
-<L167>:
+<L130>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L162>
-<L168>:
+               	b	 <L125>
+<L131>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L161>
-<L169>:
+               	b	 <L124>
+<L132>:
                	fmov	s30, #0.50000000
                	fdiv	s1, s0, s30
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmov	s30, #0.50000000
                	fmul	s2, s1, s30
                	fsub	s7, s0, s2
-<L170>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L172>
-               	mov	x0, x19
+<L133>:
                	fmov	s0, s7
-<L171>:
-               	bl	 <L171>
-               	mov	x20, x0
-               	b	 <L174>
-<L172>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L173>:
-               	bl	 <L173>
-               	mov	x20, x0
-<L174>:
+<L134>:
+               	bl	 <L134>
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L177>
+               	cset	w1, eq
+               	cbnz	w1,  <L137>
                	fmov	s30, #2.00000000
                	fmul	s0, s8, s30
                	fcmp	s8, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L175>
-               	b	 <L176>
-<L175>:
+               	cset	w2, eq
+               	cbnz	w2,  <L135>
+               	b	 <L136>
+<L135>:
                	fmov	s30, wzr
                	fcmp	s8, s30
-               	cset	w1, ne
-<L176>:
-               	b	 <L178>
-<L177>:
-               	mov	x1, x0
-<L178>:
-               	cbnz	w1,  <L191>
+               	cset	w2, ne
+<L136>:
+               	b	 <L138>
+<L137>:
+               	mov	x2, x1
+<L138>:
+               	cbnz	w2,  <L151>
                	fmov	s30, wzr
                	fcmp	s8, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L179>
+               	cset	w1, mi
+               	cbnz	w1,  <L139>
                	fmov	d0, d8
-               	b	 <L180>
-<L179>:
+               	b	 <L140>
+<L139>:
                	fmov	s31, wzr
                	fsub	s0, s31, s8
-<L180>:
+<L140>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L181>
+               	cset	w2, mi
+               	cbnz	w2,  <L141>
                	fmov	d1, d10
-               	b	 <L182>
-<L181>:
+               	b	 <L142>
+<L141>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L182>:
+<L142>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L183>:
+<L143>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L190>
+               	cset	w2, ls
+               	cbnz	w2,  <L150>
                	fmov	d4, d0
                	fmov	d5, d3
-<L184>:
+<L144>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L187>
-               	cbnz	w0,  <L185>
+               	cset	w2, ls
+               	cbnz	w2,  <L147>
+               	cbnz	w1,  <L145>
                	fmov	d6, d4
-               	b	 <L186>
-<L185>:
+               	b	 <L146>
+<L145>:
                	fneg	s6, s4
-<L186>:
-               	b	 <L192>
-<L187>:
+<L146>:
+               	b	 <L152>
+<L147>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L188>
+               	cset	w2, ls
+               	cbnz	w2,  <L148>
                	fmov	d7, d4
-               	b	 <L189>
-<L188>:
+               	b	 <L149>
+<L148>:
                	fsub	s7, s4, s5
-<L189>:
+<L149>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L184>
-<L190>:
+               	b	 <L144>
+<L150>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L183>
-<L191>:
+               	b	 <L143>
+<L151>:
                	fdiv	s0, s8, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s8, s1
-<L192>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L194>
-               	mov	x0, x20
+<L152>:
                	fmov	s0, s6
-<L193>:
-               	bl	 <L193>
-               	mov	x19, x0
-               	b	 <L196>
-<L194>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L195>:
-               	bl	 <L195>
-               	mov	x19, x0
-<L196>:
+<L153>:
+               	bl	 <L153>
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L199>
+               	cset	w1, eq
+               	cbnz	w1,  <L156>
                	fmov	s30, #2.00000000
                	fmul	s0, s10, s30
                	fcmp	s10, s0
-               	cset	w1, eq
-               	cbnz	w1,  <L197>
-               	b	 <L198>
-<L197>:
+               	cset	w2, eq
+               	cbnz	w2,  <L154>
+               	b	 <L155>
+<L154>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, ne
-<L198>:
-               	b	 <L200>
-<L199>:
-               	mov	x1, x0
-<L200>:
-               	cbnz	w1,  <L213>
-               	fmov	s30, wzr
-               	fcmp	s10, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L201>
-               	fmov	d0, d10
-               	b	 <L202>
-<L201>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s10
-<L202>:
+               	cset	w2, ne
+<L155>:
+               	b	 <L157>
+<L156>:
+               	mov	x2, x1
+<L157>:
+               	cbnz	w2,  <L170>
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L203>
+               	cbnz	w1,  <L158>
+               	fmov	d0, d10
+               	b	 <L159>
+<L158>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s10
+<L159>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w2, mi
+               	cbnz	w2,  <L160>
                	fmov	d1, d10
-               	b	 <L204>
-<L203>:
+               	b	 <L161>
+<L160>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L204>:
+<L161>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L205>:
+<L162>:
                	fcmp	s3, s2
-               	cset	w1, ls
-               	cbnz	w1,  <L212>
+               	cset	w2, ls
+               	cbnz	w2,  <L169>
                	fmov	d4, d0
                	fmov	d5, d3
-<L206>:
+<L163>:
                	fcmp	s1, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L209>
-               	cbnz	w0,  <L207>
+               	cset	w2, ls
+               	cbnz	w2,  <L166>
+               	cbnz	w1,  <L164>
                	fmov	d6, d4
-               	b	 <L208>
-<L207>:
+               	b	 <L165>
+<L164>:
                	fneg	s6, s4
-<L208>:
-               	b	 <L214>
-<L209>:
+<L165>:
+               	b	 <L171>
+<L166>:
                	fcmp	s5, s4
-               	cset	w1, ls
-               	cbnz	w1,  <L210>
+               	cset	w2, ls
+               	cbnz	w2,  <L167>
                	fmov	d7, d4
-               	b	 <L211>
-<L210>:
+               	b	 <L168>
+<L167>:
                	fsub	s7, s4, s5
-<L211>:
+<L168>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L206>
-<L212>:
+               	b	 <L163>
+<L169>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L205>
-<L213>:
+               	b	 <L162>
+<L170>:
                	fdiv	s0, s10, s10
-               	fcvtzs	x0, s0
-               	scvtf	s0, x0
+               	fcvtzs	x1, s0
+               	scvtf	s0, x1
                	fmul	s1, s0, s10
                	fsub	s6, s10, s1
-<L214>:
-               	fcmp	s6, s6
-               	cset	w0, ne
-               	cbnz	w0,  <L216>
-               	mov	x0, x19
+<L171>:
                	fmov	s0, s6
-<L215>:
-               	bl	 <L215>
-               	mov	x20, x0
-               	b	 <L218>
-<L216>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L217>:
-               	bl	 <L217>
-               	mov	x20, x0
-<L218>:
+<L172>:
+               	bl	 <L172>
                	mov	w16, #0x49800000        // =1233125376
                	fmov	s31, w16
                	fmul	s0, s31, s8
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, eq
-               	cbnz	w0,  <L221>
+               	cset	w1, eq
+               	cbnz	w1,  <L175>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w1, eq
-               	cbnz	w1,  <L219>
-               	b	 <L220>
-<L219>:
+               	cset	w2, eq
+               	cbnz	w2,  <L173>
+               	b	 <L174>
+<L173>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w1, ne
-<L220>:
-               	b	 <L222>
-<L221>:
-               	mov	x1, x0
-<L222>:
-               	cbnz	w1,  <L235>
+               	cset	w2, ne
+<L174>:
+               	b	 <L176>
+<L175>:
+               	mov	x2, x1
+<L176>:
+               	cbnz	w2,  <L189>
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, mi
-               	cbnz	w0,  <L223>
+               	cset	w1, mi
+               	cbnz	w1,  <L177>
                	fmov	d1, d0
-               	b	 <L224>
-<L223>:
+               	b	 <L178>
+<L177>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L224>:
+<L178>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L225>
+               	cset	w2, mi
+               	cbnz	w2,  <L179>
                	fmov	d2, d10
-               	b	 <L226>
-<L225>:
+               	b	 <L180>
+<L179>:
                	fmov	s31, wzr
                	fsub	s2, s31, s10
-<L226>:
+<L180>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L227>:
+<L181>:
                	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L234>
+               	cset	w2, ls
+               	cbnz	w2,  <L188>
                	fmov	d5, d1
                	fmov	d6, d4
-<L228>:
+<L182>:
                	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L231>
-               	cbnz	w0,  <L229>
+               	cset	w2, ls
+               	cbnz	w2,  <L185>
+               	cbnz	w1,  <L183>
                	fmov	d7, d5
-               	b	 <L230>
-<L229>:
+               	b	 <L184>
+<L183>:
                	fneg	s7, s5
-<L230>:
-               	b	 <L236>
-<L231>:
+<L184>:
+               	b	 <L190>
+<L185>:
                	fcmp	s6, s5
-               	cset	w1, ls
-               	cbnz	w1,  <L232>
+               	cset	w2, ls
+               	cbnz	w2,  <L186>
                	fmov	d16, d5
-               	b	 <L233>
-<L232>:
+               	b	 <L187>
+<L186>:
                	fsub	s16, s5, s6
-<L233>:
+<L187>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L228>
-<L234>:
+               	b	 <L182>
+<L188>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L227>
-<L235>:
+               	b	 <L181>
+<L189>:
                	fdiv	s1, s0, s10
-               	fcvtzs	x0, s1
-               	scvtf	s1, x0
+               	fcvtzs	x1, s1
+               	scvtf	s1, x1
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L236>:
-               	fcmp	s7, s7
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x20
+<L190>:
                	fmov	s0, s7
-<L237>:
-               	bl	 <L237>
-               	mov	x19, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L239>:
-               	bl	 <L239>
-               	mov	x19, x0
-<L240>:
-               	mov	x0, x19
-               	ldp	d8, d9, [x29, #-0x30]
-               	ldp	d10, d11, [x29, #-0x40]
+<L191>:
+               	bl	 <L191>
+               	ldp	d8, d9, [x29, #-0x28]
+               	ldp	d10, d11, [x29, #-0x38]
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/float/arith_f64.dis
+++ b/test/golden/aarch64-linux/float/arith_f64.dis
@@ -8,32 +8,56 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.arith_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.arith_f64.checksum>:
@@ -41,13 +65,10 @@ Disassembly of section .text:
                	mov	x29, sp
                	sub	sp, sp, #0x40
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	d8, d9, [x29, #-0x30]
-               	stp	d10, d11, [x29, #-0x40]
+               	stur	x21, [x29, #-0x18]
+               	stp	d8, d9, [x29, #-0x28]
+               	stp	d10, d11, [x29, #-0x38]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
                	mov	x17, #0x3ff0000000000000 // =4607182418800017408
                	add	x0, x17, x19
                	fmov	d8, x0
@@ -56,269 +77,144 @@ Disassembly of section .text:
                	fmov	d31, #0.25000000
                	fmul	d10, d31, d8
                	fadd	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	fsub	d0, d9, d10
 <L1>:
                	bl	 <L1>
-               	mov	x21, x0
-               	b	 <L4>
+               	fsub	d0, d10, d9
 <L2>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L2>
+               	fmul	d0, d9, d10
 <L3>:
                	bl	 <L3>
-               	mov	x21, x0
+               	fdiv	d0, d9, d10
 <L4>:
-               	fsub	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x21
+               	bl	 <L4>
+               	fdiv	d0, d10, d9
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
-<L6>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L7>:
-               	bl	 <L7>
-               	mov	x20, x0
-<L8>:
-               	fsub	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
-<L9>:
-               	bl	 <L9>
-               	mov	x21, x0
-               	b	 <L12>
-<L10>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L11>:
-               	bl	 <L11>
-               	mov	x21, x0
-<L12>:
-               	fmul	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x21
-<L13>:
-               	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
-<L14>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L15>:
-               	bl	 <L15>
-               	mov	x20, x0
-<L16>:
-               	fdiv	d0, d9, d10
-               	mov	x0, x20
-<L17>:
-               	bl	 <L17>
-               	fdiv	d0, d10, d9
-<L18>:
-               	bl	 <L18>
                	fneg	d0, d9
-<L19>:
-               	bl	 <L19>
+<L6>:
+               	bl	 <L6>
                	fmov	d31, xzr
                	fsub	d10, d31, d9
                	fmov	d0, d10
-<L20>:
-               	bl	 <L20>
+<L7>:
+               	bl	 <L7>
                	fsub	d0, d9, d9
-<L21>:
-               	bl	 <L21>
+<L8>:
+               	bl	 <L8>
                	fadd	d0, d10, d9
-<L22>:
-               	bl	 <L22>
+<L9>:
+               	bl	 <L9>
                	fmov	d31, #3.00000000
                	fmul	d9, d31, d8
                	fdiv	d10, d8, d9
                	fmov	d0, d10
-<L23>:
-               	bl	 <L23>
+<L10>:
+               	bl	 <L10>
                	fmul	d0, d10, d9
-<L24>:
-               	bl	 <L24>
+<L11>:
+               	bl	 <L11>
                	fsub	d0, d8, d10
                	fsub	d1, d0, d10
                	fsub	d0, d1, d10
-<L25>:
-               	bl	 <L25>
+<L12>:
+               	bl	 <L12>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-<L26>:
-               	bl	 <L26>
+<L13>:
+               	bl	 <L13>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-<L27>:
-               	bl	 <L27>
+<L14>:
+               	bl	 <L14>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d31, [x16]
                	fdiv	d0, d31, d9
-<L28>:
-               	bl	 <L28>
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0x4340000000000000 // =4845873199050653696
                	fmov	d31, x16
                	fmul	d9, d31, d8
                	fadd	d11, d9, d8
                	fmov	d0, d11
-<L29>:
-               	bl	 <L29>
+<L16>:
+               	bl	 <L16>
                	fadd	d0, d11, d8
-<L30>:
-               	bl	 <L30>
+<L17>:
+               	bl	 <L17>
                	fadd	d0, d8, d8
                	fadd	d1, d9, d0
                	fmov	d0, d1
-<L31>:
-               	bl	 <L31>
+<L18>:
+               	bl	 <L18>
                	fsub	d0, d9, d8
-<L32>:
-               	bl	 <L32>
+<L19>:
+               	bl	 <L19>
                	fsub	d0, d11, d9
-<L33>:
-               	bl	 <L33>
+<L20>:
+               	bl	 <L20>
                	fmov	d31, xzr
                	fmul	d0, d31, d8
                	mov	x20, x0
                	fmov	d9, d0
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x18
-               	b.lo	 <L34>
-               	b	 <L39>
-<L34>:
+               	b.lo	 <L21>
+               	b	 <L23>
+<L21>:
                	fadd	d0, d9, d10
                	fmov	d30, #1.50000000
-               	fmul	d11, d0, d30
-               	fcmp	d11, d11
-               	cset	w0, ne
-               	cbnz	w0,  <L36>
+               	fmul	d9, d0, d30
                	mov	x0, x20
-               	fmov	d0, d11
-<L35>:
-               	bl	 <L35>
-               	mov	x22, x0
-               	b	 <L38>
-<L36>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L37>:
-               	bl	 <L37>
-               	mov	x22, x0
-<L38>:
+               	fmov	d0, d9
+<L22>:
+               	bl	 <L22>
                	add	x21, x21, #0x1
-               	mov	x20, x22
-               	fmov	d9, d11
+               	mov	x20, x0
                	cmp	x21, #0x18
-               	b.lo	 <L34>
-<L39>:
+               	b.lo	 <L21>
+<L23>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fef, lsl #48
                	add	x0, x17, x19
                	fmov	d9, x0
-               	fcmp	d9, d9
-               	cset	w0, ne
-               	cbnz	w0,  <L41>
                	mov	x0, x20
                	fmov	d0, d9
-<L40>:
-               	bl	 <L40>
-               	mov	x21, x0
-               	b	 <L43>
-<L41>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L42>:
-               	bl	 <L42>
-               	mov	x21, x0
-<L43>:
+<L24>:
+               	bl	 <L24>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L45>
-               	mov	x0, x21
-<L44>:
-               	bl	 <L44>
-               	mov	x20, x0
-               	b	 <L47>
-<L45>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L46>:
-               	bl	 <L46>
-               	mov	x20, x0
-<L47>:
+<L25>:
+               	bl	 <L25>
                	fadd	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L49>
-               	mov	x0, x20
-<L48>:
-               	bl	 <L48>
-               	mov	x21, x0
-               	b	 <L51>
-<L49>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L50>:
-               	bl	 <L50>
-               	mov	x21, x0
-<L51>:
+<L26>:
+               	bl	 <L26>
                	fmov	d30, #2.00000000
                	fmul	d10, d9, d30
-               	mov	x0, x21
                	fmov	d0, d10
-<L52>:
-               	bl	 <L52>
+<L27>:
+               	bl	 <L27>
                	fmov	d31, xzr
                	fsub	d0, d31, d10
-<L53>:
-               	bl	 <L53>
+<L28>:
+               	bl	 <L28>
                	fmul	d0, d9, d9
-<L54>:
-               	bl	 <L54>
+<L29>:
+               	bl	 <L29>
                	fsub	d0, d9, d9
-<L55>:
-               	bl	 <L55>
+<L30>:
+               	bl	 <L30>
                	mov	x17, #0x10000000000000  // =4503599627370496
                	add	x1, x17, x19
                	fmov	d9, x1
@@ -327,869 +223,739 @@ Disassembly of section .text:
                	fmov	d10, x1
                	fmov	d30, #0.50000000
                	fmul	d0, d9, d30
-<L56>:
-               	bl	 <L56>
+<L31>:
+               	bl	 <L31>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-<L57>:
-               	bl	 <L57>
+<L32>:
+               	bl	 <L32>
                	fsub	d0, d9, d10
-<L58>:
-               	bl	 <L58>
+<L33>:
+               	bl	 <L33>
                	fmul	d0, d9, d8
-<L59>:
-               	bl	 <L59>
+<L34>:
+               	bl	 <L34>
                	fadd	d0, d10, d10
-<L60>:
-               	bl	 <L60>
+<L35>:
+               	bl	 <L35>
                	fmov	d30, #0.50000000
                	fmul	d0, d10, d30
-<L61>:
-               	bl	 <L61>
+<L36>:
+               	bl	 <L36>
                	fmov	d30, #0.75000000
                	fmul	d0, d10, d30
-<L62>:
-               	bl	 <L62>
+<L37>:
+               	bl	 <L37>
                	mov	x16, #0x4340000000000000 // =4845873199050653696
                	fmov	d30, x16
                	fmul	d0, d10, d30
-<L63>:
-               	bl	 <L63>
+<L38>:
+               	bl	 <L38>
                	fdiv	d0, d10, d9
-<L64>:
-               	bl	 <L64>
-               	mov	x19, x0
+<L39>:
+               	bl	 <L39>
                	fmov	d31, #5.50000000
                	fmul	d9, d31, d8
                	fmov	d31, #3.00000000
                	fmul	d10, d31, d8
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L67>
+               	cset	w1, eq
+               	cbnz	w1,  <L42>
                	fmov	d30, #2.00000000
                	fmul	d0, d9, d30
                	fcmp	d9, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L65>
-               	b	 <L66>
-<L65>:
+               	cset	w2, eq
+               	cbnz	w2,  <L40>
+               	b	 <L41>
+<L40>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w1, ne
-<L66>:
-               	b	 <L68>
-<L67>:
-               	mov	x1, x0
-<L68>:
-               	cbnz	w1,  <L81>
+               	cset	w2, ne
+<L41>:
+               	b	 <L43>
+<L42>:
+               	mov	x2, x1
+<L43>:
+               	cbnz	w2,  <L56>
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L69>
+               	cset	w1, mi
+               	cbnz	w1,  <L44>
                	fmov	d0, d9
-               	b	 <L70>
-<L69>:
+               	b	 <L45>
+<L44>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
-<L70>:
+<L45>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L71>
+               	cset	w2, mi
+               	cbnz	w2,  <L46>
                	fmov	d1, d10
-               	b	 <L72>
-<L71>:
+               	b	 <L47>
+<L46>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L72>:
+<L47>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L73>:
+<L48>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L80>
+               	cset	w2, ls
+               	cbnz	w2,  <L55>
                	fmov	d4, d0
                	fmov	d5, d3
-<L74>:
+<L49>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L77>
-               	cbnz	w0,  <L75>
+               	cset	w2, ls
+               	cbnz	w2,  <L52>
+               	cbnz	w1,  <L50>
                	fmov	d6, d4
-               	b	 <L76>
-<L75>:
+               	b	 <L51>
+<L50>:
                	fneg	d6, d4
-<L76>:
-               	b	 <L82>
-<L77>:
+<L51>:
+               	b	 <L57>
+<L52>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cset	w2, ls
+               	cbnz	w2,  <L53>
                	fmov	d7, d4
-               	b	 <L79>
-<L78>:
+               	b	 <L54>
+<L53>:
                	fsub	d7, d4, d5
-<L79>:
+<L54>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L74>
-<L80>:
+               	b	 <L49>
+<L55>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L73>
-<L81>:
+               	b	 <L48>
+<L56>:
                	fdiv	d0, d9, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d9, d1
-<L82>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L84>
-               	mov	x0, x19
+<L57>:
                	fmov	d0, d6
-<L83>:
-               	bl	 <L83>
-               	mov	x20, x0
-               	b	 <L86>
-<L84>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-<L86>:
+<L58>:
+               	bl	 <L58>
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L89>
+               	cset	w1, eq
+               	cbnz	w1,  <L61>
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L87>
-               	b	 <L88>
-<L87>:
+               	cset	w2, eq
+               	cbnz	w2,  <L59>
+               	b	 <L60>
+<L59>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L88>:
-               	b	 <L90>
-<L89>:
-               	mov	x1, x0
-<L90>:
-               	cbnz	w1,  <L103>
+               	cset	w2, ne
+<L60>:
+               	b	 <L62>
+<L61>:
+               	mov	x2, x1
+<L62>:
+               	cbnz	w2,  <L75>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L91>
+               	cset	w1, mi
+               	cbnz	w1,  <L63>
                	fmov	d1, d0
-               	b	 <L92>
-<L91>:
+               	b	 <L64>
+<L63>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L92>:
+<L64>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L93>
+               	cset	w2, mi
+               	cbnz	w2,  <L65>
                	fmov	d2, d10
-               	b	 <L94>
-<L93>:
+               	b	 <L66>
+<L65>:
                	fmov	d31, xzr
                	fsub	d2, d31, d10
-<L94>:
+<L66>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L95>:
+<L67>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L102>
+               	cset	w2, ls
+               	cbnz	w2,  <L74>
                	fmov	d5, d1
                	fmov	d6, d4
-<L96>:
+<L68>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L99>
-               	cbnz	w0,  <L97>
+               	cset	w2, ls
+               	cbnz	w2,  <L71>
+               	cbnz	w1,  <L69>
                	fmov	d7, d5
-               	b	 <L98>
-<L97>:
+               	b	 <L70>
+<L69>:
                	fneg	d7, d5
-<L98>:
-               	b	 <L104>
-<L99>:
+<L70>:
+               	b	 <L76>
+<L71>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L100>
+               	cset	w2, ls
+               	cbnz	w2,  <L72>
                	fmov	d16, d5
-               	b	 <L101>
-<L100>:
+               	b	 <L73>
+<L72>:
                	fsub	d16, d5, d6
-<L101>:
+<L73>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L96>
-<L102>:
+               	b	 <L68>
+<L74>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L95>
-<L103>:
+               	b	 <L67>
+<L75>:
                	fdiv	d1, d0, d10
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L104>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x20
+<L76>:
                	fmov	d0, d7
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L107>:
-               	bl	 <L107>
-               	mov	x19, x0
-<L108>:
+<L77>:
+               	bl	 <L77>
                	fmov	d31, xzr
                	fsub	d0, d31, d10
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L111>
+               	cset	w1, eq
+               	cbnz	w1,  <L80>
                	fmov	d30, #2.00000000
                	fmul	d1, d9, d30
                	fcmp	d9, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L109>
-               	b	 <L110>
-<L109>:
+               	cset	w2, eq
+               	cbnz	w2,  <L78>
+               	b	 <L79>
+<L78>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w1, ne
-<L110>:
-               	b	 <L112>
-<L111>:
-               	mov	x1, x0
-<L112>:
-               	cbnz	w1,  <L125>
+               	cset	w2, ne
+<L79>:
+               	b	 <L81>
+<L80>:
+               	mov	x2, x1
+<L81>:
+               	cbnz	w2,  <L94>
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L113>
+               	cset	w1, mi
+               	cbnz	w1,  <L82>
                	fmov	d1, d9
-               	b	 <L114>
-<L113>:
+               	b	 <L83>
+<L82>:
                	fmov	d31, xzr
                	fsub	d1, d31, d9
-<L114>:
+<L83>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L115>
+               	cset	w2, mi
+               	cbnz	w2,  <L84>
                	fmov	d2, d0
-               	b	 <L116>
-<L115>:
+               	b	 <L85>
+<L84>:
                	fmov	d31, xzr
                	fsub	d2, d31, d0
-<L116>:
+<L85>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L117>:
+<L86>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L124>
+               	cset	w2, ls
+               	cbnz	w2,  <L93>
                	fmov	d5, d1
                	fmov	d6, d4
-<L118>:
+<L87>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L121>
-               	cbnz	w0,  <L119>
+               	cset	w2, ls
+               	cbnz	w2,  <L90>
+               	cbnz	w1,  <L88>
                	fmov	d7, d5
-               	b	 <L120>
-<L119>:
+               	b	 <L89>
+<L88>:
                	fneg	d7, d5
-<L120>:
-               	b	 <L126>
-<L121>:
+<L89>:
+               	b	 <L95>
+<L90>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L122>
+               	cset	w2, ls
+               	cbnz	w2,  <L91>
                	fmov	d16, d5
-               	b	 <L123>
-<L122>:
+               	b	 <L92>
+<L91>:
                	fsub	d16, d5, d6
-<L123>:
+<L92>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L118>
-<L124>:
+               	b	 <L87>
+<L93>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L117>
-<L125>:
+               	b	 <L86>
+<L94>:
                	fdiv	d1, d9, d0
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d0
                	fsub	d7, d9, d2
-<L126>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x19
+<L95>:
                	fmov	d0, d7
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L96>:
+               	bl	 <L96>
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d31, xzr
                	fsub	d1, d31, d10
                	fmov	d30, xzr
                	fcmp	d1, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L133>
+               	cset	w1, eq
+               	cbnz	w1,  <L99>
                	fmov	d30, #2.00000000
                	fmul	d2, d0, d30
                	fcmp	d0, d2
-               	cset	w1, eq
-               	cbnz	w1,  <L131>
-               	b	 <L132>
-<L131>:
+               	cset	w2, eq
+               	cbnz	w2,  <L97>
+               	b	 <L98>
+<L97>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L132>:
-               	b	 <L134>
-<L133>:
-               	mov	x1, x0
-<L134>:
-               	cbnz	w1,  <L147>
+               	cset	w2, ne
+<L98>:
+               	b	 <L100>
+<L99>:
+               	mov	x2, x1
+<L100>:
+               	cbnz	w2,  <L113>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L135>
+               	cset	w1, mi
+               	cbnz	w1,  <L101>
                	fmov	d2, d0
-               	b	 <L136>
-<L135>:
+               	b	 <L102>
+<L101>:
                	fmov	d31, xzr
                	fsub	d2, d31, d0
-<L136>:
+<L102>:
                	fmov	d30, xzr
                	fcmp	d1, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L137>
+               	cset	w2, mi
+               	cbnz	w2,  <L103>
                	fmov	d3, d1
-               	b	 <L138>
-<L137>:
+               	b	 <L104>
+<L103>:
                	fmov	d31, xzr
                	fsub	d3, d31, d1
-<L138>:
+<L104>:
                	fmov	d30, #2.00000000
                	fdiv	d4, d2, d30
                	fmov	d5, d3
-<L139>:
+<L105>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L146>
+               	cset	w2, ls
+               	cbnz	w2,  <L112>
                	fmov	d6, d2
                	fmov	d7, d5
-<L140>:
+<L106>:
                	fcmp	d3, d7
-               	cset	w1, ls
-               	cbnz	w1,  <L143>
-               	cbnz	w0,  <L141>
+               	cset	w2, ls
+               	cbnz	w2,  <L109>
+               	cbnz	w1,  <L107>
                	fmov	d16, d6
-               	b	 <L142>
-<L141>:
+               	b	 <L108>
+<L107>:
                	fneg	d16, d6
-<L142>:
-               	b	 <L148>
-<L143>:
+<L108>:
+               	b	 <L114>
+<L109>:
                	fcmp	d7, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L144>
+               	cset	w2, ls
+               	cbnz	w2,  <L110>
                	fmov	d17, d6
-               	b	 <L145>
-<L144>:
+               	b	 <L111>
+<L110>:
                	fsub	d17, d6, d7
-<L145>:
+<L111>:
                	fmov	d30, #2.00000000
                	fdiv	d7, d7, d30
                	fmov	d6, d17
-               	b	 <L140>
-<L146>:
+               	b	 <L106>
+<L112>:
                	fmov	d30, #2.00000000
                	fmul	d5, d5, d30
-               	b	 <L139>
-<L147>:
+               	b	 <L105>
+<L113>:
                	fdiv	d2, d0, d1
-               	fcvtzs	x0, d2
-               	scvtf	d2, x0
+               	fcvtzs	x1, d2
+               	scvtf	d2, x1
                	fmul	d3, d2, d1
                	fsub	d16, d0, d3
-<L148>:
-               	fcmp	d16, d16
-               	cset	w0, ne
-               	cbnz	w0,  <L150>
-               	mov	x0, x20
+<L114>:
                	fmov	d0, d16
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-               	b	 <L152>
-<L150>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L151>:
-               	bl	 <L151>
-               	mov	x19, x0
-<L152>:
+<L115>:
+               	bl	 <L115>
                	fmov	d31, #7.00000000
                	fmul	d0, d31, d8
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w0, eq
-               	cbnz	w0,  <L153>
-               	b	 <L154>
-<L153>:
+               	cset	w1, eq
+               	cbnz	w1,  <L116>
+               	b	 <L117>
+<L116>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, ne
-<L154>:
-               	cbnz	w0,  <L165>
+               	cset	w1, ne
+<L117>:
+               	cbnz	w1,  <L128>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L155>
+               	cset	w1, mi
+               	cbnz	w1,  <L118>
                	fmov	d1, d0
-               	b	 <L156>
-<L155>:
+               	b	 <L119>
+<L118>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L156>:
+<L119>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d1, d30
                	fmov	d3, #0.50000000
-<L157>:
+<L120>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L164>
+               	cset	w2, ls
+               	cbnz	w2,  <L127>
                	fmov	d4, d1
                	fmov	d5, d3
-<L158>:
+<L121>:
                	fmov	d31, #0.50000000
                	fcmp	d31, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L161>
-               	cbnz	w0,  <L159>
+               	cset	w2, ls
+               	cbnz	w2,  <L124>
+               	cbnz	w1,  <L122>
                	fmov	d6, d4
-               	b	 <L160>
-<L159>:
+               	b	 <L123>
+<L122>:
                	fneg	d6, d4
-<L160>:
-               	b	 <L166>
-<L161>:
+<L123>:
+               	b	 <L129>
+<L124>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L162>
+               	cset	w2, ls
+               	cbnz	w2,  <L125>
                	fmov	d7, d4
-               	b	 <L163>
-<L162>:
+               	b	 <L126>
+<L125>:
                	fsub	d7, d4, d5
-<L163>:
+<L126>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L158>
-<L164>:
+               	b	 <L121>
+<L127>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L157>
-<L165>:
+               	b	 <L120>
+<L128>:
                	fmov	d30, #0.50000000
                	fdiv	d1, d0, d30
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmov	d30, #0.50000000
                	fmul	d2, d1, d30
                	fsub	d6, d0, d2
-<L166>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L168>
-               	mov	x0, x19
+<L129>:
                	fmov	d0, d6
-<L167>:
-               	bl	 <L167>
-               	mov	x20, x0
-               	b	 <L170>
-<L168>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L169>:
-               	bl	 <L169>
-               	mov	x20, x0
-<L170>:
+<L130>:
+               	bl	 <L130>
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L173>
+               	cset	w1, eq
+               	cbnz	w1,  <L133>
                	fmov	d30, #2.00000000
                	fmul	d0, d8, d30
                	fcmp	d8, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L171>
-               	b	 <L172>
-<L171>:
+               	cset	w2, eq
+               	cbnz	w2,  <L131>
+               	b	 <L132>
+<L131>:
                	fmov	d30, xzr
                	fcmp	d8, d30
-               	cset	w1, ne
-<L172>:
-               	b	 <L174>
-<L173>:
-               	mov	x1, x0
-<L174>:
-               	cbnz	w1,  <L187>
+               	cset	w2, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x2, x1
+<L134>:
+               	cbnz	w2,  <L147>
                	fmov	d30, xzr
                	fcmp	d8, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L175>
+               	cset	w1, mi
+               	cbnz	w1,  <L135>
                	fmov	d0, d8
-               	b	 <L176>
-<L175>:
+               	b	 <L136>
+<L135>:
                	fmov	d31, xzr
                	fsub	d0, d31, d8
-<L176>:
+<L136>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L177>
+               	cset	w2, mi
+               	cbnz	w2,  <L137>
                	fmov	d1, d10
-               	b	 <L178>
-<L177>:
+               	b	 <L138>
+<L137>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L178>:
+<L138>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L179>:
+<L139>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L186>
+               	cset	w2, ls
+               	cbnz	w2,  <L146>
                	fmov	d4, d0
                	fmov	d5, d3
-<L180>:
+<L140>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L183>
-               	cbnz	w0,  <L181>
+               	cset	w2, ls
+               	cbnz	w2,  <L143>
+               	cbnz	w1,  <L141>
                	fmov	d6, d4
-               	b	 <L182>
-<L181>:
+               	b	 <L142>
+<L141>:
                	fneg	d6, d4
-<L182>:
-               	b	 <L188>
-<L183>:
+<L142>:
+               	b	 <L148>
+<L143>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L184>
+               	cset	w2, ls
+               	cbnz	w2,  <L144>
                	fmov	d7, d4
-               	b	 <L185>
-<L184>:
+               	b	 <L145>
+<L144>:
                	fsub	d7, d4, d5
-<L185>:
+<L145>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L180>
-<L186>:
+               	b	 <L140>
+<L146>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L179>
-<L187>:
+               	b	 <L139>
+<L147>:
                	fdiv	d0, d8, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d8, d1
-<L188>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L190>
-               	mov	x0, x20
+<L148>:
                	fmov	d0, d6
-<L189>:
-               	bl	 <L189>
-               	mov	x19, x0
-               	b	 <L192>
-<L190>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L191>:
-               	bl	 <L191>
-               	mov	x19, x0
-<L192>:
+<L149>:
+               	bl	 <L149>
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L195>
+               	cset	w1, eq
+               	cbnz	w1,  <L152>
                	fmov	d30, #2.00000000
                	fmul	d0, d10, d30
                	fcmp	d10, d0
-               	cset	w1, eq
-               	cbnz	w1,  <L193>
-               	b	 <L194>
-<L193>:
+               	cset	w2, eq
+               	cbnz	w2,  <L150>
+               	b	 <L151>
+<L150>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, ne
-<L194>:
-               	b	 <L196>
-<L195>:
-               	mov	x1, x0
-<L196>:
-               	cbnz	w1,  <L209>
-               	fmov	d30, xzr
-               	fcmp	d10, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L197>
-               	fmov	d0, d10
-               	b	 <L198>
-<L197>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d10
-<L198>:
+               	cset	w2, ne
+<L151>:
+               	b	 <L153>
+<L152>:
+               	mov	x2, x1
+<L153>:
+               	cbnz	w2,  <L166>
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L199>
+               	cbnz	w1,  <L154>
+               	fmov	d0, d10
+               	b	 <L155>
+<L154>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d10
+<L155>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w2, mi
+               	cbnz	w2,  <L156>
                	fmov	d1, d10
-               	b	 <L200>
-<L199>:
+               	b	 <L157>
+<L156>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L200>:
+<L157>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L201>:
+<L158>:
                	fcmp	d3, d2
-               	cset	w1, ls
-               	cbnz	w1,  <L208>
+               	cset	w2, ls
+               	cbnz	w2,  <L165>
                	fmov	d4, d0
                	fmov	d5, d3
-<L202>:
+<L159>:
                	fcmp	d1, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L205>
-               	cbnz	w0,  <L203>
+               	cset	w2, ls
+               	cbnz	w2,  <L162>
+               	cbnz	w1,  <L160>
                	fmov	d6, d4
-               	b	 <L204>
-<L203>:
+               	b	 <L161>
+<L160>:
                	fneg	d6, d4
-<L204>:
-               	b	 <L210>
-<L205>:
+<L161>:
+               	b	 <L167>
+<L162>:
                	fcmp	d5, d4
-               	cset	w1, ls
-               	cbnz	w1,  <L206>
+               	cset	w2, ls
+               	cbnz	w2,  <L163>
                	fmov	d7, d4
-               	b	 <L207>
-<L206>:
+               	b	 <L164>
+<L163>:
                	fsub	d7, d4, d5
-<L207>:
+<L164>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L202>
-<L208>:
+               	b	 <L159>
+<L165>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L201>
-<L209>:
+               	b	 <L158>
+<L166>:
                	fdiv	d0, d10, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
+               	fcvtzs	x1, d0
+               	scvtf	d0, x1
                	fmul	d1, d0, d10
                	fsub	d6, d10, d1
-<L210>:
-               	fcmp	d6, d6
-               	cset	w0, ne
-               	cbnz	w0,  <L212>
-               	mov	x0, x19
+<L167>:
                	fmov	d0, d6
-<L211>:
-               	bl	 <L211>
-               	mov	x20, x0
-               	b	 <L214>
-<L212>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L213>:
-               	bl	 <L213>
-               	mov	x20, x0
-<L214>:
+<L168>:
+               	bl	 <L168>
                	mov	x16, #0x4130000000000000 // =4697254411347427328
                	fmov	d31, x16
                	fmul	d0, d31, d8
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, eq
-               	cbnz	w0,  <L217>
+               	cset	w1, eq
+               	cbnz	w1,  <L171>
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w1, eq
-               	cbnz	w1,  <L215>
-               	b	 <L216>
-<L215>:
+               	cset	w2, eq
+               	cbnz	w2,  <L169>
+               	b	 <L170>
+<L169>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w1, ne
-<L216>:
-               	b	 <L218>
-<L217>:
-               	mov	x1, x0
-<L218>:
-               	cbnz	w1,  <L231>
+               	cset	w2, ne
+<L170>:
+               	b	 <L172>
+<L171>:
+               	mov	x2, x1
+<L172>:
+               	cbnz	w2,  <L185>
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, mi
-               	cbnz	w0,  <L219>
+               	cset	w1, mi
+               	cbnz	w1,  <L173>
                	fmov	d1, d0
-               	b	 <L220>
-<L219>:
+               	b	 <L174>
+<L173>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L220>:
+<L174>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L221>
+               	cset	w2, mi
+               	cbnz	w2,  <L175>
                	fmov	d2, d10
-               	b	 <L222>
-<L221>:
+               	b	 <L176>
+<L175>:
                	fmov	d31, xzr
                	fsub	d2, d31, d10
-<L222>:
+<L176>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L223>:
+<L177>:
                	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L230>
+               	cset	w2, ls
+               	cbnz	w2,  <L184>
                	fmov	d5, d1
                	fmov	d6, d4
-<L224>:
+<L178>:
                	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L227>
-               	cbnz	w0,  <L225>
+               	cset	w2, ls
+               	cbnz	w2,  <L181>
+               	cbnz	w1,  <L179>
                	fmov	d7, d5
-               	b	 <L226>
-<L225>:
+               	b	 <L180>
+<L179>:
                	fneg	d7, d5
-<L226>:
-               	b	 <L232>
-<L227>:
+<L180>:
+               	b	 <L186>
+<L181>:
                	fcmp	d6, d5
-               	cset	w1, ls
-               	cbnz	w1,  <L228>
+               	cset	w2, ls
+               	cbnz	w2,  <L182>
                	fmov	d16, d5
-               	b	 <L229>
-<L228>:
+               	b	 <L183>
+<L182>:
                	fsub	d16, d5, d6
-<L229>:
+<L183>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L224>
-<L230>:
+               	b	 <L178>
+<L184>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L223>
-<L231>:
+               	b	 <L177>
+<L185>:
                	fdiv	d1, d0, d10
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
+               	fcvtzs	x1, d1
+               	scvtf	d1, x1
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L232>:
-               	fcmp	d7, d7
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x20
+<L186>:
                	fmov	d0, d7
-<L233>:
-               	bl	 <L233>
-               	mov	x19, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L235>:
-               	bl	 <L235>
-               	mov	x19, x0
-<L236>:
-               	mov	x0, x19
-               	ldp	d8, d9, [x29, #-0x30]
-               	ldp	d10, d11, [x29, #-0x40]
+<L187>:
+               	bl	 <L187>
+               	ldp	d8, d9, [x29, #-0x28]
+               	ldp	d10, d11, [x29, #-0x38]
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/float/cmp_f32.dis
+++ b/test/golden/aarch64-linux/float/cmp_f32.dis
@@ -3,45 +3,63 @@ float/cmp_f32.o:
 Disassembly of section .text:
 
 <corpus.cases.float.cmp_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.cmp_f32.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stur	x25, [x29, #-0x68]
-               	stp	d8, d9, [x29, #-0x78]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
+               	sub	sp, sp, #0x40
+               	stur	x19, [x29, #-0x38]
+               	stur	d8, [x29, #-0x40]
+               	mov	w1, w0
                	sub	x19, x29, #0x30
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
@@ -50,350 +68,540 @@ Disassembly of section .text:
                	str	xzr, [x19, #0x20]
                	str	xzr, [x19, #0x28]
                	mov	w17, #-0x800000         // =-8388608
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x0
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x0
+               	str	s0, [x0]
                	mov	w17, #-0x40800000       // =-1082130432
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x4
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x4
+               	str	s0, [x0]
                	mov	w17, #-0x7f800000       // =-2139095040
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x8
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x8
+               	str	s0, [x0]
                	mov	w17, #0x1               // =1
                	movk	w17, #0x8000, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0xc
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0xc
+               	str	s0, [x0]
                	mov	w17, #-0x80000000       // =-2147483648
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x10
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x10
+               	str	s0, [x0]
                	fmov	s0, w1
-               	add	x2, x19, #0x14
-               	str	s0, [x2]
+               	add	x0, x19, #0x14
+               	str	s0, [x0]
                	mov	w17, #0x1               // =1
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x18
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x18
+               	str	s0, [x0]
                	mov	w17, #0x3f800000        // =1065353216
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x1c
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x1c
+               	str	s0, [x0]
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x20
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x20
+               	str	s0, [x0]
                	mov	w17, #0x7f800000        // =2139095040
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x24
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x24
+               	str	s0, [x0]
                	mov	w17, #0x7fc00000        // =2143289344
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x2, x19, #0x28
-               	str	s0, [x2]
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x28
+               	str	s0, [x0]
                	mov	w17, #0x1               // =1
                	movk	w17, #0x7f80, lsl #16
-               	add	w2, w17, w1
-               	fmov	s0, w2
-               	add	x1, x19, #0x2c
-               	str	s0, [x1]
-               	mov	x20, x0
-               	mov	w21, #0x0               // =0
-               	cmp	w21, #0xc
-               	b.lo	 <L1>
-               	b	 <L34>
-<L1>:
-               	mov	w0, w21
-               	add	x22, x19, x0, lsl #2
-               	mov	x23, x20
-               	mov	w24, #0x0               // =0
-               	cmp	w24, #0xc
-               	b.lo	 <L2>
-               	b	 <L33>
-<L2>:
-               	ldr	s8, [x22]
-               	mov	w0, w24
-               	add	x1, x19, x0, lsl #2
-               	ldr	s9, [x1]
-               	fcmp	s8, s9
-               	cset	w1, eq
-               	mov	x0, x23
-<L3>:
-               	bl	 <L3>
-               	fcmp	s8, s9
-               	cset	w1, ne
-<L4>:
-               	bl	 <L4>
-               	fcmp	s8, s9
-               	cset	w25, mi
-               	mov	x1, x25
-<L5>:
-               	bl	 <L5>
-               	fcmp	s8, s9
-               	cset	w1, ls
-<L6>:
-               	bl	 <L6>
-               	fcmp	s9, s8
-               	cset	w1, mi
-<L7>:
-               	bl	 <L7>
-               	fcmp	s9, s8
-               	cset	w1, ls
-<L8>:
-               	bl	 <L8>
-               	cbnz	w25,  <L9>
-               	mov	x1, #0x0                // =0
-               	b	 <L10>
-<L9>:
-               	mov	x1, #0x1                // =1
-<L10>:
-               	fcmp	s8, s9
-               	cset	w2, ls
-               	cbnz	w2,  <L11>
-               	mov	x2, x1
-               	b	 <L12>
-<L11>:
-               	add	w2, w1, #0x2
-<L12>:
-               	fcmp	s9, s8
-               	cset	w1, mi
-               	cbnz	w1,  <L13>
-               	mov	x1, x2
-               	b	 <L14>
-<L13>:
-               	add	w1, w2, #0x4
-<L14>:
-               	fcmp	s9, s8
-               	cset	w2, ls
-               	cbnz	w2,  <L15>
-               	mov	x2, x1
-               	b	 <L16>
-<L15>:
-               	add	w2, w1, #0x8
-<L16>:
-               	fcmp	s8, s9
-               	cset	w1, eq
-               	cbnz	w1,  <L17>
-               	mov	x1, x2
-               	b	 <L18>
-<L17>:
-               	add	w1, w2, #0x10
-<L18>:
-               	fcmp	s8, s9
-               	cset	w2, ne
-               	cbnz	w2,  <L19>
-               	mov	x2, x1
-               	b	 <L20>
-<L19>:
-               	add	w2, w1, #0x20
-<L20>:
-               	mov	x1, x2
-<L21>:
-               	bl	 <L21>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	cbnz	w1,  <L22>
-               	b	 <L23>
-<L22>:
-               	fcmp	s9, s8
-               	cset	w1, mi
-<L23>:
-               	bl	 <L23>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	cbnz	w1,  <L24>
-               	fcmp	s9, s8
-               	cset	w2, mi
-               	b	 <L25>
-<L24>:
-               	mov	x2, x1
-<L25>:
-               	mov	x1, x2
-<L26>:
-               	bl	 <L26>
-               	fcmp	s8, s9
-               	cset	w1, mi
-               	uxtb	w17, w1
-               	cmp	w17, #0x1
-               	cset	w2, ne
-               	mov	x1, x2
-<L27>:
-               	bl	 <L27>
-               	fcmp	s8, s8
-               	cset	w1, eq
-               	cbnz	w1,  <L28>
-               	b	 <L29>
-<L28>:
-               	fcmp	s9, s9
-               	cset	w1, eq
-<L29>:
-               	bl	 <L29>
-               	fcmp	s8, s8
-               	cset	w1, ne
-               	cbnz	w1,  <L30>
-               	fcmp	s9, s9
-               	cset	w2, ne
-               	b	 <L31>
-<L30>:
-               	mov	x2, x1
-<L31>:
-               	mov	x1, x2
-<L32>:
-               	bl	 <L32>
-               	add	w24, w24, #0x1
-               	mov	x23, x0
-               	cmp	w24, #0xc
-               	b.lo	 <L2>
-<L33>:
-               	add	w21, w21, #0x1
-               	mov	x20, x23
-               	cmp	w21, #0xc
-               	b.lo	 <L1>
-<L34>:
-               	add	x0, x19, #0x0
-               	ldr	s0, [x0]
-               	ldr	s1, [x0]
-               	fmov	d8, d1
-               	mov	w0, #0x1                // =1
-               	cmp	w0, #0xc
-               	b.lo	 <L35>
-               	b	 <L40>
-<L35>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s1, [x2]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L36>
-               	fmov	d1, d0
-               	b	 <L37>
-<L36>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s1, [x2]
-<L37>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s2, [x2]
-               	fcmp	s8, s2
-               	cset	w1, mi
-               	cbnz	w1,  <L38>
-               	fmov	d2, d8
-               	b	 <L39>
-<L38>:
-               	mov	w1, w0
-               	add	x2, x19, x1, lsl #2
-               	ldr	s2, [x2]
-<L39>:
-               	add	w0, w0, #0x1
-               	fmov	d0, d1
-               	fmov	d8, d2
-               	cmp	w0, #0xc
-               	b.lo	 <L35>
-<L40>:
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
-               	fcmp	s8, s8
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-               	fmov	s0, s8
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+               	add	w0, w17, w1
+               	fmov	s0, w0
+               	add	x0, x19, #0x2c
+               	str	s0, [x0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	mov	w1, #0x0                // =0
-               	mov	w0, #0x0                // =0
-               	cmp	w0, #0xc
-               	b.lo	 <L49>
-               	b	 <L52>
-<L49>:
-               	mov	w2, w0
+               	cmp	w1, #0xc
+               	b.lo	 <L0>
+               	b	 <L47>
+<L0>:
+               	mov	w2, w1
                	add	x3, x19, x2, lsl #2
-               	mov	x2, x1
+               	mov	x2, x0
                	mov	w4, #0x0                // =0
                	cmp	w4, #0xc
-               	b.lo	 <L50>
-               	b	 <L51>
-<L50>:
+               	b.lo	 <L1>
+               	b	 <L46>
+<L1>:
                	ldr	s0, [x3]
                	mov	w5, w4
                	add	x6, x19, x5, lsl #2
                	ldr	s1, [x6]
                	fcmp	s0, s1
-               	cset	w5, mi
-               	uxtb	w7, w5
-               	add	w5, w2, w7
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
-               	fcmp	s0, s1
-               	cset	w7, ls
-               	uxtb	w8, w7
-               	add	w7, w5, w8
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
-               	fcmp	s0, s1
                	cset	w5, eq
-               	uxtb	w8, w5
-               	add	w5, w7, w8
-               	ldr	s0, [x3]
-               	ldr	s1, [x6]
+               	uxtb	w6, w5
+               	mov	x5, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L2>
+<L3>:
                	fcmp	s0, s1
                	cset	w6, ne
                	uxtb	w7, w6
-               	add	w2, w5, w7
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	fcmp	s0, s1
+               	cset	w6, ls
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	fcmp	s1, s0
+               	cset	w6, ls
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L14>
+               	mov	x6, #0x0                // =0
+               	b	 <L15>
+<L14>:
+               	mov	x6, #0x1                // =1
+<L15>:
+               	fcmp	s0, s1
+               	cset	w7, ls
+               	cbnz	w7,  <L16>
+               	mov	x7, x6
+               	b	 <L17>
+<L16>:
+               	add	w7, w6, #0x2
+<L17>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+               	cbnz	w6,  <L18>
+               	mov	x6, x7
+               	b	 <L19>
+<L18>:
+               	add	w6, w7, #0x4
+<L19>:
+               	fcmp	s1, s0
+               	cset	w7, ls
+               	cbnz	w7,  <L20>
+               	mov	x7, x6
+               	b	 <L21>
+<L20>:
+               	add	w7, w6, #0x8
+<L21>:
+               	fcmp	s0, s1
+               	cset	w6, eq
+               	cbnz	w6,  <L22>
+               	mov	x6, x7
+               	b	 <L23>
+<L22>:
+               	add	w6, w7, #0x10
+<L23>:
+               	fcmp	s0, s1
+               	cset	w7, ne
+               	cbnz	w7,  <L24>
+               	mov	x7, x6
+               	b	 <L25>
+<L24>:
+               	add	w7, w6, #0x20
+<L25>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L28>
+               	b	 <L29>
+<L28>:
+               	fcmp	s1, s0
+               	cset	w6, mi
+<L29>:
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	cbnz	w6,  <L32>
+               	fcmp	s1, s0
+               	cset	w7, mi
+               	b	 <L33>
+<L32>:
+               	mov	x7, x6
+<L33>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w17, w6
+               	cmp	w17, #0x1
+               	cset	w7, ne
+               	uxtb	w6, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	fcmp	s0, s0
+               	cset	w6, eq
+               	cbnz	w6,  <L38>
+               	b	 <L39>
+<L38>:
+               	fcmp	s1, s1
+               	cset	w6, eq
+<L39>:
+               	uxtb	w7, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x7, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	fcmp	s0, s0
+               	cset	w6, ne
+               	cbnz	w6,  <L42>
+               	fcmp	s1, s1
+               	cset	w7, ne
+               	b	 <L43>
+<L42>:
+               	mov	x7, x6
+<L43>:
+               	uxtb	w6, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L44>
+               	b	 <L45>
+<L44>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L44>
+<L45>:
                	add	w4, w4, #0x1
+               	mov	x2, x5
                	cmp	w4, #0xc
-               	b.lo	 <L50>
+               	b.lo	 <L1>
+<L46>:
+               	add	w1, w1, #0x1
+               	mov	x0, x2
+               	cmp	w1, #0xc
+               	b.lo	 <L0>
+<L47>:
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	ldr	s1, [x1]
+               	fmov	d8, d1
+               	mov	w1, #0x1                // =1
+               	cmp	w1, #0xc
+               	b.lo	 <L48>
+               	b	 <L53>
+<L48>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s1, [x3]
+               	fcmp	s1, s0
+               	cset	w2, mi
+               	cbnz	w2,  <L49>
+               	fmov	d1, d0
+               	b	 <L50>
+<L49>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s1, [x3]
+<L50>:
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s2, [x3]
+               	fcmp	s8, s2
+               	cset	w2, mi
+               	cbnz	w2,  <L51>
+               	fmov	d2, d8
+               	b	 <L52>
 <L51>:
-               	add	w0, w0, #0x1
-               	mov	x1, x2
-               	cmp	w0, #0xc
-               	b.lo	 <L49>
+               	mov	w2, w1
+               	add	x3, x19, x2, lsl #2
+               	ldr	s2, [x3]
 <L52>:
-               	mov	x0, x20
+               	add	w1, w1, #0x1
+               	fmov	d0, d1
+               	fmov	d8, d2
+               	cmp	w1, #0xc
+               	b.lo	 <L48>
 <L53>:
                	bl	 <L53>
-               	ldp	d8, d9, [x29, #-0x78]
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldur	x25, [x29, #-0x68]
+               	fmov	s0, s8
+<L54>:
+               	bl	 <L54>
+               	mov	w1, #0x0                // =0
+               	mov	w2, #0x0                // =0
+               	cmp	w2, #0xc
+               	b.lo	 <L55>
+               	b	 <L58>
+<L55>:
+               	mov	w3, w2
+               	add	x4, x19, x3, lsl #2
+               	mov	x3, x1
+               	mov	w5, #0x0                // =0
+               	cmp	w5, #0xc
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	ldr	s0, [x4]
+               	mov	w6, w5
+               	add	x7, x19, x6, lsl #2
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w6, mi
+               	uxtb	w8, w6
+               	add	w6, w3, w8
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	add	w8, w6, w12
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w6, eq
+               	uxtb	w12, w6
+               	add	w6, w8, w12
+               	ldr	s0, [x4]
+               	ldr	s1, [x7]
+               	fcmp	s0, s1
+               	cset	w7, ne
+               	uxtb	w8, w7
+               	add	w3, w6, w8
+               	add	w5, w5, #0x1
+               	cmp	w5, #0xc
+               	b.lo	 <L56>
+<L57>:
+               	add	w2, w2, #0x1
+               	mov	x1, x3
+               	cmp	w2, #0xc
+               	b.lo	 <L55>
+<L58>:
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L59>
+               	b	 <L60>
+<L59>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L59>
+<L60>:
+               	ldur	d8, [x29, #-0x40]
+               	ldur	x19, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/float/cmp_f64.dis
+++ b/test/golden/aarch64-linux/float/cmp_f64.dis
@@ -3,32 +3,56 @@ float/cmp_f64.o:
 Disassembly of section .text:
 
 <corpus.cases.float.cmp_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.cmp_f64.checksum>:
@@ -38,459 +62,675 @@ Disassembly of section .text:
                	stp	x19, x20, [x29, #-0x90]
                	stp	x21, x22, [x29, #-0xa0]
                	stp	x23, x24, [x29, #-0xb0]
-               	stp	x25, x26, [x29, #-0xc0]
-               	stp	d8, d9, [x29, #-0xd0]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
-               	sub	x21, x29, #0x60
-               	add	x1, x21, #0x0
+               	stur	x25, [x29, #-0xb8]
+               	stp	d8, d9, [x29, #-0xc8]
+               	mov	w19, w0
+               	sub	x20, x29, #0x80
+               	add	x1, x20, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               // =96
-<L1>:
+<L0>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x17, #-0x10000000000000 // =-4503599627370496
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x0
+               	add	x1, x20, #0x0
                	str	d0, [x1]
                	mov	x17, #-0x4010000000000000 // =-4616189618054758400
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x8
+               	add	x1, x20, #0x8
                	str	d0, [x1]
                	mov	x17, #-0x7ff0000000000000 // =-9218868437227405312
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x10
+               	add	x1, x20, #0x10
                	str	d0, [x1]
                	mov	x17, #0x1               // =1
                	movk	x17, #0x8000, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x18
+               	add	x1, x20, #0x18
                	str	d0, [x1]
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x20
+               	add	x1, x20, #0x20
                	str	d0, [x1]
-               	fmov	d0, x19
-               	add	x1, x21, #0x28
+               	fmov	d0, x0
+               	add	x1, x20, #0x28
                	str	d0, [x1]
                	mov	x17, #0x1               // =1
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x30
+               	add	x1, x20, #0x30
                	str	d0, [x1]
                	mov	x17, #0x3ff0000000000000 // =4607182418800017408
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x38
+               	add	x1, x20, #0x38
                	str	d0, [x1]
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fef, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x40
+               	add	x1, x20, #0x40
                	str	d0, [x1]
                	mov	x17, #0x7ff0000000000000 // =9218868437227405312
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x48
+               	add	x1, x20, #0x48
                	str	d0, [x1]
                	mov	x17, #0x7ff8000000000000 // =9221120237041090560
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x50
+               	add	x1, x20, #0x50
                	str	d0, [x1]
                	mov	x17, #0x1               // =1
                	movk	x17, #0x7ff0, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	fmov	d0, x1
-               	add	x1, x21, #0x58
-               	str	d0, [x1]
-               	mov	x19, x0
+               	add	x0, x20, #0x58
+               	str	d0, [x0]
+               	mov	x21, #0x2325            // =8997
+               	movk	x21, #0x8422, lsl #16
+               	movk	x21, #0x9ce4, lsl #32
+               	movk	x21, #0xcbf2, lsl #48
                	mov	x22, #0x0               // =0
                	cmp	x22, #0xc
-               	b.lo	 <L2>
-               	b	 <L35>
-<L2>:
-               	add	x23, x21, x22, lsl #3
-               	mov	x24, x19
+               	b.lo	 <L1>
+               	b	 <L46>
+<L1>:
+               	add	x23, x20, x22, lsl #3
+               	mov	x24, x21
                	mov	x25, #0x0               // =0
                	cmp	x25, #0xc
-               	b.lo	 <L3>
-               	b	 <L34>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L45>
+<L2>:
                	ldr	d8, [x23]
-               	add	x0, x21, x25, lsl #3
+               	add	x0, x20, x25, lsl #3
                	ldr	d9, [x0]
                	fcmp	d8, d9
-               	cset	w1, eq
+               	cset	w0, eq
+               	uxtb	w1, w0
                	mov	x0, x24
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	fcmp	d8, d9
                	cset	w1, ne
-<L5>:
-               	bl	 <L5>
-               	fcmp	d8, d9
-               	cset	w26, mi
-               	mov	x1, x26
-<L6>:
-               	bl	 <L6>
-               	fcmp	d8, d9
-               	cset	w1, ls
-<L7>:
-               	bl	 <L7>
-               	fcmp	d9, d8
-               	cset	w1, mi
-<L8>:
-               	bl	 <L8>
-               	fcmp	d9, d8
-               	cset	w1, ls
-<L9>:
-               	bl	 <L9>
-               	cbnz	w26,  <L10>
+               	uxtb	w2, w1
                	mov	x1, #0x0                // =0
-               	b	 <L11>
-<L10>:
-               	mov	x1, #0x1                // =1
-<L11>:
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+<L6>:
                	fcmp	d8, d9
-               	cset	w2, ls
-               	cbnz	w2,  <L12>
-               	mov	x2, x1
-               	b	 <L13>
-<L12>:
-               	add	w2, w1, #0x2
-<L13>:
+               	cset	w1, mi
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	fcmp	d8, d9
+               	cset	w1, ls
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
                	fcmp	d9, d8
                	cset	w1, mi
-               	cbnz	w1,  <L14>
+               	uxtb	w2, w1
                	mov	x1, x2
-               	b	 <L15>
+<L11>:
+               	bl	 <L11>
+               	fcmp	d9, d8
+               	cset	w1, ls
+<L12>:
+               	bl	 <L12>
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L13>
+               	mov	x1, #0x0                // =0
+               	b	 <L14>
+<L13>:
+               	mov	x1, #0x1                // =1
 <L14>:
-               	add	w1, w2, #0x4
+               	fcmp	d8, d9
+               	cset	w2, ls
+               	cbnz	w2,  <L15>
+               	mov	x2, x1
+               	b	 <L16>
 <L15>:
+               	add	w2, w1, #0x2
+<L16>:
+               	fcmp	d9, d8
+               	cset	w1, mi
+               	cbnz	w1,  <L17>
+               	mov	x1, x2
+               	b	 <L18>
+<L17>:
+               	add	w1, w2, #0x4
+<L18>:
                	fcmp	d9, d8
                	cset	w2, ls
-               	cbnz	w2,  <L16>
+               	cbnz	w2,  <L19>
                	mov	x2, x1
-               	b	 <L17>
-<L16>:
+               	b	 <L20>
+<L19>:
                	add	w2, w1, #0x8
-<L17>:
+<L20>:
                	fcmp	d8, d9
                	cset	w1, eq
-               	cbnz	w1,  <L18>
+               	cbnz	w1,  <L21>
                	mov	x1, x2
-               	b	 <L19>
-<L18>:
+               	b	 <L22>
+<L21>:
                	add	w1, w2, #0x10
-<L19>:
+<L22>:
                	fcmp	d8, d9
                	cset	w2, ne
-               	cbnz	w2,  <L20>
+               	cbnz	w2,  <L23>
                	mov	x2, x1
-               	b	 <L21>
-<L20>:
-               	add	w2, w1, #0x20
-<L21>:
-               	mov	x1, x2
-<L22>:
-               	bl	 <L22>
-               	fcmp	d8, d9
-               	cset	w1, mi
-               	cbnz	w1,  <L23>
                	b	 <L24>
 <L23>:
-               	fcmp	d9, d8
-               	cset	w1, mi
+               	add	w2, w1, #0x20
 <L24>:
-               	bl	 <L24>
-               	fcmp	d8, d9
-               	cset	w1, mi
-               	cbnz	w1,  <L25>
-               	fcmp	d9, d8
-               	cset	w2, mi
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
                	b	 <L26>
 <L25>:
-               	mov	x2, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	mov	x1, x2
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L27>
+               	b	 <L28>
 <L27>:
-               	bl	 <L27>
+               	fcmp	d9, d8
+               	cset	w1, mi
+<L28>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	fcmp	d8, d9
+               	cset	w1, mi
+               	cbnz	w1,  <L31>
+               	fcmp	d9, d8
+               	cset	w2, mi
+               	b	 <L32>
+<L31>:
+               	mov	x2, x1
+<L32>:
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+<L34>:
                	fcmp	d8, d9
                	cset	w1, mi
                	uxtb	w17, w1
                	cmp	w17, #0x1
                	cset	w2, ne
-               	mov	x1, x2
-<L28>:
-               	bl	 <L28>
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
                	fcmp	d8, d8
                	cset	w1, eq
-               	cbnz	w1,  <L29>
-               	b	 <L30>
-<L29>:
+               	cbnz	w1,  <L37>
+               	b	 <L38>
+<L37>:
                	fcmp	d9, d9
                	cset	w1, eq
-<L30>:
-               	bl	 <L30>
+<L38>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+<L40>:
                	fcmp	d8, d8
                	cset	w1, ne
-               	cbnz	w1,  <L31>
+               	cbnz	w1,  <L41>
                	fcmp	d9, d9
                	cset	w2, ne
-               	b	 <L32>
-<L31>:
+               	b	 <L42>
+<L41>:
                	mov	x2, x1
-<L32>:
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
+<L42>:
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L43>
+<L44>:
                	add	x25, x25, #0x1
                	mov	x24, x0
                	cmp	x25, #0xc
-               	b.lo	 <L3>
-<L34>:
-               	add	x22, x22, #0x1
-               	mov	x19, x24
-               	cmp	x22, #0xc
                	b.lo	 <L2>
-<L35>:
-               	sub	x22, x29, #0x80
+<L45>:
+               	add	x22, x22, #0x1
+               	mov	x21, x24
+               	cmp	x22, #0xc
+               	b.lo	 <L1>
+<L46>:
+               	sub	x22, x29, #0x20
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
                	str	xzr, [x22, #0x10]
                	str	xzr, [x22, #0x18]
                	mov	w17, #-0x800000         // =-8388608
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x0
                	str	s0, [x0]
                	mov	w17, #-0x40800000       // =-1082130432
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x4
                	str	s0, [x0]
                	mov	w17, #-0x80000000       // =-2147483648
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x8
                	str	s0, [x0]
-               	fmov	s0, w20
+               	fmov	s0, w19
                	add	x0, x22, #0xc
                	str	s0, [x0]
                	mov	w17, #0x1               // =1
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x10
                	str	s0, [x0]
                	mov	w17, #0x3f800000        // =1065353216
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x14
                	str	s0, [x0]
                	mov	w17, #0x7f800000        // =2139095040
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x18
                	str	s0, [x0]
                	mov	w17, #0x7fc00000        // =2143289344
-               	add	w0, w17, w20
+               	add	w0, w17, w19
                	fmov	s0, w0
                	add	x0, x22, #0x1c
                	str	s0, [x0]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0xc
-               	b.lo	 <L36>
-               	b	 <L45>
-<L36>:
-               	add	x23, x21, x20, lsl #3
-               	mov	x24, x19
+               	mov	x19, #0x0               // =0
+               	cmp	x19, #0xc
+               	b.lo	 <L47>
+               	b	 <L59>
+<L47>:
+               	add	x23, x20, x19, lsl #3
+               	mov	x24, x21
                	mov	x25, #0x0               // =0
                	cmp	x25, #0x8
-               	b.lo	 <L37>
-               	b	 <L44>
-<L37>:
+               	b.lo	 <L48>
+               	b	 <L58>
+<L48>:
                	ldr	d8, [x23]
                	add	x0, x22, x25, lsl #2
-               	ldr	s0, [x0]
-               	fcvt	d9, s0
-               	fcmp	d8, d9
-               	cset	w1, eq
+               	ldr	s9, [x0]
+               	fcvt	d0, s9
+               	fcmp	d8, d0
+               	cset	w0, eq
+               	uxtb	w1, w0
                	mov	x0, x24
-<L38>:
-               	bl	 <L38>
-               	fcmp	d8, d9
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, ne
-<L39>:
-               	bl	 <L39>
-               	fcmp	d8, d9
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L51>
+               	b	 <L52>
+<L51>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L51>
+<L52>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, mi
-<L40>:
-               	bl	 <L40>
-               	fcmp	d8, d9
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L53>
+               	b	 <L54>
+<L53>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L53>
+<L54>:
+               	fcvt	d0, s9
+               	fcmp	d8, d0
                	cset	w1, ls
-<L41>:
-               	bl	 <L41>
-               	fcmp	d9, d8
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
+               	fcvt	d0, s9
+               	fcmp	d0, d8
                	cset	w1, mi
-<L42>:
-               	bl	 <L42>
-               	fcmp	d9, d8
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
+               	fcvt	d0, s9
+               	fcmp	d0, d8
                	cset	w1, ls
-<L43>:
-               	bl	 <L43>
+<L57>:
+               	bl	 <L57>
                	add	x25, x25, #0x1
                	mov	x24, x0
                	cmp	x25, #0x8
-               	b.lo	 <L37>
-<L44>:
-               	add	x20, x20, #0x1
-               	mov	x19, x24
-               	cmp	x20, #0xc
-               	b.lo	 <L36>
-<L45>:
-               	add	x0, x21, #0x0
+               	b.lo	 <L48>
+<L58>:
+               	add	x19, x19, #0x1
+               	mov	x21, x24
+               	cmp	x19, #0xc
+               	b.lo	 <L47>
+<L59>:
+               	add	x0, x20, #0x0
                	ldr	d0, [x0]
                	ldr	d1, [x0]
                	fmov	d8, d1
                	mov	x0, #0x1                // =1
                	cmp	x0, #0xc
-               	b.lo	 <L46>
-               	b	 <L51>
-<L46>:
-               	add	x1, x21, x0, lsl #3
+               	b.lo	 <L60>
+               	b	 <L65>
+<L60>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d1, [x1]
                	fcmp	d1, d0
                	cset	w1, mi
-               	cbnz	w1,  <L47>
+               	cbnz	w1,  <L61>
                	fmov	d1, d0
-               	b	 <L48>
-<L47>:
-               	add	x1, x21, x0, lsl #3
+               	b	 <L62>
+<L61>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d1, [x1]
-<L48>:
-               	add	x1, x21, x0, lsl #3
+<L62>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d2, [x1]
                	fcmp	d8, d2
                	cset	w1, mi
-               	cbnz	w1,  <L49>
+               	cbnz	w1,  <L63>
                	fmov	d2, d8
-               	b	 <L50>
-<L49>:
-               	add	x1, x21, x0, lsl #3
+               	b	 <L64>
+<L63>:
+               	add	x1, x20, x0, lsl #3
                	ldr	d2, [x1]
-<L50>:
+<L64>:
                	add	x0, x0, #0x1
                	fmov	d0, d1
                	fmov	d8, d2
                	cmp	x0, #0xc
-               	b.lo	 <L46>
-<L51>:
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L53>
-               	mov	x0, x19
-<L52>:
-               	bl	 <L52>
-               	mov	x20, x0
-               	b	 <L55>
-<L53>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L54>:
-               	bl	 <L54>
-               	mov	x20, x0
-<L55>:
-               	fcmp	d8, d8
-               	cset	w0, ne
-               	cbnz	w0,  <L57>
-               	mov	x0, x20
+               	b.lo	 <L60>
+<L65>:
+               	mov	x0, x21
+<L66>:
+               	bl	 <L66>
                	fmov	d0, d8
-<L56>:
-               	bl	 <L56>
-               	mov	x19, x0
-               	b	 <L59>
-<L57>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L58>:
-               	bl	 <L58>
-               	mov	x19, x0
-<L59>:
+<L67>:
+               	bl	 <L67>
                	mov	w1, #0x0                // =0
-               	mov	x0, #0x0                // =0
-               	cmp	x0, #0xc
-               	b.lo	 <L60>
-               	b	 <L63>
-<L60>:
-               	add	x2, x21, x0, lsl #3
-               	mov	x3, x1
-               	mov	x4, #0x0                // =0
-               	cmp	x4, #0xc
-               	b.lo	 <L61>
-               	b	 <L62>
-<L61>:
-               	ldr	d0, [x2]
-               	add	x5, x21, x4, lsl #3
-               	ldr	d1, [x5]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0xc
+               	b.lo	 <L68>
+               	b	 <L71>
+<L68>:
+               	add	x3, x20, x2, lsl #3
+               	mov	x4, x1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0xc
+               	b.lo	 <L69>
+               	b	 <L70>
+<L69>:
+               	ldr	d0, [x3]
+               	add	x6, x20, x5, lsl #3
+               	ldr	d1, [x6]
                	fcmp	d0, d1
-               	cset	w6, mi
-               	uxtb	w7, w6
-               	add	w6, w3, w7
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
-               	fcmp	d0, d1
-               	cset	w7, ls
+               	cset	w7, mi
                	uxtb	w8, w7
-               	add	w7, w6, w8
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
+               	add	w7, w4, w8
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
                	fcmp	d0, d1
-               	cset	w6, eq
+               	cset	w8, ls
+               	uxtb	w12, w8
+               	add	w8, w7, w12
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
+               	fcmp	d0, d1
+               	cset	w7, eq
+               	uxtb	w12, w7
+               	add	w7, w8, w12
+               	ldr	d0, [x3]
+               	ldr	d1, [x6]
+               	fcmp	d0, d1
+               	cset	w6, ne
                	uxtb	w8, w6
-               	add	w6, w7, w8
-               	ldr	d0, [x2]
-               	ldr	d1, [x5]
-               	fcmp	d0, d1
-               	cset	w5, ne
-               	uxtb	w7, w5
-               	add	w3, w6, w7
-               	add	x4, x4, #0x1
-               	cmp	x4, #0xc
-               	b.lo	 <L61>
-<L62>:
-               	add	x0, x0, #0x1
-               	mov	x1, x3
-               	cmp	x0, #0xc
-               	b.lo	 <L60>
-<L63>:
-               	mov	x0, x19
-<L64>:
-               	bl	 <L64>
-               	ldp	d8, d9, [x29, #-0xd0]
+               	add	w4, w7, w8
+               	add	x5, x5, #0x1
+               	cmp	x5, #0xc
+               	b.lo	 <L69>
+<L70>:
+               	add	x2, x2, #0x1
+               	mov	x1, x4
+               	cmp	x2, #0xc
+               	b.lo	 <L68>
+<L71>:
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L72>
+<L73>:
+               	ldp	d8, d9, [x29, #-0xc8]
                	ldp	x19, x20, [x29, #-0x90]
                	ldp	x21, x22, [x29, #-0xa0]
                	ldp	x23, x24, [x29, #-0xb0]
-               	ldp	x25, x26, [x29, #-0xc0]
+               	ldur	x25, [x29, #-0xb8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/float/special_f32.dis
+++ b/test/golden/aarch64-linux/float/special_f32.dis
@@ -8,30 +8,54 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.special_f32.fold32>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	w0, s0
+               	mov	w2, w0
+               	mov	x0, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.special_f32.checksum>:
@@ -41,707 +65,743 @@ Disassembly of section .text:
                	stp	x19, x20, [x29, #-0x60]
                	stp	x21, x22, [x29, #-0x70]
                	stp	x23, x24, [x29, #-0x80]
-               	stp	x25, x26, [x29, #-0x90]
-               	stp	d8, d9, [x29, #-0xa0]
-               	stp	d10, d11, [x29, #-0xb0]
-               	stp	d12, d13, [x29, #-0xc0]
-               	stp	d14, d15, [x29, #-0xd0]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
-               	mov	w21, w19
+               	stur	x25, [x29, #-0x88]
+               	stp	d8, d9, [x29, #-0x98]
+               	stp	d10, d11, [x29, #-0xa8]
+               	stp	d12, d13, [x29, #-0xb8]
+               	stp	d14, d15, [x29, #-0xc8]
+               	mov	w19, w0
                	mov	w17, #0x3f800000        // =1065353216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s8, w0
                	mov	w17, #-0x40800000       // =-1082130432
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s9, w0
-               	fmov	s10, w21
+               	fmov	s10, w19
                	mov	w17, #-0x80000000       // =-2147483648
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s11, w0
                	mov	w17, #0x7f800000        // =2139095040
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s12, w0
                	mov	w17, #-0x800000         // =-8388608
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s13, w0
                	mov	w17, #0x7fc00000        // =2143289344
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s14, w0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7f7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	fmov	s15, w0
                	mov	w17, #0x800000          // =8388608
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x30]
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7f, lsl #16
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x40]
                	mov	w17, #0x1               // =1
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	stur	w0, [x29, #-0x50]
-               	fcmp	s10, s10
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	fmov	s0, s10
+<L0>:
+               	bl	 <L0>
+               	fmov	s0, s11
 <L1>:
                	bl	 <L1>
-               	mov	x19, x0
-               	b	 <L4>
+               	fadd	s0, s10, s10
 <L2>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L2>
+               	fadd	s0, s10, s11
 <L3>:
                	bl	 <L3>
-               	mov	x19, x0
+               	fadd	s0, s11, s10
 <L4>:
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x19
-               	fmov	s0, s11
+               	bl	 <L4>
+               	fadd	s0, s11, s11
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
+               	fsub	s0, s10, s10
 <L6>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L6>
+               	fsub	s0, s10, s11
 <L7>:
                	bl	 <L7>
-               	mov	x20, x0
+               	fsub	s0, s11, s10
 <L8>:
-               	fadd	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
+               	bl	 <L8>
+               	fsub	s0, s11, s11
 <L9>:
                	bl	 <L9>
-               	mov	x19, x0
-               	b	 <L12>
+               	fmul	s0, s10, s8
 <L10>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L10>
+               	fmul	s0, s10, s9
 <L11>:
                	bl	 <L11>
-               	mov	x19, x0
+               	fmul	s0, s11, s8
 <L12>:
-               	fadd	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x19
+               	bl	 <L12>
+               	fmul	s0, s11, s9
 <L13>:
                	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
+               	fmul	s0, s11, s11
 <L14>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L14>
+               	fmul	s0, s10, s11
 <L15>:
                	bl	 <L15>
-               	mov	x20, x0
+               	fneg	s0, s10
 <L16>:
-               	fadd	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
-               	mov	x0, x20
+               	bl	 <L16>
+               	fneg	s0, s11
 <L17>:
                	bl	 <L17>
-               	mov	x19, x0
-               	b	 <L20>
+               	fdiv	s0, s10, s8
 <L18>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L18>
+               	fdiv	s0, s10, s9
 <L19>:
                	bl	 <L19>
-               	mov	x19, x0
+               	fdiv	s0, s11, s8
 <L20>:
-               	fadd	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x19
+               	bl	 <L20>
+               	fdiv	s0, s11, s9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
-<L22>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fsub	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x19, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L27>:
-               	bl	 <L27>
-               	mov	x19, x0
-<L28>:
-               	fsub	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	s0, s11, s10
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	fsub	s0, s11, s11
-<L34>:
-               	bl	 <L34>
-               	fmul	s0, s10, s8
-<L35>:
-               	bl	 <L35>
-               	fmul	s0, s10, s9
-<L36>:
-               	bl	 <L36>
-               	fmul	s0, s11, s8
-<L37>:
-               	bl	 <L37>
-               	fmul	s0, s11, s9
-<L38>:
-               	bl	 <L38>
-               	fmul	s0, s11, s11
-<L39>:
-               	bl	 <L39>
-               	fmul	s0, s10, s11
-<L40>:
-               	bl	 <L40>
-               	fneg	s0, s10
-<L41>:
-               	bl	 <L41>
-               	fneg	s0, s11
-<L42>:
-               	bl	 <L42>
-               	fdiv	s0, s10, s8
-<L43>:
-               	bl	 <L43>
-               	fdiv	s0, s10, s9
-<L44>:
-               	bl	 <L44>
-               	fdiv	s0, s11, s8
-<L45>:
-               	bl	 <L45>
-               	fdiv	s0, s11, s9
-<L46>:
-               	bl	 <L46>
                	fcmp	s10, s11
                	cset	w1, eq
-<L47>:
-               	bl	 <L47>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	fcmp	s10, s11
                	cset	w1, mi
-<L48>:
-               	bl	 <L48>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	fcmp	s11, s10
                	cset	w1, mi
-<L49>:
-               	bl	 <L49>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
                	fmov	s0, s12
-<L50>:
-               	bl	 <L50>
+<L28>:
+               	bl	 <L28>
                	fmov	s0, s13
-<L51>:
-               	bl	 <L51>
+<L29>:
+               	bl	 <L29>
                	fneg	s0, s12
-<L52>:
-               	bl	 <L52>
+<L30>:
+               	bl	 <L30>
                	fdiv	s0, s8, s10
-<L53>:
-               	bl	 <L53>
+<L31>:
+               	bl	 <L31>
                	fdiv	s0, s8, s11
-<L54>:
-               	bl	 <L54>
+<L32>:
+               	bl	 <L32>
                	fdiv	s0, s9, s10
-<L55>:
-               	bl	 <L55>
+<L33>:
+               	bl	 <L33>
                	fdiv	s0, s9, s11
-<L56>:
-               	bl	 <L56>
+<L34>:
+               	bl	 <L34>
                	fadd	s0, s12, s8
-<L57>:
-               	bl	 <L57>
+<L35>:
+               	bl	 <L35>
                	fadd	s0, s12, s12
-<L58>:
-               	bl	 <L58>
+<L36>:
+               	bl	 <L36>
                	fsub	s0, s12, s13
-<L59>:
-               	bl	 <L59>
+<L37>:
+               	bl	 <L37>
                	fmul	s0, s12, s12
-<L60>:
-               	bl	 <L60>
+<L38>:
+               	bl	 <L38>
                	fmul	s0, s12, s13
-<L61>:
-               	bl	 <L61>
+<L39>:
+               	bl	 <L39>
                	fmul	s0, s12, s9
-<L62>:
-               	bl	 <L62>
+<L40>:
+               	bl	 <L40>
                	fdiv	s0, s8, s12
-<L63>:
-               	bl	 <L63>
+<L41>:
+               	bl	 <L41>
                	fdiv	s0, s9, s12
-<L64>:
-               	bl	 <L64>
+<L42>:
+               	bl	 <L42>
                	fdiv	s0, s8, s13
-<L65>:
-               	bl	 <L65>
+<L43>:
+               	bl	 <L43>
                	fdiv	s0, s12, s8
-<L66>:
-               	bl	 <L66>
+<L44>:
+               	bl	 <L44>
                	fadd	s0, s15, s15
-<L67>:
-               	bl	 <L67>
+<L45>:
+               	bl	 <L45>
                	fcmp	s15, s12
                	cset	w1, mi
-<L68>:
-               	bl	 <L68>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	fmov	s31, wzr
                	fsub	s0, s31, s15
                	fcmp	s13, s0
                	cset	w1, mi
-<L69>:
-               	bl	 <L69>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L47>:
+               	bl	 <L47>
                	fsub	s0, s12, s12
-<L70>:
-               	bl	 <L70>
+<L48>:
+               	bl	 <L48>
                	fadd	s0, s13, s12
-<L71>:
-               	bl	 <L71>
+<L49>:
+               	bl	 <L49>
                	fmul	s0, s12, s10
-<L72>:
-               	bl	 <L72>
+<L50>:
+               	bl	 <L50>
                	fmul	s0, s13, s11
-<L73>:
-               	bl	 <L73>
+<L51>:
+               	bl	 <L51>
                	fdiv	s0, s12, s12
-<L74>:
-               	bl	 <L74>
+<L52>:
+               	bl	 <L52>
                	fdiv	s0, s10, s10
-<L75>:
-               	bl	 <L75>
+<L53>:
+               	bl	 <L53>
                	fdiv	s0, s11, s10
-<L76>:
-               	bl	 <L76>
+<L54>:
+               	bl	 <L54>
                	fmov	w1, s14
-<L77>:
-               	bl	 <L77>
+               	mov	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
                	fcmp	s14, s14
                	cset	w1, ne
-<L78>:
-               	bl	 <L78>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
                	fcmp	s14, s14
                	cset	w1, eq
-<L79>:
-               	bl	 <L79>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L57>:
+               	bl	 <L57>
                	fcmp	s14, s14
                	cset	w1, mi
-<L80>:
-               	bl	 <L80>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L58>:
+               	bl	 <L58>
                	fcmp	s14, s14
                	cset	w1, ls
-<L81>:
-               	bl	 <L81>
-               	fneg	s9, s14
-               	fmov	w1, s9
-<L82>:
-               	bl	 <L82>
-               	fneg	s0, s9
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L59>:
+               	bl	 <L59>
+               	fneg	s0, s14
                	fmov	w1, s0
-<L83>:
-               	bl	 <L83>
+               	mov	w2, w1
+               	mov	x1, x2
+<L60>:
+               	bl	 <L60>
+               	fneg	s0, s14
+               	fneg	s4, s0
+               	fmov	w1, s4
+               	mov	w2, w1
+               	mov	x1, x2
+<L61>:
+               	bl	 <L61>
                	fadd	s0, s14, s8
-<L84>:
-               	bl	 <L84>
+<L62>:
+               	bl	 <L62>
                	fadd	s0, s8, s14
-<L85>:
-               	bl	 <L85>
+<L63>:
+               	bl	 <L63>
                	fmul	s0, s14, s10
-<L86>:
-               	bl	 <L86>
+<L64>:
+               	bl	 <L64>
                	fsub	s0, s14, s14
-<L87>:
-               	bl	 <L87>
+<L65>:
+               	bl	 <L65>
                	fdiv	s0, s14, s14
-<L88>:
-               	bl	 <L88>
+<L66>:
+               	bl	 <L66>
                	fdiv	s0, s14, s12
-<L89>:
-               	bl	 <L89>
+<L67>:
+               	bl	 <L67>
                	ldur	s0, [x29, #-0x50]
-<L90>:
-               	bl	 <L90>
+<L68>:
+               	bl	 <L68>
                	ldur	s0, [x29, #-0x40]
-<L91>:
-               	bl	 <L91>
+<L69>:
+               	bl	 <L69>
                	ldur	s0, [x29, #-0x30]
-<L92>:
-               	bl	 <L92>
+<L70>:
+               	bl	 <L70>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-<L93>:
-               	bl	 <L93>
+<L71>:
+               	bl	 <L71>
                	ldur	s31, [x29, #-0x30]
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
-<L94>:
-               	bl	 <L94>
+<L72>:
+               	bl	 <L72>
                	ldur	s31, [x29, #-0x50]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-<L95>:
-               	bl	 <L95>
+<L73>:
+               	bl	 <L73>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #1.50000000
                	fmul	s0, s31, s30
-<L96>:
-               	bl	 <L96>
+<L74>:
+               	bl	 <L74>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #0.50000000
                	fmul	s0, s31, s30
-<L97>:
-               	bl	 <L97>
+<L75>:
+               	bl	 <L75>
                	ldur	s31, [x29, #-0x50]
                	fneg	s0, s31
-<L98>:
-               	bl	 <L98>
+<L76>:
+               	bl	 <L76>
                	ldur	s31, [x29, #-0x50]
                	mov	w16, #0x4b000000        // =1258291200
                	fmov	s30, w16
                	fmul	s0, s31, s30
-<L99>:
-               	bl	 <L99>
+<L77>:
+               	bl	 <L77>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x30]
                	fdiv	s0, s31, s30
-<L100>:
-               	bl	 <L100>
+<L78>:
+               	bl	 <L78>
                	ldur	s30, [x29, #-0x50]
                	fcmp	s10, s30
                	cset	w1, mi
-<L101>:
-               	bl	 <L101>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
                	ldur	s31, [x29, #-0x50]
                	fcmp	s31, s10
                	cset	w1, eq
-<L102>:
-               	bl	 <L102>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L80>:
+               	bl	 <L80>
                	fmov	s31, wzr
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
                	fcmp	s0, s11
                	cset	w1, mi
-<L103>:
-               	bl	 <L103>
-               	mov	x19, x0
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L81>:
+               	bl	 <L81>
+               	mov	x20, x0
                	ldur	d9, [x29, #-0x30]
-               	mov	w20, #0x0               // =0
-               	cmp	w20, #0x1e
-               	b.lo	 <L104>
-               	b	 <L109>
-<L104>:
+               	mov	w21, #0x0               // =0
+               	cmp	w21, #0x1e
+               	b.lo	 <L82>
+               	b	 <L84>
+<L82>:
                	fmov	s30, #0.50000000
-               	fmul	s11, s9, s30
-               	fcmp	s11, s11
-               	cset	w0, ne
-               	cbnz	w0,  <L106>
-               	mov	x0, x19
-               	fmov	s0, s11
-<L105>:
-               	bl	 <L105>
-               	mov	x22, x0
-               	b	 <L108>
-<L106>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L107>:
-               	bl	 <L107>
-               	mov	x22, x0
-<L108>:
-               	add	w20, w20, #0x1
-               	mov	x19, x22
-               	fmov	d9, d11
-               	cmp	w20, #0x1e
-               	b.lo	 <L104>
-<L109>:
-               	sub	x20, x29, #0x20
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	add	x0, x20, #0x0
-               	str	wzr, [x0]
-               	add	x0, x20, #0x4
+               	fmul	s9, s9, s30
+               	mov	x0, x20
+               	fmov	s0, s9
+<L83>:
+               	bl	 <L83>
+               	add	w21, w21, #0x1
+               	mov	x20, x0
+               	cmp	w21, #0x1e
+               	b.lo	 <L82>
+<L84>:
+               	sub	x0, x29, #0x20
+               	str	xzr, [x0]
+               	str	xzr, [x0, #0x8]
+               	str	xzr, [x0, #0x10]
+               	str	xzr, [x0, #0x18]
+               	add	x1, x0, #0x0
+               	str	wzr, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x0]
-               	add	x0, x20, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x1               // =1
-               	str	w17, [x0]
-               	add	x0, x20, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x7f800000        // =2139095040
-               	str	w17, [x0]
-               	add	x0, x20, #0x10
+               	str	w17, [x1]
+               	add	x1, x0, #0x10
                	mov	w17, #-0x800000         // =-8388608
-               	str	w17, [x0]
-               	add	x0, x20, #0x14
+               	str	w17, [x1]
+               	add	x1, x0, #0x14
                	mov	w17, #0x7fc00000        // =2143289344
-               	str	w17, [x0]
-               	add	x0, x20, #0x18
+               	str	w17, [x1]
+               	add	x1, x0, #0x18
                	mov	w17, #0xdead            // =57005
                	movk	w17, #0xffc0, lsl #16
-               	str	w17, [x0]
-               	add	x0, x20, #0x1c
+               	str	w17, [x1]
+               	add	x1, x0, #0x1c
                	mov	w17, #0x1               // =1
                	movk	w17, #0x7f80, lsl #16
-               	str	w17, [x0]
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x8
-               	b.lo	 <L110>
-               	b	 <L112>
-<L110>:
-               	mov	w0, w22
-               	add	x1, x20, x0, lsl #2
-               	ldr	w0, [x1]
-               	add	w1, w0, w21
-               	fmov	s0, w1
-               	fmov	w1, s0
-               	mov	x0, x19
-<L111>:
-               	bl	 <L111>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x8
-               	b.lo	 <L110>
-<L112>:
+               	str	w17, [x1]
+               	mov	w1, #0x0                // =0
+               	cmp	w1, #0x8
+               	b.lo	 <L85>
+               	b	 <L88>
+<L85>:
+               	mov	w2, w1
+               	add	x3, x0, x2, lsl #2
+               	ldr	w2, [x3]
+               	add	w3, w2, w19
+               	fmov	s0, w3
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, x20
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L86>
+               	b	 <L87>
+<L86>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L86>
+<L87>:
+               	add	w1, w1, #0x1
+               	mov	x20, x2
+               	cmp	w1, #0x8
+               	b.lo	 <L85>
+<L88>:
                	mov	w17, #0x1000000         // =16777216
-               	add	w0, w17, w21
+               	add	w0, w17, w19
                	mov	w17, #0x1               // =1
                	movk	w17, #0x100, lsl #16
-               	add	w20, w17, w21
+               	add	w21, w17, w19
                	mov	w17, #0x3               // =3
                	movk	w17, #0x100, lsl #16
-               	add	w22, w17, w21
+               	add	w22, w17, w19
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w23, w17, w21
+               	add	w23, w17, w19
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xfeff, lsl #16
-               	add	w24, w17, w21
+               	add	w24, w17, w19
                	mov	w17, #-0x80000000       // =-2147483648
-               	add	w25, w17, w21
+               	add	w25, w17, w19
                	ucvtf	s0, w0
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L114>
-               	mov	x0, x19
-<L113>:
-               	bl	 <L113>
-               	mov	x26, x0
-               	b	 <L116>
-<L114>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L115>:
-               	bl	 <L115>
-               	mov	x26, x0
-<L116>:
-               	ucvtf	s0, w20
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L118>
-               	mov	x0, x26
-<L117>:
-               	bl	 <L117>
-               	mov	x19, x0
-               	b	 <L120>
-<L118>:
-               	mov	x0, x26
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-<L120>:
-               	ucvtf	s0, w22
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L122>
-               	mov	x0, x19
-<L121>:
-               	bl	 <L121>
-               	mov	x20, x0
-               	b	 <L124>
-<L122>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L123>:
-               	bl	 <L123>
-               	mov	x20, x0
-<L124>:
-               	ucvtf	s0, w23
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L126>
                	mov	x0, x20
-<L125>:
-               	bl	 <L125>
-               	mov	x19, x0
-               	b	 <L128>
-<L126>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L127>:
-               	bl	 <L127>
-               	mov	x19, x0
-<L128>:
+<L89>:
+               	bl	 <L89>
                	ucvtf	s0, w21
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L130>
-               	mov	x0, x19
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-               	b	 <L132>
-<L130>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-<L132>:
+<L90>:
+               	bl	 <L90>
+               	ucvtf	s0, w22
+<L91>:
+               	bl	 <L91>
+               	ucvtf	s0, w23
+<L92>:
+               	bl	 <L92>
+               	ucvtf	s0, w19
+<L93>:
+               	bl	 <L93>
                	scvtf	s0, w24
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L134>
-               	mov	x0, x20
-<L133>:
-               	bl	 <L133>
-               	mov	x19, x0
-               	b	 <L136>
-<L134>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-<L136>:
+<L94>:
+               	bl	 <L94>
                	scvtf	s0, w25
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L138>
-               	mov	x0, x19
-<L137>:
-               	bl	 <L137>
-               	mov	x20, x0
-               	b	 <L140>
-<L138>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-<L140>:
+<L95>:
+               	bl	 <L95>
                	fmov	s31, #1.50000000
                	fmul	s0, s31, s8
                	mov	w16, #0x4b800000        // =1266679808
                	fmov	s31, w16
-               	fmul	s9, s31, s8
+               	fmul	s1, s31, s8
                	adrp	x16, 0x0 <corpus.cases.float.special_f32.opaque_f32>
                	ldr	s31, [x16]
-               	fmul	s11, s31, s8
+               	fmul	s2, s31, s8
                	fmov	s31, wzr
-               	fsub	s12, s31, s0
+               	fsub	s3, s31, s0
                	fmov	s31, #0.50000000
-               	fmul	s13, s31, s8
+               	fmul	s4, s31, s8
                	fcvtzu	w1, s0
-               	mov	x0, x20
-<L141>:
-               	bl	 <L141>
-               	fcvtzu	w1, s9
-<L142>:
-               	bl	 <L142>
-               	fcvtzu	w1, s11
-<L143>:
-               	bl	 <L143>
-               	fcvtzu	w1, s13
-<L144>:
-               	bl	 <L144>
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L96>
+               	b	 <L97>
+<L96>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L96>
+<L97>:
+               	fcvtzu	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L98>
+               	b	 <L99>
+<L98>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L98>
+<L99>:
+               	fcvtzu	w1, s2
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L100>
+               	b	 <L101>
+<L100>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L100>
+<L101>:
+               	fcvtzu	w1, s4
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L102>
+               	b	 <L103>
+<L102>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L102>
+<L103>:
                	fcvtzu	w1, s10
-<L145>:
-               	bl	 <L145>
-               	fcvtzs	w1, s12
-<L146>:
-               	bl	 <L146>
-               	fcvtzs	w1, s11
-<L147>:
-               	bl	 <L147>
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L104>
+               	b	 <L105>
+<L104>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L104>
+<L105>:
+               	fcvtzs	w1, s3
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L106>
+               	b	 <L107>
+<L106>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L106>
+<L107>:
+               	fcvtzs	w1, s2
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L108>
+               	b	 <L109>
+<L108>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L108>
+<L109>:
                	fmov	s31, wzr
-               	fsub	s0, s31, s13
+               	fsub	s0, s31, s4
                	fcvtzs	w1, s0
-<L148>:
-               	bl	 <L148>
-               	fcvtzs	x1, s12
-<L149>:
-               	bl	 <L149>
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L110>
+               	b	 <L111>
+<L110>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L110>
+<L111>:
+               	fcvtzs	x1, s3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+               	b	 <L113>
+<L112>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+<L113>:
                	fmov	s31, wzr
-               	fsub	s0, s31, s9
+               	fsub	s0, s31, s1
                	fcvtzs	x1, s0
-<L150>:
-               	bl	 <L150>
-               	ldp	d8, d9, [x29, #-0xa0]
-               	ldp	d10, d11, [x29, #-0xb0]
-               	ldp	d12, d13, [x29, #-0xc0]
-               	ldp	d14, d15, [x29, #-0xd0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+               	b	 <L115>
+<L114>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+<L115>:
+               	ldp	d8, d9, [x29, #-0x98]
+               	ldp	d10, d11, [x29, #-0xa8]
+               	ldp	d12, d13, [x29, #-0xb8]
+               	ldp	d14, d15, [x29, #-0xc8]
                	ldp	x19, x20, [x29, #-0x60]
                	ldp	x21, x22, [x29, #-0x70]
                	ldp	x23, x24, [x29, #-0x80]
-               	ldp	x25, x26, [x29, #-0x90]
+               	ldur	x25, [x29, #-0x88]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/float/special_f64.dis
+++ b/test/golden/aarch64-linux/float/special_f64.dis
@@ -8,50 +8,70 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.special_f64.fold64>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	stur	x19, [x29, #-0x8]
-               	mov	x19, x0
+               	mov	x1, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L1>
-               	mov	x0, x19
+               	cbnz	w0,  <L2>
+               	fmov	x0, d0
+               	mov	x2, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
-               	ret
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	mov	x0, x2
+               	ret
 <L2>:
-               	bl	 <L2>
-               	ldur	x19, [x29, #-0x8]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	mov	x0, x1
                	ret
 
 <corpus.cases.float.special_f64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
-               	stp	x19, x20, [x29, #-0x90]
-               	stp	x21, x22, [x29, #-0xa0]
-               	stp	x23, x24, [x29, #-0xb0]
-               	stp	x25, x26, [x29, #-0xc0]
-               	stp	d8, d9, [x29, #-0xd0]
-               	stp	d10, d11, [x29, #-0xe0]
-               	stp	d12, d13, [x29, #-0xf0]
-               	stp	d14, d15, [x29, #-0x100]
+               	sub	sp, sp, #0xe0
+               	stp	x19, x20, [x29, #-0x80]
+               	stp	x21, x22, [x29, #-0x90]
+               	stp	x23, x24, [x29, #-0xa0]
+               	stp	d8, d9, [x29, #-0xb0]
+               	stp	d10, d11, [x29, #-0xc0]
+               	stp	d12, d13, [x29, #-0xd0]
+               	stp	d14, d15, [x29, #-0xe0]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
                	mov	x17, #0x3ff0000000000000 // =4607182418800017408
                	add	x0, x17, x19
                	fmov	d8, x0
@@ -89,754 +109,754 @@ Disassembly of section .text:
                	mov	x17, #0x1               // =1
                	add	x0, x17, x19
                	stur	x0, [x29, #-0x70]
-               	fcmp	d10, d10
-               	cset	w0, ne
-               	cbnz	w0,  <L2>
-               	mov	x0, x20
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	fmov	d0, d10
+<L0>:
+               	bl	 <L0>
+               	fmov	d0, d11
 <L1>:
                	bl	 <L1>
-               	mov	x21, x0
-               	b	 <L4>
+               	fadd	d0, d10, d10
 <L2>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L2>
+               	fadd	d0, d10, d11
 <L3>:
                	bl	 <L3>
-               	mov	x21, x0
+               	fadd	d0, d11, d10
 <L4>:
-               	fcmp	d11, d11
-               	cset	w0, ne
-               	cbnz	w0,  <L6>
-               	mov	x0, x21
-               	fmov	d0, d11
+               	bl	 <L4>
+               	fadd	d0, d11, d11
 <L5>:
                	bl	 <L5>
-               	mov	x20, x0
-               	b	 <L8>
+               	fsub	d0, d10, d10
 <L6>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L6>
+               	fsub	d0, d10, d11
 <L7>:
                	bl	 <L7>
-               	mov	x20, x0
+               	fsub	d0, d11, d10
 <L8>:
-               	fadd	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L10>
-               	mov	x0, x20
+               	bl	 <L8>
+               	fsub	d0, d11, d11
 <L9>:
                	bl	 <L9>
-               	mov	x21, x0
-               	b	 <L12>
+               	fmul	d0, d10, d8
 <L10>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L10>
+               	fmul	d0, d10, d9
 <L11>:
                	bl	 <L11>
-               	mov	x21, x0
+               	fmul	d0, d11, d8
 <L12>:
-               	fadd	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L14>
-               	mov	x0, x21
+               	bl	 <L12>
+               	fmul	d0, d11, d9
 <L13>:
                	bl	 <L13>
-               	mov	x20, x0
-               	b	 <L16>
+               	fmul	d0, d11, d11
 <L14>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L14>
+               	fmul	d0, d10, d11
 <L15>:
                	bl	 <L15>
-               	mov	x20, x0
+               	fneg	d0, d10
 <L16>:
-               	fadd	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
-               	mov	x0, x20
+               	bl	 <L16>
+               	fneg	d0, d11
 <L17>:
                	bl	 <L17>
-               	mov	x21, x0
-               	b	 <L20>
+               	fdiv	d0, d10, d8
 <L18>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L18>
+               	fdiv	d0, d10, d9
 <L19>:
                	bl	 <L19>
-               	mov	x21, x0
+               	fdiv	d0, d11, d8
 <L20>:
-               	fadd	d0, d11, d11
-               	mov	x0, x21
+               	bl	 <L20>
+               	fdiv	d0, d11, d9
 <L21>:
                	bl	 <L21>
-               	fsub	d0, d10, d10
-<L22>:
-               	bl	 <L22>
-               	fsub	d0, d10, d11
-<L23>:
-               	bl	 <L23>
-               	fsub	d0, d11, d10
-<L24>:
-               	bl	 <L24>
-               	fsub	d0, d11, d11
-<L25>:
-               	bl	 <L25>
-               	fmul	d0, d10, d8
-<L26>:
-               	bl	 <L26>
-               	fmul	d0, d10, d9
-<L27>:
-               	bl	 <L27>
-               	fmul	d0, d11, d8
-<L28>:
-               	bl	 <L28>
-               	fmul	d0, d11, d9
-<L29>:
-               	bl	 <L29>
-               	fmul	d0, d11, d11
-<L30>:
-               	bl	 <L30>
-               	fmul	d0, d10, d11
-<L31>:
-               	bl	 <L31>
-               	fneg	d0, d10
-<L32>:
-               	bl	 <L32>
-               	fneg	d0, d11
-<L33>:
-               	bl	 <L33>
-               	fdiv	d0, d10, d8
-<L34>:
-               	bl	 <L34>
-               	fdiv	d0, d10, d9
-<L35>:
-               	bl	 <L35>
-               	fdiv	d0, d11, d8
-<L36>:
-               	bl	 <L36>
-               	fdiv	d0, d11, d9
-<L37>:
-               	bl	 <L37>
                	fcmp	d10, d11
                	cset	w1, eq
-<L38>:
-               	bl	 <L38>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	fcmp	d10, d11
                	cset	w1, mi
-<L39>:
-               	bl	 <L39>
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	fcmp	d11, d10
                	cset	w1, mi
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	fmov	d0, d12
+<L27>:
+               	bl	 <L27>
+               	fmov	d0, d13
+<L28>:
+               	bl	 <L28>
+               	fneg	d0, d12
+<L29>:
+               	bl	 <L29>
+               	fdiv	d0, d8, d10
+<L30>:
+               	bl	 <L30>
+               	fdiv	d0, d8, d11
+<L31>:
+               	bl	 <L31>
+               	fdiv	d0, d9, d10
+<L32>:
+               	bl	 <L32>
+               	fdiv	d0, d9, d11
+<L33>:
+               	bl	 <L33>
+               	fadd	d0, d12, d8
+<L34>:
+               	bl	 <L34>
+               	fadd	d0, d12, d12
+<L35>:
+               	bl	 <L35>
+               	fsub	d0, d12, d13
+<L36>:
+               	bl	 <L36>
+               	fmul	d0, d12, d12
+<L37>:
+               	bl	 <L37>
+               	fmul	d0, d12, d13
+<L38>:
+               	bl	 <L38>
+               	fmul	d0, d12, d9
+<L39>:
+               	bl	 <L39>
+               	fdiv	d0, d8, d12
 <L40>:
                	bl	 <L40>
-               	fmov	d0, d12
+               	fdiv	d0, d9, d12
 <L41>:
                	bl	 <L41>
-               	fmov	d0, d13
+               	fdiv	d0, d8, d13
 <L42>:
                	bl	 <L42>
-               	fneg	d0, d12
+               	fdiv	d0, d12, d8
 <L43>:
                	bl	 <L43>
-               	fdiv	d0, d8, d10
+               	fadd	d0, d15, d15
 <L44>:
                	bl	 <L44>
-               	fdiv	d0, d8, d11
-<L45>:
-               	bl	 <L45>
-               	fdiv	d0, d9, d10
-<L46>:
-               	bl	 <L46>
-               	fdiv	d0, d9, d11
-<L47>:
-               	bl	 <L47>
-               	fadd	d0, d12, d8
-<L48>:
-               	bl	 <L48>
-               	fadd	d0, d12, d12
-<L49>:
-               	bl	 <L49>
-               	fsub	d0, d12, d13
-<L50>:
-               	bl	 <L50>
-               	fmul	d0, d12, d12
-<L51>:
-               	bl	 <L51>
-               	fmul	d0, d12, d13
-<L52>:
-               	bl	 <L52>
-               	fmul	d0, d12, d9
-<L53>:
-               	bl	 <L53>
-               	fdiv	d0, d8, d12
-<L54>:
-               	bl	 <L54>
-               	fdiv	d0, d9, d12
-<L55>:
-               	bl	 <L55>
-               	fdiv	d0, d8, d13
-<L56>:
-               	bl	 <L56>
-               	fdiv	d0, d12, d8
-<L57>:
-               	bl	 <L57>
-               	fadd	d0, d15, d15
-<L58>:
-               	bl	 <L58>
                	fcmp	d15, d12
                	cset	w1, mi
-<L59>:
-               	bl	 <L59>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L45>:
+               	bl	 <L45>
                	fmov	d31, xzr
                	fsub	d0, d31, d15
                	fcmp	d13, d0
                	cset	w1, mi
-<L60>:
-               	bl	 <L60>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L46>:
+               	bl	 <L46>
                	fsub	d0, d12, d12
-<L61>:
-               	bl	 <L61>
+<L47>:
+               	bl	 <L47>
                	fadd	d0, d13, d12
-<L62>:
-               	bl	 <L62>
+<L48>:
+               	bl	 <L48>
                	fmul	d0, d12, d10
-<L63>:
-               	bl	 <L63>
+<L49>:
+               	bl	 <L49>
                	fmul	d0, d13, d11
-<L64>:
-               	bl	 <L64>
+<L50>:
+               	bl	 <L50>
                	fdiv	d0, d12, d12
-<L65>:
-               	bl	 <L65>
+<L51>:
+               	bl	 <L51>
                	fdiv	d0, d10, d10
-<L66>:
-               	bl	 <L66>
+<L52>:
+               	bl	 <L52>
                	fdiv	d0, d11, d10
-<L67>:
-               	bl	 <L67>
+<L53>:
+               	bl	 <L53>
                	fmov	x1, d14
-<L68>:
-               	bl	 <L68>
+<L54>:
+               	bl	 <L54>
                	fcmp	d14, d14
                	cset	w1, ne
-<L69>:
-               	bl	 <L69>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L55>:
+               	bl	 <L55>
                	fcmp	d14, d14
                	cset	w1, eq
-<L70>:
-               	bl	 <L70>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
                	fcmp	d14, d14
                	cset	w1, mi
-<L71>:
-               	bl	 <L71>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L57>:
+               	bl	 <L57>
                	fcmp	d14, d14
                	cset	w1, ls
-<L72>:
-               	bl	 <L72>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L58>:
+               	bl	 <L58>
                	fneg	d9, d14
                	fmov	x1, d9
-<L73>:
-               	bl	 <L73>
+<L59>:
+               	bl	 <L59>
                	fneg	d0, d9
                	fmov	x1, d0
-<L74>:
-               	bl	 <L74>
+<L60>:
+               	bl	 <L60>
                	fadd	d0, d14, d8
-<L75>:
-               	bl	 <L75>
+<L61>:
+               	bl	 <L61>
                	fadd	d0, d8, d14
-<L76>:
-               	bl	 <L76>
+<L62>:
+               	bl	 <L62>
                	fmul	d0, d14, d10
-<L77>:
-               	bl	 <L77>
+<L63>:
+               	bl	 <L63>
                	fsub	d0, d14, d14
-<L78>:
-               	bl	 <L78>
+<L64>:
+               	bl	 <L64>
                	fdiv	d0, d14, d14
-<L79>:
-               	bl	 <L79>
+<L65>:
+               	bl	 <L65>
                	fdiv	d0, d14, d12
-<L80>:
-               	bl	 <L80>
+<L66>:
+               	bl	 <L66>
                	ldur	d0, [x29, #-0x70]
-<L81>:
-               	bl	 <L81>
+<L67>:
+               	bl	 <L67>
                	ldur	d0, [x29, #-0x60]
-<L82>:
-               	bl	 <L82>
+<L68>:
+               	bl	 <L68>
                	ldur	d0, [x29, #-0x50]
-<L83>:
-               	bl	 <L83>
+<L69>:
+               	bl	 <L69>
                	ldur	d31, [x29, #-0x60]
                	ldur	d30, [x29, #-0x70]
                	fadd	d0, d31, d30
-<L84>:
-               	bl	 <L84>
+<L70>:
+               	bl	 <L70>
                	ldur	d31, [x29, #-0x50]
                	ldur	d30, [x29, #-0x70]
                	fsub	d0, d31, d30
-<L85>:
-               	bl	 <L85>
+<L71>:
+               	bl	 <L71>
                	ldur	d31, [x29, #-0x70]
                	ldur	d30, [x29, #-0x70]
                	fadd	d0, d31, d30
-<L86>:
-               	bl	 <L86>
+<L72>:
+               	bl	 <L72>
                	ldur	d31, [x29, #-0x70]
                	fmov	d30, #1.50000000
                	fmul	d0, d31, d30
-<L87>:
-               	bl	 <L87>
+<L73>:
+               	bl	 <L73>
                	ldur	d31, [x29, #-0x70]
                	fmov	d30, #0.50000000
                	fmul	d0, d31, d30
-<L88>:
-               	bl	 <L88>
+<L74>:
+               	bl	 <L74>
                	ldur	d31, [x29, #-0x70]
                	fneg	d0, d31
-<L89>:
-               	bl	 <L89>
+<L75>:
+               	bl	 <L75>
                	ldur	d31, [x29, #-0x70]
                	mov	x16, #0x4330000000000000 // =4841369599423283200
                	fmov	d30, x16
                	fmul	d0, d31, d30
-<L90>:
-               	bl	 <L90>
+<L76>:
+               	bl	 <L76>
                	ldur	d31, [x29, #-0x60]
                	ldur	d30, [x29, #-0x50]
                	fdiv	d0, d31, d30
-<L91>:
-               	bl	 <L91>
+<L77>:
+               	bl	 <L77>
                	ldur	d30, [x29, #-0x70]
                	fcmp	d10, d30
                	cset	w1, mi
-<L92>:
-               	bl	 <L92>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L78>:
+               	bl	 <L78>
                	ldur	d31, [x29, #-0x70]
                	fcmp	d31, d10
                	cset	w1, eq
-<L93>:
-               	bl	 <L93>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L79>:
+               	bl	 <L79>
                	fmov	d31, xzr
                	ldur	d30, [x29, #-0x70]
                	fsub	d0, d31, d30
                	fcmp	d0, d11
                	cset	w1, mi
-<L94>:
-               	bl	 <L94>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L80>:
+               	bl	 <L80>
                	mov	x20, x0
                	ldur	d9, [x29, #-0x50]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x3c
-               	b.lo	 <L95>
-               	b	 <L100>
-<L95>:
+               	b.lo	 <L81>
+               	b	 <L83>
+<L81>:
                	fmov	d30, #0.50000000
-               	fmul	d12, d9, d30
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L97>
+               	fmul	d9, d9, d30
                	mov	x0, x20
-               	fmov	d0, d12
-<L96>:
-               	bl	 <L96>
-               	mov	x22, x0
-               	b	 <L99>
-<L97>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L98>:
-               	bl	 <L98>
-               	mov	x22, x0
-<L99>:
+               	fmov	d0, d9
+<L82>:
+               	bl	 <L82>
                	add	x21, x21, #0x1
-               	mov	x20, x22
-               	fmov	d9, d12
+               	mov	x20, x0
                	cmp	x21, #0x3c
-               	b.lo	 <L95>
-<L100>:
-               	sub	x21, x29, #0x40
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	str	xzr, [x21, #0x20]
-               	str	xzr, [x21, #0x28]
-               	str	xzr, [x21, #0x30]
-               	str	xzr, [x21, #0x38]
-               	add	x0, x21, #0x0
+               	b.lo	 <L81>
+<L83>:
+               	sub	x0, x29, #0x40
                	str	xzr, [x0]
-               	add	x0, x21, #0x8
+               	str	xzr, [x0, #0x8]
+               	str	xzr, [x0, #0x10]
+               	str	xzr, [x0, #0x18]
+               	str	xzr, [x0, #0x20]
+               	str	xzr, [x0, #0x28]
+               	str	xzr, [x0, #0x30]
+               	str	xzr, [x0, #0x38]
+               	add	x1, x0, #0x0
+               	str	xzr, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x0]
-               	add	x0, x21, #0x10
+               	str	x17, [x1]
+               	add	x1, x0, #0x10
                	mov	x17, #0x1               // =1
-               	str	x17, [x0]
-               	add	x0, x21, #0x18
+               	str	x17, [x1]
+               	add	x1, x0, #0x18
                	mov	x17, #0x7ff0000000000000 // =9218868437227405312
-               	str	x17, [x0]
-               	add	x0, x21, #0x20
+               	str	x17, [x1]
+               	add	x1, x0, #0x20
                	mov	x17, #-0x10000000000000 // =-4503599627370496
-               	str	x17, [x0]
-               	add	x0, x21, #0x28
+               	str	x17, [x1]
+               	add	x1, x0, #0x28
                	mov	x17, #0x7ff8000000000000 // =9221120237041090560
-               	str	x17, [x0]
-               	add	x0, x21, #0x30
+               	str	x17, [x1]
+               	add	x1, x0, #0x30
                	mov	x17, #0xdead            // =57005
                	movk	x17, #0xc0, lsl #16
                	movk	x17, #0xfff8, lsl #48
-               	str	x17, [x0]
-               	add	x0, x21, #0x38
+               	str	x17, [x1]
+               	add	x1, x0, #0x38
                	mov	x17, #0x1               // =1
                	movk	x17, #0x7ff0, lsl #48
-               	str	x17, [x0]
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x8
-               	b.lo	 <L101>
-               	b	 <L103>
-<L101>:
-               	add	x0, x21, x22, lsl #3
-               	ldr	x1, [x0]
-               	add	x0, x1, x19
-               	fmov	d0, x0
-               	fmov	x1, d0
-               	mov	x0, x20
-<L102>:
-               	bl	 <L102>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x8
-               	b.lo	 <L101>
-<L103>:
+               	str	x17, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L84>
+               	b	 <L87>
+<L84>:
+               	add	x2, x0, x1, lsl #3
+               	ldr	x3, [x2]
+               	add	x2, x3, x19
+               	fmov	d0, x2
+               	fmov	x2, d0
+               	mov	x3, x20
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L85>
+               	b	 <L86>
+<L85>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L85>
+<L86>:
+               	add	x1, x1, #0x1
+               	mov	x20, x3
+               	cmp	x1, #0x8
+               	b.lo	 <L84>
+<L87>:
                	fcvt	s0, d15
                	ldur	d31, [x29, #-0x70]
-               	fcvt	s9, d31
+               	fcvt	s1, d31
                	mov	x17, #0x36a0000000000000 // =3936146074321813504
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s12, d1
+               	fmov	d2, x0
+               	fcvt	s3, d2
                	mov	x17, #0x10000000        // =268435456
                	movk	x17, #0x3ff0, lsl #48
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s14, d1
+               	fmov	d2, x0
+               	fcvt	s4, d2
                	mov	x17, #0x30000000        // =805306368
                	movk	x17, #0x3ff0, lsl #48
                	add	x0, x17, x19
-               	fmov	d1, x0
-               	fcvt	s15, d1
-               	fcvt	s31, d11
-               	stur	s31, [x29, #-0x80]
+               	fmov	d2, x0
+               	fcvt	s5, d2
+               	fcvt	s9, d11
                	fcvt	s11, d13
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L88>
+               	b	 <L89>
+<L88>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L88>
+<L89>:
+               	fmov	w0, s1
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L90>
+               	b	 <L91>
+<L90>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L90>
+<L91>:
+               	fmov	w0, s3
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L92>
+               	b	 <L93>
+<L92>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L92>
+<L93>:
+               	fmov	w0, s4
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L94>
+               	b	 <L95>
+<L94>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L94>
+<L95>:
+               	fmov	w0, s5
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L96>
+               	b	 <L97>
+<L96>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L96>
+<L97>:
+               	fmov	w0, s9
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L98>
+               	b	 <L99>
+<L98>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L98>
+<L99>:
+               	fmov	w0, s11
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L100>
+               	b	 <L101>
+<L100>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L100>
+<L101>:
+               	fcvt	d0, s3
                	mov	x0, x20
+<L102>:
+               	bl	 <L102>
+               	fcvt	d0, s9
+<L103>:
+               	bl	 <L103>
+               	fcvt	d0, s11
 <L104>:
                	bl	 <L104>
-               	fmov	s0, s9
-<L105>:
-               	bl	 <L105>
-               	fmov	s0, s12
-<L106>:
-               	bl	 <L106>
-               	fmov	s0, s14
-<L107>:
-               	bl	 <L107>
-               	fmov	s0, s15
-<L108>:
-               	bl	 <L108>
-               	ldur	s0, [x29, #-0x80]
-<L109>:
-               	bl	 <L109>
-               	fmov	s0, s11
-<L110>:
-               	bl	 <L110>
-               	mov	x20, x0
-               	fcvt	d0, s12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x21, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L113>:
-               	bl	 <L113>
-               	mov	x21, x0
-<L114>:
-               	ldur	s31, [x29, #-0x80]
-               	fcvt	d0, s31
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x21
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
-               	fcvt	d0, s11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x21, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L121>:
-               	bl	 <L121>
-               	mov	x21, x0
-<L122>:
                	mov	x17, #0x20000000000000  // =9007199254740992
-               	add	x0, x17, x19
+               	add	x1, x17, x19
                	mov	x17, #0x1               // =1
                	movk	x17, #0x20, lsl #48
                	add	x20, x17, x19
                	mov	x17, #0x3               // =3
                	movk	x17, #0x20, lsl #48
-               	add	x22, x17, x19
+               	add	x21, x17, x19
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x23, x17, x19
+               	add	x22, x17, x19
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffdf, lsl #48
-               	add	x24, x17, x19
+               	add	x23, x17, x19
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	add	x25, x17, x19
-               	ucvtf	d0, x0
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L124>
-               	mov	x0, x21
-<L123>:
-               	bl	 <L123>
-               	mov	x26, x0
-               	b	 <L126>
-<L124>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L125>:
-               	bl	 <L125>
-               	mov	x26, x0
-<L126>:
+               	add	x24, x17, x19
+               	ucvtf	d0, x1
+<L105>:
+               	bl	 <L105>
                	ucvtf	d0, x20
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x26
-<L127>:
-               	bl	 <L127>
-               	mov	x20, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x26
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L129>:
-               	bl	 <L129>
-               	mov	x20, x0
-<L130>:
+<L106>:
+               	bl	 <L106>
+               	ucvtf	d0, x21
+<L107>:
+               	bl	 <L107>
                	ucvtf	d0, x22
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x20
-<L131>:
-               	bl	 <L131>
-               	mov	x21, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L133>:
-               	bl	 <L133>
-               	mov	x21, x0
-<L134>:
-               	ucvtf	d0, x23
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x21
-<L135>:
-               	bl	 <L135>
-               	mov	x20, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L137>:
-               	bl	 <L137>
-               	mov	x20, x0
-<L138>:
+<L108>:
+               	bl	 <L108>
                	ucvtf	d0, x19
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x20
-<L139>:
-               	bl	 <L139>
-               	mov	x19, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L141>:
-               	bl	 <L141>
-               	mov	x19, x0
-<L142>:
+<L109>:
+               	bl	 <L109>
+               	scvtf	d0, x23
+<L110>:
+               	bl	 <L110>
                	scvtf	d0, x24
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x19
-<L143>:
-               	bl	 <L143>
-               	mov	x20, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L145>:
-               	bl	 <L145>
-               	mov	x20, x0
-<L146>:
-               	scvtf	d0, x25
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x20
-<L147>:
-               	bl	 <L147>
-               	mov	x19, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L149>:
-               	bl	 <L149>
-               	mov	x19, x0
-<L150>:
+<L111>:
+               	bl	 <L111>
                	fmov	d31, #1.50000000
                	fmul	d9, d31, d8
                	mov	x16, #0x4340000000000000 // =4845873199050653696
                	fmov	d31, x16
-               	fmul	d11, d31, d8
+               	fmul	d0, d31, d8
                	mov	x16, #0x43d0000000000000 // =4886405595696988160
                	fmov	d31, x16
-               	fmul	d12, d31, d8
+               	fmul	d11, d31, d8
                	fmov	d31, xzr
-               	fsub	d13, d31, d9
+               	fsub	d12, d31, d9
                	fmov	d31, #0.50000000
-               	fmul	d14, d31, d8
+               	fmul	d13, d31, d8
                	fcvtzu	x1, d9
-               	mov	x0, x19
-<L151>:
-               	bl	 <L151>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+               	b	 <L113>
+<L112>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L112>
+<L113>:
+               	fcvtzu	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+               	b	 <L115>
+<L114>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L114>
+<L115>:
                	fcvtzu	x1, d11
-<L152>:
-               	bl	 <L152>
-               	fcvtzu	x1, d12
-<L153>:
-               	bl	 <L153>
-               	fcvtzu	x1, d14
-<L154>:
-               	bl	 <L154>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L116>
+               	b	 <L117>
+<L116>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L116>
+<L117>:
+               	fcvtzu	x1, d13
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L118>
+               	b	 <L119>
+<L118>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L118>
+<L119>:
                	fcvtzu	x1, d10
-<L155>:
-               	bl	 <L155>
-               	fcvtzs	x1, d13
-<L156>:
-               	bl	 <L156>
+<L120>:
+               	bl	 <L120>
                	fcvtzs	x1, d12
-<L157>:
-               	bl	 <L157>
+<L121>:
+               	bl	 <L121>
+               	fcvtzs	x1, d11
+<L122>:
+               	bl	 <L122>
                	fmov	d31, xzr
-               	fsub	d0, d31, d14
+               	fsub	d0, d31, d13
                	fcvtzs	x1, d0
-<L158>:
-               	bl	 <L158>
-               	fcvtzs	w1, d13
-<L159>:
-               	bl	 <L159>
+<L123>:
+               	bl	 <L123>
+               	fcvtzs	w1, d12
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L124>:
+               	bl	 <L124>
                	fcvtzu	w1, d9
-<L160>:
-               	bl	 <L160>
-               	ldp	d8, d9, [x29, #-0xd0]
-               	ldp	d10, d11, [x29, #-0xe0]
-               	ldp	d12, d13, [x29, #-0xf0]
-               	ldp	d14, d15, [x29, #-0x100]
-               	ldp	x19, x20, [x29, #-0x90]
-               	ldp	x21, x22, [x29, #-0xa0]
-               	ldp	x23, x24, [x29, #-0xb0]
-               	ldp	x25, x26, [x29, #-0xc0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L125>:
+               	bl	 <L125>
+               	ldp	d8, d9, [x29, #-0xb0]
+               	ldp	d10, d11, [x29, #-0xc0]
+               	ldp	d12, d13, [x29, #-0xd0]
+               	ldp	d14, d15, [x29, #-0xe0]
+               	ldp	x19, x20, [x29, #-0x80]
+               	ldp	x21, x22, [x29, #-0x90]
+               	ldp	x23, x24, [x29, #-0xa0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/frame/frame_align.dis
+++ b/test/golden/aarch64-linux/frame/frame_align.dis
@@ -3,94 +3,216 @@ frame/frame_align.o:
 Disassembly of section .text:
 
 <corpus.cases.frame.frame_align.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0.s[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.frame.frame_align.fold_f64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[0]
-               	mov	x0, x1
+               	mov	d1, v0.d[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0.d[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.frame.frame_align.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.frame.frame_align.spin>:
@@ -160,97 +282,95 @@ Disassembly of section .text:
                	lsr	x16, x16, #6
                	lsl	x16, x16, #6
                	mov	sp, x16
-               	sub	sp, sp, #0x300
-               	add	x16, sp, #0x60
+               	sub	sp, sp, #0x280
+               	add	x16, sp, #0x70
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	ucvtf	s0, x19
                	ucvtf	d1, x19
-               	add	x1, sp, #0x2f0
-               	add	x2, x1, #0x0
+               	add	x0, sp, #0x270
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s2, s31
-               	add	x2, x1, #0x4
-               	str	s2, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s2, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s2, s31
-               	add	x2, x1, #0xc
-               	str	s2, [x2]
-               	ldr	q2, [x1]
-               	add	x1, sp, #0x2e0
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0xc
+               	str	s2, [x1]
+               	ldr	q2, [x0]
+               	add	x0, sp, #0x260
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff4000000000000 // =4608308318706860032
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x3ff4000000000000 // =-4608308318706860032
-               	str	x17, [x2]
-               	ldr	q3, [x1]
-               	add	x1, sp, #0x2d0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q3, [x0]
+               	add	x0, sp, #0x250
+               	add	x1, x0, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x1               // =1
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x79b1            // =31153
                	movk	w17, #0x9e37, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x2]
-               	ldr	q4, [x1]
-               	add	x1, sp, #0x2c0
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q4, [x0]
+               	add	x0, sp, #0x240
+               	add	x1, x0, #0x0
                	mov	x17, #0x3fe0000000000000 // =4602678819172646912
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x4019000000000000 // =4618722892845154304
-               	str	x17, [x2]
-               	ldr	q31, [x1]
-               	str	q31, [sp, #0x170]
-               	add	x1, sp, #0x2b0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q31, [x0]
+               	str	q31, [sp, #0xf0]
+               	add	x0, sp, #0x230
+               	add	x1, x0, #0x0
                	mov	w17, #0xae3d            // =44605
                	movk	w17, #0xc2b2, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0xca77            // =51831
                	movk	w17, #0x85eb, lsl #16
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x7               // =7
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0xfffb            // =65531
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	ldr	q31, [x1]
-               	str	q31, [sp, #0x160]
-               	add	x20, sp, #0x1c0
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0xc0               // =192
-<L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	add	x21, sp, #0x180
+               	str	w17, [x1]
+               	ldr	q31, [x0]
+               	str	q31, [sp, #0xe0]
+               	add	x20, sp, #0x140
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0xc0               // =192
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	add	x21, sp, #0x100
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -259,363 +379,202 @@ Disassembly of section .text:
                	str	xzr, [x21, #0x28]
                	str	xzr, [x21, #0x30]
                	str	xzr, [x21, #0x38]
-               	add	x1, x19, #0x1
-               	mov	w22, w1
-               	add	x1, x19, #0x3
-               	mov	w23, w1
-               	add	x1, x19, #0x5
-               	mov	w24, w1
-               	add	x1, x19, #0x7
-               	mov	w25, w1
+               	add	x0, x19, #0x1
+               	mov	w22, w0
+               	add	x0, x19, #0x3
+               	mov	w23, w0
+               	add	x0, x19, #0x5
+               	mov	w24, w0
+               	add	x0, x19, #0x7
+               	mov	w25, w0
                	mov	x16, #0xfff1            // =65521
-               	add	x1, x19, x16
-               	mov	w26, w1
-               	add	x1, x19, #0xfb
-               	mov	w27, w1
+               	add	x0, x19, x16
+               	mov	w26, w0
+               	add	x0, x19, #0xfb
+               	mov	w27, w0
                	mov	s5, v2.s[0]
                	fadd	s6, s5, s0
                	mov	v30.16b, v2.16b
                	mov	v30.s[0], v6.s[0]
-               	str	q30, [sp, #0x150]
+               	str	q30, [sp, #0xd0]
                	mov	d0, v3.d[1]
                	fadd	d2, d0, d1
                	mov	v30.16b, v3.16b
                	mov	v30.d[1], v2.d[0]
-               	str	q30, [sp, #0x140]
-               	mov	w1, v4.s[2]
-               	mov	w2, w19
-               	add	w3, w1, w2
+               	str	q30, [sp, #0xc0]
+               	mov	w0, v4.s[2]
+               	mov	w1, w19
+               	add	w2, w0, w1
                	mov	v30.16b, v4.16b
-               	mov	v30.s[2], w3
-               	str	q30, [sp, #0x130]
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31.s[0]
+               	mov	v30.s[2], w2
+               	str	q30, [sp, #0xb0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldr	q0, [sp, #0xd0]
+<L1>:
+               	bl	 <L1>
+               	ldr	q0, [sp, #0xc0]
 <L2>:
                	bl	 <L2>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31.s[1]
+               	ldr	q0, [sp, #0xb0]
 <L3>:
                	bl	 <L3>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31.s[2]
+               	ldr	q31, [sp, #0xd0]
+               	ldr	q30, [sp, #0xd0]
+               	fadd	v31.4s, v31.4s, v30.4s
+               	str	q31, [sp, #0xa0]
+               	ldr	q0, [sp, #0xa0]
 <L4>:
                	bl	 <L4>
-               	ldr	q31, [sp, #0x150]
-               	mov	s0, v31.s[3]
+               	ldr	q31, [sp, #0xd0]
+               	ldr	q30, [sp, #0xd0]
+               	fmul	v31.4s, v31.4s, v30.4s
+               	str	q31, [sp, #0x90]
+               	ldr	q0, [sp, #0x90]
 <L5>:
                	bl	 <L5>
-               	ldr	q31, [sp, #0x140]
-               	mov	d0, v31.d[0]
+               	ldr	q0, [sp, #0xf0]
 <L6>:
                	bl	 <L6>
-               	ldr	q31, [sp, #0x140]
-               	mov	d0, v31.d[1]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fmul	v0.2d, v31.2d, v30.2d
 <L7>:
                	bl	 <L7>
-               	ldr	q31, [sp, #0x130]
-               	mov	w1, v31.s[0]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fsub	v0.2d, v31.2d, v30.2d
 <L8>:
                	bl	 <L8>
-               	ldr	q31, [sp, #0x130]
-               	mov	w1, v31.s[1]
+               	ldr	q31, [sp, #0xc0]
+               	ldr	q30, [sp, #0xf0]
+               	fdiv	v0.2d, v31.2d, v30.2d
 <L9>:
                	bl	 <L9>
-               	ldr	q31, [sp, #0x130]
-               	mov	w1, v31.s[2]
+               	ldr	q0, [sp, #0xe0]
 <L10>:
                	bl	 <L10>
-               	ldr	q31, [sp, #0x130]
-               	mov	w1, v31.s[3]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	mul	v0.4s, v31.4s, v30.4s
 <L11>:
                	bl	 <L11>
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fadd	v31.4s, v31.4s, v30.4s
-               	str	q31, [sp, #0x120]
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31.s[0]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	add	v0.4s, v31.4s, v30.4s
 <L12>:
                	bl	 <L12>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31.s[1]
+               	ldr	q31, [sp, #0xb0]
+               	ldr	q30, [sp, #0xe0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L13>:
                	bl	 <L13>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31.s[2]
+               	mov	x28, x0
+               	ldr	q0, [sp, #0xd0]
 <L14>:
                	bl	 <L14>
-               	ldr	q31, [sp, #0x120]
-               	mov	s0, v31.s[3]
+               	mov	x0, x28
 <L15>:
                	bl	 <L15>
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	str	q31, [sp, #0x110]
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31.s[0]
+               	mov	x28, x0
+               	ldr	q0, [sp, #0x90]
 <L16>:
                	bl	 <L16>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31.s[1]
+               	mov	x0, x28
 <L17>:
                	bl	 <L17>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31.s[2]
-<L18>:
-               	bl	 <L18>
-               	ldr	q31, [sp, #0x110]
-               	mov	s0, v31.s[3]
-<L19>:
-               	bl	 <L19>
-               	ldr	q31, [sp, #0x170]
-               	mov	d0, v31.d[0]
-<L20>:
-               	bl	 <L20>
-               	ldr	q31, [sp, #0x170]
-               	mov	d0, v31.d[1]
-<L21>:
-               	bl	 <L21>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fmul	v31.2d, v31.2d, v30.2d
-               	str	q31, [sp, #0x100]
-               	ldr	q31, [sp, #0x100]
-               	mov	d0, v31.d[0]
-<L22>:
-               	bl	 <L22>
-               	ldr	q31, [sp, #0x100]
-               	mov	d0, v31.d[1]
-<L23>:
-               	bl	 <L23>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fsub	v31.2d, v31.2d, v30.2d
-               	str	q31, [sp, #0xf0]
-               	ldr	q31, [sp, #0xf0]
-               	mov	d0, v31.d[0]
-<L24>:
-               	bl	 <L24>
-               	ldr	q31, [sp, #0xf0]
-               	mov	d0, v31.d[1]
-<L25>:
-               	bl	 <L25>
-               	ldr	q31, [sp, #0x140]
-               	ldr	q30, [sp, #0x170]
-               	fdiv	v31.2d, v31.2d, v30.2d
-               	str	q31, [sp, #0xe0]
-               	ldr	q31, [sp, #0xe0]
-               	mov	d0, v31.d[0]
-<L26>:
-               	bl	 <L26>
-               	ldr	q31, [sp, #0xe0]
-               	mov	d0, v31.d[1]
-<L27>:
-               	bl	 <L27>
-               	ldr	q31, [sp, #0x160]
-               	mov	w1, v31.s[0]
-<L28>:
-               	bl	 <L28>
-               	ldr	q31, [sp, #0x160]
-               	mov	w1, v31.s[1]
-<L29>:
-               	bl	 <L29>
-               	ldr	q31, [sp, #0x160]
-               	mov	w1, v31.s[2]
-<L30>:
-               	bl	 <L30>
-               	ldr	q31, [sp, #0x160]
-               	mov	w1, v31.s[3]
-<L31>:
-               	bl	 <L31>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	mul	v31.4s, v31.4s, v30.4s
-               	str	q31, [sp, #0xd0]
-               	ldr	q31, [sp, #0xd0]
-               	mov	w1, v31.s[0]
-<L32>:
-               	bl	 <L32>
-               	ldr	q31, [sp, #0xd0]
-               	mov	w1, v31.s[1]
-<L33>:
-               	bl	 <L33>
-               	ldr	q31, [sp, #0xd0]
-               	mov	w1, v31.s[2]
-<L34>:
-               	bl	 <L34>
-               	ldr	q31, [sp, #0xd0]
-               	mov	w1, v31.s[3]
-<L35>:
-               	bl	 <L35>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	add	v31.4s, v31.4s, v30.4s
-               	str	q31, [sp, #0xc0]
-               	ldr	q31, [sp, #0xc0]
-               	mov	w1, v31.s[0]
-<L36>:
-               	bl	 <L36>
-               	ldr	q31, [sp, #0xc0]
-               	mov	w1, v31.s[1]
-<L37>:
-               	bl	 <L37>
-               	ldr	q31, [sp, #0xc0]
-               	mov	w1, v31.s[2]
-<L38>:
-               	bl	 <L38>
-               	ldr	q31, [sp, #0xc0]
-               	mov	w1, v31.s[3]
-<L39>:
-               	bl	 <L39>
-               	ldr	q31, [sp, #0x130]
-               	ldr	q30, [sp, #0x160]
-               	eor	v31.16b, v31.16b, v30.16b
-               	str	q31, [sp, #0xb0]
-               	ldr	q31, [sp, #0xb0]
-               	mov	w1, v31.s[0]
-<L40>:
-               	bl	 <L40>
-               	ldr	q31, [sp, #0xb0]
-               	mov	w1, v31.s[1]
-<L41>:
-               	bl	 <L41>
-               	ldr	q31, [sp, #0xb0]
-               	mov	w1, v31.s[2]
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [sp, #0xb0]
-               	mov	w1, v31.s[3]
-<L43>:
-               	bl	 <L43>
-               	mov	x28, x0
-               	ldr	q0, [sp, #0x150]
-<L44>:
-               	bl	 <L44>
-               	str	q0, [sp, #0xa0]
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31.s[0]
-               	mov	x0, x28
-<L45>:
-               	bl	 <L45>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31.s[1]
-<L46>:
-               	bl	 <L46>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31.s[2]
-<L47>:
-               	bl	 <L47>
-               	ldr	q31, [sp, #0xa0]
-               	mov	s0, v31.s[3]
-<L48>:
-               	bl	 <L48>
-               	mov	x28, x0
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul	v0.4s, v31.4s, v30.4s
-<L49>:
-               	bl	 <L49>
-               	str	q0, [sp, #0x90]
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31.s[0]
-               	mov	x0, x28
-<L50>:
-               	bl	 <L50>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31.s[1]
-<L51>:
-               	bl	 <L51>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31.s[2]
-<L52>:
-               	bl	 <L52>
-               	ldr	q31, [sp, #0x90]
-               	mov	s0, v31.s[3]
-<L53>:
-               	bl	 <L53>
                	mov	x28, x0
                	add	x0, x21, #0x0
-               	ldr	q31, [sp, #0x150]
+               	ldr	q31, [sp, #0xd0]
                	str	q31, [x0]
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fadd	v0.4s, v31.4s, v30.4s
                	add	x0, x21, #0x10
-               	str	q0, [x0]
-               	ldr	q0, [sp, #0x150]
-<L54>:
-               	bl	 <L54>
+               	ldr	q31, [sp, #0xa0]
+               	str	q31, [x0]
+               	ldr	q0, [sp, #0xd0]
+<L18>:
+               	bl	 <L18>
                	add	x0, x21, #0x20
                	str	q0, [x0]
-               	ldr	q31, [sp, #0x150]
-               	ldr	q30, [sp, #0x150]
-               	fmul	v0.4s, v31.4s, v30.4s
                	add	x0, x21, #0x30
-               	str	q0, [x0]
+               	ldr	q31, [sp, #0x90]
+               	str	q31, [x0]
                	mov	x9, #0x0                // =0
-               	str	x9, [sp, #0x78]
-               	ldr	x9, [sp, #0x78]
+               	str	x9, [sp, #0x88]
+               	ldr	x9, [sp, #0x88]
                	cmp	x9, #0x4
-               	b.lo	 <L55>
-               	b	 <L60>
-<L55>:
-               	ldr	x9, [sp, #0x78]
+               	b.lo	 <L19>
+               	b	 <L21>
+<L19>:
+               	ldr	x9, [sp, #0x88]
                	mov	x16, #0x10              // =16
                	mul	x0, x9, x16
                	add	x2, x21, x0
-               	ldr	q31, [x2]
-               	str	q31, [sp, #0x80]
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31.s[0]
+               	ldr	q0, [x2]
                	mov	x0, x28
-<L56>:
-               	bl	 <L56>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31.s[1]
-<L57>:
-               	bl	 <L57>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31.s[2]
-<L58>:
-               	bl	 <L58>
-               	ldr	q31, [sp, #0x80]
-               	mov	s0, v31.s[3]
-<L59>:
-               	bl	 <L59>
-               	ldr	x9, [sp, #0x78]
+<L20>:
+               	bl	 <L20>
+               	ldr	x9, [sp, #0x88]
                	add	x1, x9, #0x1
                	mov	x28, x0
                	mov	x9, x1
-               	str	x9, [sp, #0x78]
-               	ldr	x9, [sp, #0x78]
+               	str	x9, [sp, #0x88]
+               	ldr	x9, [sp, #0x88]
                	cmp	x9, #0x4
-               	b.lo	 <L55>
-<L60>:
+               	b.lo	 <L19>
+<L21>:
                	mov	x17, #0x1111            // =4369
                	movk	x17, #0x1111, lsl #16
                	movk	x17, #0x1111, lsl #32
                	movk	x17, #0x1111, lsl #48
-               	add	x21, x17, x19
+               	add	x0, x17, x19
                	mov	x17, #0x7777            // =30583
                	movk	x17, #0x7777, lsl #16
                	movk	x17, #0x7777, lsl #32
                	movk	x17, #0x7777, lsl #48
-               	eor	x9, x17, x19
-               	str	x9, [sp, #0x70]
-               	mov	x0, x28
-               	mov	x1, x21
-<L61>:
-               	bl	 <L61>
-               	ldr	x9, [sp, #0x70]
-               	mov	x1, x9
-<L62>:
-               	bl	 <L62>
+               	eor	x1, x17, x19
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x28, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x28, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x3
-               	b.lo	 <L63>
-               	b	 <L64>
-<L63>:
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
                	mov	x16, #0x79b1            // =31153
                	movk	x16, #0x9e37, lsl #16
                	mul	x2, x1, x16
@@ -626,60 +585,125 @@ Disassembly of section .text:
                	add	x2, x4, #0x0
                	str	x3, [x2]
                	lsl	x2, x1, #40
-               	eor	x3, x2, x21
+               	eor	x3, x2, x0
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	add	x1, x1, #0x1
                	cmp	x1, #0x3
-               	b.lo	 <L63>
-<L64>:
-               	mov	x19, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x3
-               	b.lo	 <L65>
-               	b	 <L68>
-<L65>:
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x3
+               	b.lo	 <L28>
+               	b	 <L33>
+<L28>:
                	mov	x16, #0x40              // =64
-               	mul	x0, x21, x16
-               	add	x28, x20, x0
-               	add	x0, x28, #0x0
-               	ldr	x1, [x0]
-               	mov	x0, x19
-<L66>:
-               	bl	 <L66>
-               	add	x1, x28, #0x8
+               	mul	x1, x0, x16
+               	add	x2, x20, x1
+               	add	x1, x2, #0x0
                	ldr	x2, [x1]
-               	mov	x1, x2
-<L67>:
-               	bl	 <L67>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	cmp	x21, #0x3
-               	b.lo	 <L65>
-<L68>:
-               	mov	x0, x19
-               	mov	x1, x22
-<L69>:
-               	bl	 <L69>
+               	mov	x1, x28
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x16, #0x40              // =64
+               	mul	x2, x0, x16
+               	add	x3, x20, x2
+               	add	x2, x3, #0x8
+               	ldr	x3, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	add	x0, x0, #0x1
+               	mov	x28, x1
+               	cmp	x0, #0x3
+               	b.lo	 <L28>
+<L33>:
+               	uxtb	w0, w22
                	mov	x1, #0x0                // =0
-<L70>:
-               	bl	 <L70>
-               	mov	x1, x23
-<L71>:
-               	bl	 <L71>
-               	mov	x1, x24
-<L72>:
-               	bl	 <L72>
-               	mov	x1, x25
-<L73>:
-               	bl	 <L73>
-               	mov	x1, x26
-<L74>:
-               	bl	 <L74>
-               	mov	x1, x27
-<L75>:
-               	bl	 <L75>
-               	add	x16, sp, #0x60
+               	cmp	x1, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x28, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x17, #0x0               // =0
+               	lsr	x2, x17, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x28, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x28, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	uxtb	w1, w23
+               	mov	x0, x28
+<L38>:
+               	bl	 <L38>
+               	uxtb	w1, w24
+<L39>:
+               	bl	 <L39>
+               	uxtb	w1, w25
+<L40>:
+               	bl	 <L40>
+               	uxth	w1, w26
+<L41>:
+               	bl	 <L41>
+               	uxtb	w1, w27
+<L42>:
+               	bl	 <L42>
+               	add	x16, sp, #0x70
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/frame/frame_large.dis
+++ b/test/golden/aarch64-linux/frame/frame_large.dis
@@ -6,257 +6,482 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x2, lsl #12   // =0x2000
-               	sub	sp, sp, #0x40
-               	mov	x16, #0xdff0            // =57328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x16, #0xec00            // =60416
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	add	x1, x20, #0x0
+               	add	x1, x29, x16
                	add	x2, x1, #0x0
-               	mov	x1, #0x1400             // =5120
-<L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	add	x3, x2, #0x0
+               	mov	x2, #0x1400             // =5120
+<L0>:
+               	str	xzr, [x3]
+               	add	x3, x3, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L0>
                	mov	x16, #0xe400            // =58368
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x800              // =2048
+               	add	x2, x29, x16
+               	add	x3, x2, #0x0
+               	add	x4, x3, #0x0
+               	mov	x3, #0x800              // =2048
+<L1>:
+               	str	xzr, [x4]
+               	add	x4, x4, #0x8
+               	sub	x3, x3, #0x8
+               	cmp	x3, #0x0
+               	b.ne	 <L1>
+               	sub	x3, x29, #0x2, lsl #12  // =0x2000
+               	add	x4, x3, #0x0
+               	add	x5, x4, #0x0
+               	mov	x4, #0x400              // =1024
 <L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x5]
+               	add	x5, x5, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
                	b.ne	 <L2>
-               	sub	x22, x29, #0x2, lsl #12 // =0x2000
-               	add	x1, x22, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x400              // =1024
+               	add	x4, x1, #0x0
+               	ldr	x5, [x4]
+               	mov	x4, #0x2325             // =8997
+               	movk	x4, #0x8422, lsl #16
+               	movk	x4, #0x9ce4, lsl #32
+               	movk	x4, #0xcbf2, lsl #48
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L3>
-               	add	x1, x20, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
                	mov	x16, #0x13f8            // =5112
-               	add	x1, x20, x16
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x5, x1, x16
+               	ldr	x6, [x5]
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x7, x5, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, #0x7fc
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x5, x2, #0x0
+               	ldr	w6, [x5]
+               	mov	w5, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x1, x22, #0x0
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	add	x1, x22, #0x3ff
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	add	x5, x2, #0x7fc
+               	ldr	w6, [x5]
+               	mov	w5, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x280
-               	b.lo	 <L10>
-               	b	 <L11>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	add	x2, x1, x19
+               	add	x5, x3, #0x0
+               	ldrb	w6, [x5]
+               	uxtb	w5, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x5, x3, #0x3ff
+               	ldrb	w6, [x5]
+               	uxtb	w5, w6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x4, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x280
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
+               	add	x6, x5, x0
                	mov	x16, #0x7f2d            // =32557
                	movk	x16, #0x4c95, lsl #16
                	movk	x16, #0xf42d, lsl #32
                	movk	x16, #0x5851, lsl #48
-               	mul	x3, x2, x16
-               	lsl	x2, x1, #17
-               	eor	x4, x3, x2
-               	add	x2, x20, x1, lsl #3
-               	str	x4, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x280
-               	b.lo	 <L10>
-<L11>:
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x200
-               	b.lo	 <L12>
-               	b	 <L13>
-<L12>:
+               	mul	x7, x6, x16
+               	lsl	x6, x5, #17
+               	eor	x8, x7, x6
+               	add	x6, x1, x5, lsl #3
+               	str	x8, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x280
+               	b.lo	 <L15>
+<L16>:
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x200
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
                	mov	x16, #0x79b1            // =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	lsr	x2, x1, #3
-               	eor	x4, x3, x2
-               	mov	w2, w4
-               	add	x3, x21, x1, lsl #2
-               	str	w2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x200
-               	b.lo	 <L12>
-<L13>:
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x400
-               	b.lo	 <L14>
-               	b	 <L15>
-<L14>:
-               	mov	x16, #0x83              // =131
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	lsr	x2, x1, #2
-               	eor	x4, x3, x2
-               	mov	w2, w4
-               	add	x3, x22, x1
-               	strb	w2, [x3]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x400
-               	b.lo	 <L14>
-<L15>:
-               	mov	x23, x0
-               	mov	x24, #0x0               // =0
-               	cmp	x24, #0x40
-               	b.lo	 <L16>
-               	b	 <L23>
-<L16>:
-               	mov	x16, #0x9               // =9
-               	mul	x0, x24, x16
-               	add	x1, x0, x19
-               	mov	x0, #0x280              // =640
-               	cbnz	x0,  <L17>
-               	brk	#0
-<L17>:
-               	udiv	x16, x1, x0
-               	msub	x2, x16, x0, x1
-               	add	x0, x20, x2, lsl #3
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	lsr	x6, x5, #3
+               	eor	x8, x7, x6
+               	mov	w6, w8
+               	add	x7, x2, x5, lsl #2
+               	str	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x200
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	mov	x16, #0xd               // =13
-               	mul	x1, x24, x16
-               	add	x2, x1, x19
-               	mov	x1, #0x200              // =512
-               	cbnz	x1,  <L19>
-               	brk	#0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x400
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
-               	udiv	x16, x2, x1
-               	msub	x3, x16, x1, x2
-               	add	x1, x21, x3, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x83              // =131
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	lsr	x6, x5, #2
+               	eor	x8, x7, x6
+               	mov	w6, w8
+               	add	x7, x3, x5
+               	strb	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x400
+               	b.lo	 <L19>
 <L20>:
-               	bl	 <L20>
-               	mov	x16, #0x1d              // =29
-               	mul	x1, x24, x16
-               	add	x2, x1, x19
-               	mov	x1, #0x400              // =1024
-               	cbnz	x1,  <L21>
-               	brk	#0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x40
+               	b.lo	 <L21>
+               	b	 <L31>
 <L21>:
-               	udiv	x16, x2, x1
-               	msub	x3, x16, x1, x2
-               	add	x1, x22, x3
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x9               // =9
+               	mul	x6, x5, x16
+               	add	x7, x6, x0
+               	mov	x6, #0x280              // =640
+               	cbnz	x6,  <L22>
+               	brk	#0
 <L22>:
-               	bl	 <L22>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x40
-               	b.lo	 <L16>
+               	udiv	x16, x7, x6
+               	msub	x8, x16, x6, x7
+               	add	x6, x1, x8, lsl #3
+               	ldr	x7, [x6]
+               	mov	x6, x4
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	mov	x16, #0x13f8            // =5112
-               	add	x24, x20, x16
-               	ldr	x0, [x24]
-               	add	x1, x0, #0x1
-               	mov	x16, #0x1               // =1
-               	and	x0, x19, x16
-               	mov	x17, #0x27f             // =639
-               	sub	x2, x17, x0
-               	add	x0, x20, x2, lsl #3
-               	str	x1, [x0]
-               	add	x25, x21, #0x7fc
-               	ldr	w0, [x25]
-               	add	w1, w0, #0x7
-               	mov	x16, #0x3               // =3
-               	and	x0, x19, x16
-               	mov	x17, #0x1ff             // =511
-               	sub	x2, x17, x0
-               	add	x0, x21, x2, lsl #2
-               	str	w1, [x0]
-               	add	x26, x22, #0x3ff
-               	ldrb	w0, [x26]
-               	add	w1, w0, #0xb
-               	mov	x16, #0x7               // =7
-               	and	x0, x19, x16
-               	mov	x17, #0x3ff             // =1023
-               	sub	x2, x17, x0
-               	add	x0, x22, x2
-               	strb	w1, [x0]
-               	mov	x16, #0x13f0            // =5104
-               	add	x0, x20, x16
-               	ldr	x1, [x0]
-               	mov	x0, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
-               	ldr	x1, [x24]
+               	mov	x16, #0xd               // =13
+               	mul	x7, x5, x16
+               	add	x8, x7, x0
+               	mov	x7, #0x200              // =512
+               	cbnz	x7,  <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	add	x1, x21, #0x7f0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	udiv	x16, x8, x7
+               	msub	x12, x16, x7, x8
+               	add	x7, x2, x12, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	bl	 <L26>
-               	ldr	w1, [x25]
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L26>
 <L27>:
-               	bl	 <L27>
-               	add	x1, x22, #0x3f8
-               	ldrb	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x1d              // =29
+               	mul	x7, x5, x16
+               	add	x8, x7, x0
+               	mov	x7, #0x400              // =1024
+               	cbnz	x7,  <L28>
+               	brk	#0
 <L28>:
-               	bl	 <L28>
-               	ldrb	w1, [x26]
+               	udiv	x16, x8, x7
+               	msub	x12, x16, x7, x8
+               	add	x7, x3, x12
+               	ldrb	w8, [x7]
+               	uxtb	w7, w8
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
 <L29>:
-               	bl	 <L29>
-               	mov	x16, #0xdff0            // =57328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	add	x5, x5, #0x1
+               	mov	x4, x6
+               	cmp	x5, #0x40
+               	b.lo	 <L21>
+<L31>:
+               	mov	x16, #0x13f8            // =5112
+               	add	x5, x1, x16
+               	ldr	x6, [x5]
+               	add	x5, x6, #0x1
+               	mov	x16, #0x1               // =1
+               	and	x6, x0, x16
+               	mov	x17, #0x27f             // =639
+               	sub	x7, x17, x6
+               	add	x6, x1, x7, lsl #3
+               	str	x5, [x6]
+               	add	x5, x2, #0x7fc
+               	ldr	w6, [x5]
+               	add	w5, w6, #0x7
+               	mov	x16, #0x3               // =3
+               	and	x6, x0, x16
+               	mov	x17, #0x1ff             // =511
+               	sub	x7, x17, x6
+               	add	x6, x2, x7, lsl #2
+               	str	w5, [x6]
+               	add	x5, x3, #0x3ff
+               	ldrb	w6, [x5]
+               	add	w5, w6, #0xb
+               	mov	x16, #0x7               // =7
+               	and	x6, x0, x16
+               	mov	x17, #0x3ff             // =1023
+               	sub	x0, x17, x6
+               	add	x6, x3, x0
+               	strb	w5, [x6]
+               	mov	x16, #0x13f0            // =5104
+               	add	x0, x1, x16
+               	ldr	x5, [x0]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
+<L32>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x0, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	mov	x16, #0x13f8            // =5112
+               	add	x0, x1, x16
+               	ldr	x1, [x0]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L34>
+               	b	 <L35>
+<L34>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x0, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L34>
+<L35>:
+               	add	x0, x2, #0x7f0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x4, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x0, x2, #0x7fc
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x5, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x5, x16
+               	eor	x5, x4, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	add	x0, x3, #0x3f8
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x5, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x5, x16
+               	eor	x5, x4, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	add	x0, x3, #0x3ff
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x4, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x4
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/frame/frame_spill.dis
+++ b/test/golden/aarch64-linux/frame/frame_spill.dis
@@ -13,116 +13,114 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_spill.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x220
-               	stp	x19, x20, [x29, #-0x1a0]
-               	stp	x21, x22, [x29, #-0x1b0]
-               	stp	x23, x24, [x29, #-0x1c0]
-               	stp	x25, x26, [x29, #-0x1d0]
-               	stp	x27, x28, [x29, #-0x1e0]
-               	sub	x16, x29, #0x1f0
+               	sub	sp, sp, #0x2a0
+               	sub	x16, x29, #0x220
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x270
                	stp	d8, d9, [x16]
                	stp	d10, d11, [x16, #-0x10]
                	stp	d12, d13, [x16, #-0x20]
                	stp	d14, d15, [x16, #-0x30]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7f2d            // =32557
                	movk	x17, #0x4c95, lsl #16
                	movk	x17, #0xf42d, lsl #32
                	movk	x17, #0x5851, lsl #48
-               	add	x1, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x814f            // =33103
                	movk	x17, #0xf767, lsl #16
                	movk	x17, #0x7b7e, lsl #32
                	movk	x17, #0x1405, lsl #48
-               	eor	x2, x17, x19
+               	eor	x2, x17, x0
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x3, x17, x19
+               	add	x3, x17, x0
                	mov	x17, #0xeb4f            // =60239
                	movk	x17, #0x27d4, lsl #16
                	movk	x17, #0xae3d, lsl #32
                	movk	x17, #0xc2b2, lsl #48
-               	eor	x4, x17, x19
+               	eor	x4, x17, x0
                	mov	x17, #0x79f9            // =31225
                	movk	x17, #0x9e37, lsl #16
                	movk	x17, #0x67b1, lsl #32
                	movk	x17, #0x1656, lsl #48
-               	add	x5, x17, x19
+               	add	x5, x17, x0
                	mov	x17, #0xae63            // =44643
                	movk	x17, #0xc2b2, lsl #16
                	movk	x17, #0xca77, lsl #32
                	movk	x17, #0x85eb, lsl #48
-               	eor	x6, x17, x19
+               	eor	x6, x17, x0
                	mov	x17, #0x67c5            // =26565
                	movk	x17, #0x1656, lsl #16
                	movk	x17, #0xeb2f, lsl #32
                	movk	x17, #0x27d4, lsl #48
-               	add	x7, x17, x19
+               	add	x7, x17, x0
                	mov	x17, #0x1e61            // =7777
                	movk	x17, #0x2e2d, lsl #16
                	movk	x17, #0x3cd7, lsl #32
                	movk	x17, #0x72a6, lsl #48
-               	eor	x8, x17, x19
+               	eor	x8, x17, x0
                	mov	x17, #0x1475            // =5237
                	movk	x17, #0x85a5, lsl #16
                	movk	x17, #0xea7f, lsl #32
                	movk	x17, #0x42f1, lsl #48
-               	add	x12, x17, x19
+               	add	x12, x17, x0
                	mov	x17, #0xdf1f            // =57119
                	movk	x17, #0xbe84, lsl #16
                	movk	x17, #0xfe08, lsl #32
                	movk	x17, #0x30be, lsl #48
-               	eor	x13, x17, x19
+               	eor	x13, x17, x0
                	mov	x17, #0x83eb            // =33771
                	movk	x17, #0x80b5, lsl #16
                	movk	x17, #0x8646, lsl #32
                	movk	x17, #0x61c8, lsl #48
-               	add	x14, x17, x19
+               	add	x14, x17, x0
                	mov	x17, #0x99b1            // =39345
                	movk	x17, #0x9dbb, lsl #16
                	movk	x17, #0x3f34, lsl #32
                	movk	x17, #0x4cf4, lsl #48
-               	eor	x15, x17, x19
+               	eor	x15, x17, x0
                	mov	x17, #0xaaab            // =43691
                	movk	x17, #0xaaaa, lsl #16
                	movk	x17, #0xaaaa, lsl #32
                	movk	x17, #0xaaaa, lsl #48
-               	add	x18, x17, x19
+               	add	x18, x17, x0
                	mov	x17, #0x5bdb            // =23515
                	movk	x17, #0x94b9, lsl #16
                	movk	x17, #0x39cb, lsl #32
                	movk	x17, #0xda3e, lsl #48
-               	eor	x20, x17, x19
+               	eor	x19, x17, x0
                	mov	x17, #0x2ad1            // =10961
                	movk	x17, #0x5ac2, lsl #16
                	movk	x17, #0x512d, lsl #32
                	movk	x17, #0x1f2e, lsl #48
-               	add	x21, x17, x19
+               	add	x20, x17, x0
                	mov	x17, #0x977f            // =38783
                	movk	x17, #0x111a, lsl #16
                	movk	x17, #0xe746, lsl #32
                	movk	x17, #0x2d54, lsl #48
-               	eor	x22, x17, x19
+               	eor	x21, x17, x0
                	mov	x17, #0x79b1            // =31153
                	movk	x17, #0x9e37, lsl #16
-               	add	x23, x17, x19
-               	mov	w24, w23
+               	add	x22, x17, x0
+               	mov	w23, w22
                	mov	x17, #0x9e37            // =40503
-               	eor	x23, x17, x19
-               	mov	w25, w23
+               	eor	x22, x17, x0
+               	mov	w24, w22
                	mov	x17, #0xca77            // =51831
                	movk	x17, #0x85eb, lsl #16
-               	add	x23, x17, x19
-               	mov	w26, w23
+               	add	x22, x17, x0
+               	mov	w25, w22
                	mov	x17, #0xae3d            // =44605
                	movk	x17, #0xc2b2, lsl #16
-               	eor	x23, x17, x19
-               	mov	w27, w23
-               	ucvtf	d0, x19
+               	eor	x22, x17, x0
+               	mov	w26, w22
+               	ucvtf	d0, x0
                	fmov	d31, #1.50000000
                	fadd	d1, d31, d0
                	fmov	d31, #-2.25000000
@@ -140,83 +138,88 @@ Disassembly of section .text:
                	fadd	d7, d31, d0
                	fmov	d31, #-4.50000000
                	fadd	d16, d31, d0
-               	mov	x19, x0
-               	mov	x23, x1
+               	mov	x22, #0x2325            // =8997
+               	movk	x22, #0x8422, lsl #16
+               	movk	x22, #0x9ce4, lsl #32
+               	movk	x22, #0xcbf2, lsl #48
+               	mov	x27, x1
                	mov	x28, x2
                	mov	x9, x3
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x4
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x5
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x6
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x7
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x8
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x12
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe18            // =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x13
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x14
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe08            // =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x15
-               	mov	x16, #0xfe88            // =65160
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x18
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	stur	x9, [x29, #-0x90]
+               	mov	x9, x19
+               	stur	x9, [x29, #-0x70]
+               	mov	x9, x20
+               	stur	x9, [x29, #-0x80]
+               	mov	x9, x21
+               	stur	x9, [x29, #-0x60]
+               	mov	x9, x23
+               	stur	x9, [x29, #-0x40]
                	mov	x9, x24
                	stur	x9, [x29, #-0x50]
                	mov	x9, x25
                	stur	x9, [x29, #-0x20]
                	mov	x9, x26
                	stur	x9, [x29, #-0x30]
-               	mov	x9, x27
-               	stur	x9, [x29, #-0x40]
                	fmov	d8, d1
                	fmov	d9, d2
                	fmov	d10, d3
@@ -226,29 +229,31 @@ Disassembly of section .text:
                	fmov	d14, d7
                	fmov	d15, d16
                	mov	x9, #0x0                // =0
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x18
-               	b.lo	 <L1>
-               	b	 <L5>
-<L1>:
-               	lsl	x0, x22, #29
-               	lsr	x1, x22, #35
+               	b.lo	 <L0>
+               	b	 <L4>
+<L0>:
+               	ldur	x9, [x29, #-0x60]
+               	lsl	x0, x9, #29
+               	ldur	x9, [x29, #-0x60]
+               	lsr	x1, x9, #35
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x8]
                	ldur	x10, [x29, #-0x8]
-               	eor	x9, x23, x10
+               	eor	x9, x27, x10
                	stur	x9, [x29, #-0x10]
-               	lsl	x1, x23, #7
-               	lsr	x0, x23, #57
+               	lsl	x1, x27, #7
+               	lsr	x0, x27, #57
                	orr	x9, x1, x0
                	stur	x9, [x29, #-0x18]
                	ldur	x9, [x29, #-0x18]
@@ -257,20 +262,20 @@ Disassembly of section .text:
                	lsr	x1, x28, #53
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x28]
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x28]
                	eor	x26, x9, x10
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #13
-               	mov	x16, #0xfed0            // =65232
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -278,20 +283,20 @@ Disassembly of section .text:
                	lsr	x1, x9, #51
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x38]
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x38]
-               	add	x27, x9, x10
-               	mov	x16, #0xfec8            // =65224
+               	add	x23, x9, x10
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #17
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -299,20 +304,20 @@ Disassembly of section .text:
                	lsr	x1, x9, #47
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x48]
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldur	x10, [x29, #-0x48]
                	eor	x24, x9, x10
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #19
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -320,21 +325,20 @@ Disassembly of section .text:
                	lsr	x1, x9, #45
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x58]
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x58]
-               	add	x9, x10, x11
-               	stur	x9, [x29, #-0x60]
-               	mov	x16, #0xfeb8            // =65208
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x58]
+               	add	x21, x9, x10
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #23
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -342,21 +346,20 @@ Disassembly of section .text:
                	lsr	x1, x9, #41
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x68]
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x68]
-               	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x70]
-               	mov	x16, #0xfeb0            // =65200
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x68]
+               	eor	x19, x9, x10
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #31
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -364,21 +367,20 @@ Disassembly of section .text:
                	lsr	x1, x9, #33
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x78]
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x78]
-               	add	x9, x10, x11
-               	stur	x9, [x29, #-0x80]
-               	mov	x16, #0xfea8            // =65192
+               	ldr	x9, [x29, x16]
+               	ldur	x10, [x29, #-0x78]
+               	add	x20, x9, x10
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #37
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -386,21 +388,25 @@ Disassembly of section .text:
                	lsr	x1, x9, #27
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x88]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe18            // =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	ldur	x11, [x29, #-0x88]
                	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x90]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfe18            // =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #41
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe18            // =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -408,7 +414,7 @@ Disassembly of section .text:
                	lsr	x1, x9, #23
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0x98]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -416,13 +422,13 @@ Disassembly of section .text:
                	ldur	x11, [x29, #-0x98]
                	add	x9, x10, x11
                	stur	x9, [x29, #-0xa0]
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #43
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -430,7 +436,7 @@ Disassembly of section .text:
                	lsr	x1, x9, #21
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xa8]
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe08            // =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -438,13 +444,13 @@ Disassembly of section .text:
                	ldur	x11, [x29, #-0xa8]
                	eor	x9, x10, x11
                	stur	x9, [x29, #-0xb0]
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe08            // =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #47
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe08            // =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -452,7 +458,7 @@ Disassembly of section .text:
                	lsr	x1, x9, #17
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xb8]
-               	mov	x16, #0xfe88            // =65160
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -460,13 +466,13 @@ Disassembly of section .text:
                	ldur	x11, [x29, #-0xb8]
                	add	x9, x10, x11
                	stur	x9, [x29, #-0xc0]
-               	mov	x16, #0xfe88            // =65160
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #53
-               	mov	x16, #0xfe88            // =65160
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -474,78 +480,82 @@ Disassembly of section .text:
                	lsr	x1, x9, #11
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xc8]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
+               	ldur	x10, [x29, #-0x90]
                	ldur	x11, [x29, #-0xc8]
                	eor	x9, x10, x11
                	stur	x9, [x29, #-0xd0]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0x90]
                	lsl	x0, x9, #59
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0x90]
                	lsr	x1, x9, #5
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xd8]
-               	ldur	x10, [x29, #-0xd8]
-               	add	x9, x20, x10
+               	ldur	x10, [x29, #-0x70]
+               	ldur	x11, [x29, #-0xd8]
+               	add	x9, x10, x11
                	stur	x9, [x29, #-0xe0]
-               	lsl	x0, x20, #61
-               	lsr	x1, x20, #3
+               	ldur	x9, [x29, #-0x70]
+               	lsl	x0, x9, #61
+               	ldur	x9, [x29, #-0x70]
+               	lsr	x1, x9, #3
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xe8]
-               	ldur	x10, [x29, #-0xe8]
-               	eor	x9, x21, x10
+               	ldur	x10, [x29, #-0x80]
+               	ldur	x11, [x29, #-0xe8]
+               	eor	x9, x10, x11
                	stur	x9, [x29, #-0xf0]
-               	lsl	x0, x21, #3
-               	lsr	x1, x21, #61
+               	ldur	x9, [x29, #-0x80]
+               	lsl	x0, x9, #3
+               	ldur	x9, [x29, #-0x80]
+               	lsr	x1, x9, #61
                	orr	x9, x0, x1
                	stur	x9, [x29, #-0xf8]
-               	ldur	x9, [x29, #-0xf8]
-               	add	x21, x22, x9
-               	ldur	x9, [x29, #-0x10]
-               	mov	x16, #0xfe78            // =65144
+               	ldur	x10, [x29, #-0x60]
+               	ldur	x11, [x29, #-0xf8]
+               	add	x9, x10, x11
+               	stur	x9, [x29, #-0x100]
+               	ldur	x10, [x29, #-0x10]
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	add	x22, x9, x10
-               	ldur	x9, [x29, #-0xe0]
-               	mov	w0, w9
-               	ldur	x10, [x29, #-0x50]
-               	eor	w9, w10, w0
-               	stur	x9, [x29, #-0x100]
-               	mov	w0, w25
-               	ldur	x10, [x29, #-0x20]
-               	add	w9, w10, w0
+               	ldr	x11, [x29, x16]
+               	add	x9, x10, x11
                	mov	x16, #0xfef8            // =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0xe0]
                	mov	w0, w9
-               	ldur	x10, [x29, #-0x30]
+               	ldur	x10, [x29, #-0x40]
                	eor	w9, w10, w0
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xa0]
-               	mov	w0, w9
-               	ldur	x10, [x29, #-0x40]
+               	mov	w0, w25
+               	ldur	x10, [x29, #-0x50]
                	add	w9, w10, w0
                	mov	x16, #0xfee8            // =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	w0, w21
+               	ldur	x10, [x29, #-0x20]
+               	eor	w9, w10, w0
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xa0]
+               	mov	w0, w9
+               	ldur	x10, [x29, #-0x30]
+               	add	w9, w10, w0
+               	mov	x16, #0xfed8            // =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -553,336 +563,664 @@ Disassembly of section .text:
                	fmov	d30, #1.50000000
                	fmul	d0, d8, d30
                	fadd	d31, d0, d9
-               	mov	x16, #0xfed8            // =65240
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
                	fmov	d30, #0.75000000
                	fmul	d0, d9, d30
-               	fadd	d9, d0, d10
+               	fadd	d31, d0, d10
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.25000000
                	fmul	d0, d10, d30
-               	fadd	d10, d0, d11
+               	fadd	d31, d0, d11
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.50000000
                	fmul	d0, d11, d30
-               	fadd	d11, d0, d12
+               	fadd	d31, d0, d12
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.75000000
                	fmul	d0, d12, d30
-               	fadd	d12, d0, d13
+               	fadd	d31, d0, d13
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.62500000
                	fmul	d0, d13, d30
-               	fadd	d13, d0, d14
+               	fadd	d31, d0, d14
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #1.12500000
                	fmul	d0, d14, d30
-               	fadd	d14, d0, d15
+               	fadd	d31, d0, d15
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	fmov	d30, #0.87500000
                	fmul	d0, d15, d30
-               	fadd	d15, d0, d8
+               	fadd	d31, d0, d8
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	ldur	x9, [x29, #-0xa0]
                	eor	x1, x25, x9
-               	mov	x0, x19
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0xfef8            // =65272
+               	mov	x0, x22
+<L1>:
+               	bl	 <L1>
+               	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	w1, w9
-<L3>:
-               	bl	 <L3>
-               	mov	x16, #0xfed8            // =65240
+<L2>:
+               	bl	 <L2>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
-               	fadd	d0, d31, d12
-<L4>:
-               	bl	 <L4>
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d30, [x29, x16]
+               	fadd	d0, d31, d30
+               	fmov	x1, d0
+<L3>:
+               	bl	 <L3>
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x18, x9, #0x1
-               	mov	x19, x0
-               	mov	x23, x25
+               	mov	x22, x0
+               	mov	x27, x25
                	mov	x28, x26
-               	mov	x9, x27
-               	mov	x16, #0xfed0            // =65232
+               	mov	x9, x23
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, x24
-               	mov	x16, #0xfec8            // =65224
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x60]
-               	mov	x9, x10
-               	mov	x16, #0xfec0            // =65216
+               	mov	x9, x21
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x70]
-               	mov	x9, x10
-               	mov	x16, #0xfeb8            // =65208
+               	mov	x9, x19
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x80]
-               	mov	x9, x10
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x9, x20
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x90]
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	mov	x16, #0xfea8            // =65192
+               	mov	x16, #0xfe20            // =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xa0]
                	mov	x9, x10
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfe18            // =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xb0]
                	mov	x9, x10
-               	mov	x16, #0xfe98            // =65176
+               	mov	x16, #0xfe10            // =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xc0]
                	mov	x9, x10
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfe08            // =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xd0]
                	mov	x9, x10
-               	mov	x16, #0xfe88            // =65160
+               	mov	x16, #0xfe00            // =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldur	x10, [x29, #-0xe0]
                	mov	x9, x10
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xf0]
-               	mov	x20, x9
+               	stur	x9, [x29, #-0x90]
+               	ldur	x10, [x29, #-0xf0]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x70]
+               	ldur	x10, [x29, #-0x100]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x80]
                	mov	x16, #0xfef8            // =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x50]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	mov	x9, x10
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x60]
                	mov	x16, #0xfee8            // =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x30]
-               	ldur	x10, [x29, #-0x100]
-               	mov	x9, x10
                	stur	x9, [x29, #-0x40]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x50]
                	mov	x16, #0xfed8            // =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x20]
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x30]
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	ldr	d8, [x29, x16]
+               	mov	x16, #0xfeb0            // =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d9, [x29, x16]
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d10, [x29, x16]
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d11, [x29, x16]
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d12, [x29, x16]
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d13, [x29, x16]
+               	mov	x16, #0xfe60            // =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d14, [x29, x16]
+               	mov	x16, #0xfe50            // =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d15, [x29, x16]
                	mov	x9, x18
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfe78            // =65144
+               	mov	x16, #0xfdf8            // =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x18
-               	b.lo	 <L1>
+               	b.lo	 <L0>
+<L4>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x15, x27, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x15, x16
+               	eor	x15, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x28
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	lsr	x15, x28, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x15, x16
+               	eor	x15, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfec8            // =65224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfec0            // =65216
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe48            // =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x15, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x15, x16
+               	eor	x15, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x15, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfeb0            // =65200
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe40            // =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0xfea8            // =65192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
 <L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe38            // =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
 <L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfe98            // =65176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
 <L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe30            // =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L15>
 <L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfe88            // =65160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe28            // =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	mov	x1, x20
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
-               	bl	 <L19>
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L19>
 <L20>:
-               	bl	 <L20>
-               	mov	x1, x22
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
-               	ldur	x9, [x29, #-0x50]
-               	mov	w1, w9
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe18            // =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L21>
 <L22>:
-               	bl	 <L22>
-               	ldur	x9, [x29, #-0x20]
-               	mov	w1, w9
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
 <L23>:
-               	bl	 <L23>
-               	ldur	x9, [x29, #-0x30]
-               	mov	w1, w9
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L23>
 <L24>:
-               	bl	 <L24>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe08            // =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x90]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x70]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x80]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	ldur	x9, [x29, #-0x60]
+               	lsr	x2, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x2, x16
+               	eor	x2, x22, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x2, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L35>
+<L36>:
                	ldur	x9, [x29, #-0x40]
                	mov	w1, w9
-<L25>:
-               	bl	 <L25>
-               	fmov	d0, d8
-<L26>:
-               	bl	 <L26>
-               	fmov	d0, d9
-<L27>:
-               	bl	 <L27>
-               	fmov	d0, d10
-<L28>:
-               	bl	 <L28>
-               	fmov	d0, d11
-<L29>:
-               	bl	 <L29>
-               	fmov	d0, d12
-<L30>:
-               	bl	 <L30>
-               	fmov	d0, d13
-<L31>:
-               	bl	 <L31>
-               	fmov	d0, d14
-<L32>:
-               	bl	 <L32>
-               	fmov	d0, d15
-<L33>:
-               	bl	 <L33>
-               	sub	x16, x29, #0x1f0
+               	mov	x0, x22
+<L37>:
+               	bl	 <L37>
+               	ldur	x9, [x29, #-0x50]
+               	mov	w1, w9
+<L38>:
+               	bl	 <L38>
+               	ldur	x9, [x29, #-0x20]
+               	mov	w1, w9
+<L39>:
+               	bl	 <L39>
+               	ldur	x9, [x29, #-0x30]
+               	mov	w1, w9
+<L40>:
+               	bl	 <L40>
+               	fmov	x1, d8
+<L41>:
+               	bl	 <L41>
+               	fmov	x1, d9
+<L42>:
+               	bl	 <L42>
+               	fmov	x1, d10
+<L43>:
+               	bl	 <L43>
+               	fmov	x1, d11
+<L44>:
+               	bl	 <L44>
+               	fmov	x1, d12
+<L45>:
+               	bl	 <L45>
+               	fmov	x1, d13
+<L46>:
+               	bl	 <L46>
+               	fmov	x1, d14
+<L47>:
+               	bl	 <L47>
+               	fmov	x1, d15
+<L48>:
+               	bl	 <L48>
+               	sub	x16, x29, #0x270
                	ldp	d8, d9, [x16]
                	ldp	d10, d11, [x16, #-0x10]
                	ldp	d12, d13, [x16, #-0x20]
                	ldp	d14, d15, [x16, #-0x30]
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	ldp	x21, x22, [x29, #-0x1b0]
-               	ldp	x23, x24, [x29, #-0x1c0]
-               	ldp	x25, x26, [x29, #-0x1d0]
-               	ldp	x27, x28, [x29, #-0x1e0]
+               	sub	x16, x29, #0x220
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/imm/imm_add.dis
+++ b/test/golden/aarch64-linux/imm/imm_add.dis
@@ -5,178 +5,382 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_add.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x20
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
+               	stur	x21, [x29, #-0x18]
                	mov	x19, x0
+               	mov	w0, w19
+               	add	w1, w0, #0x7ff
+               	mov	w0, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	add	w20, w2, #0x7ff
-               	mov	x0, x1
-               	mov	w1, w20
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	w21, w20, #0x800
-               	mov	x0, x1
-               	mov	w1, w21
+               	add	w0, w1, #0x800
+               	mov	w1, w0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	w22, w21, #0xfff
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	w21, w22, #0x1, lsl #12 // =0x1000
-               	mov	x0, x1
-               	mov	w1, w21
+               	add	w1, w0, #0xfff
+               	mov	w0, w1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	w0, w1, #0x1, lsl #12   // =0x1000
+               	mov	w1, w0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+<L7>:
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0x7fff, lsl #16
-               	add	w22, w21, w16
-               	mov	x0, x1
-               	mov	w1, w22
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+               	add	w1, w0, w16
+               	mov	w0, w1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	w16, #-0x80000000       // =-2147483648
-               	add	w21, w22, w16
-               	mov	x0, x1
-               	mov	w1, w21
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	add	w0, w1, w16
+               	mov	w1, w0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0xffff, lsl #16
-               	add	w2, w21, w16
-               	mov	x0, x1
-               	mov	w1, w2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	add	x21, x19, #0x7ff
-               	mov	x0, x1
-               	mov	x1, x21
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	sub	x19, x21, #0x800
-               	mov	x0, x1
-               	mov	x1, x19
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	add	x22, x19, #0xfff, lsl #12 // =0xfff000
-               	mov	x0, x1
-               	mov	x1, x22
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+               	add	w1, w0, w16
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x0, x19, #0x7ff
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	sub	x1, x0, #0x800
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	add	x0, x1, #0xfff, lsl #12 // =0xfff000
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xff, lsl #16
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L20>
+<L21>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x7fff, lsl #16
-               	add	x22, x23, x16
-               	mov	x0, x1
-               	mov	x1, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
                	mov	x16, #0x80000000        // =2147483648
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
-               	add	x22, x23, x16
-               	mov	x0, x1
-               	mov	x1, x22
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
                	mov	x16, #0x100000000       // =4294967296
-               	add	x23, x22, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+               	add	x1, x0, x16
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L28>
+<L29>:
                	mov	x16, #-0x8000000000000000 // =-9223372036854775808
-               	add	x2, x23, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w20
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	sub	w22, w20, #0x800
-               	mov	x0, x1
-               	mov	w1, w22
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
+               	add	x0, x1, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	w0, w19
+               	add	w20, w0, #0x7ff
+               	sxtw	x1, w20
+               	mov	x0, x2
+<L32>:
+               	bl	 <L32>
+               	sub	w21, w20, #0x800
+               	sxtw	x1, w21
+<L33>:
+               	bl	 <L33>
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0x7fff, lsl #16
-               	add	w20, w22, w16
-               	mov	x0, x1
-               	mov	w1, w20
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
+               	add	w20, w21, w16
+               	sxtw	x1, w20
+<L34>:
+               	bl	 <L34>
                	mov	w16, #-0x80000000       // =-2147483648
-               	sub	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
-<L20>:
-               	bl	 <L20>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
-<L21>:
-               	bl	 <L21>
-               	mov	x1, x0
-               	mov	x0, x1
+               	sub	w1, w20, w16
+               	sxtw	x2, w1
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
+               	add	x20, x19, #0x7ff
+               	mov	x1, x20
+<L36>:
+               	bl	 <L36>
+               	sub	x19, x20, #0x800
                	mov	x1, x19
-<L22>:
-               	bl	 <L22>
-               	mov	x1, x0
+<L37>:
+               	bl	 <L37>
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x7fff, lsl #16
                	add	x20, x19, x16
-               	mov	x0, x1
                	mov	x1, x20
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x0
+<L38>:
+               	bl	 <L38>
                	mov	x16, #-0x8000000000000000 // =-9223372036854775808
-               	sub	x2, x20, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L24>:
-               	bl	 <L24>
+               	sub	x1, x20, x16
+<L39>:
+               	bl	 <L39>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	ldur	x21, [x29, #-0x18]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/imm/imm_addr.dis
+++ b/test/golden/aarch64-linux/imm/imm_addr.dis
@@ -6,230 +6,532 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x9, lsl #12   // =0x9000
-               	sub	sp, sp, #0x350
+               	sub	sp, sp, #0x320
                	mov	x16, #0x6cf0            // =27888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x16, x29, x16
                	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stp	x25, x26, [x16, #-0x30]
-               	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
+               	stur	x21, [x16, #-0x8]
                	mov	x16, #0x7c00            // =31744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	add	x1, x20, #0x0
+               	add	x19, x29, x16
+               	add	x1, x19, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x8400             // =33792
-<L1>:
+<L0>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L1>
+               	b.ne	 <L0>
                	mov	x16, #0x6d00            // =27904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x1, x21, #0x0
+               	add	x1, x29, x16
                	add	x2, x1, #0x0
-               	mov	x1, #0xf00              // =3840
-<L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L2>
-               	add	x1, x19, #0x1
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	add	x1, x19, #0x2
-               	add	x22, x20, #0x7f8
-               	str	x1, [x22]
-               	add	x1, x19, #0x3
-               	add	x23, x20, #0x800
-               	str	x1, [x23]
-               	add	x1, x19, #0x4
+               	add	x3, x2, #0x0
+               	mov	x2, #0xf00              // =3840
+<L1>:
+               	str	xzr, [x3]
+               	add	x3, x3, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L1>
+               	add	x2, x0, #0x1
+               	add	x3, x19, #0x0
+               	str	x2, [x3]
+               	add	x2, x0, #0x2
+               	add	x4, x19, #0x7f8
+               	str	x2, [x4]
+               	add	x2, x0, #0x3
+               	add	x4, x19, #0x800
+               	str	x2, [x4]
+               	add	x2, x0, #0x4
                	mov	x16, #0x7ff8            // =32760
-               	add	x24, x20, x16
-               	str	x1, [x24]
-               	add	x1, x19, #0x5
-               	add	x25, x20, #0x8, lsl #12 // =0x8000
-               	str	x1, [x25]
-               	add	x1, x19, #0x6
+               	add	x4, x19, x16
+               	str	x2, [x4]
+               	add	x2, x0, #0x5
+               	add	x4, x19, #0x8, lsl #12  // =0x8000
+               	str	x2, [x4]
+               	add	x2, x0, #0x6
                	mov	x16, #0x83f8            // =33784
-               	add	x26, x20, x16
-               	str	x1, [x26]
-               	ldr	x1, [x2]
+               	add	x4, x19, x16
+               	str	x2, [x4]
+               	ldr	x2, [x3]
+               	mov	x3, #0x2325             // =8997
+               	movk	x3, #0x8422, lsl #16
+               	movk	x3, #0x9ce4, lsl #32
+               	movk	x3, #0xcbf2, lsl #48
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	ldr	x1, [x22]
+               	add	x2, x19, #0x7f8
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldr	x1, [x23]
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	ldr	x1, [x24]
+               	add	x2, x19, #0x800
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ldr	x1, [x25]
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ldr	x1, [x26]
+               	mov	x16, #0x7ff8            // =32760
+               	add	x2, x19, x16
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, #0x1080             // =4224
-               	cbnz	x1,  <L9>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x19, #0xfff
-               	mov	x3, #0x1080             // =4224
-               	cbnz	x3,  <L10>
-               	brk	#0
+               	add	x2, x19, #0x8, lsl #12  // =0x8000
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
-               	add	x1, x19, #0x800
-               	mov	x3, #0x1080             // =4224
-               	cbnz	x3,  <L11>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	udiv	x16, x1, x3
-               	msub	x5, x16, x3, x1
-               	add	x1, x20, x2, lsl #3
-               	ldr	x2, [x1]
-               	add	x3, x2, #0x7
-               	str	x3, [x1]
-               	add	x22, x20, x4, lsl #3
-               	ldr	x2, [x22]
-               	add	x3, x2, #0x8
-               	str	x3, [x22]
-               	add	x23, x20, x5, lsl #3
-               	ldr	x2, [x23]
-               	add	x3, x2, #0x9
-               	str	x3, [x23]
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x83f8            // =33784
+               	add	x2, x19, x16
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	ldr	x1, [x22]
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	ldr	x1, [x23]
+               	mov	x2, #0x1080             // =4224
+               	cbnz	x2,  <L14>
+               	brk	#0
 <L14>:
-               	bl	 <L14>
-               	mov	x1, #0x60               // =96
-               	cbnz	x1,  <L15>
+               	udiv	x16, x0, x2
+               	msub	x4, x16, x2, x0
+               	add	x2, x0, #0xfff
+               	mov	x5, #0x1080             // =4224
+               	cbnz	x5,  <L15>
                	brk	#0
 <L15>:
-               	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x19, #0x3f
-               	mov	x3, #0x60               // =96
-               	cbnz	x3,  <L16>
+               	udiv	x16, x2, x5
+               	msub	x6, x16, x5, x2
+               	add	x2, x0, #0x800
+               	mov	x5, #0x1080             // =4224
+               	cbnz	x5,  <L16>
                	brk	#0
 <L16>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
-               	mov	x16, #0x28              // =40
-               	mul	x1, x2, x16
-               	add	x2, x21, x1
-               	add	x1, x2, #0x0
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x3, x19, #0xa
-               	add	x5, x2, #0x8
-               	add	x20, x5, #0x0
-               	str	x3, [x20]
-               	add	x3, x19, #0xb
-               	add	x22, x5, #0x8
-               	str	x3, [x22]
-               	add	x3, x19, #0xc
-               	add	x23, x5, #0x10
-               	str	x3, [x23]
-               	add	x25, x2, #0x20
-               	mov	w17, #0x5678            // =22136
-               	movk	w17, #0x1234, lsl #16
-               	str	w17, [x25]
+               	udiv	x16, x2, x5
+               	msub	x7, x16, x5, x2
+               	add	x2, x19, x4, lsl #3
+               	ldr	x4, [x2]
+               	add	x5, x4, #0x7
+               	str	x5, [x2]
+               	add	x4, x19, x6, lsl #3
+               	ldr	x5, [x4]
+               	add	x8, x5, #0x8
+               	str	x8, [x4]
+               	add	x4, x19, x7, lsl #3
+               	ldr	x5, [x4]
+               	add	x8, x5, #0x9
+               	str	x8, [x4]
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x8, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x8, x16
+               	eor	x8, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x8, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	add	x2, x19, x6, lsl #3
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x19, x7, lsl #3
+               	ldr	x4, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	mov	x2, #0x60               // =96
+               	cbnz	x2,  <L23>
+               	brk	#0
+<L23>:
+               	udiv	x16, x0, x2
+               	msub	x4, x16, x2, x0
+               	add	x2, x0, #0x3f
+               	mov	x5, #0x60               // =96
+               	cbnz	x5,  <L24>
+               	brk	#0
+<L24>:
+               	udiv	x16, x2, x5
+               	msub	x6, x16, x5, x2
                	mov	x16, #0x28              // =40
                	mul	x2, x4, x16
-               	add	x3, x21, x2
-               	add	x21, x3, #0x0
+               	add	x5, x1, x2
+               	add	x2, x5, #0x0
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x2]
+               	add	x7, x0, #0xa
+               	add	x8, x5, #0x8
+               	add	x12, x8, #0x0
+               	str	x7, [x12]
+               	add	x7, x0, #0xb
+               	add	x12, x8, #0x8
+               	str	x7, [x12]
+               	add	x7, x0, #0xc
+               	add	x12, x8, #0x10
+               	str	x7, [x12]
+               	add	x7, x5, #0x20
+               	mov	w17, #0x5678            // =22136
+               	movk	w17, #0x1234, lsl #16
+               	str	w17, [x7]
+               	mov	x16, #0x28              // =40
+               	mul	x5, x6, x16
+               	add	x7, x1, x5
+               	add	x5, x7, #0x0
                	mov	w17, #0xef01            // =61185
                	movk	w17, #0xabcd, lsl #16
-               	str	w17, [x21]
-               	add	x2, x19, #0xd
-               	add	x4, x3, #0x8
-               	add	x26, x4, #0x0
-               	str	x2, [x26]
-               	add	x2, x19, #0xe
-               	add	x27, x4, #0x8
-               	str	x2, [x27]
-               	add	x2, x19, #0xf
-               	add	x19, x4, #0x10
-               	str	x2, [x19]
-               	add	x28, x3, #0x20
+               	str	w17, [x5]
+               	add	x5, x0, #0xd
+               	add	x8, x7, #0x8
+               	add	x12, x8, #0x0
+               	str	x5, [x12]
+               	add	x5, x0, #0xe
+               	add	x12, x8, #0x8
+               	str	x5, [x12]
+               	add	x5, x0, #0xf
+               	add	x0, x8, #0x10
+               	str	x5, [x0]
+               	add	x0, x7, #0x20
                	mov	w17, #0x4567            // =17767
                	movk	w17, #0x123, lsl #16
-               	str	w17, [x28]
+               	str	w17, [x0]
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x0, x16
+               	lsr	x7, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x0
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x8
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x10
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x7, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x7, x16
+               	eor	x7, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x4, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x20
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L33>
+<L34>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x6, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x0
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L35>
+<L36>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x6, x16
+               	add	x2, x1, x0
+               	add	x0, x2, #0x8
+               	add	x2, x0, #0x0
+               	ldr	x0, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+               	b	 <L38>
+<L37>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x3, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L37>
+<L38>:
+               	mov	x16, #0x28              // =40
+               	mul	x0, x6, x16
+               	add	x20, x1, x0
+               	add	x21, x20, #0x8
+               	add	x0, x21, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x3
+<L39>:
+               	bl	 <L39>
+               	add	x1, x21, #0x10
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
+               	add	x1, x20, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L17>:
-               	bl	 <L17>
-               	ldr	x1, [x20]
-<L18>:
-               	bl	 <L18>
-               	ldr	x1, [x22]
-<L19>:
-               	bl	 <L19>
-               	ldr	x1, [x23]
-<L20>:
-               	bl	 <L20>
-               	ldr	w1, [x25]
-<L21>:
-               	bl	 <L21>
-               	ldr	w1, [x21]
-<L22>:
-               	bl	 <L22>
-               	ldr	x1, [x26]
-<L23>:
-               	bl	 <L23>
-               	ldr	x1, [x27]
-<L24>:
-               	bl	 <L24>
-               	ldr	x1, [x19]
-<L25>:
-               	bl	 <L25>
-               	ldr	w1, [x28]
-<L26>:
-               	bl	 <L26>
-               	ldr	x1, [x24]
-               	add	x2, x1, #0x10
-               	str	x2, [x24]
-               	ldr	x1, [x24]
-<L27>:
-               	bl	 <L27>
+<L41>:
+               	bl	 <L41>
+               	mov	x16, #0x7ff8            // =32760
+               	add	x1, x19, x16
+               	ldr	x2, [x1]
+               	add	x3, x2, #0x10
+               	str	x3, [x1]
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L42>:
+               	bl	 <L42>
                	mov	x16, #0x6cf0            // =27888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x16, x29, x16
                	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldp	x25, x26, [x16, #-0x30]
-               	ldp	x27, x28, [x16, #-0x40]
+               	ldur	x21, [x16, #-0x8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/imm/imm_logic.dis
+++ b/test/golden/aarch64-linux/imm/imm_logic.dis
@@ -5,188 +5,407 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_logic.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
+               	sub	sp, sp, #0x10
                	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
                	mov	x19, x0
+               	mov	w0, w19
+               	mov	w16, #0x5555            // =21845
+               	movk	w16, #0x5555, lsl #16
+               	orr	w1, w0, w16
+               	mov	w2, w1
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	w20, w19
-               	mov	w16, #0x5555            // =21845
-               	movk	w16, #0x5555, lsl #16
-               	orr	w21, w20, w16
-               	mov	x0, x1
-               	mov	w1, w21
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	mov	w16, #0x5555            // =21845
                	movk	w16, #0x5555, lsl #16
-               	eor	w2, w20, w16
+               	eor	w2, w0, w16
                	mov	w16, #0xf0f             // =3855
                	movk	w16, #0xf0f, lsl #16
                	and	w3, w2, w16
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	w16, #-0x10000          // =-65536
-               	orr	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	w16, #0xffff            // =65535
-               	and	w2, w20, w16
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w16, #-0x10000          // =-65536
+               	orr	w2, w0, w16
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mvn	w22, w20
-               	mov	x0, x1
-               	mov	w1, w22
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+               	mov	w16, #0xffff            // =65535
+               	and	w2, w0, w16
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	mvn	w2, w0
+               	mov	w3, w2
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	w16, #0x5555            // =21845
                	movk	w16, #0x5555, lsl #16
-               	orr	w2, w22, w16
-               	mvn	w3, w2
-               	mov	x0, x1
-               	mov	w1, w3
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	orr	w3, w2, w16
+               	mvn	w2, w3
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w16, #0xf0f             // =3855
                	movk	w16, #0xf0f, lsl #16
-               	and	w2, w20, w16
+               	and	w2, w0, w16
                	mov	w16, #-0x10000          // =-65536
-               	eor	w3, w2, w16
-               	mov	x0, x1
-               	mov	w1, w3
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+               	eor	w0, w2, w16
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0x5555            // =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	orr	x23, x19, x16
-               	mov	x0, x1
-               	mov	x1, x23
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+               	orr	x0, x19, x16
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x16, #0x5555            // =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	eor	x2, x19, x16
+               	eor	x0, x19, x16
                	mov	x16, #0xf0f             // =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+               	and	x2, x0, x16
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x16, #0xffff0000        // =4294901760
                	movk	x16, #0xffff, lsl #48
-               	orr	x2, x19, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+               	orr	x0, x19, x16
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x16, #0xff              // =255
                	movk	x16, #0xff, lsl #16
                	movk	x16, #0xff, lsl #32
                	movk	x16, #0xff, lsl #48
-               	and	x2, x19, x16
-               	mov	x0, x1
-               	mov	x1, x2
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	mvn	x24, x19
-               	mov	x0, x1
-               	mov	x1, x24
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+               	and	x0, x19, x16
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mvn	x0, x19
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
                	mov	x16, #0x5555            // =21845
                	movk	x16, #0x5555, lsl #16
                	movk	x16, #0x5555, lsl #32
                	movk	x16, #0x5555, lsl #48
-               	orr	x2, x24, x16
-               	mvn	x3, x2
-               	mov	x0, x1
-               	mov	x1, x3
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+               	orr	x2, x0, x16
+               	mvn	x0, x2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
                	mov	x16, #0xf0f             // =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x2, x19, x16
+               	and	x0, x19, x16
                	mov	x16, #0xffff0000        // =4294901760
                	movk	x16, #0xffff, lsl #48
-               	eor	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w21
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w22
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
-               	eor	w2, w20, w22
+               	eor	x2, x0, x16
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	w0, w19
+               	mov	w16, #0x5555            // =21845
+               	movk	w16, #0x5555, lsl #16
+               	orr	w2, w0, w16
+               	sxtw	x3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mvn	w2, w0
+               	sxtw	x3, w2
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x1, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	eor	w3, w0, w2
                	mov	w16, #0xf0f             // =3855
                	movk	w16, #0xf0f, lsl #16
-               	and	w3, w2, w16
+               	and	w0, w3, w16
+               	sxtw	x2, w0
                	mov	x0, x1
-               	mov	w1, w3
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x24
-<L19>:
-               	bl	 <L19>
-               	mov	x1, x0
-               	eor	x2, x19, x24
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0x5555            // =21845
+               	movk	x16, #0x5555, lsl #16
+               	movk	x16, #0x5555, lsl #32
+               	movk	x16, #0x5555, lsl #48
+               	orr	x1, x19, x16
+<L33>:
+               	bl	 <L33>
+               	mvn	x20, x19
+               	mov	x1, x20
+<L34>:
+               	bl	 <L34>
+               	eor	x1, x19, x20
                	mov	x16, #0xf0f             // =3855
                	movk	x16, #0xf0f, lsl #16
                	movk	x16, #0xf0f, lsl #32
                	movk	x16, #0xf0f, lsl #48
-               	and	x3, x2, x16
-               	mov	x0, x1
-               	mov	x1, x3
-<L20>:
-               	bl	 <L20>
+               	and	x2, x1, x16
+               	mov	x1, x2
+<L35>:
+               	bl	 <L35>
                	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/imm/imm_mov.dis
+++ b/test/golden/aarch64-linux/imm/imm_mov.dis
@@ -5,120 +5,297 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_mov.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x30]
-               	stur	x21, [x29, #-0x38]
-               	mov	x19, x0
+               	sub	sp, sp, #0x20
+               	cmp	x0, #0x0
+               	b.eq	 <L0>
+               	mov	w1, #-0x80000000        // =-2147483648
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	cmp	x19, #0x0
-               	b.eq	 <L1>
-               	mov	w1, #-0x80000000        // =-2147483648
-               	b	 <L2>
-<L1>:
                	mov	w1, #0x7ff              // =2047
+<L1>:
+               	mov	w2, w1
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	cmp	x19, #0x1
-               	b.eq	 <L3>
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0x7fff, lsl #48
-               	b	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	mov	x1, #0xffff             // =65535
-               	movk	x1, #0xffff, lsl #16
+               	cmp	x0, #0x1
+               	b.eq	 <L4>
+               	mov	x2, #0xffff             // =65535
+               	movk	x2, #0xffff, lsl #16
+               	movk	x2, #0xffff, lsl #32
+               	movk	x2, #0x7fff, lsl #48
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	cmp	x19, #0x2
-               	b.eq	 <L5>
-               	mov	w1, #0xf0f              // =3855
-               	movk	w1, #0xf0f, lsl #16
-               	b	 <L6>
+               	mov	x2, #0xffff             // =65535
+               	movk	x2, #0xffff, lsl #16
 <L5>:
-               	mov	w1, #0x5555             // =21845
-               	movk	w1, #0x5555, lsl #16
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	cmp	x19, #0x3
-               	b.eq	 <L7>
-               	mov	x1, #0xffff0000         // =4294901760
-               	movk	x1, #0xffff, lsl #48
-               	b	 <L8>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x1, #0x5555             // =21845
-               	movk	x1, #0x5555, lsl #16
-               	movk	x1, #0x5555, lsl #32
-               	movk	x1, #0x5555, lsl #48
+               	cmp	x0, #0x2
+               	b.eq	 <L8>
+               	mov	w2, #0xf0f              // =3855
+               	movk	w2, #0xf0f, lsl #16
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	sub	x20, x29, #0x18
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	add	x1, x20, #0x0
-               	mov	x17, #0x100000000       // =4294967296
-               	str	x17, [x1]
-               	add	x1, x20, #0x8
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x1]
-               	add	x1, x20, #0x10
-               	mov	x17, #0xffff0000        // =4294901760
-               	str	x17, [x1]
-               	mov	x1, #0x3                // =3
-               	cbnz	x1,  <L9>
-               	brk	#0
+               	mov	w2, #0x5555             // =21845
+               	movk	w2, #0x5555, lsl #16
 <L9>:
-               	udiv	x16, x19, x1
-               	msub	x21, x16, x1, x19
-               	add	x1, x20, x21, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x1, x21, #0x1
-               	mov	x2, #0x3                // =3
-               	cbnz	x2,  <L11>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x20, x3, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	cmp	x0, #0x3
+               	b.eq	 <L12>
+               	mov	x2, #0xffff0000         // =4294901760
+               	movk	x2, #0xffff, lsl #48
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	add	x1, x21, #0x2
-               	mov	x2, #0x3                // =3
-               	cbnz	x2,  <L13>
-               	brk	#0
+               	mov	x2, #0x5555             // =21845
+               	movk	x2, #0x5555, lsl #16
+               	movk	x2, #0x5555, lsl #32
+               	movk	x2, #0x5555, lsl #48
 <L13>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x20, x3, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	w1, w19
-               	mov	w17, #0x7ff             // =2047
-               	add	w2, w17, w1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, #-0x80000000        // =-2147483648
+               	sub	x2, x29, #0x18
+               	str	xzr, [x2]
+               	str	xzr, [x2, #0x8]
+               	str	xzr, [x2, #0x10]
+               	add	x3, x2, #0x0
+               	mov	x17, #0x100000000       // =4294967296
+               	str	x17, [x3]
+               	add	x3, x2, #0x8
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x3]
+               	add	x3, x2, #0x10
+               	mov	x17, #0xffff0000        // =4294901760
+               	str	x17, [x3]
+               	mov	x3, #0x3                // =3
+               	cbnz	x3,  <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mov	x1, #-0x8000000000000000 // =-9223372036854775808
+               	udiv	x16, x0, x3
+               	msub	x4, x16, x3, x0
+               	add	x3, x2, x4, lsl #3
+               	ldr	x5, [x3]
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	mov	w1, #0x5555             // =21845
-               	movk	w1, #0x5555, lsl #16
+               	mov	x16, #0x8               // =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x1, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	ldp	x19, x20, [x29, #-0x30]
-               	ldur	x21, [x29, #-0x38]
+               	add	x3, x4, #0x1
+               	mov	x5, #0x3                // =3
+               	cbnz	x5,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	x16, x3, x5
+               	msub	x6, x16, x5, x3
+               	add	x3, x2, x6, lsl #3
+               	ldr	x5, [x3]
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x3, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x1, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x7, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x3, x4, #0x2
+               	mov	x4, #0x3                // =3
+               	cbnz	x4,  <L22>
+               	brk	#0
+<L22>:
+               	udiv	x16, x3, x4
+               	msub	x5, x16, x4, x3
+               	add	x3, x2, x5, lsl #3
+               	ldr	x2, [x3]
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x1, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	mov	w2, w0
+               	mov	w17, #0x7ff             // =2047
+               	add	w0, w17, w2
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x80000000        // =2147483648
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	mov	x17, #0x5555            // =21845
+               	movk	x17, #0x5555, lsl #16
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x1, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L31>
+<L32>:
+               	mov	x0, x1
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/addr_modes.dis
+++ b/test/golden/aarch64-linux/mem/addr_modes.dis
@@ -6,8 +6,8 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x3, lsl #12   // =0x3000
-               	sub	sp, sp, #0x430
-               	mov	x16, #0xcc10            // =52240
+               	sub	sp, sp, #0x420
+               	mov	x16, #0xcc20            // =52256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -18,9 +18,7 @@ Disassembly of section .text:
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x40
+               	sub	x20, x29, #0x140
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -29,142 +27,145 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x28]
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
-               	sub	x21, x29, #0xc0
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x80               // =128
+               	sub	x21, x29, #0x1c0
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x80               // =128
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	sub	x22, x29, #0x2c0
+               	add	x0, x22, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x100              // =256
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L1>
-               	sub	x22, x29, #0x1c0
-               	add	x1, x22, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x100              // =256
+               	sub	x23, x29, #0x4c0
+               	add	x0, x23, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x200              // =512
 <L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L2>
-               	sub	x23, x29, #0x3c0
-               	add	x1, x23, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x200              // =512
+               	sub	x24, x29, #0x8c0
+               	add	x0, x24, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x400              // =1024
 <L3>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L3>
-               	sub	x24, x29, #0x7c0
-               	add	x1, x24, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x400              // =1024
+               	sub	x25, x29, #0xbc0
+               	add	x0, x25, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x300              // =768
 <L4>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L4>
-               	sub	x25, x29, #0xac0
-               	add	x1, x25, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x300              // =768
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x40
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L5>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x40
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
                	mov	x16, #0x3               // =3
-               	mul	x2, x1, x16
-               	add	x3, x2, #0x1
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x20, x1
-               	strb	w3, [x2]
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x1
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x20, x0
+               	strb	w2, [x1]
                	mov	x16, #0x44f             // =1103
-               	mul	x2, x1, x16
-               	add	x3, x2, #0x7
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x21, x1, lsl #1
-               	strh	w3, [x2]
+               	mul	x1, x0, x16
+               	add	x2, x1, #0x7
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x21, x0, lsl #1
+               	strh	w2, [x1]
                	mov	x16, #0x79b1            // =31153
                	movk	x16, #0x9e37, lsl #16
-               	mul	x2, x1, x16
-               	add	x3, x2, #0xb
-               	add	x2, x3, x19
-               	mov	w3, w2
-               	add	x2, x22, x1, lsl #2
-               	str	w3, [x2]
-               	add	x2, x1, #0x1
+               	mul	x1, x0, x16
+               	add	x2, x1, #0xb
+               	add	x1, x2, x19
+               	mov	w2, w1
+               	add	x1, x22, x0, lsl #2
+               	str	w2, [x1]
+               	add	x1, x0, #0x1
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	add	x3, x23, x1, lsl #3
-               	str	x4, [x3]
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	add	x2, x23, x0, lsl #3
+               	str	x3, [x2]
                	mov	x16, #0x5               // =5
-               	mul	x3, x1, x16
-               	add	x4, x3, #0x2
-               	add	x3, x4, x19
-               	mov	w4, w3
+               	mul	x2, x0, x16
+               	add	x3, x2, #0x2
+               	add	x2, x3, x19
+               	mov	w3, w2
                	mov	x16, #0x10              // =16
-               	mul	x3, x1, x16
-               	add	x5, x24, x3
-               	add	x3, x5, #0x0
-               	strh	w4, [x3]
-               	add	x3, x1, #0x80
-               	mov	w4, w3
-               	add	x3, x5, #0x2
-               	strb	w4, [x3]
+               	mul	x2, x0, x16
+               	add	x4, x24, x2
+               	add	x2, x4, #0x0
+               	strh	w3, [x2]
+               	add	x2, x0, #0x80
+               	mov	w3, w2
+               	add	x2, x4, #0x2
+               	strb	w3, [x2]
                	mov	x17, #0x1b3             // =435
                	movk	x17, #0x100, lsl #32
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	add	x3, x5, #0x8
-               	str	x4, [x3]
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	add	x2, x4, #0x8
+               	str	x3, [x2]
                	mov	x16, #0x11              // =17
-               	mul	x3, x1, x16
-               	add	x4, x3, #0x1
-               	add	x5, x4, x19
-               	mov	w4, w5
+               	mul	x2, x0, x16
+               	add	x3, x2, #0x1
+               	add	x4, x3, x19
+               	mov	w3, w4
                	mov	x16, #0xc               // =12
-               	mul	x5, x1, x16
-               	add	x6, x25, x5
-               	add	x5, x6, #0x0
-               	str	w4, [x5]
-               	add	x4, x3, #0x2
-               	add	x5, x4, x19
-               	mov	w4, w5
-               	add	x5, x6, #0x4
-               	str	w4, [x5]
-               	add	x4, x3, #0x3
-               	add	x3, x4, x19
-               	mov	w4, w3
-               	add	x3, x6, #0x8
-               	str	w4, [x3]
-               	mov	x1, x2
-               	cmp	x1, #0x40
-               	b.lo	 <L6>
-<L7>:
-               	mov	x26, x0
+               	mul	x4, x0, x16
+               	add	x5, x25, x4
+               	add	x4, x5, #0x0
+               	str	w3, [x4]
+               	add	x3, x2, #0x2
+               	add	x4, x3, x19
+               	mov	w3, w4
+               	add	x4, x5, #0x4
+               	str	w3, [x4]
+               	add	x3, x2, #0x3
+               	add	x2, x3, x19
+               	mov	w3, w2
+               	add	x2, x5, #0x8
+               	str	w3, [x2]
+               	mov	x0, x1
+               	cmp	x0, #0x40
+               	b.lo	 <L5>
+<L6>:
+               	mov	x26, #0x2325            // =8997
+               	movk	x26, #0x8422, lsl #16
+               	movk	x26, #0x9ce4, lsl #32
+               	movk	x26, #0xcbf2, lsl #48
                	mov	x27, #0x0               // =0
                	cmp	x27, #0x40
-               	b.lo	 <L8>
-               	b	 <L19>
-<L8>:
+               	b.lo	 <L7>
+               	b	 <L22>
+<L7>:
                	mov	x16, #0xd               // =13
                	mul	x0, x27, x16
                	add	x1, x0, x19
@@ -172,148 +173,258 @@ Disassembly of section .text:
                	and	x28, x1, x16
                	add	x0, x20, x28
                	ldrb	w1, [x0]
-               	mov	x0, x26
+               	uxtb	w0, w1
+               	mov	x1, x26
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	add	x1, x21, x28, lsl #1
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	add	x0, x21, x28, lsl #1
+               	ldrh	w2, [x0]
+               	uxth	w0, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x1, x22, x28, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	add	x1, x23, x28, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x0, x22, x28, lsl #2
+               	ldr	w2, [x0]
+               	mov	w0, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0x10              // =16
-               	mul	x1, x28, x16
-               	add	x9, x24, x1
-               	mov	x16, #0xcc28            // =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xcc28            // =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrh	w3, [x1]
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x16, #0xcc28            // =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x2
-               	ldrb	w3, [x1]
-               	mov	x1, x3
+               	add	x0, x23, x28, lsl #3
+               	ldr	x2, [x0]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x16, #0xcc28            // =52264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x16, #0xc               // =12
-               	mul	x1, x28, x16
-               	add	x28, x25, x1
-               	add	x1, x28, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x10              // =16
+               	mul	x0, x28, x16
+               	add	x2, x24, x0
+               	add	x0, x2, #0x0
+               	ldrh	w2, [x0]
+               	uxth	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
 <L16>:
                	bl	 <L16>
-               	add	x1, x28, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x10              // =16
+               	mul	x1, x28, x16
+               	add	x2, x24, x1
+               	add	x1, x2, #0x2
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
 <L17>:
                	bl	 <L17>
-               	add	x1, x28, #0x8
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L18>:
-               	bl	 <L18>
-               	add	x27, x27, #0x1
-               	mov	x26, x0
-               	cmp	x27, #0x40
-               	b.lo	 <L8>
-<L19>:
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x20
-               	b.lo	 <L20>
-               	b	 <L26>
-<L20>:
-               	mov	x16, #0x2               // =2
-               	mul	x25, x21, x16
-               	add	x0, x22, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x26
-<L21>:
-               	bl	 <L21>
-               	lsl	x1, x21, #1
-               	add	x2, x22, x1, lsl #2
-               	ldr	w1, [x2]
-<L22>:
-               	bl	 <L22>
-               	add	x27, x21, #0x1
-               	mov	x16, #0x2               // =2
-               	mul	x1, x27, x16
-               	sub	x2, x1, #0x2
-               	add	x1, x23, x2, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	mov	x17, #0x3f              // =63
-               	sub	x1, x17, x21
-               	add	x2, x20, x1
-               	ldrb	w1, [x2]
-<L24>:
-               	bl	 <L24>
-               	add	x1, x25, x19
-               	mov	x16, #0x3f              // =63
-               	and	x2, x1, x16
                	mov	x16, #0x10              // =16
-               	mul	x1, x2, x16
+               	mul	x1, x28, x16
                	add	x2, x24, x1
                	add	x1, x2, #0x8
                	ldr	x2, [x1]
                	mov	x1, x2
-<L25>:
-               	bl	 <L25>
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xc               // =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x0
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xc               // =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x4
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xc               // =12
+               	mul	x1, x28, x16
+               	add	x2, x25, x1
+               	add	x1, x2, #0x8
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L21>:
+               	bl	 <L21>
+               	add	x27, x27, #0x1
                	mov	x26, x0
-               	mov	x21, x27
+               	cmp	x27, #0x40
+               	b.lo	 <L7>
+<L22>:
+               	mov	x21, #0x0               // =0
                	cmp	x21, #0x20
-               	b.lo	 <L20>
+               	b.lo	 <L23>
+               	b	 <L32>
+<L23>:
+               	mov	x16, #0x2               // =2
+               	mul	x0, x21, x16
+               	add	x1, x22, x0, lsl #2
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, x26
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	lsl	x1, x21, #1
+               	add	x2, x22, x1, lsl #2
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
 <L26>:
-               	sub	x20, x29, #0xbc0
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x1, x21, #0x1
+               	mov	x16, #0x2               // =2
+               	mul	x2, x1, x16
+               	sub	x1, x2, #0x2
+               	add	x2, x23, x1, lsl #3
+               	ldr	x1, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	mov	x17, #0x3f              // =63
+               	sub	x1, x17, x21
+               	add	x2, x20, x1
+               	ldrb	w1, [x2]
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0x2               // =2
+               	mul	x1, x21, x16
+               	add	x2, x1, x19
+               	mov	x16, #0x3f              // =63
+               	and	x1, x2, x16
+               	mov	x16, #0x10              // =16
+               	mul	x2, x1, x16
+               	add	x1, x24, x2
+               	add	x2, x1, #0x8
+               	ldr	x1, [x2]
+<L31>:
+               	bl	 <L31>
+               	add	x21, x21, #0x1
+               	mov	x26, x0
+               	cmp	x21, #0x20
+               	b.lo	 <L23>
+<L32>:
+               	sub	x20, x29, #0x100
                	add	x0, x20, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x100              // =256
-<L27>:
+<L33>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L27>
+               	b.ne	 <L33>
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x8
-               	b.lo	 <L28>
-               	b	 <L31>
-<L28>:
+               	b.lo	 <L34>
+               	b	 <L37>
+<L34>:
                	mov	x16, #0x47              // =71
                	mul	x1, x0, x16
                	mov	x16, #0x20              // =32
@@ -321,9 +432,9 @@ Disassembly of section .text:
                	add	x3, x20, x2
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x8
-               	b.lo	 <L29>
-               	b	 <L30>
-<L29>:
+               	b.lo	 <L35>
+               	b	 <L36>
+<L35>:
                	mov	x16, #0xd               // =13
                	mul	x4, x2, x16
                	add	x5, x1, x4
@@ -333,202 +444,328 @@ Disassembly of section .text:
                	str	w5, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x8
-               	b.lo	 <L29>
-<L30>:
+               	b.lo	 <L35>
+<L36>:
                	add	x0, x0, #0x1
                	cmp	x0, #0x8
-               	b.lo	 <L28>
-<L31>:
+               	b.lo	 <L34>
+<L37>:
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x8
-               	b.lo	 <L32>
-               	b	 <L36>
-<L32>:
+               	b.lo	 <L38>
+               	b	 <L44>
+<L38>:
                	mov	x16, #0x20              // =32
                	mul	x0, x21, x16
-               	add	x22, x20, x0
-               	add	x0, x22, #0xc
+               	add	x1, x20, x0
+               	add	x0, x1, #0xc
                	ldr	w1, [x0]
-               	mov	x0, x26
-<L33>:
-               	bl	 <L33>
-               	add	x1, x20, #0x60
-               	add	x2, x1, x21, lsl #2
-               	ldr	w1, [x2]
-<L34>:
-               	bl	 <L34>
-               	add	x1, x21, x19
+               	mov	w0, w1
+               	mov	x1, x26
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	add	x0, x20, #0x60
+               	add	x2, x0, x21, lsl #2
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+<L42>:
+               	mov	x16, #0x20              // =32
+               	mul	x0, x21, x16
+               	add	x2, x20, x0
+               	add	x0, x21, x19
                	mov	x16, #0x7               // =7
-               	and	x2, x1, x16
-               	add	x1, x22, x2, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L35>:
-               	bl	 <L35>
+               	and	x3, x0, x16
+               	add	x0, x2, x3, lsl #2
+               	ldr	w2, [x0]
+               	mov	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
+<L43>:
+               	bl	 <L43>
                	add	x21, x21, #0x1
                	mov	x26, x0
                	cmp	x21, #0x8
-               	b.lo	 <L32>
-<L36>:
+               	b.lo	 <L38>
+<L44>:
                	add	x0, x20, #0xe0
                	add	x1, x0, #0x1c
-               	ldr	w2, [x1]
-               	mov	x0, x26
-               	mov	w1, w2
-<L37>:
-               	bl	 <L37>
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	ldr	w1, [x2]
-<L38>:
-               	bl	 <L38>
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L45>
+               	b	 <L46>
+<L45>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L45>
+<L46>:
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	ldr	w0, [x1]
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L47>
+               	b	 <L48>
+<L47>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L47>
+<L48>:
                	mov	x16, #0xcc30            // =52272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	add	x20, x29, x16
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x2810             // =10256
-<L39>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L39>
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x2810             // =10256
+<L49>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L49>
                	mov	x17, #0x5678            // =22136
                	movk	x17, #0x1234, lsl #16
-               	add	x1, x17, x19
-               	add	x2, x20, #0x0
-               	str	x1, [x2]
-               	mov	w1, w19
+               	add	x0, x17, x19
+               	add	x1, x20, #0x0
+               	str	x0, [x1]
+               	mov	w0, w19
                	mov	w17, #0xdef0            // =57072
                	movk	w17, #0x9abc, lsl #16
-               	add	w2, w17, w1
+               	add	w1, w17, w0
                	mov	x16, #0x2008            // =8200
-               	add	x1, x20, x16
-               	str	w2, [x1]
-               	mov	w1, w19
+               	add	x0, x20, x16
+               	str	w1, [x0]
+               	mov	w0, w19
                	mov	w17, #0x1234            // =4660
-               	add	w2, w17, w1
+               	add	w1, w17, w0
                	mov	x16, #0x280c            // =10252
-               	add	x1, x20, x16
-               	strh	w2, [x1]
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x400
-               	b.lo	 <L40>
-               	b	 <L41>
-<L40>:
+               	add	x0, x20, x16
+               	strh	w1, [x0]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x400
+               	b.lo	 <L50>
+               	b	 <L51>
+<L50>:
                	mov	x16, #0x1f              // =31
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	add	x2, x20, #0x8
-               	add	x4, x2, x1, lsl #3
-               	str	x3, [x4]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x400
-               	b.lo	 <L40>
-<L41>:
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x200
-               	b.lo	 <L42>
-               	b	 <L43>
-<L42>:
+               	mul	x1, x0, x16
+               	add	x2, x1, x19
+               	add	x1, x20, #0x8
+               	add	x3, x1, x0, lsl #3
+               	str	x2, [x3]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x400
+               	b.lo	 <L50>
+<L51>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x200
+               	b.lo	 <L52>
+               	b	 <L53>
+<L52>:
                	mov	x16, #0x25              // =37
-               	mul	x2, x1, x16
-               	add	x3, x2, x19
-               	mov	w2, w3
+               	mul	x1, x0, x16
+               	add	x2, x1, x19
+               	mov	w1, w2
                	mov	x16, #0x200c            // =8204
-               	add	x3, x20, x16
-               	add	x4, x3, x1, lsl #2
-               	str	w2, [x4]
+               	add	x2, x20, x16
+               	add	x3, x2, x0, lsl #2
+               	str	w1, [x3]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x200
+               	b.lo	 <L52>
+<L53>:
+               	add	x0, x20, #0x0
+               	ldr	x1, [x0]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x0, x20, #0x8
+               	add	x1, x0, #0x0
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+               	b	 <L57>
+<L56>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
                	add	x1, x1, #0x1
-               	cmp	x1, #0x200
-               	b.lo	 <L42>
-<L43>:
-               	add	x1, x20, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L44>:
-               	bl	 <L44>
-               	add	x21, x20, #0x8
-               	add	x1, x21, #0x0
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L45>:
-               	bl	 <L45>
+               	cmp	x1, #0x8
+               	b.lo	 <L56>
+<L57>:
+               	add	x0, x20, #0x8
                	mov	x16, #0x1ff8            // =8184
-               	add	x1, x21, x16
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L46>:
-               	bl	 <L46>
+               	add	x1, x0, x16
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L58>
+               	b	 <L59>
+<L58>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x26, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x26, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L58>
+<L59>:
+               	add	x0, x20, #0x8
                	add	x1, x19, #0x2bc
                	mov	x2, #0x400              // =1024
-               	cbnz	x2,  <L47>
+               	cbnz	x2,  <L60>
                	brk	#0
-<L47>:
+<L60>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
-               	add	x1, x21, x3, lsl #3
+               	add	x1, x0, x3, lsl #3
                	ldr	x2, [x1]
+               	mov	x0, x26
                	mov	x1, x2
-<L48>:
-               	bl	 <L48>
+<L61>:
+               	bl	 <L61>
                	mov	x16, #0x2008            // =8200
                	add	x1, x20, x16
                	ldr	w2, [x1]
                	mov	w1, w2
-<L49>:
-               	bl	 <L49>
+<L62>:
+               	bl	 <L62>
                	mov	x16, #0x200c            // =8204
-               	add	x21, x20, x16
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L50>:
-               	bl	 <L50>
-               	add	x1, x21, #0x7fc
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L51>:
-               	bl	 <L51>
-               	add	x1, x19, #0x12c
-               	mov	x2, #0x200              // =512
-               	cbnz	x2,  <L52>
+               	add	x1, x20, x16
+               	add	x2, x1, #0x0
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L63>:
+               	bl	 <L63>
+               	mov	x16, #0x200c            // =8204
+               	add	x1, x20, x16
+               	add	x2, x1, #0x7fc
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L64>:
+               	bl	 <L64>
+               	mov	x16, #0x200c            // =8204
+               	add	x1, x20, x16
+               	add	x2, x19, #0x12c
+               	mov	x3, #0x200              // =512
+               	cbnz	x3,  <L65>
                	brk	#0
-<L52>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
-               	add	x1, x21, x3, lsl #2
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L53>:
-               	bl	 <L53>
+<L65>:
+               	udiv	x16, x2, x3
+               	msub	x4, x16, x3, x2
+               	add	x2, x1, x4, lsl #2
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L66>:
+               	bl	 <L66>
                	mov	x16, #0x280c            // =10252
                	add	x1, x20, x16
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L54>:
-               	bl	 <L54>
+               	uxth	w1, w2
+<L67>:
+               	bl	 <L67>
                	mov	x1, #0x2008             // =8200
-<L55>:
-               	bl	 <L55>
+<L68>:
+               	bl	 <L68>
                	mov	x1, #0x200c             // =8204
-<L56>:
-               	bl	 <L56>
+<L69>:
+               	bl	 <L69>
                	mov	x1, #0x280c             // =10252
-<L57>:
-               	bl	 <L57>
+<L70>:
+               	bl	 <L70>
                	mov	x1, #0x2810             // =10256
-<L58>:
-               	bl	 <L58>
+<L71>:
+               	bl	 <L71>
                	mov	x1, #0x0                // =0
                	mov	x2, #0x0                // =0
                	cmp	x1, #0x400
-               	b.lo	 <L59>
-               	b	 <L60>
-<L59>:
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
                	add	x3, x20, #0x8
                	add	x4, x3, x1, lsl #3
                	ldr	x3, [x4]
@@ -536,17 +773,32 @@ Disassembly of section .text:
                	mul	x4, x3, x1
                	eor	x2, x2, x4
                	cmp	x1, #0x400
-               	b.lo	 <L59>
-<L60>:
-               	mov	x1, x2
-<L61>:
-               	bl	 <L61>
+               	b.lo	 <L72>
+<L73>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L74>
+               	b	 <L75>
+<L74>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L74>
+<L75>:
                	mov	x1, #0x0                // =0
                	mov	x2, #0x0                // =0
                	cmp	x1, #0x200
-               	b.lo	 <L62>
-               	b	 <L63>
-<L62>:
+               	b.lo	 <L76>
+               	b	 <L77>
+<L76>:
                	mov	x16, #0x200c            // =8204
                	add	x3, x20, x16
                	add	x4, x3, x1, lsl #2
@@ -557,12 +809,27 @@ Disassembly of section .text:
                	add	x2, x2, x5
                	add	x1, x1, #0x1
                	cmp	x1, #0x200
-               	b.lo	 <L62>
-<L63>:
-               	mov	x1, x2
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xcc10            // =52240
+               	b.lo	 <L76>
+<L77>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L78>
+               	b	 <L79>
+<L78>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L78>
+<L79>:
+               	mov	x16, #0xcc20            // =52256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/mem/array_index.dis
+++ b/test/golden/aarch64-linux/mem/array_index.dis
@@ -5,32 +5,71 @@ Disassembly of section .text:
 <corpus.cases.mem.array_index.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -39,54 +78,72 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x190
-               	stp	x19, x20, [x29, #-0x150]
-               	stp	x21, x22, [x29, #-0x160]
-               	stp	x23, x24, [x29, #-0x170]
-               	stp	x25, x26, [x29, #-0x180]
+               	stp	x19, x20, [x29, #-0x170]
+               	stp	x21, x22, [x29, #-0x180]
                	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x27, [x29, x16]
+               	str	x23, [x29, x16]
                	mov	x19, x0
                	sub	x20, x29, #0x1c
+               	sub	x21, x29, #0x108
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x80               // =128
 <L0>:
-               	bl	 <L0>
-               	sub	x21, x29, #0x9c
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x80               // =128
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x20
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x20
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
-               	add	x2, x1, #0x1
+               	add	x1, x0, #0x1
                	mov	x17, #0x79b1            // =31153
                	movk	x17, #0x9e37, lsl #16
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	mov	w3, w4
-               	add	x4, x21, x1, lsl #2
-               	str	w3, [x4]
-               	mov	x1, x2
-               	cmp	x1, #0x20
-               	b.lo	 <L2>
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	mov	w2, w3
+               	add	x3, x21, x0, lsl #2
+               	str	w2, [x3]
+               	mov	x0, x1
+               	cmp	x0, #0x20
+               	b.lo	 <L1>
+<L2>:
+               	add	x0, x21, #0x0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x2325             // =8997
+               	movk	x1, #0x8422, lsl #16
+               	movk	x1, #0x9ce4, lsl #32
+               	movk	x1, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	add	x1, x21, #0x0
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	add	x1, x21, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x0, x21, #0x4
+               	ldr	w2, [x0]
+               	mov	w3, w2
+               	mov	x0, x1
+               	mov	x1, x3
 <L5>:
                	bl	 <L5>
                	add	x1, x21, #0x3c
@@ -99,109 +156,176 @@ Disassembly of section .text:
                	mov	w1, w2
 <L7>:
                	bl	 <L7>
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x20
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x20
                	b.lo	 <L8>
-               	b	 <L10>
+               	b	 <L11>
 <L8>:
                	mov	x16, #0x7               // =7
-               	mul	x0, x23, x16
-               	add	x1, x0, x19
+               	mul	x2, x1, x16
+               	add	x3, x2, x19
                	mov	x16, #0x1f              // =31
-               	and	x0, x1, x16
-               	add	x1, x21, x0, lsl #2
-               	ldr	w2, [x1]
-               	mov	x0, x22
-               	mov	w1, w2
+               	and	x2, x3, x16
+               	add	x3, x21, x2, lsl #2
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x20
-               	b.lo	 <L8>
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	mov	x23, #0x20              // =32
-               	mov	x17, #0x0               // =0
-               	cmp	x17, x23
-               	b.lo	 <L11>
-               	b	 <L13>
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x20
+               	b.lo	 <L8>
 <L11>:
-               	sub	x23, x23, #0x1
-               	add	x0, x21, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L12>:
-               	bl	 <L12>
-               	mov	x22, x0
+               	mov	x1, #0x20               // =32
                	mov	x17, #0x0               // =0
-               	cmp	x17, x23
-               	b.lo	 <L11>
+               	cmp	x17, x1
+               	b.lo	 <L12>
+               	b	 <L15>
+<L12>:
+               	sub	x2, x1, #0x1
+               	add	x3, x21, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
 <L13>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x20
-               	b.lo	 <L14>
-               	b	 <L16>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L13>
 <L14>:
-               	add	x0, x21, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
+               	mov	x0, x4
+               	mov	x1, x2
+               	mov	x17, #0x0               // =0
+               	cmp	x17, x1
+               	b.lo	 <L12>
 <L15>:
-               	bl	 <L15>
-               	add	x23, x23, #0x5
-               	mov	x22, x0
-               	cmp	x23, #0x20
-               	b.lo	 <L14>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x20
+               	b.lo	 <L16>
+               	b	 <L19>
 <L16>:
-               	sub	x21, x29, #0xcc
+               	add	x2, x21, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L17>
+<L18>:
+               	add	x1, x1, #0x5
+               	mov	x0, x3
+               	cmp	x1, #0x20
+               	b.lo	 <L16>
+<L19>:
+               	sub	x21, x29, #0x4c
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	str	xzr, [x21, #0x18]
                	str	xzr, [x21, #0x20]
                	str	xzr, [x21, #0x28]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, #0x4
-               	b.lo	 <L17>
-               	b	 <L20>
-<L17>:
-               	mov	x16, #0x64              // =100
-               	mul	x1, x0, x16
-               	mov	x16, #0xc               // =12
-               	mul	x2, x0, x16
-               	add	x3, x21, x2
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x6
-               	b.lo	 <L18>
-               	b	 <L19>
-<L18>:
-               	mov	x16, #0x7               // =7
-               	mul	x4, x2, x16
-               	add	x5, x1, x4
-               	add	x4, x5, x19
-               	mov	w5, w4
-               	add	x4, x3, x2, lsl #1
-               	strh	w5, [x4]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x6
-               	b.lo	 <L18>
-<L19>:
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x4
-               	b.lo	 <L17>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x4
+               	b.lo	 <L20>
+               	b	 <L23>
 <L20>:
-               	add	x0, x21, #0x0
-               	add	x1, x0, #0x0
-               	ldrh	w2, [x1]
-               	mov	x0, x22
-               	mov	x1, x2
+               	mov	x16, #0x64              // =100
+               	mul	x2, x1, x16
+               	mov	x16, #0xc               // =12
+               	mul	x3, x1, x16
+               	add	x4, x21, x3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x6
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
+               	mov	x16, #0x7               // =7
+               	mul	x5, x3, x16
+               	add	x6, x2, x5
+               	add	x5, x6, x19
+               	mov	w6, w5
+               	add	x5, x4, x3, lsl #1
+               	strh	w6, [x5]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x6
+               	b.lo	 <L21>
+<L22>:
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x4
+               	b.lo	 <L20>
+<L23>:
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
                	add	x1, x21, #0x24
                	add	x2, x1, #0xa
                	ldrh	w1, [x2]
-<L22>:
-               	bl	 <L22>
+               	uxth	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
                	add	x1, x19, #0x2
                	mov	x16, #0x3               // =3
                	and	x2, x1, x16
@@ -213,213 +337,279 @@ Disassembly of section .text:
                	and	x3, x1, x16
                	add	x1, x2, x3, lsl #1
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L23>:
-               	bl	 <L23>
-               	mov	x22, x0
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x4
-               	b.lo	 <L24>
-               	b	 <L28>
-<L24>:
-               	mov	x16, #0xc               // =12
-               	mul	x0, x23, x16
-               	add	x24, x21, x0
-               	mov	x25, x22
-               	mov	x26, #0x0               // =0
-               	cmp	x26, #0x6
-               	b.lo	 <L25>
-               	b	 <L27>
-<L25>:
-               	add	x0, x24, x26, lsl #1
-               	ldrh	w1, [x0]
-               	mov	x0, x25
-<L26>:
-               	bl	 <L26>
-               	add	x26, x26, #0x1
-               	mov	x25, x0
-               	cmp	x26, #0x6
-               	b.lo	 <L25>
+               	uxth	w1, w2
 <L27>:
-               	add	x23, x23, #0x1
-               	mov	x22, x25
-               	cmp	x23, #0x4
-               	b.lo	 <L24>
-<L28>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x6
-               	b.lo	 <L29>
+               	bl	 <L27>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x4
+               	b.lo	 <L28>
                	b	 <L33>
-<L29>:
-               	mov	x24, x22
-               	mov	x25, #0x0               // =0
-               	cmp	x25, #0x4
-               	b.lo	 <L30>
-               	b	 <L32>
-<L30>:
+<L28>:
                	mov	x16, #0xc               // =12
-               	mul	x0, x25, x16
-               	add	x1, x21, x0
-               	add	x0, x1, x23, lsl #1
-               	ldrh	w1, [x0]
-               	mov	x0, x24
-<L31>:
-               	bl	 <L31>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x4
-               	b.lo	 <L30>
-<L32>:
-               	add	x23, x23, #0x1
-               	mov	x22, x24
-               	cmp	x23, #0x6
+               	mul	x2, x1, x16
+               	add	x3, x21, x2
+               	mov	x2, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x6
                	b.lo	 <L29>
+               	b	 <L32>
+<L29>:
+               	add	x5, x3, x4, lsl #1
+               	ldrh	w6, [x5]
+               	uxth	w5, w6
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	cmp	x4, #0x6
+               	b.lo	 <L29>
+<L32>:
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x4
+               	b.lo	 <L28>
 <L33>:
-               	sub	x21, x29, #0xe7
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	strh	wzr, [x21, #0x18]
-               	strb	wzr, [x21, #0x1a]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, #0x3
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x6
                	b.lo	 <L34>
                	b	 <L39>
 <L34>:
-               	mov	x16, #0x9               // =9
-               	mul	x1, x0, x16
-               	mov	x16, #0x9               // =9
-               	mul	x2, x0, x16
-               	add	x3, x21, x2
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x3
+               	mov	x2, x0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x4
                	b.lo	 <L35>
                	b	 <L38>
 <L35>:
-               	mov	x16, #0x3               // =3
-               	mul	x4, x2, x16
-               	add	x5, x1, x4
-               	mov	x16, #0x3               // =3
-               	mul	x4, x2, x16
-               	add	x6, x3, x4
-               	mov	x4, #0x0                // =0
-               	cmp	x4, #0x3
+               	mov	x16, #0xc               // =12
+               	mul	x4, x3, x16
+               	add	x5, x21, x4
+               	add	x4, x5, x1, lsl #1
+               	ldrh	w5, [x4]
+               	uxth	w4, w5
+               	mov	x5, x2
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
                	b.lo	 <L36>
                	b	 <L37>
 <L36>:
-               	add	x7, x5, x4
-               	add	x8, x7, x19
-               	mov	w7, w8
-               	add	x8, x6, x4
-               	strb	w7, [x8]
-               	add	x4, x4, #0x1
-               	cmp	x4, #0x3
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
                	b.lo	 <L36>
 <L37>:
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x3
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	cmp	x3, #0x4
                	b.lo	 <L35>
 <L38>:
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x3
+               	add	x1, x1, #0x1
+               	mov	x0, x2
+               	cmp	x1, #0x6
                	b.lo	 <L34>
 <L39>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x3
+               	sub	x1, x29, #0x67
+               	str	xzr, [x1]
+               	str	xzr, [x1, #0x8]
+               	str	xzr, [x1, #0x10]
+               	strh	wzr, [x1, #0x18]
+               	strb	wzr, [x1, #0x1a]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x3
                	b.lo	 <L40>
-               	b	 <L46>
-<L40>:
-               	mov	x24, x22
-               	mov	x25, #0x0               // =0
-               	cmp	x25, #0x3
-               	b.lo	 <L41>
                	b	 <L45>
-<L41>:
-               	mov	x26, x24
-               	mov	x27, #0x0               // =0
-               	cmp	x27, #0x3
-               	b.lo	 <L42>
-               	b	 <L44>
-<L42>:
+<L40>:
                	mov	x16, #0x9               // =9
-               	mul	x0, x27, x16
-               	add	x1, x21, x0
-               	mov	x16, #0x3               // =3
-               	mul	x0, x25, x16
-               	add	x2, x1, x0
-               	add	x0, x2, x23
-               	ldrb	w1, [x0]
-               	mov	x0, x26
-<L43>:
-               	bl	 <L43>
-               	add	x27, x27, #0x1
-               	mov	x26, x0
-               	cmp	x27, #0x3
-               	b.lo	 <L42>
-<L44>:
-               	add	x25, x25, #0x1
-               	mov	x24, x26
-               	cmp	x25, #0x3
+               	mul	x3, x2, x16
+               	mov	x16, #0x9               // =9
+               	mul	x4, x2, x16
+               	add	x5, x1, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x3
                	b.lo	 <L41>
-<L45>:
-               	add	x23, x23, #0x1
-               	mov	x22, x24
-               	cmp	x23, #0x3
+               	b	 <L44>
+<L41>:
+               	mov	x16, #0x3               // =3
+               	mul	x6, x4, x16
+               	add	x7, x3, x6
+               	mov	x16, #0x3               // =3
+               	mul	x6, x4, x16
+               	add	x8, x5, x6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x3
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	add	x12, x7, x6
+               	add	x13, x12, x19
+               	mov	w12, w13
+               	add	x13, x8, x6
+               	strb	w12, [x13]
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x3
+               	b.lo	 <L42>
+<L43>:
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x3
+               	b.lo	 <L41>
+<L44>:
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x3
                	b.lo	 <L40>
+<L45>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x3
+               	b.lo	 <L46>
+               	b	 <L53>
 <L46>:
-               	add	x0, x21, #0x12
-               	add	x1, x0, #0x0
-               	add	x0, x1, #0x1
-               	ldrb	w1, [x0]
-               	mov	x0, x22
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x3
+               	b.lo	 <L47>
+               	b	 <L52>
 <L47>:
-               	bl	 <L47>
-               	add	x1, x19, #0x1
-               	mov	x2, #0x3                // =3
-               	cbnz	x2,  <L48>
-               	brk	#0
+               	mov	x5, x3
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x3
+               	b.lo	 <L48>
+               	b	 <L51>
 <L48>:
-               	udiv	x16, x1, x2
-               	msub	x3, x16, x2, x1
                	mov	x16, #0x9               // =9
-               	mul	x1, x3, x16
-               	add	x2, x21, x1
-               	add	x1, x19, #0x2
-               	mov	x3, #0x3                // =3
-               	cbnz	x3,  <L49>
-               	brk	#0
+               	mul	x7, x6, x16
+               	add	x8, x1, x7
+               	mov	x16, #0x3               // =3
+               	mul	x7, x4, x16
+               	add	x12, x8, x7
+               	add	x7, x12, x2
+               	ldrb	w8, [x7]
+               	uxtb	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
 <L49>:
-               	udiv	x16, x1, x3
-               	msub	x4, x16, x3, x1
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	add	x6, x6, #0x1
+               	mov	x5, x8
+               	cmp	x6, #0x3
+               	b.lo	 <L48>
+<L51>:
+               	add	x4, x4, #0x1
+               	mov	x3, x5
+               	cmp	x4, #0x3
+               	b.lo	 <L47>
+<L52>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x3
+               	b.lo	 <L46>
+<L53>:
+               	add	x2, x1, #0x12
+               	add	x3, x2, #0x0
+               	add	x2, x3, #0x1
+               	ldrb	w3, [x2]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x2, x19, #0x1
+               	mov	x3, #0x3                // =3
+               	cbnz	x3,  <L56>
+               	brk	#0
+<L56>:
+               	udiv	x16, x2, x3
+               	msub	x4, x16, x3, x2
+               	mov	x16, #0x9               // =9
+               	mul	x2, x4, x16
+               	add	x3, x1, x2
+               	add	x1, x19, #0x2
+               	mov	x2, #0x3                // =3
+               	cbnz	x2,  <L57>
+               	brk	#0
+<L57>:
+               	udiv	x16, x1, x2
+               	msub	x4, x16, x2, x1
                	mov	x16, #0x3               // =3
                	mul	x1, x4, x16
-               	add	x3, x2, x1
+               	add	x2, x3, x1
                	mov	x1, #0x3                // =3
-               	cbnz	x1,  <L50>
+               	cbnz	x1,  <L58>
                	brk	#0
-<L50>:
+<L58>:
                	udiv	x16, x19, x1
-               	msub	x2, x16, x1, x19
-               	add	x1, x3, x2
+               	msub	x3, x16, x1, x19
+               	add	x1, x2, x3
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L51>:
-               	bl	 <L51>
-               	sub	x21, x29, #0x138
+               	uxtb	w1, w2
+<L59>:
+               	bl	 <L59>
+               	sub	x21, x29, #0x158
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x50               // =80
-<L52>:
+<L60>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L52>
+               	b.ne	 <L60>
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x5
-               	b.lo	 <L53>
-               	b	 <L54>
-<L53>:
+               	b.lo	 <L61>
+               	b	 <L62>
+<L61>:
                	mov	x16, #0x3               // =3
                	mul	x2, x1, x16
                	add	x3, x2, #0x1
@@ -442,74 +632,78 @@ Disassembly of section .text:
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	cmp	x1, #0x5
-               	b.lo	 <L53>
-<L54>:
+               	b.lo	 <L61>
+<L62>:
                	mov	x22, x0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x5
-               	b.lo	 <L55>
-               	b	 <L59>
-<L55>:
+               	b.lo	 <L63>
+               	b	 <L65>
+<L63>:
                	mov	x16, #0x10              // =16
                	mul	x0, x23, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w24, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x25, [x0]
+               	sub	x0, x29, #0x78
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x22
-               	mov	x1, x2
-<L56>:
-               	bl	 <L56>
-               	mov	x1, x24
-<L57>:
-               	bl	 <L57>
-               	mov	x1, x25
-<L58>:
-               	bl	 <L58>
+<L64>:
+               	bl	 <L64>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x5
-               	b.lo	 <L55>
-<L59>:
+               	b.lo	 <L63>
+<L65>:
                	add	x0, x19, #0x3
                	mov	x1, #0x5                // =5
-               	cbnz	x1,  <L60>
+               	cbnz	x1,  <L66>
                	brk	#0
-<L60>:
+<L66>:
                	udiv	x16, x0, x1
                	msub	x2, x16, x1, x0
                	mov	x16, #0x10              // =16
                	mul	x0, x2, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w23, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x24, [x0]
+               	sub	x0, x29, #0x88
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x22
-               	mov	x1, x2
-<L61>:
-               	bl	 <L61>
-               	mov	x1, x23
-<L62>:
-               	bl	 <L62>
-               	mov	x1, x24
-<L63>:
-               	bl	 <L63>
+<L67>:
+               	bl	 <L67>
                	add	x1, x21, #0x40
                	add	x2, x1, #0x8
                	ldr	x1, [x2]
-<L64>:
-               	bl	 <L64>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L68>
+               	b	 <L69>
+<L68>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L68>
+<L69>:
                	add	x1, x19, #0x1
                	mov	x2, #0x5                // =5
-               	cbnz	x2,  <L65>
+               	cbnz	x2,  <L70>
                	brk	#0
-<L65>:
+<L70>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
                	mov	x16, #0x10              // =16
@@ -517,12 +711,12 @@ Disassembly of section .text:
                	add	x2, x21, x1
                	add	x1, x2, #0x0
                	ldrh	w2, [x1]
-               	mov	x1, x2
-<L66>:
-               	bl	 <L66>
+               	uxth	w1, w2
+<L71>:
+               	bl	 <L71>
                	mov	x1, #0x10               // =16
-<L67>:
-               	bl	 <L67>
+<L72>:
+               	bl	 <L72>
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -530,9 +724,9 @@ Disassembly of section .text:
                	mov	w1, w19
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x7
-               	b.lo	 <L68>
-               	b	 <L69>
-<L68>:
+               	b.lo	 <L73>
+               	b	 <L74>
+<L73>:
                	mov	w3, w2
                	mov	w16, #0x5678            // =22136
                	movk	w16, #0x1234, lsl #16
@@ -542,43 +736,90 @@ Disassembly of section .text:
                	str	w3, [x4]
                	add	x2, x2, #0x1
                	cmp	x2, #0x7
-               	b.lo	 <L68>
-<L69>:
-               	mov	x1, #0x11               // =17
-<L70>:
-               	bl	 <L70>
-               	mov	x21, x0
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x7
-               	b.lo	 <L71>
-               	b	 <L74>
-<L71>:
-               	mov	x16, #0x3               // =3
-               	mul	x0, x22, x16
-               	add	x1, x0, x19
-               	mov	x0, #0x7                // =7
-               	cbnz	x0,  <L72>
-               	brk	#0
-<L72>:
-               	udiv	x16, x1, x0
-               	msub	x2, x16, x0, x1
-               	add	x0, x20, x2, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x21
-<L73>:
-               	bl	 <L73>
-               	add	x22, x22, #0x1
-               	mov	x21, x0
-               	cmp	x22, #0x7
-               	b.lo	 <L71>
+               	b.lo	 <L73>
 <L74>:
-               	mov	x0, x21
-               	mov	x1, #0x1234             // =4660
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L75>
+               	b	 <L76>
 <L75>:
-               	bl	 <L75>
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x11              // =17
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L75>
 <L76>:
-               	bl	 <L76>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x7
+               	b.lo	 <L77>
+               	b	 <L81>
+<L77>:
+               	mov	x16, #0x3               // =3
+               	mul	x2, x1, x16
+               	add	x3, x2, x19
+               	mov	x2, #0x7                // =7
+               	cbnz	x2,  <L78>
+               	brk	#0
+<L78>:
+               	udiv	x16, x3, x2
+               	msub	x4, x16, x2, x3
+               	add	x2, x20, x4, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L79>
+               	b	 <L80>
+<L79>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L79>
+<L80>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x7
+               	b.lo	 <L77>
+<L81>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L82>
+               	b	 <L83>
+<L82>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x1234            // =4660
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L82>
+<L83>:
+               	mov	x1, #0x4                // =4
+<L84>:
+               	bl	 <L84>
                	add	x1, x20, #0x0
                	ldr	w2, [x1]
                	add	x1, x20, #0x4
@@ -598,26 +839,24 @@ Disassembly of section .text:
                	eor	w19, w2, w16
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
+<L85>:
+               	bl	 <L85>
                	mov	w1, w19
-<L78>:
-               	bl	 <L78>
+<L86>:
+               	bl	 <L86>
                	mov	x1, #0x11               // =17
-<L79>:
-               	bl	 <L79>
+<L87>:
+               	bl	 <L87>
                	mov	x1, #0x1234             // =4660
-<L80>:
-               	bl	 <L80>
-               	ldp	x19, x20, [x29, #-0x150]
-               	ldp	x21, x22, [x29, #-0x160]
-               	ldp	x23, x24, [x29, #-0x170]
-               	ldp	x25, x26, [x29, #-0x180]
+<L88>:
+               	bl	 <L88>
+               	ldp	x19, x20, [x29, #-0x170]
+               	ldp	x21, x22, [x29, #-0x180]
                	mov	x16, #0xfe78            // =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x27, [x29, x16]
+               	ldr	x23, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/global_data.dis
+++ b/test/golden/aarch64-linux/mem/global_data.dis
@@ -5,32 +5,71 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -39,156 +78,336 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stur	x21, [x29, #-0x18]
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldrb	w1, [x16]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldrh	w1, [x16]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	w1, [x16]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldrb	w1, [x16]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldrh	w1, [x16]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	w1, [x16]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	d0, [x1]
+               	fmov	x1, d0
+<L17>:
+               	bl	 <L17>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x6
+               	b.lo	 <L18>
+               	b	 <L21>
+<L18>:
+               	add	x3, x1, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x6
+               	b.lo	 <L18>
+<L21>:
+               	sub	x1, x29, #0x10
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
-               	mov	x0, x1
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x3, [x16]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x6
-               	b.lo	 <L10>
-               	b	 <L12>
-<L10>:
-               	add	x0, x19, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x20
-<L11>:
-               	bl	 <L11>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x6
-               	b.lo	 <L10>
-<L12>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrh	w1, [x0]
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrb	w19, [x0]
-               	adrp	x0, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x0, x0, #0x0
-               	ldr	x21, [x0]
-               	mov	x0, x20
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x19
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x21
-<L15>:
-               	bl	 <L15>
+               	mov	x2, x3
+<L22>:
+               	bl	 <L22>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	sub	x2, x29, #0x20
+               	ldr	x3, [x1]
+               	ldr	x4, [x1, #0x8]
+               	str	x3, [x2]
+               	str	x4, [x2, #0x8]
+               	ldr	x1, [x2]
+               	ldr	x3, [x2, #0x8]
+               	mov	x2, x3
+<L23>:
+               	bl	 <L23>
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	add	x2, x1, #0x0
-               	ldrh	w3, [x2]
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
                	add	x2, x1, #0x2
-               	ldrb	w19, [x2]
-               	add	x2, x1, #0x8
-               	ldr	x20, [x2]
-               	mov	x1, x3
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x19
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x20
-<L18>:
-               	bl	 <L18>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x19, x19, #0x0
-               	add	x1, x19, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L19>:
-               	bl	 <L19>
-               	add	x1, x19, #0x2
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L20>:
-               	bl	 <L20>
-               	add	x1, x19, #0x4
-               	ldrh	w2, [x1]
-               	mov	x1, x2
-<L21>:
-               	bl	 <L21>
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	add	x1, x1, #0x0
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
                	mov	w1, w2
-<L22>:
-               	bl	 <L22>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldur	x21, [x29, #-0x18]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -341,40 +560,35 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x90
-               	stp	x19, x20, [x29, #-0x50]
-               	stp	x21, x22, [x29, #-0x60]
-               	stp	x23, x24, [x29, #-0x70]
-               	stp	x25, x26, [x29, #-0x80]
-               	stp	x27, x28, [x29, #-0x90]
+               	sub	sp, sp, #0xa0
+               	stp	x19, x20, [x29, #-0x60]
+               	stp	x21, x22, [x29, #-0x70]
+               	stp	x23, x24, [x29, #-0x80]
+               	stp	x25, x26, [x29, #-0x90]
+               	stp	x27, x28, [x29, #-0xa0]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-<L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x2, x17, x19
-               	mov	x0, x1
-               	mov	x1, x2
+               	add	x1, x17, x19
+<L1>:
+               	bl	 <L1>
+               	mov	x1, #0x2979             // =10617
+               	movk	x1, #0xffed, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, #0x2979             // =10617
-               	movk	w1, #0xffed, lsl #16
+               	mov	x1, #0x3fc4000000000000 // =4594797519824748544
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	d0, #0.15625000
-<L4>:
-               	bl	 <L4>
                	adrp	x20, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x20, x20, #0x0
                	adrp	x21, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -392,9 +606,9 @@ Disassembly of section .text:
                	mov	x27, x0
                	mov	x28, #0x0               // =0
                	cmp	x28, #0x5
-               	b.lo	 <L5>
-               	b	 <L11>
-<L5>:
+               	b.lo	 <L4>
+               	b	 <L10>
+<L4>:
                	add	x0, x28, #0x1
                	add	x1, x0, x19
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -461,9 +675,9 @@ Disassembly of section .text:
                	mov	w0, w1
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x6
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
                	add	x3, x20, x2, lsl #2
                	ldr	w4, [x3]
                	mov	w5, w2
@@ -473,8 +687,8 @@ Disassembly of section .text:
                	str	w6, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x6
-               	b.lo	 <L6>
-<L7>:
+               	b.lo	 <L5>
+<L6>:
                	ldrh	w0, [x21]
                	mov	w2, w1
                	add	w3, w0, w2
@@ -488,7 +702,7 @@ Disassembly of section .text:
                	mul	x2, x0, x16
                	add	x0, x2, x1
                	str	x0, [x23]
-               	sub	x0, x29, #0x40
+               	sub	x0, x29, #0x50
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -500,18 +714,18 @@ Disassembly of section .text:
                	str	x2, [x24]
                	str	x3, [x24, #0x8]
                	mov	x0, #0x3                // =3
-               	cbnz	x0,  <L8>
+               	cbnz	x0,  <L7>
                	brk	#0
-<L8>:
+<L7>:
                	udiv	x16, x1, x0
                	msub	x2, x16, x0, x1
                	add	x0, x25, x2, lsl #1
                	ldrh	w2, [x0]
                	add	w0, w2, #0x64
                	mov	x2, #0x3                // =3
-               	cbnz	x2,  <L9>
+               	cbnz	x2,  <L8>
                	brk	#0
-<L9>:
+<L8>:
                	udiv	x16, x1, x2
                	msub	x3, x16, x2, x1
                	add	x2, x25, x3, lsl #1
@@ -521,13 +735,13 @@ Disassembly of section .text:
                	sub	w1, w0, w2
                	str	w1, [x26]
                	mov	x0, x27
-<L10>:
-               	bl	 <L10>
+<L9>:
+               	bl	 <L9>
                	add	x28, x28, #0x1
                	mov	x27, x0
                	cmp	x28, #0x5
-               	b.lo	 <L5>
-<L11>:
+               	b.lo	 <L4>
+<L10>:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x0, [x16]
                	mov	x16, #0x7c15            // =31765
@@ -540,8 +754,8 @@ Disassembly of section .text:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x1, [x16]
                	mov	x0, x27
-<L12>:
-               	bl	 <L12>
+<L11>:
+               	bl	 <L11>
                	sub	x1, x29, #0x10
                	sub	x2, x29, #0x20
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
@@ -569,31 +783,26 @@ Disassembly of section .text:
                	str	x1, [x16]
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	str	x3, [x16]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldrh	w2, [x1]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldrb	w19, [x1]
-               	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
-               	add	x1, x1, #0x0
-               	ldr	x20, [x1]
+               	sub	x1, x29, #0x40
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x2, [x16]
+               	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
+               	ldr	x3, [x16]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
                	mov	x1, x2
+               	mov	x2, x3
+<L12>:
+               	bl	 <L12>
 <L13>:
                	bl	 <L13>
-               	mov	x1, x19
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x20
-<L15>:
-               	bl	 <L15>
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x50]
-               	ldp	x21, x22, [x29, #-0x60]
-               	ldp	x23, x24, [x29, #-0x70]
-               	ldp	x25, x26, [x29, #-0x80]
-               	ldp	x27, x28, [x29, #-0x90]
+               	ldp	x19, x20, [x29, #-0x60]
+               	ldp	x21, x22, [x29, #-0x70]
+               	ldp	x23, x24, [x29, #-0x80]
+               	ldp	x25, x26, [x29, #-0x90]
+               	ldp	x27, x28, [x29, #-0xa0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/global_zero.dis
+++ b/test/golden/aarch64-linux/mem/global_zero.dis
@@ -5,32 +5,71 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -38,167 +77,329 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.fold_zeros>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x1, x0
+               	sub	sp, sp, #0x40
+               	stp	x19, x20, [x29, #-0x30]
+               	stur	x21, [x29, #-0x38]
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldrb	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldrb	w1, [x16]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldrh	w2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldrh	w1, [x16]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	w2, [x16]
-               	mov	x0, x1
-               	mov	w1, w2
+               	ldr	w1, [x16]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	adrp	x2, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x2, x2, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	ldr	x2, [x16]
-               	mov	x0, x1
-               	mov	x1, x2
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	w1, [x16]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x200
-               	b.lo	 <L9>
-               	b	 <L11>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	add	x0, x19, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x20
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x200
-               	b.lo	 <L9>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
 <L11>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldr	d0, [x1]
+               	fmov	x1, d0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	adrp	x16, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	ldr	x1, [x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x200
+               	b.lo	 <L18>
+               	b	 <L21>
+<L18>:
+               	add	x3, x1, x2, lsl #2
+               	ldr	w4, [x3]
+               	mov	w3, w4
+               	mov	x4, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x4, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x4, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x2, x2, #0x1
+               	mov	x0, x4
+               	cmp	x2, #0x200
+               	b.lo	 <L18>
+<L21>:
                	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x19, x19, #0x0
+               	mov	x20, x0
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x8
-               	b.lo	 <L12>
-               	b	 <L16>
-<L12>:
+               	b.lo	 <L22>
+               	b	 <L24>
+<L22>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x19, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w22, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x23, [x0]
-               	mov	x0, x20
-               	mov	x1, x2
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x22
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x23
-<L15>:
-               	bl	 <L15>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L12>
-<L16>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x0, x0, #0x0
-               	add	x1, x0, #0x0
-               	ldrh	w2, [x1]
-               	add	x1, x0, #0x2
-               	ldrb	w19, [x1]
-               	add	x1, x0, #0x8
-               	ldr	x21, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
-<L17>:
-               	bl	 <L17>
-               	mov	x1, x19
-<L18>:
-               	bl	 <L18>
-               	mov	x1, x21
-<L19>:
-               	bl	 <L19>
-               	adrp	x19, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x19, x19, #0x0
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x4
-               	b.lo	 <L20>
-               	b	 <L22>
-<L20>:
-               	add	x0, x19, x21, lsl #3
+               	sub	x0, x29, #0x10
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
                	ldr	x1, [x0]
-               	mov	x0, x20
-<L21>:
-               	bl	 <L21>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x4
-               	b.lo	 <L20>
-<L22>:
-               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
-               	add	x0, x0, #0x0
-               	ldrb	w1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x20
 <L23>:
                	bl	 <L23>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
+               	add	x21, x21, #0x1
+               	mov	x20, x0
+               	cmp	x21, #0x8
+               	b.lo	 <L22>
+<L24>:
+               	adrp	x0, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x0, x0, #0x0
+               	sub	x1, x29, #0x20
+               	ldr	x2, [x0]
+               	ldr	x3, [x0, #0x8]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	mov	x0, x20
+               	mov	x1, x2
+               	mov	x2, x3
+<L25>:
+               	bl	 <L25>
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x4
+               	b.lo	 <L26>
+               	b	 <L29>
+<L26>:
+               	add	x3, x1, x2, lsl #3
+               	ldr	x4, [x3]
+               	mov	x3, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x4
+               	b.lo	 <L26>
+<L29>:
+               	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
+               	add	x1, x1, #0x0
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	ldp	x19, x20, [x29, #-0x30]
+               	ldur	x21, [x29, #-0x38]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -209,12 +410,12 @@ Disassembly of section .text:
                	sub	sp, sp, #0x40
                	stur	x19, [x29, #-0x38]
                	mov	x19, x0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-<L1>:
-               	bl	 <L1>
                	mov	w1, w19
                	mov	w17, #0xc8              // =200
                	add	w2, w17, w1
@@ -266,9 +467,9 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x200
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
                	add	x3, x2, #0x1
                	mov	x17, #0x79b1            // =31153
                	movk	x17, #0x9e37, lsl #16
@@ -279,15 +480,15 @@ Disassembly of section .text:
                	str	w4, [x5]
                	mov	x2, x3
                	cmp	x2, #0x200
-               	b.lo	 <L2>
-<L3>:
+               	b.lo	 <L1>
+<L2>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x8
-               	b.lo	 <L4>
-               	b	 <L5>
-<L4>:
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
                	mov	x16, #0xb               // =11
                	mul	x3, x2, x16
                	add	x4, x3, #0x3
@@ -312,8 +513,8 @@ Disassembly of section .text:
                	add	x3, x5, #0x8
                	str	x4, [x3]
                	cmp	x2, #0x8
-               	b.lo	 <L4>
-<L5>:
+               	b.lo	 <L3>
+<L4>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	sub	x2, x29, #0x10
@@ -331,9 +532,9 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                // =0
                	cmp	x2, #0x4
-               	b.lo	 <L6>
-               	b	 <L7>
-<L6>:
+               	b.lo	 <L5>
+               	b	 <L6>
+<L5>:
                	add	x3, x2, #0x1
                	mov	x17, #0x5678            // =22136
                	movk	x17, #0x1234, lsl #16
@@ -343,20 +544,36 @@ Disassembly of section .text:
                	str	x5, [x4]
                	mov	x2, x3
                	cmp	x2, #0x4
-               	b.lo	 <L6>
-<L7>:
+               	b.lo	 <L5>
+<L6>:
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	mov	w17, #0x4d              // =77
                	strb	w17, [x1]
-<L8>:
-               	bl	 <L8>
+<L7>:
+               	bl	 <L7>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
                	mov	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
@@ -374,6 +591,8 @@ Disassembly of section .text:
                	add	x1, x1, #0x0
                	add	x2, x1, x3, lsl #2
                	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L12>:
                	bl	 <L12>
                	adrp	x1, 0x0 <corpus.cases.mem.global_zero.fold_cell>

--- a/test/golden/aarch64-linux/mem/loadstore.dis
+++ b/test/golden/aarch64-linux/mem/loadstore.dis
@@ -3,75 +3,173 @@ mem/loadstore.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.loadstore.fold_packed>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldrb	w4, [x3]
-               	add	x3, x1, #0x1
-               	ldrb	w19, [x3]
-               	add	x3, x1, #0x2
-               	ldrb	w20, [x3]
-               	add	x3, x1, #0x3
-               	ldrb	w21, [x3]
-               	add	x3, x1, #0x4
-               	ldrh	w22, [x3]
-               	add	x3, x1, #0x6
-               	ldrh	w23, [x3]
-               	add	x3, x1, #0x8
-               	ldr	w24, [x3]
-               	add	x3, x1, #0x10
-               	ldr	x25, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldrb	w3, [x2]
+               	add	x2, x1, #0x1
+               	ldrb	w4, [x2]
+               	add	x2, x1, #0x2
+               	ldrb	w5, [x2]
+               	add	x2, x1, #0x3
+               	ldrb	w6, [x2]
+               	add	x2, x1, #0x4
+               	ldrh	w7, [x2]
+               	add	x2, x1, #0x6
+               	ldrh	w8, [x2]
+               	add	x2, x1, #0x8
+               	ldr	w12, [x2]
+               	add	x2, x1, #0x10
+               	ldr	x1, [x2]
+               	uxtb	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x13, x3, x16
+               	lsr	x14, x2, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x0, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x14, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w2, w4
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x13, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x13, x16
+               	eor	x13, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x13, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x22
+               	uxtb	w2, w5
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w24
+               	uxtb	w2, w6
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x25
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	uxth	w2, w7
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	uxth	w2, w8
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w2, w12
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.mem.loadstore.checksum>:
@@ -81,90 +179,86 @@ Disassembly of section .text:
                	stp	x19, x20, [x29, #-0xd0]
                	stp	x21, x22, [x29, #-0xe0]
                	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
+               	stur	x25, [x29, #-0xf8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	sub	x20, x29, #0x18
+               	sub	x20, x29, #0x58
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
-               	sub	x2, x29, #0x30
-               	ldr	x3, [x20]
-               	ldr	x4, [x20, #0x8]
-               	ldr	x5, [x20, #0x10]
-               	str	x3, [x2]
-               	str	x4, [x2, #0x8]
-               	str	x5, [x2, #0x10]
-               	ldr	x3, [x2]
-               	ldr	x4, [x2, #0x8]
-               	ldr	x5, [x2, #0x10]
-               	stur	x3, [x29, #-0x48]
-               	stur	x4, [x29, #-0x40]
-               	stur	x5, [x29, #-0x38]
-               	sub	x2, x29, #0x48
-               	mov	x0, x1
-               	mov	x1, x2
-<L1>:
-               	bl	 <L1>
-               	mov	x1, x0
+               	sub	x0, x29, #0x70
+               	ldr	x1, [x20]
+               	ldr	x2, [x20, #0x8]
+               	ldr	x3, [x20, #0x10]
+               	str	x1, [x0]
+               	str	x2, [x0, #0x8]
+               	str	x3, [x0, #0x10]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
+               	ldr	x3, [x0, #0x10]
+               	stur	x1, [x29, #-0x88]
+               	stur	x2, [x29, #-0x80]
+               	stur	x3, [x29, #-0x78]
+               	sub	x1, x29, #0x88
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
                	mov	x17, #0x3210            // =12816
                	movk	x17, #0x7654, lsl #16
                	movk	x17, #0xba98, lsl #32
                	movk	x17, #0xfedc, lsl #48
                	add	x21, x17, x19
-               	mov	w2, w21
-               	add	x3, x20, #0x0
-               	strb	w2, [x3]
-               	lsr	x2, x21, #8
-               	mov	w3, w2
-               	add	x2, x20, #0x1
-               	strb	w3, [x2]
-               	lsr	x2, x21, #16
-               	mov	w3, w2
-               	add	x2, x20, #0x2
-               	strb	w3, [x2]
-               	lsr	x2, x21, #24
-               	mov	w3, w2
-               	add	x2, x20, #0x3
-               	strb	w3, [x2]
-               	mov	w2, w21
-               	add	x3, x20, #0x4
-               	strh	w2, [x3]
-               	lsr	x2, x21, #32
-               	mov	w3, w2
-               	add	x2, x20, #0x6
-               	strh	w3, [x2]
-               	mov	w2, w21
-               	add	x3, x20, #0x8
-               	str	w2, [x3]
-               	add	x2, x20, #0x10
-               	str	x21, [x2]
-               	sub	x2, x29, #0x60
-               	ldr	x3, [x20]
-               	ldr	x4, [x20, #0x8]
-               	ldr	x5, [x20, #0x10]
-               	str	x3, [x2]
-               	str	x4, [x2, #0x8]
-               	str	x5, [x2, #0x10]
-               	ldr	x3, [x2]
-               	ldr	x4, [x2, #0x8]
-               	ldr	x5, [x2, #0x10]
-               	stur	x3, [x29, #-0x78]
-               	stur	x4, [x29, #-0x70]
-               	stur	x5, [x29, #-0x68]
-               	sub	x2, x29, #0x78
-               	mov	x0, x1
-               	mov	x1, x2
-<L2>:
-               	bl	 <L2>
+               	mov	w1, w21
+               	add	x2, x20, #0x0
+               	strb	w1, [x2]
+               	lsr	x1, x21, #8
+               	mov	w2, w1
+               	add	x1, x20, #0x1
+               	strb	w2, [x1]
+               	lsr	x1, x21, #16
+               	mov	w2, w1
+               	add	x1, x20, #0x2
+               	strb	w2, [x1]
+               	lsr	x1, x21, #24
+               	mov	w2, w1
+               	add	x1, x20, #0x3
+               	strb	w2, [x1]
+               	mov	w1, w21
+               	add	x2, x20, #0x4
+               	strh	w1, [x2]
+               	lsr	x1, x21, #32
+               	mov	w2, w1
+               	add	x1, x20, #0x6
+               	strh	w2, [x1]
+               	mov	w1, w21
+               	add	x2, x20, #0x8
+               	str	w1, [x2]
+               	add	x1, x20, #0x10
+               	str	x21, [x1]
+               	sub	x1, x29, #0xa0
+               	ldr	x2, [x20]
+               	ldr	x3, [x20, #0x8]
+               	ldr	x4, [x20, #0x10]
+               	str	x2, [x1]
+               	str	x3, [x1, #0x8]
+               	str	x4, [x1, #0x10]
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	ldr	x4, [x1, #0x10]
+               	stur	x2, [x29, #-0xb8]
+               	stur	x3, [x29, #-0xb0]
+               	stur	x4, [x29, #-0xa8]
+               	sub	x1, x29, #0xb8
+<L1>:
+               	bl	 <L1>
                	mov	x22, x0
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x8
-               	b.lo	 <L3>
-               	b	 <L5>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L4>
+<L2>:
                	add	x23, x23, #0x1
                	mul	x0, x21, x23
                	add	x1, x0, x19
@@ -179,7 +273,7 @@ Disassembly of section .text:
                	mov	w1, w0
                	add	x0, x20, #0x8
                	str	w1, [x0]
-               	sub	x0, x29, #0x90
+               	sub	x0, x29, #0x18
                	ldr	x1, [x20]
                	ldr	x2, [x20, #0x8]
                	ldr	x3, [x20, #0x10]
@@ -189,122 +283,251 @@ Disassembly of section .text:
                	ldr	x1, [x0]
                	ldr	x2, [x0, #0x8]
                	ldr	x3, [x0, #0x10]
-               	stur	x1, [x29, #-0xa8]
-               	stur	x2, [x29, #-0xa0]
-               	stur	x3, [x29, #-0x98]
-               	sub	x1, x29, #0xa8
+               	stur	x1, [x29, #-0x30]
+               	stur	x2, [x29, #-0x28]
+               	stur	x3, [x29, #-0x20]
+               	sub	x1, x29, #0x30
                	mov	x0, x22
-<L4>:
-               	bl	 <L4>
+<L3>:
+               	bl	 <L3>
                	mov	x22, x0
                	cmp	x23, #0x8
-               	b.lo	 <L3>
-<L5>:
+               	b.lo	 <L2>
+<L4>:
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L6>
-               	b	 <L17>
-<L6>:
-               	add	x20, x20, #0x1
+               	b.lo	 <L5>
+               	b	 <L21>
+<L5>:
+               	add	x0, x20, #0x1
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	mul	x0, x17, x20
-               	add	x23, x0, x19
-               	mov	w24, w23
-               	lsr	x0, x23, #8
-               	mov	w25, w0
-               	lsr	x0, x23, #16
-               	mov	w26, w0
-               	mov	x0, x22
-               	mov	x1, x24
+               	mul	x1, x17, x0
+               	add	x0, x1, x19
+               	mov	w23, w0
+               	lsr	x1, x0, #8
+               	mov	w24, w1
+               	lsr	x1, x0, #16
+               	mov	w25, w1
+               	sxtb	x1, w23
+               	mov	x2, x22
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x25
+               	sxth	x1, w24
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	w1, w26
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x23
+               	sxtw	x1, w25
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	sxtb	x1, w24
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x1, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	sxth	x1, w25
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	sxtw	x1, w26
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	uxtb	w1, w24
+               	sxtb	x0, w23
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	uxth	w1, w25
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w26
+               	sxth	x1, w24
+               	mov	x0, x2
 <L16>:
                	bl	 <L16>
-               	mov	x22, x0
-               	cmp	x20, #0x6
-               	b.lo	 <L6>
+               	sxtw	x1, w25
 <L17>:
-               	sub	x19, x29, #0xb8
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, #0x10
-               	b.lo	 <L18>
-               	b	 <L19>
+               	bl	 <L17>
+               	uxtb	w1, w23
 <L18>:
-               	mov	x16, #0x7               // =7
-               	and	x1, x0, x16
-               	mov	x16, #0x8               // =8
-               	mul	x2, x1, x16
-               	lsr	x1, x21, x2
-               	mov	w2, w1
-               	mov	w1, w0
-               	add	w3, w2, w1
-               	add	x1, x19, x0
-               	strb	w3, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, #0x10
-               	b.lo	 <L18>
+               	bl	 <L18>
+               	uxth	w1, w24
 <L19>:
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x10
-               	b.lo	 <L20>
-               	b	 <L22>
+               	bl	 <L19>
+               	mov	w1, w25
 <L20>:
-               	add	x0, x19, x20
-               	ldrb	w1, [x0]
-               	mov	x0, x22
-<L21>:
-               	bl	 <L21>
+               	bl	 <L20>
                	add	x20, x20, #0x1
                	mov	x22, x0
-               	cmp	x20, #0x10
-               	b.lo	 <L20>
+               	cmp	x20, #0x6
+               	b.lo	 <L5>
+<L21>:
+               	sub	x0, x29, #0x40
+               	str	xzr, [x0]
+               	str	xzr, [x0, #0x8]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x10
+               	b.lo	 <L22>
+               	b	 <L23>
 <L22>:
+               	mov	x16, #0x7               // =7
+               	and	x2, x1, x16
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x2, x21, x3
+               	mov	w3, w2
+               	mov	w2, w1
+               	add	w4, w3, w2
+               	add	x2, x0, x1
+               	strb	w4, [x2]
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x10
+               	b.lo	 <L22>
+<L23>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x10
+               	b.lo	 <L24>
+               	b	 <L27>
+<L24>:
+               	add	x2, x0, x1
+               	ldrb	w3, [x2]
+               	uxtb	w2, w3
+               	mov	x3, x22
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L25>
+<L26>:
+               	add	x1, x1, #0x1
+               	mov	x22, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L24>
+<L27>:
                	mov	x16, #0x7c15            // =31765
                	movk	x16, #0x7f4a, lsl #16
                	movk	x16, #0x79b9, lsl #32
                	movk	x16, #0x9e37, lsl #48
-               	eor	x19, x21, x16
+               	eor	x0, x21, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	add	x1, x0, #0x1
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L30>
+<L31>:
                	mov	x0, x22
-               	mov	x1, x19
-<L23>:
-               	bl	 <L23>
-               	add	x1, x19, #0x1
-<L24>:
-               	bl	 <L24>
                	ldp	x19, x20, [x29, #-0xd0]
                	ldp	x21, x22, [x29, #-0xe0]
                	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
+               	ldur	x25, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/ptr_arith.dis
+++ b/test/golden/aarch64-linux/mem/ptr_arith.dis
@@ -5,32 +5,71 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.fold_cell>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrh	w2, [x1]
                	sub	x1, x29, #0xe
-               	ldrb	w19, [x1]
+               	ldrb	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldr	x20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldr	x4, [x1]
+               	uxth	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	uxtb	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x4, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -56,16 +95,13 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
-               	stp	x19, x20, [x29, #-0xd0]
-               	stp	x21, x22, [x29, #-0xe0]
-               	stp	x23, x24, [x29, #-0xf0]
-               	stp	x25, x26, [x29, #-0x100]
+               	sub	sp, sp, #0x110
+               	stp	x19, x20, [x29, #-0xf0]
+               	stp	x21, x22, [x29, #-0x100]
+               	stp	x23, x24, [x29, #-0x110]
                	mov	x19, x0
                	sub	x20, x29, #0x20
-<L0>:
-               	bl	 <L0>
-               	sub	x21, x29, #0x60
+               	sub	x21, x29, #0x80
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -74,78 +110,147 @@ Disassembly of section .text:
                	str	xzr, [x21, #0x28]
                	str	xzr, [x21, #0x30]
                	str	xzr, [x21, #0x38]
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x10
-               	b.lo	 <L1>
-               	b	 <L2>
-<L1>:
-               	add	x2, x1, #0x1
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x10
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	add	x1, x0, #0x1
                	mov	x17, #0x79b1            // =31153
                	movk	x17, #0x9e37, lsl #16
-               	mul	x3, x17, x2
-               	add	x4, x3, x19
-               	mov	w3, w4
-               	add	x4, x21, x1, lsl #2
-               	str	w3, [x4]
-               	mov	x1, x2
-               	cmp	x1, #0x10
-               	b.lo	 <L1>
-<L2>:
+               	mul	x2, x17, x1
+               	add	x3, x2, x19
+               	mov	w2, w3
+               	add	x3, x21, x0, lsl #2
+               	str	w2, [x3]
+               	mov	x0, x1
+               	cmp	x0, #0x10
+               	b.lo	 <L0>
+<L1>:
                	add	x22, x21, #0x0
                	add	x23, x21, #0x20
-               	mov	x24, x0
-               	mov	x25, #0x0               // =0
-               	cmp	x25, #0x10
-               	b.lo	 <L3>
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
                	b	 <L5>
-<L3>:
-               	add	x0, x22, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L4>:
-               	bl	 <L4>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x10
+<L2>:
+               	add	x2, x22, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
                	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+<L4>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L2>
 <L5>:
-               	mov	x25, #0xfff8            // =65528
-               	movk	x25, #0xffff, lsl #16
-               	movk	x25, #0xffff, lsl #32
-               	movk	x25, #0xffff, lsl #48
-               	cmp	x25, #0x8
+               	mov	x1, #0xfff8             // =65528
+               	movk	x1, #0xffff, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
+               	cmp	x1, #0x8
                	b.lt	 <L6>
-               	b	 <L8>
+               	b	 <L9>
 <L6>:
-               	add	x0, x23, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
+               	add	x2, x23, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x8
-               	b.lt	 <L6>
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	ldr	w1, [x23]
-               	mov	x0, x24
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
+               	ldr	w1, [x23]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	sub	x1, x23, #0x4
                	ldr	w2, [x1]
                	mov	w1, w2
-<L10>:
-               	bl	 <L10>
-               	add	x1, x23, #0x1c
-               	ldr	w2, [x1]
-               	mov	w1, w2
-<L11>:
-               	bl	 <L11>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x8
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
                	b.lo	 <L12>
                	b	 <L13>
 <L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x1, x23, #0x1c
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L14>:
+               	bl	 <L14>
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L15>
+               	b	 <L16>
+<L15>:
                	add	x2, x23, x1, lsl #2
                	ldr	w3, [x2]
                	mov	w4, w1
@@ -154,74 +259,133 @@ Disassembly of section .text:
                	str	w3, [x2]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L12>
-<L13>:
-               	mov	x24, x0
-               	mov	x25, #0x0               // =0
-               	cmp	x25, #0x10
-               	b.lo	 <L14>
-               	b	 <L16>
-<L14>:
-               	add	x0, x21, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L15>:
-               	bl	 <L15>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, #0x10
-               	b.lo	 <L14>
+               	b.lo	 <L15>
 <L16>:
-               	add	x25, x21, #0x14
-               	ldr	w0, [x25]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x10
+               	b.lo	 <L17>
+               	b	 <L20>
+<L17>:
+               	add	x2, x21, x1, lsl #2
+               	ldr	w3, [x2]
+               	mov	w2, w3
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x2, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	add	x1, x1, #0x1
+               	mov	x0, x3
+               	cmp	x1, #0x10
+               	b.lo	 <L17>
+<L20>:
+               	add	x24, x21, #0x14
+               	ldr	w1, [x24]
                	mov	w16, #0xf0f0            // =61680
                	movk	w16, #0xf0f0, lsl #16
-               	eor	w1, w0, w16
-               	str	w1, [x25]
-               	ldr	w1, [x25]
-               	mov	x0, x24
-<L17>:
-               	bl	 <L17>
-               	ldr	w1, [x25]
-               	add	w2, w1, #0x3
-               	str	w2, [x25]
-               	ldr	w1, [x25]
-<L18>:
-               	bl	 <L18>
-               	ldr	w1, [x25]
-<L19>:
-               	bl	 <L19>
-               	cmp	x25, x25
-               	cset	w1, eq
-<L20>:
-               	bl	 <L20>
-               	cmp	x25, x22
-               	cset	w1, eq
+               	eor	w2, w1, w16
+               	str	w2, [x24]
+               	ldr	w1, [x24]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
 <L21>:
-               	bl	 <L21>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	ldr	w1, [x24]
+               	add	w2, w1, #0x3
+               	str	w2, [x24]
+               	ldr	w1, [x24]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	add	x1, x21, #0x14
+               	ldr	w2, [x1]
+               	mov	w1, w2
+<L25>:
+               	bl	 <L25>
+               	cmp	x24, x24
+               	cset	w1, eq
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	cmp	x24, x22
+               	cset	w1, eq
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L27>:
+               	bl	 <L27>
                	cmp	x22, #0x0
                	cset	w1, eq
-<L22>:
-               	bl	 <L22>
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L28>:
+               	bl	 <L28>
                	cmp	x23, x22
                	cset	w1, ne
-<L23>:
-               	bl	 <L23>
-               	sub	x21, x29, #0xc0
+               	uxtb	w2, w1
+               	mov	x1, x2
+<L29>:
+               	bl	 <L29>
+               	sub	x21, x29, #0xe0
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x60               // =96
-<L24>:
+<L30>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L24>
+               	b.ne	 <L30>
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x6
-               	b.lo	 <L25>
-               	b	 <L26>
-<L25>:
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
                	mov	x16, #0x5               // =5
                	mul	x2, x1, x16
                	add	x3, x2, #0x1
@@ -244,8 +408,8 @@ Disassembly of section .text:
                	add	x2, x4, #0x8
                	str	x3, [x2]
                	cmp	x1, #0x6
-               	b.lo	 <L25>
-<L26>:
+               	b.lo	 <L31>
+<L32>:
                	add	x22, x21, #0x20
                	mov	x23, x0
                	mov	x24, #0xfffe            // =65534
@@ -253,33 +417,27 @@ Disassembly of section .text:
                	movk	x24, #0xffff, lsl #32
                	movk	x24, #0xffff, lsl #48
                	cmp	x24, #0x4
-               	b.lt	 <L27>
-               	b	 <L31>
-<L27>:
+               	b.lt	 <L33>
+               	b	 <L35>
+<L33>:
                	mov	x16, #0x10              // =16
                	mul	x0, x24, x16
                	add	x1, x22, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w25, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x26, [x0]
+               	sub	x0, x29, #0x30
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x23
-               	mov	x1, x2
-<L28>:
-               	bl	 <L28>
-               	mov	x1, x25
-<L29>:
-               	bl	 <L29>
-               	mov	x1, x26
-<L30>:
-               	bl	 <L30>
+<L34>:
+               	bl	 <L34>
                	add	x24, x24, #0x1
                	mov	x23, x0
                	cmp	x24, #0x4
-               	b.lt	 <L27>
-<L31>:
+               	b.lt	 <L33>
+<L35>:
                	add	x0, x22, #0x10
                	add	x1, x0, #0x8
                	ldr	x0, [x1]
@@ -292,144 +450,231 @@ Disassembly of section .text:
                	strh	w2, [x1]
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x6
-               	b.lo	 <L32>
-               	b	 <L36>
-<L32>:
+               	b.lo	 <L36>
+               	b	 <L38>
+<L36>:
                	mov	x16, #0x10              // =16
                	mul	x0, x22, x16
                	add	x1, x21, x0
-               	add	x0, x1, #0x0
-               	ldrh	w2, [x0]
-               	add	x0, x1, #0x2
-               	ldrb	w24, [x0]
-               	add	x0, x1, #0x8
-               	ldr	x25, [x0]
+               	sub	x0, x29, #0x40
+               	ldr	x2, [x1]
+               	ldr	x3, [x1, #0x8]
+               	str	x2, [x0]
+               	str	x3, [x0, #0x8]
+               	ldr	x1, [x0]
+               	ldr	x2, [x0, #0x8]
                	mov	x0, x23
-               	mov	x1, x2
-<L33>:
-               	bl	 <L33>
-               	mov	x1, x24
-<L34>:
-               	bl	 <L34>
-               	mov	x1, x25
-<L35>:
-               	bl	 <L35>
+<L37>:
+               	bl	 <L37>
                	add	x22, x22, #0x1
                	mov	x23, x0
                	cmp	x22, #0x6
-               	b.lo	 <L32>
-<L36>:
+               	b.lo	 <L36>
+<L38>:
                	add	x0, x21, #0x40
                	add	x1, x0, #0x8
                	ldr	x0, [x1]
                	mov	x16, #0x3               // =3
                	mul	x2, x0, x16
                	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x0, x23
-               	mov	x1, x2
-<L37>:
-               	bl	 <L37>
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	ldrh	w1, [x2]
-               	add	w3, w1, #0x1
-               	strh	w3, [x2]
-               	ldrh	w1, [x2]
-<L38>:
-               	bl	 <L38>
+               	ldr	x0, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+               	b	 <L40>
+<L39>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L39>
+<L40>:
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	ldrh	w0, [x1]
+               	add	w2, w0, #0x1
+               	strh	w2, [x1]
+               	ldrh	w0, [x1]
+               	uxth	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+               	b	 <L42>
+<L41>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L41>
+<L42>:
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
                	str	xzr, [x20, #0x18]
-               	mov	w1, w19
+               	mov	w0, w19
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
-               	add	w21, w17, w1
+               	add	w1, w17, w0
                	mov	w17, #0xdef0            // =57072
                	movk	w17, #0x9abc, lsl #16
-               	add	w22, w17, w1
-               	mov	w1, w19
-               	mov	x2, #0x0                // =0
-               	cmp	x2, #0x8
-               	b.lo	 <L39>
-               	b	 <L40>
-<L39>:
-               	mov	w3, w2
-               	mov	w16, #0x7               // =7
-               	mul	w4, w3, w16
-               	add	w3, w4, #0x3
-               	add	w4, w3, w1
-               	add	x3, x20, x2, lsl #2
-               	str	w4, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x8
-               	b.lo	 <L39>
-<L40>:
-               	add	x19, x20, #0xc
-               	mov	x23, x0
-               	mov	x24, #0xfffd            // =65533
-               	movk	x24, #0xffff, lsl #16
-               	movk	x24, #0xffff, lsl #32
-               	movk	x24, #0xffff, lsl #48
-               	cmp	x24, #0x5
-               	b.lt	 <L41>
-               	b	 <L43>
-<L41>:
-               	add	x0, x19, x24, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x23
-<L42>:
-               	bl	 <L42>
-               	add	x24, x24, #0x1
-               	mov	x23, x0
-               	cmp	x24, #0x5
-               	b.lt	 <L41>
+               	add	w2, w17, w0
+               	mov	w0, w19
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
 <L43>:
+               	mov	w4, w3
+               	mov	w16, #0x7               // =7
+               	mul	w5, w4, w16
+               	add	w4, w5, #0x3
+               	add	w5, w4, w0
+               	add	x4, x20, x3, lsl #2
+               	str	w5, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x20, #0xc
+               	mov	x3, #0xfffd             // =65533
+               	movk	x3, #0xffff, lsl #16
+               	movk	x3, #0xffff, lsl #32
+               	movk	x3, #0xffff, lsl #48
+               	cmp	x3, #0x5
+               	b.lt	 <L45>
+               	b	 <L48>
+<L45>:
+               	add	x4, x0, x3, lsl #2
+               	ldr	w5, [x4]
+               	mov	w4, w5
+               	mov	x5, x23
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L46>
+               	b	 <L47>
+<L46>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L46>
+<L47>:
+               	add	x3, x3, #0x1
+               	mov	x23, x5
+               	cmp	x3, #0x5
+               	b.lt	 <L45>
+<L48>:
                	add	x0, x20, #0x0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L49>
+               	b	 <L50>
+<L49>:
+               	add	x4, x0, x3, lsl #2
+               	ldr	w5, [x4]
+               	mov	w6, w3
+               	add	w7, w5, w6
+               	add	w5, w7, #0x1
+               	str	w5, [x4]
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L49>
+<L50>:
+               	mov	w0, w1
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x8
-               	b.lo	 <L44>
-               	b	 <L45>
-<L44>:
-               	add	x2, x0, x1, lsl #2
-               	ldr	w3, [x2]
-               	mov	w4, w1
-               	add	w5, w3, w4
-               	add	w3, w5, #0x1
-               	str	w3, [x2]
+               	b.lo	 <L51>
+               	b	 <L52>
+<L51>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x23, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x4, x16
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
-               	b.lo	 <L44>
-<L45>:
+               	b.lo	 <L51>
+<L52>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L53>
+               	b	 <L56>
+<L53>:
+               	add	x1, x20, x0, lsl #2
+               	ldr	w3, [x1]
+               	mov	w1, w3
+               	mov	x3, x23
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L54>
+               	b	 <L55>
+<L54>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x3, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L54>
+<L55>:
+               	add	x0, x0, #0x1
+               	mov	x23, x3
+               	cmp	x0, #0x8
+               	b.lo	 <L53>
+<L56>:
+               	mov	w0, w2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L57>
+               	b	 <L58>
+<L57>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x23, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x23, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L57>
+<L58>:
                	mov	x0, x23
-               	mov	w1, w21
-<L46>:
-               	bl	 <L46>
-               	mov	x19, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x8
-               	b.lo	 <L47>
-               	b	 <L49>
-<L47>:
-               	add	x0, x20, x21, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x19
-<L48>:
-               	bl	 <L48>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L47>
-<L49>:
-               	mov	x0, x19
-               	mov	w1, w22
-<L50>:
-               	bl	 <L50>
-               	ldp	x19, x20, [x29, #-0xd0]
-               	ldp	x21, x22, [x29, #-0xe0]
-               	ldp	x23, x24, [x29, #-0xf0]
-               	ldp	x25, x26, [x29, #-0x100]
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldp	x21, x22, [x29, #-0x100]
+               	ldp	x23, x24, [x29, #-0x110]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/mem/rec_layout.dis
+++ b/test/golden/aarch64-linux/mem/rec_layout.dis
@@ -5,81 +5,190 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_tiny>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x3, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x10]
                	stur	x2, [x29, #-0x8]
                	sub	x1, x29, #0x10
                	ldrb	w2, [x1]
                	sub	x1, x29, #0xc
-               	ldr	w19, [x1]
+               	ldr	w3, [x1]
                	sub	x1, x29, #0x8
-               	ldrb	w20, [x1]
-               	mov	x0, x3
-               	mov	x1, x2
+               	ldrb	w4, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x5, x2, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, x20
+               	mov	w1, w3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x5, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	uxtb	w1, w4
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
 
 <corpus.cases.mem.rec_layout.fold_mid>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x2, x0
-               	add	x3, x1, #0x0
-               	ldrh	w4, [x3]
-               	add	x3, x1, #0x4
-               	add	x5, x3, #0x0
-               	ldrb	w19, [x5]
-               	add	x5, x3, #0x4
-               	ldr	w20, [x5]
-               	add	x5, x3, #0x8
-               	ldrb	w21, [x5]
-               	add	x3, x1, #0x10
-               	ldrb	w22, [x3]
-               	mov	x0, x2
-               	mov	x1, x4
+               	add	x2, x1, #0x0
+               	ldrh	w3, [x2]
+               	add	x2, x1, #0x4
+               	add	x4, x2, #0x0
+               	ldrb	w5, [x4]
+               	add	x4, x2, #0x4
+               	ldr	w6, [x4]
+               	add	x4, x2, #0x8
+               	ldrb	w2, [x4]
+               	add	x4, x1, #0x10
+               	ldrb	w1, [x4]
+               	uxth	w4, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x7, x3, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x0, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x8, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	w1, w20
+               	uxtb	w3, w5
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x21
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x7, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x7, x16
+               	eor	x7, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x22
+               	mov	w3, w6
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x3, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x0, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	uxtb	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	ret
 
 <corpus.cases.mem.rec_layout.fold_wide>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x70
-               	stp	x19, x20, [x29, #-0x70]
+               	stur	x19, [x29, #-0x68]
                	mov	x2, x0
                	sub	x19, x29, #0x28
                	ldr	x3, [x1]
@@ -110,43 +219,114 @@ Disassembly of section .text:
                	mov	x0, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x18
-               	ldr	x3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x18
+               	ldr	x2, [x1]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x20, x19, #0x20
-               	add	x2, x20, #0x0
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x20, #0x2
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x4
-               	ldrh	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x19, #0x26
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	ldp	x19, x20, [x29, #-0x70]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+<L6>:
+               	add	x1, x19, #0x20
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
+<L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	add	x1, x19, #0x26
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	ldur	x19, [x29, #-0x68]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -154,13 +334,8 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_nest>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x150
+               	sub	sp, sp, #0x140
                	stp	x19, x20, [x29, #-0x140]
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x21, [x29, x16]
                	sub	x19, x29, #0x58
                	add	x2, x19, #0x0
                	add	x3, x1, #0x0
@@ -233,30 +408,111 @@ Disassembly of section .text:
                	bl	 <L4>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
-               	mov	x1, x2
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	add	x21, x20, #0x20
-               	add	x1, x21, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	add	x1, x21, #0x2
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x0
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	add	x1, x21, #0x4
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	add	x1, x20, #0x20
+               	add	x2, x1, #0x4
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L11>
+<L12>:
                	add	x1, x20, #0x26
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L9>:
-               	bl	 <L9>
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
                	add	x20, x19, #0x28
                	add	x1, x20, #0x0
                	sub	x2, x29, #0xe8
@@ -273,8 +529,8 @@ Disassembly of section .text:
                	stur	x3, [x29, #-0xf8]
                	stur	w4, [x29, #-0xf0]
                	sub	x1, x29, #0x100
-<L10>:
-               	bl	 <L10>
+<L15>:
+               	bl	 <L15>
                	add	x1, x20, #0x14
                	sub	x2, x29, #0x114
                	ldr	x3, [x1]
@@ -302,19 +558,30 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x12c
-<L11>:
-               	bl	 <L11>
+<L16>:
+               	bl	 <L16>
                	add	x1, x19, #0x50
                	ldr	w2, [x1]
                	mov	w1, w2
-<L12>:
-               	bl	 <L12>
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
+<L17>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L17>
+<L18>:
                	ldp	x19, x20, [x29, #-0x140]
-               	mov	x16, #0xfeb8            // =65208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -349,166 +616,214 @@ Disassembly of section .text:
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	mov	w20, w19
-               	mov	x0, x1
-               	mov	x1, #0xc                // =12
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0xc               // =12
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x14               // =20
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x28               // =40
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x14              // =20
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x58               // =88
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x28              // =40
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x58              // =88
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	mov	x17, #0x4               // =4
+               	lsr	x3, x17, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x0, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x8                // =8
+               	mov	x1, #0x4                // =4
 <L10>:
                	bl	 <L10>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x4                // =4
+               	mov	x1, #0x8                // =8
 <L11>:
                	bl	 <L11>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x10               // =16
+               	mov	x1, #0x8                // =8
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x18               // =24
+               	mov	x1, #0x4                // =4
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x20               // =32
+               	mov	x1, #0x8                // =8
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x26               // =38
+               	mov	x1, #0x4                // =4
 <L15>:
                	bl	 <L15>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x28               // =40
+               	mov	x1, #0x10               // =16
 <L16>:
                	bl	 <L16>
-               	mov	x1, x0
-               	mov	x0, x1
-               	mov	x1, #0x50               // =80
+               	mov	x1, #0x18               // =24
 <L17>:
                	bl	 <L17>
+               	mov	x1, #0x20               // =32
+<L18>:
+               	bl	 <L18>
+               	mov	x1, #0x26               // =38
+<L19>:
+               	bl	 <L19>
+               	mov	x1, #0x28               // =40
+<L20>:
+               	bl	 <L20>
+               	mov	x1, #0x50               // =80
+<L21>:
+               	bl	 <L21>
                	sub	x21, x29, #0x58
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	x1, #0x58               // =88
-<L18>:
+<L22>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L18>
+               	b.ne	 <L22>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L20>
+               	b.lo	 <L24>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L19>:
+<L23>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L19>
-               	b	 <L22>
-<L20>:
+               	b.ne	 <L23>
+               	b	 <L26>
+<L24>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L21>:
+<L25>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L21>
-<L22>:
+               	b.ne	 <L25>
+<L26>:
                	sub	x2, x29, #0x108
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L24>
+               	b.lo	 <L28>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L23>:
+<L27>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L23>
-               	b	 <L26>
-<L24>:
+               	b.ne	 <L27>
+               	b	 <L30>
+<L28>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L25>:
+<L29>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L25>
-<L26>:
+               	b.ne	 <L29>
+<L30>:
                	sub	x1, x29, #0x108
-<L27>:
-               	bl	 <L27>
+<L31>:
+               	bl	 <L31>
                	add	x1, x21, #0x0
                	add	x2, x1, #0x0
                	mov	w17, #0xa               // =10
@@ -615,64 +930,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L29>
+               	b.lo	 <L33>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L28>:
+<L32>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L28>
-               	b	 <L31>
-<L29>:
+               	b.ne	 <L32>
+               	b	 <L35>
+<L33>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L30>:
+<L34>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L30>
-<L31>:
+               	b.ne	 <L34>
+<L35>:
                	sub	x2, x29, #0x1b8
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L33>
+               	b.lo	 <L37>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L32>:
+<L36>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L32>
-               	b	 <L35>
-<L33>:
+               	b.ne	 <L36>
+               	b	 <L39>
+<L37>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L34>:
+<L38>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L34>
-<L35>:
+               	b.ne	 <L38>
+<L39>:
                	sub	x1, x29, #0x1b8
-<L36>:
-               	bl	 <L36>
+<L40>:
+               	bl	 <L40>
                	add	x20, x21, #0x0
                	add	x1, x20, #0x0
                	add	x2, x1, #0x4
@@ -686,64 +1001,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L38>
+               	b.lo	 <L42>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L37>:
+<L41>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L37>
-               	b	 <L40>
-<L38>:
+               	b.ne	 <L41>
+               	b	 <L44>
+<L42>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L39>:
+<L43>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L39>
-<L40>:
+               	b.ne	 <L43>
+<L44>:
                	sub	x2, x29, #0x268
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L42>
+               	b.lo	 <L46>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L41>:
+<L45>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L41>
-               	b	 <L44>
-<L42>:
+               	b.ne	 <L45>
+               	b	 <L48>
+<L46>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L43>:
+<L47>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L43>
-<L44>:
+               	b.ne	 <L47>
+<L48>:
                	sub	x1, x29, #0x268
-<L45>:
-               	bl	 <L45>
+<L49>:
+               	bl	 <L49>
                	add	x22, x21, #0x28
                	add	x1, x22, #0x14
                	add	x2, x1, #0x4
@@ -755,64 +1070,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L47>
+               	b.lo	 <L51>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L46>:
+<L50>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L46>
-               	b	 <L49>
-<L47>:
+               	b.ne	 <L50>
+               	b	 <L53>
+<L51>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L48>:
+<L52>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L48>
-<L49>:
+               	b.ne	 <L52>
+<L53>:
                	sub	x2, x29, #0x318
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L51>
+               	b.lo	 <L55>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L50>:
+<L54>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L50>
-               	b	 <L53>
-<L51>:
+               	b.ne	 <L54>
+               	b	 <L57>
+<L55>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L52>:
+<L56>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L52>
-<L53>:
+               	b.ne	 <L56>
+<L57>:
                	sub	x1, x29, #0x318
-<L54>:
-               	bl	 <L54>
+<L58>:
+               	bl	 <L58>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
                	lsr	x3, x2, #3
@@ -821,64 +1136,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L56>
+               	b.lo	 <L60>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L55>:
+<L59>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L55>
-               	b	 <L58>
-<L56>:
+               	b.ne	 <L59>
+               	b	 <L62>
+<L60>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L57>:
+<L61>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L57>
-<L58>:
+               	b.ne	 <L61>
+<L62>:
                	sub	x2, x29, #0x3c8
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L60>
+               	b.lo	 <L64>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L59>:
+<L63>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L59>
-               	b	 <L62>
-<L60>:
+               	b.ne	 <L63>
+               	b	 <L66>
+<L64>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L61>:
+<L65>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L61>
-<L62>:
+               	b.ne	 <L65>
+<L66>:
                	sub	x1, x29, #0x3c8
-<L63>:
-               	bl	 <L63>
+<L67>:
+               	bl	 <L67>
                	ldr	w1, [x19]
                	mov	w16, #0x3               // =3
                	mul	w2, w1, w16
@@ -887,64 +1202,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L65>
+               	b.lo	 <L69>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L64>:
+<L68>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L64>
-               	b	 <L67>
-<L65>:
+               	b.ne	 <L68>
+               	b	 <L71>
+<L69>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L66>:
+<L70>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L66>
-<L67>:
+               	b.ne	 <L70>
+<L71>:
                	sub	x2, x29, #0x478
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L69>
+               	b.lo	 <L73>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L68>:
+<L72>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L68>
-               	b	 <L71>
-<L69>:
+               	b.ne	 <L72>
+               	b	 <L75>
+<L73>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L70>:
+<L74>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L70>
-<L71>:
+               	b.ne	 <L74>
+<L75>:
                	sub	x1, x29, #0x478
-<L72>:
-               	bl	 <L72>
+<L76>:
+               	bl	 <L76>
                	sub	x19, x29, #0x48c
                	add	x20, x22, #0x0
                	sub	x1, x29, #0x4a0
@@ -991,8 +1306,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x4cc
-<L73>:
-               	bl	 <L73>
+<L77>:
+               	bl	 <L77>
                	sub	x1, x29, #0x4e0
                	ldr	x2, [x20]
                	ldr	x3, [x20, #0x8]
@@ -1019,8 +1334,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	str	w4, [x29, x16]
                	sub	x1, x29, #0x4f8
-<L74>:
-               	bl	 <L74>
+<L78>:
+               	bl	 <L78>
                	sub	x1, x29, #0x50c
                	ldr	x2, [x19]
                	ldr	x3, [x19, #0x8]
@@ -1038,64 +1353,64 @@ Disassembly of section .text:
                	add	x2, x1, #0x0
                	add	x3, x21, #0x0
                	cmp	x2, x3
-               	b.lo	 <L76>
+               	b.lo	 <L80>
                	add	x4, x2, #0x58
                	add	x5, x3, #0x58
                	mov	x6, #0x58               // =88
-<L75>:
+<L79>:
                	sub	x4, x4, #0x8
                	sub	x5, x5, #0x8
                	ldr	x7, [x5]
                	str	x7, [x4]
                	sub	x6, x6, #0x8
                	cmp	x6, #0x0
-               	b.ne	 <L75>
-               	b	 <L78>
-<L76>:
+               	b.ne	 <L79>
+               	b	 <L82>
+<L80>:
                	add	x4, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L77>:
+<L81>:
                	ldr	x5, [x2]
                	str	x5, [x4]
                	add	x4, x4, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L77>
-<L78>:
+               	b.ne	 <L81>
+<L82>:
                	sub	x2, x29, #0x5c0
                	add	x3, x1, #0x0
                	cmp	x2, x3
-               	b.lo	 <L80>
+               	b.lo	 <L84>
                	add	x1, x2, #0x58
                	add	x4, x3, #0x58
                	mov	x5, #0x58               // =88
-<L79>:
+<L83>:
                	sub	x1, x1, #0x8
                	sub	x4, x4, #0x8
                	ldr	x6, [x4]
                	str	x6, [x1]
                	sub	x5, x5, #0x8
                	cmp	x5, #0x0
-               	b.ne	 <L79>
-               	b	 <L82>
-<L80>:
+               	b.ne	 <L83>
+               	b	 <L86>
+<L84>:
                	add	x1, x2, #0x0
                	add	x2, x3, #0x0
                	mov	x3, #0x58               // =88
-<L81>:
+<L85>:
                	ldr	x4, [x2]
                	str	x4, [x1]
                	add	x1, x1, #0x8
                	add	x2, x2, #0x8
                	sub	x3, x3, #0x8
                	cmp	x3, #0x0
-               	b.ne	 <L81>
-<L82>:
+               	b.ne	 <L85>
+<L86>:
                	sub	x1, x29, #0x5c0
-<L83>:
-               	bl	 <L83>
+<L87>:
+               	bl	 <L87>
                	sub	x16, x29, #0x5d0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]

--- a/test/golden/aarch64-linux/mem/uni_layout.dis
+++ b/test/golden/aarch64-linux/mem/uni_layout.dis
@@ -26,62 +26,163 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.fold_w4>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x20]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
-               	sub	x19, x29, #0xc
-               	ldur	w1, [x29, #-0x8]
-               	str	w1, [x19]
-               	add	x1, x19, #0x0
-               	ldr	w3, [x1]
-               	mov	x0, x2
-               	mov	w1, w3
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
+               	sub	x1, x29, #0xc
+               	ldur	w2, [x29, #-0x8]
+               	str	w2, [x1]
+               	add	x2, x1, #0x0
                	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	w2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	add	x2, x1, #0x0
+               	ldr	w3, [x2]
+               	sxtw	x2, w3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x20, x19, #0x0
-               	add	x2, x20, #0x0
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x1
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x20, #0x2
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	add	x2, x20, #0x3
-               	ldrb	w3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	ldp	x19, x20, [x29, #-0x20]
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x1
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x2
+               	ldrb	w2, [x3]
+               	uxtb	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x2, x1, #0x0
+               	add	x1, x2, #0x3
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -89,69 +190,149 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.fold_w8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x20]
-               	stur	x21, [x29, #-0x28]
-               	mov	x2, x0
+               	sub	sp, sp, #0x10
                	stur	x1, [x29, #-0x8]
-               	sub	x19, x29, #0x10
-               	ldur	x1, [x29, #-0x8]
-               	str	x1, [x19]
-               	add	x1, x19, #0x0
-               	ldr	x3, [x1]
-               	mov	x0, x2
-               	mov	x1, x3
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
+               	sub	x1, x29, #0x10
+               	ldur	x2, [x29, #-0x8]
+               	str	x2, [x1]
+               	add	x2, x1, #0x0
                	ldr	x3, [x2]
-               	mov	x0, x1
-               	mov	x1, x3
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x0
-               	ldr	d0, [x2]
-               	mov	x0, x1
+               	add	x2, x1, #0x0
+               	ldr	x3, [x2]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x20, x19, #0x0
-               	add	x2, x20, #0x0
-               	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x20, #0x4
-               	ldr	w3, [x2]
-               	mov	x0, x1
-               	mov	w1, w3
+               	add	x2, x1, #0x0
+               	ldr	d0, [x2]
+               	fmov	x2, d0
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x20, x0
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x2, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	add	x0, x19, #0x0
-               	add	x1, x0, x21
-               	ldrb	w2, [x1]
-               	mov	x0, x20
-               	mov	x1, x2
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x0
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lo	 <L5>
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	mov	x0, x20
-               	ldp	x19, x20, [x29, #-0x20]
-               	ldur	x21, [x29, #-0x28]
+               	add	x2, x1, #0x0
+               	add	x3, x2, #0x4
+               	ldr	w2, [x3]
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L13>
+<L10>:
+               	add	x3, x1, #0x0
+               	add	x4, x3, x2
+               	ldrb	w3, [x4]
+               	uxtb	w4, w3
+               	mov	x3, x0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
+<L11>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x3, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x3, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L11>
+<L12>:
+               	add	x2, x2, #0x1
+               	mov	x0, x3
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L13>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -159,21 +340,20 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x100
+               	sub	sp, sp, #0xe0
                	stp	x19, x20, [x29, #-0xc0]
                	stp	x21, x22, [x29, #-0xd0]
                	stp	x23, x24, [x29, #-0xe0]
-               	stp	x25, x26, [x29, #-0xf0]
-               	stur	x27, [x29, #-0xf8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x20, x0
+               	mov	x20, #0x2325            // =8997
+               	movk	x20, #0x8422, lsl #16
+               	movk	x20, #0x9ce4, lsl #32
+               	movk	x20, #0xcbf2, lsl #48
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x6
-               	b.lo	 <L1>
-               	b	 <L8>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L7>
+<L0>:
                	add	x0, x21, #0x1
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
@@ -191,16 +371,16 @@ Disassembly of section .text:
                	orr	w0, w1, w16
                	add	x1, x23, #0x0
                	str	w0, [x1]
-               	sub	x0, x29, #0x54
+               	sub	x0, x29, #0x4c
                	ldr	w1, [x23]
                	str	w1, [x0]
-               	stur	xzr, [x29, #-0x60]
+               	stur	xzr, [x29, #-0x58]
                	ldr	w1, [x0]
-               	stur	w1, [x29, #-0x60]
-               	ldur	x1, [x29, #-0x60]
+               	stur	w1, [x29, #-0x58]
+               	ldur	x1, [x29, #-0x58]
                	mov	x0, x20
-<L2>:
-               	bl	 <L2>
+<L1>:
+               	bl	 <L1>
                	lsr	x1, x22, #7
                	mov	w2, w1
                	mov	w16, #0xffff            // =65535
@@ -210,30 +390,30 @@ Disassembly of section .text:
                	orr	w2, w1, w16
                	add	x1, x23, #0x0
                	str	w2, [x1]
-               	sub	x1, x29, #0x74
+               	sub	x1, x29, #0x5c
                	ldr	w2, [x23]
                	str	w2, [x1]
-               	stur	xzr, [x29, #-0x80]
+               	stur	xzr, [x29, #-0x68]
                	ldr	w2, [x1]
-               	stur	w2, [x29, #-0x80]
-               	ldur	x1, [x29, #-0x80]
-<L3>:
-               	bl	 <L3>
+               	stur	w2, [x29, #-0x68]
+               	ldur	x1, [x29, #-0x68]
+<L2>:
+               	bl	 <L2>
                	add	x1, x23, #0x0
                	ldr	s0, [x1]
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	str	s1, [x1]
-               	sub	x1, x29, #0x84
+               	sub	x1, x29, #0x6c
                	ldr	w2, [x23]
                	str	w2, [x1]
-               	stur	xzr, [x29, #-0x90]
+               	stur	xzr, [x29, #-0x78]
                	ldr	w2, [x1]
-               	stur	w2, [x29, #-0x90]
-               	ldur	x1, [x29, #-0x90]
-<L4>:
-               	bl	 <L4>
-               	sub	x23, x29, #0x98
+               	stur	w2, [x29, #-0x78]
+               	ldur	x1, [x29, #-0x78]
+<L3>:
+               	bl	 <L3>
+               	sub	x23, x29, #0x80
                	str	xzr, [x23]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x1f, lsl #16
@@ -247,13 +427,13 @@ Disassembly of section .text:
                	orr	x2, x1, x16
                	add	x1, x23, #0x0
                	str	x2, [x1]
-               	sub	x1, x29, #0xa0
+               	sub	x1, x29, #0x90
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L5>:
-               	bl	 <L5>
+<L4>:
+               	bl	 <L4>
                	lsr	x1, x22, #9
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0x1f, lsl #16
@@ -267,13 +447,13 @@ Disassembly of section .text:
                	orr	x1, x2, x16
                	add	x2, x23, #0x0
                	str	x1, [x2]
-               	sub	x1, x29, #0xa8
+               	sub	x1, x29, #0xa0
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L6>:
-               	bl	 <L6>
+<L5>:
+               	bl	 <L5>
                	add	x1, x23, #0x0
                	ldr	d0, [x1]
                	fmov	d30, #3.00000000
@@ -281,26 +461,26 @@ Disassembly of section .text:
                	fmov	d30, #1.00000000
                	fadd	d0, d1, d30
                	str	d0, [x1]
-               	sub	x1, x29, #0xb0
+               	sub	x1, x29, #0xa8
                	ldr	x2, [x23]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x1, x2
-<L7>:
-               	bl	 <L7>
+<L6>:
+               	bl	 <L6>
                	add	x21, x21, #0x1
                	mov	x20, x0
                	cmp	x21, #0x6
-               	b.lo	 <L1>
-<L8>:
+               	b.lo	 <L0>
+<L7>:
                	sub	x21, x29, #0xc
                	str	xzr, [x21]
                	mov	w22, w19
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x4
-               	b.lo	 <L9>
-               	b	 <L17>
-<L9>:
+               	b.lo	 <L8>
+               	b	 <L18>
+<L8>:
                	mov	w0, w23
                	add	w1, w0, #0x1
                	mov	w17, #0x79b1            // =31153
@@ -315,35 +495,76 @@ Disassembly of section .text:
                	eor	w1, w24, w16
                	add	x2, x0, #0x4
                	str	w1, [x2]
-               	add	x25, x21, #0x0
-               	ldr	x1, [x0]
-               	str	x1, [x25]
-               	add	x26, x25, #0x0
-               	ldr	w1, [x26]
-               	mov	x0, x20
+               	add	x1, x21, #0x0
+               	ldr	x2, [x0]
+               	str	x2, [x1]
+               	add	x0, x1, #0x0
+               	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
+<L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	add	x27, x25, #0x4
-               	ldr	w1, [x27]
+               	add	x0, x21, #0x0
+               	add	x2, x0, #0x4
+               	ldr	w0, [x2]
+               	mov	w2, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	add	x25, x21, #0x0
-               	add	x1, x25, #0x0
-               	ldrh	w2, [x1]
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	add	x1, x25, #0x2
-               	ldrh	w2, [x1]
+               	add	x0, x21, #0x0
+               	add	x2, x0, #0x0
+               	ldrh	w0, [x2]
+               	uxth	w2, w0
+               	mov	x0, x1
                	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	add	x1, x25, #0x4
-               	ldr	w2, [x1]
-               	mov	w1, w2
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x2
+               	ldrh	w1, [x2]
+               	uxth	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	sub	x1, x29, #0x1c
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x4
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L15>:
+               	bl	 <L15>
+               	sub	x1, x29, #0xb0
                	mov	w2, w24
                	add	x3, x1, #0x0
                	strh	w2, [x3]
@@ -354,27 +575,36 @@ Disassembly of section .text:
                	add	w2, w24, #0x1
                	add	x3, x1, #0x4
                	str	w2, [x3]
-               	ldr	x2, [x1]
-               	str	x2, [x25]
-               	ldr	w1, [x26]
-<L15>:
-               	bl	 <L15>
-               	ldr	w1, [x27]
+               	add	x2, x21, #0x0
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L16>:
                	bl	 <L16>
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x4
+               	ldr	w1, [x2]
+               	mov	w2, w1
+               	mov	x1, x2
+<L17>:
+               	bl	 <L17>
                	add	x23, x23, #0x1
                	mov	x20, x0
                	cmp	x23, #0x4
-               	b.lo	 <L9>
-<L17>:
-               	sub	x21, x29, #0x30
+               	b.lo	 <L8>
+<L18>:
+               	sub	x21, x29, #0x28
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	mov	x22, #0x0               // =0
                	cmp	x22, #0x4
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L19>
+               	b	 <L25>
+<L19>:
                	add	x0, x22, #0x1
                	mov	w1, w0
                	add	x2, x21, #0x0
@@ -395,50 +625,71 @@ Disassembly of section .text:
                	movk	x16, #0x9999, lsl #32
                	movk	x16, #0x3fd9, lsl #48
                	orr	x0, x1, x16
-               	add	x23, x21, #0x8
-               	add	x1, x23, #0x0
-               	str	x0, [x1]
-               	add	x24, x21, #0x0
-               	ldrb	w1, [x24]
-               	mov	x0, x20
-<L19>:
-               	bl	 <L19>
-               	sub	x1, x29, #0x68
-               	ldr	x2, [x23]
-               	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x1, x2
+               	add	x1, x21, #0x8
+               	add	x2, x1, #0x0
+               	str	x0, [x2]
+               	add	x0, x21, #0x0
+               	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, x20
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
 <L20>:
-               	bl	 <L20>
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x1, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x23, x21, #0x8
+               	sub	x0, x29, #0x88
+               	ldr	x2, [x23]
+               	str	x2, [x0]
+               	ldr	x2, [x0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L22>:
+               	bl	 <L22>
                	add	x1, x23, #0x0
                	ldr	d0, [x1]
                	fmov	d30, #0.50000000
                	fadd	d1, d0, d30
                	str	d1, [x1]
-               	ldrb	w1, [x24]
-<L21>:
-               	bl	 <L21>
-               	sub	x1, x29, #0x70
-               	ldr	x2, [x23]
-               	str	x2, [x1]
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L22>:
-               	bl	 <L22>
+               	add	x1, x21, #0x0
+               	ldrb	w2, [x1]
+               	uxtb	w1, w2
+<L23>:
+               	bl	 <L23>
+               	add	x1, x21, #0x8
+               	sub	x2, x29, #0x98
+               	ldr	x3, [x1]
+               	str	x3, [x2]
+               	ldr	x1, [x2]
+<L24>:
+               	bl	 <L24>
                	add	x22, x22, #0x1
                	mov	x20, x0
                	cmp	x22, #0x4
-               	b.lo	 <L18>
-<L23>:
-               	sub	x21, x29, #0x48
+               	b.lo	 <L19>
+<L25>:
+               	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
                	mov	x0, #0x0                // =0
                	cmp	x0, #0x3
-               	b.lo	 <L24>
-               	b	 <L25>
-<L24>:
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
                	add	x1, x0, #0x1
                	mov	x17, #0x1b3             // =435
                	movk	x17, #0x100, lsl #32
@@ -459,33 +710,31 @@ Disassembly of section .text:
                	str	x1, [x3]
                	add	x0, x0, #0x1
                	cmp	x0, #0x3
-               	b.lo	 <L24>
-<L25>:
+               	b.lo	 <L26>
+<L27>:
                	mov	x19, #0x0               // =0
                	cmp	x19, #0x3
-               	b.lo	 <L26>
-               	b	 <L28>
-<L26>:
+               	b.lo	 <L28>
+               	b	 <L30>
+<L28>:
                	add	x0, x21, x19, lsl #3
-               	sub	x1, x29, #0x50
+               	sub	x1, x29, #0x48
                	ldr	x2, [x0]
                	str	x2, [x1]
                	ldr	x2, [x1]
                	mov	x0, x20
                	mov	x1, x2
-<L27>:
-               	bl	 <L27>
+<L29>:
+               	bl	 <L29>
                	add	x19, x19, #0x1
                	mov	x20, x0
                	cmp	x19, #0x3
-               	b.lo	 <L26>
-<L28>:
+               	b.lo	 <L28>
+<L30>:
                	mov	x0, x20
                	ldp	x19, x20, [x29, #-0xc0]
                	ldp	x21, x22, [x29, #-0xd0]
                	ldp	x23, x24, [x29, #-0xe0]
-               	ldp	x25, x26, [x29, #-0xf0]
-               	ldur	x27, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_i16.dis
+++ b/test/golden/aarch64-linux/scalar/arith_i16.dis
@@ -3,106 +3,296 @@ scalar/arith_i16.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i16.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            // =65520
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	sxth	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	sxth	w17, w3
                	cmp	w17, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxth	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxth	x4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	sxth	w17, w22
-               	cmp	w17, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               // =0
-               	sxth	w17, w23
-               	cmp	w17, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	sxth	w17, w3
+               	cmp	w17, #0x20
+               	b.lt	 <L0>
 <L5>:
-               	mov	w16, #0x3039            // =12345
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	sxth	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                // =0
+               	sxth	w17, w4
                	cmp	w17, #0x8
-               	b.lt	 <L5>
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0x3039            // =12345
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxth	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	sxth	w17, w4
+               	cmp	w17, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxth	x5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7fff            // =32767
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x8000            // =32768
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	sxth	x4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xffff            // =65535
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	sxth	x1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7fff            // =32767
+               	add	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x8000            // =32768
+               	sub	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xffff            // =65535
+               	add	w1, w17, w0
+               	sxth	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxth	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxth	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxth	x0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_i32.dis
+++ b/test/golden/aarch64-linux/scalar/arith_i32.dis
@@ -3,106 +3,296 @@ scalar/arith_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            // =65520
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x20
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	w1, w23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxtw	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	w1, w21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxtw	x4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	w23, #0x0               // =0
-               	cmp	w23, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	cmp	w3, #0x20
+               	b.lt	 <L0>
 <L5>:
+               	mov	x3, x1
+               	mov	w4, #0x0                // =0
+               	cmp	w4, #0x8
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	w16, #0x5678            // =22136
                	movk	w16, #0x1234, lsl #16
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	w1, w22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	cmp	w23, #0x8
-               	b.lt	 <L5>
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxtw	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	cmp	w4, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxtw	x5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	sxtw	x4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	sxtw	x1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7fff, lsl #16
-               	add	w1, w17, w21
-<L11>:
-               	bl	 <L11>
+               	add	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	w17, #-0x80000000       // =-2147483648
-               	sub	w1, w17, w21
-<L12>:
-               	bl	 <L12>
+               	sub	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w21
-<L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
-<L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
-<L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w1, w17, w0
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxtw	x0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_i64.dis
+++ b/test/golden/aarch64-linux/scalar/arith_i64.dis
@@ -3,113 +3,291 @@ scalar/arith_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xfff0            // =65520
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x20
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	x16, #0x7               // =7
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x1
-               	add	x23, x21, x1
-               	mov	x0, x20
-               	mov	x1, x23
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x1
+               	add	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	x16, #0x3               // =3
-               	mul	x1, x22, x16
-               	add	x2, x1, #0x2
-               	sub	x21, x23, x2
-               	mov	x1, x21
+               	mul	x6, x3, x16
+               	add	x7, x6, #0x2
+               	sub	x6, x4, x7
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x4, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x19
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x6
+               	cmp	x3, #0x20
+               	b.lt	 <L0>
 <L5>:
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	x16, #0xcdef            // =52719
                	movk	x16, #0x90ab, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	mul	x0, x23, x16
-               	add	x1, x0, #0x1
-               	sub	x22, x22, x1
-               	mov	x0, x20
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x20, x0
-               	cmp	x23, #0x8
-               	b.lt	 <L5>
+               	mul	x5, x4, x16
+               	add	x6, x5, #0x1
+               	sub	x5, x3, x6
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	x17, #0x0               // =0
-               	sub	x23, x17, x21
-               	mov	x0, x20
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x17, #0x0               // =0
-               	sub	x1, x17, x23
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	mov	x3, x5
+               	cmp	x4, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	x17, #0x0               // =0
-               	sub	x1, x17, x19
+               	sub	x4, x17, x1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x17, #0x0               // =0
+               	sub	x5, x17, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x17, #0x0               // =0
+               	sub	x4, x17, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x0, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x1, x17, x21
-<L11>:
-               	bl	 <L11>
+               	add	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	sub	x1, x17, x21
-<L12>:
-               	bl	 <L12>
+               	sub	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x21
-<L13>:
-               	bl	 <L13>
-               	add	x1, x21, x22
-<L14>:
-               	bl	 <L14>
-               	sub	x1, x21, x22
-<L15>:
-               	bl	 <L15>
-               	sub	x1, x22, x21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x1, x3
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	x0, x1, x3
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	x0, x3, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_i8.dis
+++ b/test/golden/aarch64-linux/scalar/arith_i8.dis
@@ -3,106 +3,296 @@ scalar/arith_i8.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i8.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xf0              // =240
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	sxtb	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	sxtb	w17, w3
                	cmp	w17, #0x20
-               	b.lt	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lt	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	sxtb	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
                	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	sxtb	x4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	sxtb	w17, w22
-               	cmp	w17, #0x20
-               	b.lt	 <L1>
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               // =0
-               	sxtb	w17, w23
-               	cmp	w17, #0x8
-               	b.lt	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	sxtb	w17, w3
+               	cmp	w17, #0x20
+               	b.lt	 <L0>
 <L5>:
-               	mov	w16, #0x35              // =53
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	sxtb	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                // =0
+               	sxtb	w17, w4
                	cmp	w17, #0x8
-               	b.lt	 <L5>
+               	b.lt	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0x35              // =53
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	sxtb	x6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	sxtb	w17, w4
+               	cmp	w17, #0x8
+               	b.lt	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	sxtb	x5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7f              // =127
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x80              // =128
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	sxtb	x4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xff              // =255
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	sxtb	x1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7f              // =127
+               	add	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x80              // =128
+               	sub	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xff              // =255
+               	add	w1, w17, w0
+               	sxtb	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	sxtb	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	sxtb	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	sxtb	x0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_u16.dis
+++ b/test/golden/aarch64-linux/scalar/arith_u16.dis
@@ -3,106 +3,296 @@ scalar/arith_u16.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u16.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            // =65520
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	uxth	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	uxth	w17, w3
                	cmp	w17, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	uxth	w17, w22
-               	cmp	w17, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	uxth	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               // =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	uxth	w4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               // =0
-               	uxth	w17, w23
-               	cmp	w17, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	uxth	w17, w3
+               	cmp	w17, #0x20
+               	b.lo	 <L0>
 <L5>:
-               	mov	w16, #0xabcd            // =43981
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	uxth	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                // =0
+               	uxth	w17, w4
                	cmp	w17, #0x8
-               	b.lo	 <L5>
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0xabcd            // =43981
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	uxth	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	uxth	w17, w4
+               	cmp	w17, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	uxth	w5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7fff            // =32767
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x8000            // =32768
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	uxth	w4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xffff            // =65535
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	uxth	w1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7fff            // =32767
+               	add	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x8000            // =32768
+               	sub	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xffff            // =65535
+               	add	w1, w17, w0
+               	uxth	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	uxth	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	uxth	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	uxth	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_u32.dis
+++ b/test/golden/aarch64-linux/scalar/arith_u32.dis
@@ -3,106 +3,296 @@ scalar/arith_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xfff0            // =65520
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x20
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	w1, w23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	w1, w21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	mov	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               // =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	mov	w4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	w23, #0x0               // =0
-               	cmp	w23, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	cmp	w3, #0x20
+               	b.lo	 <L0>
 <L5>:
+               	mov	x3, x1
+               	mov	w4, #0x0                // =0
+               	cmp	w4, #0x8
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	w16, #0x5678            // =22136
                	movk	w16, #0x1234, lsl #16
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	w1, w22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	cmp	w23, #0x8
-               	b.lo	 <L5>
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	mov	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	w1, w23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	cmp	w4, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	mov	w5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	mov	w4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	mov	w1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0x7fff, lsl #16
-               	add	w1, w17, w21
-<L11>:
-               	bl	 <L11>
+               	add	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	w17, #-0x80000000       // =-2147483648
-               	sub	w1, w17, w21
-<L12>:
-               	bl	 <L12>
+               	sub	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	add	w1, w17, w21
-<L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
-<L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
-<L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	w1, w17, w0
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_u64.dis
+++ b/test/golden/aarch64-linux/scalar/arith_u64.dis
@@ -3,113 +3,291 @@ scalar/arith_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xfff0            // =65520
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x20
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	x16, #0x7               // =7
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x1
-               	add	x23, x21, x1
-               	mov	x0, x20
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0x3               // =3
-               	mul	x1, x22, x16
-               	add	x2, x1, #0x2
-               	sub	x21, x23, x2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x20
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x1
+               	add	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	x16, #0x3               // =3
+               	mul	x6, x3, x16
+               	add	x7, x6, #0x2
+               	sub	x6, x4, x7
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x4, x16
+               	lsr	x8, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x19
-               	mov	x23, #0x0               // =0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x6
+               	cmp	x3, #0x20
+               	b.lo	 <L0>
 <L5>:
+               	mov	x3, x0
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
                	mov	x16, #0xcdef            // =52719
                	movk	x16, #0x90ab, lsl #16
                	movk	x16, #0x5678, lsl #32
                	movk	x16, #0x1234, lsl #48
-               	mul	x0, x23, x16
-               	add	x1, x0, #0x1
-               	sub	x22, x22, x1
-               	mov	x0, x20
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	x23, x23, #0x1
-               	mov	x20, x0
-               	cmp	x23, #0x8
-               	b.lo	 <L5>
+               	mul	x5, x4, x16
+               	add	x6, x5, #0x1
+               	sub	x5, x3, x6
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	x17, #0x0               // =0
-               	sub	x23, x17, x21
-               	mov	x0, x20
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	x17, #0x0               // =0
-               	sub	x1, x17, x23
+               	add	x4, x4, #0x1
+               	mov	x2, x6
+               	mov	x3, x5
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	x17, #0x0               // =0
-               	sub	x1, x17, x19
+               	sub	x4, x17, x1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x17, #0x0               // =0
+               	sub	x5, x17, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	mov	x17, #0x0               // =0
+               	sub	x4, x17, x0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x0, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x1, x17, x21
-<L11>:
-               	bl	 <L11>
+               	add	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+<L17>:
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	sub	x1, x17, x21
-<L12>:
-               	bl	 <L12>
+               	sub	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L18>
+<L19>:
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x1, x17, x21
-<L13>:
-               	bl	 <L13>
-               	add	x1, x21, x22
-<L14>:
-               	bl	 <L14>
-               	sub	x1, x21, x22
-<L15>:
-               	bl	 <L15>
-               	sub	x1, x22, x21
-<L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	add	x0, x17, x1
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x1, x3
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	x0, x1, x3
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	x0, x3, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/arith_u8.dis
+++ b/test/golden/aarch64-linux/scalar/arith_u8.dis
@@ -3,106 +3,296 @@ scalar/arith_u8.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u8.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x30
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stur	x23, [x29, #-0x28]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xf0              // =240
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	uxtb	w17, w22
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	uxtb	w17, w3
                	cmp	w17, #0x20
-               	b.lo	 <L1>
-               	b	 <L4>
-<L1>:
+               	b.lo	 <L0>
+               	b	 <L5>
+<L0>:
                	mov	w16, #0x7               // =7
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x1
-               	add	w23, w21, w1
-               	mov	x0, x19
-               	mov	x1, x23
-<L2>:
-               	bl	 <L2>
-               	mov	w16, #0x3               // =3
-               	mul	w1, w22, w16
-               	add	w2, w1, #0x2
-               	sub	w21, w23, w2
-               	mov	x1, x21
-<L3>:
-               	bl	 <L3>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	uxtb	w17, w22
-               	cmp	w17, #0x20
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x1
+               	add	w4, w0, w5
+               	uxtb	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	mov	w16, #0x3               // =3
+               	mul	w5, w3, w16
+               	add	w7, w5, #0x2
+               	sub	w5, w4, w7
+               	uxtb	w4, w5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
+<L3>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	mov	x22, x20
-               	mov	x23, #0x0               // =0
-               	uxtb	w17, w23
-               	cmp	w17, #0x8
-               	b.lo	 <L5>
-               	b	 <L7>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x5
+               	uxtb	w17, w3
+               	cmp	w17, #0x20
+               	b.lo	 <L0>
 <L5>:
-               	mov	w16, #0xb5              // =181
-               	mul	w0, w23, w16
-               	add	w1, w0, #0x1
-               	sub	w22, w22, w1
-               	mov	x0, x19
-               	mov	x1, x22
-<L6>:
-               	bl	 <L6>
-               	add	w23, w23, #0x1
-               	mov	x19, x0
-               	uxtb	w17, w23
+               	mov	x3, x1
+               	mov	x4, #0x0                // =0
+               	uxtb	w17, w4
                	cmp	w17, #0x8
-               	b.lo	 <L5>
+               	b.lo	 <L6>
+               	b	 <L9>
+<L6>:
+               	mov	w16, #0xb5              // =181
+               	mul	w5, w4, w16
+               	add	w6, w5, #0x1
+               	sub	w5, w3, w6
+               	uxtb	w6, w5
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	mov	w17, #0x0               // =0
-               	sub	w23, w17, w21
-               	mov	x0, x19
-               	mov	x1, x23
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	mov	w17, #0x0               // =0
-               	sub	w1, w17, w23
+               	add	w4, w4, #0x1
+               	mov	x2, x7
+               	mov	x3, x5
+               	uxtb	w17, w4
+               	cmp	w17, #0x8
+               	b.lo	 <L6>
 <L9>:
-               	bl	 <L9>
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w20
+               	sub	w4, w17, w0
+               	uxtb	w5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	w17, #0x7f              // =127
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	w17, #0x80              // =128
-               	sub	w1, w17, w21
+               	mov	w17, #0x0               // =0
+               	sub	w5, w17, w4
+               	uxtb	w4, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	w17, #0xff              // =255
-               	add	w1, w17, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	add	w1, w21, w22
+               	mov	w17, #0x0               // =0
+               	sub	w4, w17, w1
+               	uxtb	w1, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	sub	w1, w21, w22
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x1, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	sub	w1, w22, w21
+               	mov	w17, #0x7f              // =127
+               	add	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldur	x23, [x29, #-0x28]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	mov	w17, #0x80              // =128
+               	sub	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	w17, #0xff              // =255
+               	add	w1, w17, w0
+               	uxtb	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	w1, w0, w3
+               	uxtb	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	sub	w1, w0, w3
+               	uxtb	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	sub	w1, w3, w0
+               	uxtb	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/divrem_i32.dis
+++ b/test/golden/aarch64-linux/scalar/divrem_i32.dis
@@ -3,206 +3,383 @@ scalar/divrem_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x9400            // =37888
                	movk	w17, #0x7735, lsl #16
-               	sub	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
-               	b	 <L9>
-<L1>:
+               	sub	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
+               	b	 <L11>
+<L0>:
                	mov	w16, #0x83              // =131
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x3
-               	add	w23, w1, w20
-               	cbnz	w23,  <L2>
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x3
+               	add	w4, w5, w1
+               	cbnz	w4,  <L1>
+               	brk	#0
+<L1>:
+               	cmn	w4, #0x1
+               	b.ne	 <L2>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L2>
                	brk	#0
 <L2>:
-               	cmn	w23, #0x1
-               	b.ne	 <L3>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L3>
+               	sdiv	w5, w0, w4
+               	cbnz	w4,  <L3>
                	brk	#0
 <L3>:
-               	sdiv	w24, w21, w23
-               	cbnz	w23,  <L4>
+               	cmn	w4, #0x1
+               	b.ne	 <L4>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L4>
                	brk	#0
 <L4>:
-               	cmn	w23, #0x1
-               	b.ne	 <L5>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L5>
-               	brk	#0
+               	sdiv	w16, w0, w4
+               	msub	w6, w16, w4, w0
+               	sxtw	x7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	sdiv	w16, w21, w23
-               	msub	w25, w16, w23, w21
-               	mov	x0, x19
-               	mov	w1, w24
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	w1, w25
+               	sxtw	x7, w6
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	sub	w21, w21, w23
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	sxtw	x6, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	sub	w0, w0, w4
+               	add	w3, w3, #0x1
+               	mov	x2, x8
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
+<L11>:
                	mov	w17, #0x9400            // =37888
                	movk	w17, #0x7735, lsl #16
-               	add	w0, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x0               // =0
-               	sub	w1, w17, w0
-               	mov	w21, #0x0               // =0
-               	mov	x22, x1
-               	cmp	w21, #0x8
-               	b.lt	 <L10>
-               	b	 <L18>
-<L10>:
-               	mov	w16, #0xc5              // =197
-               	mul	w0, w21, w16
-               	add	w1, w0, #0x5
-               	add	w23, w1, w20
-               	cbnz	w23,  <L11>
-               	brk	#0
-<L11>:
-               	cmn	w23, #0x1
-               	b.ne	 <L12>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w22, w17
-               	b.ne	 <L12>
-               	brk	#0
+               	sub	w3, w17, w0
+               	mov	w0, #0x0                // =0
+               	cmp	w0, #0x8
+               	b.lt	 <L12>
+               	b	 <L23>
 <L12>:
-               	sdiv	w24, w22, w23
-               	cbnz	w23,  <L13>
+               	mov	w16, #0xc5              // =197
+               	mul	w4, w0, w16
+               	add	w5, w4, #0x5
+               	add	w4, w5, w1
+               	cbnz	w4,  <L13>
                	brk	#0
 <L13>:
-               	cmn	w23, #0x1
+               	cmn	w4, #0x1
                	b.ne	 <L14>
                	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w22, w17
+               	cmp	w3, w17
                	b.ne	 <L14>
                	brk	#0
 <L14>:
-               	sdiv	w16, w22, w23
-               	msub	w25, w16, w23, w22
-               	mov	x0, x19
-               	mov	w1, w24
+               	sdiv	w5, w3, w4
+               	cbnz	w4,  <L15>
+               	brk	#0
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w25
+               	cmn	w4, #0x1
+               	b.ne	 <L16>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	sdiv	w16, w3, w4
+               	msub	w6, w16, w4, w3
+               	sxtw	x7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	add	w22, w22, w23
-               	add	w21, w21, #0x1
-               	mov	x19, x0
-               	cmp	w21, #0x8
-               	b.lt	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L17>
 <L18>:
+               	sxtw	x7, w6
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	sxtw	x6, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	add	w3, w3, w4
+               	add	w0, w0, #0x1
+               	mov	x2, x8
+               	cmp	w0, #0x8
+               	b.lt	 <L12>
+<L23>:
                	mov	w17, #0xfffc            // =65532
                	movk	w17, #0x7fff, lsl #16
-               	add	w21, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x3               // =3
-               	add	w22, w17, w20
-               	cbnz	w22,  <L19>
+               	add	w3, w17, w1
+               	cbnz	w3,  <L24>
                	brk	#0
-<L19>:
-               	cmn	w22, #0x1
-               	b.ne	 <L20>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L20>
-               	brk	#0
-<L20>:
-               	sdiv	w20, w21, w22
-               	cbnz	w22,  <L21>
-               	brk	#0
-<L21>:
-               	cmn	w22, #0x1
-               	b.ne	 <L22>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w21, w17
-               	b.ne	 <L22>
-               	brk	#0
-<L22>:
-               	sdiv	w16, w21, w22
-               	msub	w23, w16, w22, w21
-               	mov	x0, x19
-               	mov	w1, w20
-<L23>:
-               	bl	 <L23>
-               	mov	w1, w23
 <L24>:
-               	bl	 <L24>
-               	mul	w1, w22, w20
-               	add	w2, w1, w23
-               	mov	w1, w2
+               	cmn	w3, #0x1
+               	b.ne	 <L25>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w0, w17
+               	b.ne	 <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	cbnz	w21,  <L26>
+               	sdiv	w1, w0, w3
+               	cbnz	w3,  <L26>
                	brk	#0
 <L26>:
-               	cmn	w21, #0x1
+               	cmn	w3, #0x1
                	b.ne	 <L27>
                	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w22, w17
+               	cmp	w0, w17
                	b.ne	 <L27>
                	brk	#0
 <L27>:
-               	sdiv	w19, w22, w21
-               	cbnz	w21,  <L28>
-               	brk	#0
+               	sdiv	w16, w0, w3
+               	msub	w4, w16, w3, w0
+               	sxtw	x5, w1
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	cmn	w21, #0x1
-               	b.ne	 <L29>
-               	mov	w17, #-0x80000000       // =-2147483648
-               	cmp	w22, w17
-               	b.ne	 <L29>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	sdiv	w16, w22, w21
-               	msub	w20, w16, w21, w22
-               	mov	w1, w19
+               	sxtw	x5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	w1, w20
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	mul	w1, w21, w19
-               	add	w2, w1, w20
-               	mov	w1, w2
+               	mul	w5, w3, w1
+               	add	w1, w5, w4
+               	sxtw	x4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
 <L32>:
-               	bl	 <L32>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	cbnz	w0,  <L34>
+               	brk	#0
+<L34>:
+               	cmn	w0, #0x1
+               	b.ne	 <L35>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L35>
+               	brk	#0
+<L35>:
+               	sdiv	w1, w3, w0
+               	cbnz	w0,  <L36>
+               	brk	#0
+<L36>:
+               	cmn	w0, #0x1
+               	b.ne	 <L37>
+               	mov	w17, #-0x80000000       // =-2147483648
+               	cmp	w3, w17
+               	b.ne	 <L37>
+               	brk	#0
+<L37>:
+               	sdiv	w16, w3, w0
+               	msub	w4, w16, w0, w3
+               	sxtw	x3, w1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	sxtw	x3, w4
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	mul	w3, w0, w1
+               	add	w0, w3, w4
+               	sxtw	x1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/divrem_i64.dis
+++ b/test/golden/aarch64-linux/scalar/divrem_i64.dis
@@ -3,209 +3,374 @@ scalar/divrem_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xe2840000        // =3800301568
                	movk	x17, #0x6c50, lsl #32
                	movk	x17, #0x7ce6, lsl #48
-               	sub	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
-               	b	 <L9>
-<L1>:
+               	sub	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
+               	b	 <L11>
+<L0>:
                	mov	x16, #0x83              // =131
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x3
-               	add	x23, x1, x19
-               	cbnz	x23,  <L2>
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x3
+               	add	x4, x5, x0
+               	cbnz	x4,  <L1>
+               	brk	#0
+<L1>:
+               	cmn	x4, #0x1
+               	b.ne	 <L2>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L2>
                	brk	#0
 <L2>:
-               	cmn	x23, #0x1
-               	b.ne	 <L3>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L3>
+               	sdiv	x5, x1, x4
+               	cbnz	x4,  <L3>
                	brk	#0
 <L3>:
-               	sdiv	x24, x21, x23
-               	cbnz	x23,  <L4>
+               	cmn	x4, #0x1
+               	b.ne	 <L4>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L4>
                	brk	#0
 <L4>:
-               	cmn	x23, #0x1
-               	b.ne	 <L5>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L5>
-               	brk	#0
+               	sdiv	x16, x1, x4
+               	msub	x6, x16, x4, x1
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	sdiv	x16, x21, x23
-               	msub	x25, x16, x23, x21
-               	mov	x0, x20
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x25
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
-               	bl	 <L7>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L7>
 <L8>:
-               	bl	 <L8>
-               	sub	x21, x21, x23
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L9>
+<L10>:
+               	sub	x1, x1, x4
+               	add	x3, x3, #0x1
+               	mov	x2, x7
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
+<L11>:
                	mov	x17, #0xe2840000        // =3800301568
                	movk	x17, #0x6c50, lsl #32
                	movk	x17, #0x7ce6, lsl #48
-               	add	x0, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x0               // =0
-               	sub	x1, x17, x0
-               	mov	x21, #0x0               // =0
-               	mov	x22, x1
-               	cmp	x21, #0x8
-               	b.lt	 <L10>
-               	b	 <L18>
-<L10>:
-               	mov	x16, #0xc5              // =197
-               	mul	x0, x21, x16
-               	add	x1, x0, #0x5
-               	add	x23, x1, x19
-               	cbnz	x23,  <L11>
-               	brk	#0
-<L11>:
-               	cmn	x23, #0x1
-               	b.ne	 <L12>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x22, x17
-               	b.ne	 <L12>
-               	brk	#0
+               	sub	x3, x17, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lt	 <L12>
+               	b	 <L23>
 <L12>:
-               	sdiv	x24, x22, x23
-               	cbnz	x23,  <L13>
+               	mov	x16, #0xc5              // =197
+               	mul	x4, x1, x16
+               	add	x5, x4, #0x5
+               	add	x4, x5, x0
+               	cbnz	x4,  <L13>
                	brk	#0
 <L13>:
-               	cmn	x23, #0x1
+               	cmn	x4, #0x1
                	b.ne	 <L14>
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x22, x17
+               	cmp	x3, x17
                	b.ne	 <L14>
                	brk	#0
 <L14>:
-               	sdiv	x16, x22, x23
-               	msub	x25, x16, x23, x22
-               	mov	x0, x20
-               	mov	x1, x24
+               	sdiv	x5, x3, x4
+               	cbnz	x4,  <L15>
+               	brk	#0
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x25
+               	cmn	x4, #0x1
+               	b.ne	 <L16>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L16>
+               	brk	#0
 <L16>:
-               	bl	 <L16>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	sdiv	x16, x3, x4
+               	msub	x6, x16, x4, x3
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	add	x22, x22, x23
-               	add	x21, x21, #0x1
-               	mov	x20, x0
-               	cmp	x21, #0x8
-               	b.lt	 <L10>
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L17>
 <L18>:
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	add	x3, x3, x4
+               	add	x1, x1, #0x1
+               	mov	x2, x7
+               	cmp	x1, #0x8
+               	b.lt	 <L12>
+<L23>:
                	mov	x17, #0xfffc            // =65532
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	add	x21, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x3               // =3
-               	add	x22, x17, x19
-               	cbnz	x22,  <L19>
+               	add	x3, x17, x0
+               	cbnz	x3,  <L24>
                	brk	#0
-<L19>:
-               	cmn	x22, #0x1
-               	b.ne	 <L20>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L20>
-               	brk	#0
-<L20>:
-               	sdiv	x19, x21, x22
-               	cbnz	x22,  <L21>
-               	brk	#0
-<L21>:
-               	cmn	x22, #0x1
-               	b.ne	 <L22>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x21, x17
-               	b.ne	 <L22>
-               	brk	#0
-<L22>:
-               	sdiv	x16, x21, x22
-               	msub	x23, x16, x22, x21
-               	mov	x0, x20
-               	mov	x1, x19
-<L23>:
-               	bl	 <L23>
-               	mov	x1, x23
 <L24>:
-               	bl	 <L24>
-               	mul	x1, x22, x19
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	cmn	x3, #0x1
+               	b.ne	 <L25>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x1, x17
+               	b.ne	 <L25>
+               	brk	#0
 <L25>:
-               	bl	 <L25>
-               	cbnz	x21,  <L26>
+               	sdiv	x0, x1, x3
+               	cbnz	x3,  <L26>
                	brk	#0
 <L26>:
-               	cmn	x21, #0x1
+               	cmn	x3, #0x1
                	b.ne	 <L27>
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x22, x17
+               	cmp	x1, x17
                	b.ne	 <L27>
                	brk	#0
 <L27>:
-               	sdiv	x19, x22, x21
-               	cbnz	x21,  <L28>
-               	brk	#0
+               	sdiv	x16, x1, x3
+               	msub	x4, x16, x3, x1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
 <L28>:
-               	cmn	x21, #0x1
-               	b.ne	 <L29>
-               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	cmp	x22, x17
-               	b.ne	 <L29>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L28>
 <L29>:
-               	sdiv	x16, x22, x21
-               	msub	x20, x16, x21, x22
-               	mov	x1, x19
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
 <L30>:
-               	bl	 <L30>
-               	mov	x1, x20
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L30>
 <L31>:
-               	bl	 <L31>
-               	mul	x1, x21, x19
-               	add	x2, x1, x20
-               	mov	x1, x2
+               	mul	x5, x3, x0
+               	add	x0, x5, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+               	b	 <L33>
 <L32>:
-               	bl	 <L32>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L32>
+<L33>:
+               	cbnz	x1,  <L34>
+               	brk	#0
+<L34>:
+               	cmn	x1, #0x1
+               	b.ne	 <L35>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L35>
+               	brk	#0
+<L35>:
+               	sdiv	x0, x3, x1
+               	cbnz	x1,  <L36>
+               	brk	#0
+<L36>:
+               	cmn	x1, #0x1
+               	b.ne	 <L37>
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	cmp	x3, x17
+               	b.ne	 <L37>
+               	brk	#0
+<L37>:
+               	sdiv	x16, x3, x1
+               	msub	x4, x16, x1, x3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L38>
+<L39>:
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L40>
+<L41>:
+               	mul	x3, x1, x0
+               	add	x0, x3, x4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+               	b	 <L43>
+<L42>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L42>
+<L43>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/divrem_u32.dis
+++ b/test/golden/aarch64-linux/scalar/divrem_u32.dis
@@ -3,108 +3,238 @@ scalar/divrem_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
-               	b	 <L7>
-<L1>:
+               	sub	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
+               	b	 <L9>
+<L0>:
                	mov	w16, #0x83              // =131
-               	mul	w0, w22, w16
-               	add	w1, w0, #0x3
-               	add	w23, w1, w20
-               	cbnz	w23,  <L2>
+               	mul	w4, w3, w16
+               	add	w5, w4, #0x3
+               	add	w4, w5, w1
+               	cbnz	w4,  <L1>
+               	brk	#0
+<L1>:
+               	udiv	w5, w0, w4
+               	cbnz	w4,  <L2>
                	brk	#0
 <L2>:
-               	udiv	w24, w21, w23
-               	cbnz	w23,  <L3>
-               	brk	#0
+               	udiv	w16, w0, w4
+               	msub	w6, w16, w4, w0
+               	mov	w7, w5
+               	mov	x8, x2
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	udiv	w16, w21, w23
-               	msub	w25, w16, w23, w21
-               	mov	x0, x19
-               	mov	w1, w24
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	w1, w25
+               	mov	w7, w6
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mul	w1, w23, w24
-               	add	w2, w1, w25
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	sub	w21, w21, w23
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
+               	mul	w7, w4, w5
+               	add	w5, w7, w6
+               	mov	w6, w5
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x5, x16
+               	lsr	x12, x6, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x12, x16
+               	eor	x12, x8, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x12, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	sub	w0, w0, w4
+               	add	w3, w3, #0x1
+               	mov	x2, x8
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
+<L9>:
                	mov	w17, #0xfffd            // =65533
                	movk	w17, #0xffff, lsl #16
-               	add	w21, w17, w20
+               	add	w0, w17, w1
                	mov	w17, #0x3               // =3
-               	add	w22, w17, w20
-               	cbnz	w22,  <L8>
+               	add	w3, w17, w1
+               	cbnz	w3,  <L10>
                	brk	#0
-<L8>:
-               	udiv	w20, w21, w22
-               	cbnz	w22,  <L9>
-               	brk	#0
-<L9>:
-               	udiv	w16, w21, w22
-               	msub	w23, w16, w22, w21
-               	mov	x0, x19
-               	mov	w1, w20
 <L10>:
-               	bl	 <L10>
-               	mov	w1, w23
+               	udiv	w1, w0, w3
+               	cbnz	w3,  <L11>
+               	brk	#0
 <L11>:
-               	bl	 <L11>
-               	mul	w1, w22, w20
-               	add	w2, w1, w23
-               	mov	w1, w2
+               	udiv	w16, w0, w3
+               	msub	w4, w16, w3, w0
+               	mov	w5, w1
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	cbnz	w21,  <L13>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	udiv	w19, w22, w21
-               	cbnz	w21,  <L14>
-               	brk	#0
+               	mov	w5, w4
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	udiv	w16, w22, w21
-               	msub	w20, w16, w21, w22
-               	mov	w1, w19
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x5, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x2, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	w1, w20
+               	mul	w5, w3, w1
+               	add	w1, w5, w4
+               	mov	w4, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mul	w1, w21, w19
-               	add	w2, w1, w20
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x5, x1, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	cbnz	w0,  <L18>
+               	brk	#0
+<L18>:
+               	udiv	w1, w3, w0
+               	cbnz	w0,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	w16, w3, w0
+               	msub	w4, w16, w0, w3
+               	mov	w3, w1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	w3, w4
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x3, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mul	w3, w0, w1
+               	add	w0, w3, w4
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x0, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/divrem_u64.dis
+++ b/test/golden/aarch64-linux/scalar/divrem_u64.dis
@@ -3,111 +3,232 @@ scalar/divrem_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x40
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	stp	x23, x24, [x29, #-0x30]
-               	stur	x25, [x29, #-0x38]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	sub	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
-               	b	 <L7>
-<L1>:
+               	sub	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
+               	b	 <L9>
+<L0>:
                	mov	x16, #0x83              // =131
-               	mul	x0, x22, x16
-               	add	x1, x0, #0x3
-               	add	x23, x1, x19
-               	cbnz	x23,  <L2>
+               	mul	x4, x3, x16
+               	add	x5, x4, #0x3
+               	add	x4, x5, x0
+               	cbnz	x4,  <L1>
+               	brk	#0
+<L1>:
+               	udiv	x5, x1, x4
+               	cbnz	x4,  <L2>
                	brk	#0
 <L2>:
-               	udiv	x24, x21, x23
-               	cbnz	x23,  <L3>
-               	brk	#0
+               	udiv	x16, x1, x4
+               	msub	x6, x16, x4, x1
+               	mov	x7, x2
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
+               	b	 <L4>
 <L3>:
-               	udiv	x16, x21, x23
-               	msub	x25, x16, x23, x21
-               	mov	x0, x20
-               	mov	x1, x24
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x5, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L3>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x25
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
+               	b	 <L6>
 <L5>:
-               	bl	 <L5>
-               	mul	x1, x23, x24
-               	add	x2, x1, x25
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L5>
 <L6>:
-               	bl	 <L6>
-               	sub	x21, x21, x23
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
+               	mul	x8, x4, x5
+               	add	x5, x8, x6
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+               	b	 <L8>
 <L7>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x6, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x7, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x12, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L7>
+<L8>:
+               	sub	x1, x1, x4
+               	add	x3, x3, #0x1
+               	mov	x2, x7
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
+<L9>:
                	mov	x17, #0xfffd            // =65533
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x21, x17, x19
+               	add	x1, x17, x0
                	mov	x17, #0x3               // =3
-               	add	x22, x17, x19
-               	cbnz	x22,  <L8>
+               	add	x3, x17, x0
+               	cbnz	x3,  <L10>
                	brk	#0
-<L8>:
-               	udiv	x19, x21, x22
-               	cbnz	x22,  <L9>
-               	brk	#0
-<L9>:
-               	udiv	x16, x21, x22
-               	msub	x23, x16, x22, x21
-               	mov	x0, x20
-               	mov	x1, x19
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x23
+               	udiv	x0, x1, x3
+               	cbnz	x3,  <L11>
+               	brk	#0
 <L11>:
-               	bl	 <L11>
-               	mul	x1, x22, x19
-               	add	x2, x1, x23
-               	mov	x1, x2
+               	udiv	x16, x1, x3
+               	msub	x4, x16, x3, x1
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	cbnz	x21,  <L13>
-               	brk	#0
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x0, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	udiv	x19, x22, x21
-               	cbnz	x21,  <L14>
-               	brk	#0
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	udiv	x16, x22, x21
-               	msub	x20, x16, x21, x22
-               	mov	x1, x19
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	x1, x20
+               	mul	x5, x3, x0
+               	add	x0, x5, x4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
 <L16>:
-               	bl	 <L16>
-               	mul	x1, x21, x19
-               	add	x2, x1, x20
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x5, x4, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L16>
 <L17>:
-               	bl	 <L17>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	ldp	x23, x24, [x29, #-0x30]
-               	ldur	x25, [x29, #-0x38]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	cbnz	x1,  <L18>
+               	brk	#0
+<L18>:
+               	udiv	x0, x3, x1
+               	cbnz	x1,  <L19>
+               	brk	#0
+<L19>:
+               	udiv	x16, x3, x1
+               	msub	x4, x16, x1, x3
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x0, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x5, x3, x16
+               	lsr	x6, x4, x5
+               	mov	x16, #0xff              // =255
+               	and	x5, x6, x16
+               	eor	x6, x2, x5
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x6, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	mul	x3, x1, x0
+               	add	x0, x3, x4
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/mul_i32.dis
+++ b/test/golden/aarch64-linux/scalar/mul_i32.dis
@@ -3,69 +3,178 @@ scalar/mul_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_i32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x79b9            // =31161
                	movk	w17, #0x9e37, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w17, #0x2               // =2
-               	mul	w0, w17, w22
-               	add	w1, w0, #0x3
-               	mul	w21, w21, w1
-               	mov	x0, x19
-               	mov	w1, w21
+               	mul	w4, w17, w3
+               	add	w5, w4, #0x3
+               	mul	w4, w0, w5
+               	sxtw	x5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
-               	b.lt	 <L1>
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x4
+               	cmp	w3, #0x10
+               	b.lt	 <L0>
 <L3>:
                	mov	w17, #0xffbf            // =65471
                	movk	w17, #0xffff, lsl #16
-               	add	w22, w17, w20
-               	mul	w1, w22, w22
-               	mov	x0, x19
+               	add	w3, w17, w1
+               	mul	w4, w3, w3
+               	sxtw	x5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w22, w16
-<L5>:
-               	bl	 <L5>
-               	mul	w1, w21, w22
+               	mul	w4, w3, w16
+               	sxtw	x5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	w1, w22, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	w4, w0, w3
+               	sxtw	x5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	w4, w3, w0
+               	sxtw	x0, w4
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w17, #0x1               // =1
                	movk	w17, #0x1, lsl #16
-               	add	w19, w17, w20
-               	mul	w1, w19, w19
-<L8>:
-               	bl	 <L8>
+               	add	w0, w17, w1
+               	mul	w1, w0, w0
+               	sxtw	x3, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w19, w16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	w1, w0, w16
+               	sxtw	x0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/mul_i64.dis
+++ b/test/golden/aarch64-linux/scalar/mul_i64.dis
@@ -3,76 +3,178 @@ scalar/mul_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_i64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	x17, #0x2               // =2
-               	mul	x0, x17, x22
-               	add	x1, x0, #0x3
-               	mul	x21, x21, x1
-               	mov	x0, x20
-               	mov	x1, x21
+               	mul	x4, x17, x3
+               	add	x5, x4, #0x3
+               	mul	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
 <L2>:
-               	bl	 <L2>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
-               	b.lt	 <L1>
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x4
+               	cmp	x3, #0x10
+               	b.lt	 <L0>
 <L3>:
                	mov	x17, #0xffc1            // =65473
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x22, x17, x19
-               	mul	x1, x22, x22
-               	mov	x0, x20
+               	add	x3, x17, x0
+               	mul	x4, x3, x3
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x22, x16
-<L5>:
-               	bl	 <L5>
-               	mul	x1, x21, x22
+               	mul	x4, x3, x16
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	x1, x22, x21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	x4, x1, x3
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	x4, x3, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x17, #0xf               // =15
                	movk	x17, #0x1, lsl #32
-               	add	x20, x17, x19
-               	mul	x1, x20, x20
-<L8>:
-               	bl	 <L8>
+               	add	x1, x17, x0
+               	mul	x0, x1, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x20, x16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	x0, x1, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/mul_u32.dis
+++ b/test/golden/aarch64-linux/scalar/mul_u32.dis
@@ -3,68 +3,177 @@ scalar/mul_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_u32.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w20, w19
+               	mov	w1, w0
                	mov	w17, #0x79b1            // =31153
                	movk	w17, #0x9e37, lsl #16
-               	add	w1, w17, w20
-               	mov	x19, x0
-               	mov	x21, x1
-               	mov	w22, #0x0               // =0
-               	cmp	w22, #0x10
-               	b.lo	 <L1>
+               	add	w0, w17, w1
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	w3, #0x0                // =0
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	w17, #0x2               // =2
-               	mul	w0, w17, w22
-               	add	w1, w0, #0x3
-               	mul	w21, w21, w1
-               	mov	x0, x19
-               	mov	w1, w21
-<L2>:
-               	bl	 <L2>
-               	add	w22, w22, #0x1
-               	mov	x19, x0
-               	cmp	w22, #0x10
+               	mul	w4, w17, w3
+               	add	w5, w4, #0x3
+               	mul	w4, w0, w5
+               	mov	w5, w4
+               	mov	x6, x2
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x5, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	w3, w3, #0x1
+               	mov	x2, x6
+               	mov	x0, x4
+               	cmp	w3, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	w17, #0xffbf            // =65471
                	movk	w17, #0xffff, lsl #16
-               	add	w22, w17, w20
-               	mul	w1, w22, w22
-               	mov	x0, x19
+               	add	w3, w17, w1
+               	mul	w4, w3, w3
+               	mov	w5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	w16, #0xffff            // =65535
                	movk	w16, #0xffff, lsl #16
-               	mul	w1, w22, w16
-<L5>:
-               	bl	 <L5>
-               	mul	w1, w21, w22
+               	mul	w4, w3, w16
+               	mov	w5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	w1, w22, w21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	w4, w0, w3
+               	mov	w5, w4
+               	mov	x4, #0x0                // =0
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x4, x16
+               	lsr	x7, x5, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x4, x4, #0x1
+               	cmp	x4, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	w4, w3, w0
+               	mov	w0, w4
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	w17, #0x1               // =1
                	movk	w17, #0x1, lsl #16
-               	add	w19, w17, w20
-               	mul	w1, w19, w19
-<L8>:
-               	bl	 <L8>
+               	add	w0, w17, w1
+               	mul	w1, w0, w0
+               	mov	w3, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x1, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	w16, #0xffff            // =65535
-               	mul	w1, w19, w16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	w1, w0, w16
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/scalar/mul_u64.dis
+++ b/test/golden/aarch64-linux/scalar/mul_u64.dis
@@ -3,74 +3,176 @@ scalar/mul_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_u64.checksum>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x20
-               	stp	x19, x20, [x29, #-0x10]
-               	stp	x21, x22, [x29, #-0x20]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	x17, #0x7c15            // =31765
                	movk	x17, #0x7f4a, lsl #16
                	movk	x17, #0x79b9, lsl #32
                	movk	x17, #0x9e37, lsl #48
-               	add	x1, x17, x19
-               	mov	x20, x0
-               	mov	x21, x1
-               	mov	x22, #0x0               // =0
-               	cmp	x22, #0x10
-               	b.lo	 <L1>
+               	add	x1, x17, x0
+               	mov	x2, #0x2325             // =8997
+               	movk	x2, #0x8422, lsl #16
+               	movk	x2, #0x9ce4, lsl #32
+               	movk	x2, #0xcbf2, lsl #48
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
                	b	 <L3>
-<L1>:
+<L0>:
                	mov	x17, #0x2               // =2
-               	mul	x0, x17, x22
-               	add	x1, x0, #0x3
-               	mul	x21, x21, x1
-               	mov	x0, x20
-               	mov	x1, x21
-<L2>:
-               	bl	 <L2>
-               	add	x22, x22, #0x1
-               	mov	x20, x0
-               	cmp	x22, #0x10
+               	mul	x4, x17, x3
+               	add	x5, x4, #0x3
+               	mul	x4, x1, x5
+               	mov	x5, x2
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
                	b.lo	 <L1>
+               	b	 <L2>
+<L1>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x5, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L1>
+<L2>:
+               	add	x3, x3, #0x1
+               	mov	x2, x5
+               	mov	x1, x4
+               	cmp	x3, #0x10
+               	b.lo	 <L0>
 <L3>:
                	mov	x17, #0xffc1            // =65473
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	add	x22, x17, x19
-               	mul	x1, x22, x22
-               	mov	x0, x20
+               	add	x3, x17, x0
+               	mul	x4, x3, x3
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L4>
+<L5>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	mul	x1, x22, x16
-<L5>:
-               	bl	 <L5>
-               	mul	x1, x21, x22
+               	mul	x4, x3, x16
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mul	x1, x22, x21
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
+               	mul	x4, x1, x3
+               	mov	x5, #0x0                // =0
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x6, x5, x16
+               	lsr	x7, x4, x6
+               	mov	x16, #0xff              // =255
+               	and	x6, x7, x16
+               	eor	x7, x2, x6
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x7, x16
+               	add	x5, x5, #0x1
+               	cmp	x5, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	mul	x4, x3, x1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x5, x4, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x5, x16
+               	eor	x5, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
                	mov	x17, #0xf               // =15
                	movk	x17, #0x1, lsl #32
-               	add	x20, x17, x19
-               	mul	x1, x20, x20
-<L8>:
-               	bl	 <L8>
+               	add	x1, x17, x0
+               	mul	x0, x1, x1
+               	mov	x3, #0x0                // =0
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x3, x16
+               	lsr	x5, x0, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x2, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x5, x16
+               	add	x3, x3, #0x1
+               	cmp	x3, #0x8
+               	b.lo	 <L12>
+<L13>:
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
-               	mul	x1, x20, x16
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x10]
-               	ldp	x21, x22, [x29, #-0x20]
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mul	x0, x1, x16
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x0, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x2, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x2, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
+               	mov	x0, x2
                	ret

--- a/test/golden/aarch64-linux/vec/autovec_loop.dis
+++ b/test/golden/aarch64-linux/vec/autovec_loop.dis
@@ -5,673 +5,812 @@ Disassembly of section .text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x8f0
-               	sub	x16, x29, #0x8c0
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stp	x23, x24, [x16, #-0x20]
-               	stur	x25, [x16, #-0x28]
-               	sub	x16, x29, #0x8f8
-               	str	d8, [x16, #0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
+               	sub	sp, sp, #0x8b0
                	mov	x16, #0x1               // =1
-               	and	x1, x19, x16
+               	and	x1, x0, x16
                	mov	x17, #0x43              // =67
-               	sub	x20, x17, x1
+               	sub	x2, x17, x1
                	mov	x17, #0x25              // =37
-               	sub	x21, x17, x1
-               	mov	w1, w19
-               	ucvtf	s8, x19
-               	sub	x19, x29, #0x10c
-               	add	x2, x19, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x108              // =264
+               	sub	x3, x17, x1
+               	mov	w1, w0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x680
+               	add	x4, x0, #0x0
+               	add	x5, x4, #0x0
+               	mov	x4, #0x108              // =264
+<L0>:
+               	str	xzr, [x5]
+               	add	x5, x5, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L0>
+               	str	wzr, [x5]
+               	sub	x4, x29, #0x78c
+               	add	x5, x4, #0x0
+               	add	x6, x5, #0x0
+               	mov	x5, #0x108              // =264
 <L1>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x5, x5, #0x8
+               	cmp	x5, #0x0
                	b.ne	 <L1>
-               	str	wzr, [x3]
-               	sub	x22, x29, #0x218
-               	add	x2, x22, #0x0
-               	add	x3, x2, #0x0
-               	mov	x2, #0x108              // =264
+               	str	wzr, [x6]
+               	mov	x5, #0x0                // =0
+               	cmp	x5, x2
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	str	xzr, [x3]
-               	add	x3, x3, #0x8
-               	sub	x2, x2, #0x8
-               	cmp	x2, #0x0
-               	b.ne	 <L2>
-               	str	wzr, [x3]
-               	mov	x2, #0x0                // =0
-               	cmp	x2, x20
-               	b.lo	 <L3>
-               	b	 <L4>
-<L3>:
-               	mov	w3, w2
+               	mov	w6, w5
                	mov	w16, #0x79b1            // =31153
                	movk	w16, #0x9e37, lsl #16
-               	mul	w4, w3, w16
+               	mul	w7, w6, w16
                	mov	w16, #0x3039            // =12345
-               	add	w5, w4, w16
-               	add	x4, x19, x2, lsl #2
-               	str	w5, [x4]
+               	add	w8, w7, w16
+               	add	x7, x0, x5, lsl #2
+               	str	w8, [x7]
                	mov	w16, #0x9e37            // =40503
-               	mul	w4, w3, w16
+               	mul	w7, w6, w16
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	sub	w3, w17, w4
-               	add	x4, x22, x2, lsl #2
-               	str	w3, [x4]
-               	add	x2, x2, #0x1
-               	cmp	x2, x20
-               	b.lo	 <L3>
+               	sub	w6, w17, w7
+               	add	x7, x4, x5, lsl #2
+               	str	w6, [x7]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L2>
+<L3>:
+               	add	x5, x0, #0x0
+               	ldr	w6, [x5]
+               	add	w7, w6, w1
+               	str	w7, [x5]
+               	add	x5, x4, #0x4
+               	ldr	w6, [x5]
+               	add	w7, w6, w1
+               	str	w7, [x5]
+               	sub	x1, x29, #0x10c
+               	add	x5, x1, #0x0
+               	add	x6, x5, #0x0
+               	mov	x5, #0x108              // =264
 <L4>:
-               	add	x2, x19, #0x0
-               	ldr	w3, [x2]
-               	add	w4, w3, w1
-               	str	w4, [x2]
-               	add	x2, x22, #0x4
-               	ldr	w3, [x2]
-               	add	w4, w3, w1
-               	str	w4, [x2]
-               	sub	x23, x29, #0x324
-               	add	x1, x23, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x108              // =264
-<L5>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L5>
-               	str	wzr, [x2]
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x5, x5, #0x8
+               	cmp	x5, #0x0
+               	b.ne	 <L4>
+               	str	wzr, [x6]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xfffe, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	cmp	x20, x16
-               	cset	w1, ls
+               	cmp	x2, x16
+               	cset	w5, ls
                	mov	w16, #0x1               // =1
-               	and	w2, w1, w16
+               	and	w6, w5, w16
                	mov	w16, #0x1               // =1
-               	and	w1, w2, w16
+               	and	w5, w6, w16
                	mov	w16, #0x1               // =1
-               	and	w2, w1, w16
+               	and	w6, w5, w16
                	mov	w16, #0x1               // =1
-               	and	w1, w2, w16
-               	add	x2, x19, #0x0
-               	add	x3, x19, x20, lsl #2
-               	add	x4, x22, #0x0
-               	add	x5, x22, x20, lsl #2
-               	add	x6, x23, #0x0
-               	add	x7, x23, x20, lsl #2
-               	cmp	x7, x2
+               	and	w5, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x2, lsl #2
+               	add	x8, x4, #0x0
+               	add	x12, x4, x2, lsl #2
+               	add	x13, x1, #0x0
+               	add	x14, x1, x2, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
                	cset	w8, ls
-               	cmp	x3, x6
-               	cset	w2, ls
-               	orr	w3, w8, w2
-               	cmp	x7, x4
-               	cset	w2, ls
-               	cmp	x5, x6
-               	cset	w4, ls
-               	orr	w5, w2, w4
-               	and	w2, w3, w5
-               	and	w3, w1, w2
-               	cbnz	w3,  <L7>
-               	mov	x1, #0x0                // =0
-               	cmp	x1, x20
-               	b.lo	 <L6>
-               	b	 <L11>
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w5, w6
+               	cbnz	w7,  <L6>
+               	mov	x5, #0x0                // =0
+               	cmp	x5, x2
+               	b.lo	 <L5>
+               	b	 <L10>
+<L5>:
+               	add	x6, x0, x5, lsl #2
+               	ldr	w7, [x6]
+               	mov	w16, #0x3               // =3
+               	mul	w6, w7, w16
+               	add	x7, x4, x5, lsl #2
+               	ldr	w8, [x7]
+               	add	w7, w6, w8
+               	add	x6, x1, x5, lsl #2
+               	str	w7, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L5>
+               	b	 <L10>
 <L6>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	mov	w16, #0x3               // =3
-               	mul	w2, w3, w16
-               	add	x3, x22, x1, lsl #2
-               	ldr	w4, [x3]
-               	add	w3, w2, w4
-               	add	x2, x23, x1, lsl #2
-               	str	w3, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L6>
-               	b	 <L11>
+               	sub	x5, x29, #0x8a8
+               	add	x6, x5, #0x0
+               	mov	w17, #0x3               // =3
+               	str	w17, [x6]
+               	add	x6, x5, #0x4
+               	mov	w17, #0x3               // =3
+               	str	w17, [x6]
+               	add	x6, x5, #0x8
+               	mov	w17, #0x3               // =3
+               	str	w17, [x6]
+               	add	x6, x5, #0xc
+               	mov	w17, #0x3               // =3
+               	str	w17, [x6]
+               	ldr	q1, [x5]
+               	mov	x5, #0x0                // =0
+               	add	x6, x5, #0x4
+               	cmp	x6, x2
+               	b.ls	 <L7>
+               	b	 <L8>
 <L7>:
-               	sub	x1, x29, #0x8a8
-               	add	x2, x1, #0x0
-               	mov	w17, #0x3               // =3
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
-               	mov	w17, #0x3               // =3
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
-               	mov	w17, #0x3               // =3
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
-               	mov	w17, #0x3               // =3
-               	str	w17, [x2]
-               	ldr	q0, [x1]
-               	mov	x1, #0x0                // =0
-               	add	x2, x1, #0x4
-               	cmp	x2, x20
-               	b.ls	 <L8>
-               	b	 <L9>
+               	add	x6, x0, x5, lsl #2
+               	ldr	q2, [x6]
+               	mul	v3.4s, v2.4s, v1.4s
+               	add	x6, x4, x5, lsl #2
+               	ldr	q2, [x6]
+               	add	v4.4s, v3.4s, v2.4s
+               	add	x6, x1, x5, lsl #2
+               	str	q4, [x6]
+               	add	x5, x5, #0x4
+               	add	x6, x5, #0x4
+               	cmp	x6, x2
+               	b.ls	 <L7>
 <L8>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q1, [x2]
-               	mul	v2.4s, v1.4s, v0.4s
-               	add	x2, x22, x1, lsl #2
-               	ldr	q1, [x2]
-               	add	v3.4s, v2.4s, v1.4s
-               	add	x2, x23, x1, lsl #2
-               	str	q3, [x2]
-               	add	x1, x1, #0x4
-               	add	x2, x1, #0x4
-               	cmp	x2, x20
-               	b.ls	 <L8>
+               	cmp	x5, x2
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	cmp	x1, x20
-               	b.lo	 <L10>
-               	b	 <L11>
-<L10>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
+               	add	x6, x0, x5, lsl #2
+               	ldr	w7, [x6]
                	mov	w16, #0x3               // =3
-               	mul	w2, w3, w16
-               	add	x3, x22, x1, lsl #2
-               	ldr	w4, [x3]
-               	add	w3, w2, w4
-               	add	x2, x23, x1, lsl #2
-               	str	w3, [x2]
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L10>
-<L11>:
-               	mov	x24, x0
-               	mov	x25, #0x0               // =0
-               	cmp	x25, x20
-               	b.lo	 <L12>
+               	mul	w6, w7, w16
+               	add	x7, x4, x5, lsl #2
+               	ldr	w8, [x7]
+               	add	w7, w6, w8
+               	add	x6, x1, x5, lsl #2
+               	str	w7, [x6]
+               	add	x5, x5, #0x1
+               	cmp	x5, x2
+               	b.lo	 <L9>
+<L10>:
+               	mov	x5, #0x2325             // =8997
+               	movk	x5, #0x8422, lsl #16
+               	movk	x5, #0x9ce4, lsl #32
+               	movk	x5, #0xcbf2, lsl #48
+               	mov	x6, #0x0                // =0
+               	cmp	x6, x2
+               	b.lo	 <L11>
                	b	 <L14>
-<L12>:
-               	add	x0, x23, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x24
-<L13>:
-               	bl	 <L13>
-               	add	x25, x25, #0x1
-               	mov	x24, x0
-               	cmp	x25, x20
+<L11>:
+               	add	x7, x1, x6, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
                	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x6, x6, #0x1
+               	mov	x5, x8
+               	cmp	x6, x2
+               	b.lo	 <L11>
 <L14>:
-               	mov	x0, #0x0                // =0
-               	mov	w1, #0x0                // =0
-               	mov	w25, #0x0               // =0
-               	cmp	x0, x20
+               	mov	x6, #0x0                // =0
+               	mov	w7, #0x0                // =0
+               	mov	w8, #0x0                // =0
+               	cmp	x6, x2
                	b.lo	 <L15>
                	b	 <L16>
 <L15>:
-               	add	x2, x23, x0, lsl #2
-               	ldr	w3, [x2]
-               	add	w1, w1, w3
-               	add	x2, x19, x0, lsl #2
-               	ldr	w3, [x2]
-               	eor	w25, w25, w3
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
+               	add	x12, x1, x6, lsl #2
+               	ldr	w13, [x12]
+               	add	w7, w7, w13
+               	add	x12, x0, x6, lsl #2
+               	ldr	w13, [x12]
+               	eor	w8, w8, w13
+               	add	x6, x6, #0x1
+               	cmp	x6, x2
                	b.lo	 <L15>
 <L16>:
-               	mov	x0, x24
+               	mov	w6, w7
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L17>
+               	b	 <L18>
 <L17>:
-               	bl	 <L17>
-               	mov	w1, w25
+               	mov	x16, #0x8               // =8
+               	mul	x12, x7, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x5, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x13, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L17>
 <L18>:
-               	bl	 <L18>
-               	sub	x24, x29, #0x430
-               	add	x1, x24, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x108              // =264
+               	mov	w6, w8
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
 <L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x6, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x5, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	sub	x6, x29, #0x898
+               	add	x7, x6, #0x0
+               	add	x8, x7, #0x0
+               	mov	x7, #0x108              // =264
+<L21>:
+               	str	xzr, [x8]
+               	add	x8, x8, #0x8
+               	sub	x7, x7, #0x8
+               	cmp	x7, #0x0
+               	b.ne	 <L21>
+               	str	wzr, [x8]
+               	mov	x7, #0x0                // =0
+               	cmp	x7, x2
+               	b.lo	 <L22>
+               	b	 <L25>
+<L22>:
+               	add	x8, x0, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x4, x7, lsl #2
+               	ldr	w13, [x8]
+               	cmp	w13, w12
+               	b.lo	 <L23>
+               	add	x8, x4, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x0, x7, lsl #2
+               	ldr	w13, [x8]
+               	sub	w8, w12, w13
+               	add	x12, x6, x7, lsl #2
+               	str	w8, [x12]
+               	b	 <L24>
+<L23>:
+               	add	x8, x0, x7, lsl #2
+               	ldr	w12, [x8]
+               	add	x8, x4, x7, lsl #2
+               	ldr	w13, [x8]
+               	sub	w8, w12, w13
+               	add	x12, x6, x7, lsl #2
+               	str	w8, [x12]
+<L24>:
+               	add	x7, x7, #0x1
+               	cmp	x7, x2
+               	b.lo	 <L22>
+<L25>:
+               	mov	x4, #0x0                // =0
+               	cmp	x4, x2
+               	b.lo	 <L26>
+               	b	 <L29>
+<L26>:
+               	add	x7, x6, x4, lsl #2
+               	ldr	w8, [x7]
+               	mov	w7, w8
+               	mov	x8, x5
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L27>
+               	b	 <L28>
+<L27>:
+               	mov	x16, #0x8               // =8
+               	mul	x13, x12, x16
+               	lsr	x14, x7, x13
+               	mov	x16, #0xff              // =255
+               	and	x13, x14, x16
+               	eor	x14, x8, x13
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x8, x14, x16
+               	add	x12, x12, #0x1
+               	cmp	x12, #0x8
+               	b.lo	 <L27>
+<L28>:
+               	add	x4, x4, #0x1
+               	mov	x5, x8
+               	cmp	x4, x2
+               	b.lo	 <L26>
+<L29>:
+               	sub	x4, x29, #0x218
+               	add	x6, x4, #0x0
+               	add	x7, x6, #0x0
+               	mov	x6, #0x108              // =264
+<L30>:
+               	str	xzr, [x7]
+               	add	x7, x7, #0x8
+               	sub	x6, x6, #0x8
+               	cmp	x6, #0x0
+               	b.ne	 <L30>
+               	str	wzr, [x7]
+               	mov	x6, #0x0                // =0
+               	cmp	x6, x2
+               	b.lo	 <L31>
+               	b	 <L32>
+<L31>:
+               	add	x7, x4, x6, lsl #2
+               	mov	w17, #0xaaaa            // =43690
+               	movk	w17, #0xaaaa, lsl #16
+               	str	w17, [x7]
+               	add	x6, x6, #0x1
+               	cmp	x6, x2
+               	b.lo	 <L31>
+<L32>:
+               	mov	x6, #0x0                // =0
+               	cmp	x6, x2
+               	b.lo	 <L33>
+               	b	 <L34>
+<L33>:
+               	add	x7, x1, x6, lsl #2
+               	ldr	w8, [x7]
+               	mov	w16, #0x1               // =1
+               	eor	w7, w8, w16
+               	add	x8, x4, x6, lsl #2
+               	str	w7, [x8]
+               	add	x6, x6, #0x2
+               	cmp	x6, x2
+               	b.lo	 <L33>
+<L34>:
+               	mov	x1, #0x0                // =0
+               	cmp	x1, x2
+               	b.lo	 <L35>
+               	b	 <L38>
+<L35>:
+               	add	x6, x4, x1, lsl #2
+               	ldr	w7, [x6]
+               	mov	w6, w7
+               	mov	x7, x5
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x6, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x7, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x7, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L36>
+<L37>:
+               	add	x1, x1, #0x1
+               	mov	x5, x7
+               	cmp	x1, x2
+               	b.lo	 <L35>
+<L38>:
+               	sub	x1, x29, #0x324
+               	add	x4, x1, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x108              // =264
+<L39>:
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L39>
+               	str	wzr, [x6]
+               	add	x4, x0, #0x0
+               	ldr	w6, [x4]
+               	add	x4, x1, #0x0
+               	str	w6, [x4]
+               	mov	x4, #0x1                // =1
+               	cmp	x4, x2
+               	b.lo	 <L40>
+               	b	 <L41>
+<L40>:
+               	sub	x6, x4, #0x1
+               	add	x7, x1, x6, lsl #2
+               	ldr	w6, [x7]
+               	mov	w16, #0x1f              // =31
+               	mul	w7, w6, w16
+               	add	x6, x0, x4, lsl #2
+               	ldr	w8, [x6]
+               	add	w6, w7, w8
+               	add	x7, x1, x4, lsl #2
+               	str	w6, [x7]
+               	add	x4, x4, #0x1
+               	cmp	x4, x2
+               	b.lo	 <L40>
+<L41>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, x2
+               	b.lo	 <L42>
+               	b	 <L45>
+<L42>:
+               	add	x4, x1, x0, lsl #2
+               	ldr	w6, [x4]
+               	mov	w4, w6
+               	mov	x6, x5
+               	mov	x7, #0x0                // =0
+               	cmp	x7, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               // =8
+               	mul	x8, x7, x16
+               	lsr	x12, x4, x8
+               	mov	x16, #0xff              // =255
+               	and	x8, x12, x16
+               	eor	x12, x6, x8
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x12, x16
+               	add	x7, x7, #0x1
+               	cmp	x7, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x0, #0x1
+               	mov	x5, x6
+               	cmp	x0, x2
+               	b.lo	 <L42>
+<L45>:
+               	sub	x0, x29, #0x3b8
+               	add	x1, x0, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x90               // =144
+<L46>:
                	str	xzr, [x2]
                	add	x2, x2, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L19>
+               	b.ne	 <L46>
                	str	wzr, [x2]
-               	mov	x1, #0x0                // =0
-               	cmp	x1, x20
-               	b.lo	 <L20>
-               	b	 <L23>
-<L20>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x22, x1, lsl #2
-               	ldr	w4, [x2]
-               	cmp	w4, w3
-               	b.lo	 <L21>
-               	add	x2, x22, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x19, x1, lsl #2
-               	ldr	w4, [x2]
-               	sub	w2, w3, w4
-               	add	x3, x24, x1, lsl #2
-               	str	w2, [x3]
-               	b	 <L22>
-<L21>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	w3, [x2]
-               	add	x2, x22, x1, lsl #2
-               	ldr	w4, [x2]
-               	sub	w2, w3, w4
-               	add	x3, x24, x1, lsl #2
-               	str	w2, [x3]
-<L22>:
-               	add	x1, x1, #0x1
-               	cmp	x1, x20
-               	b.lo	 <L20>
-<L23>:
-               	mov	x22, x0
-               	mov	x25, #0x0               // =0
-               	cmp	x25, x20
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
-               	add	x0, x24, x25, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L25>:
-               	bl	 <L25>
-               	add	x25, x25, #0x1
-               	mov	x22, x0
-               	cmp	x25, x20
-               	b.lo	 <L24>
-<L26>:
-               	sub	x24, x29, #0x53c
-               	add	x0, x24, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x108              // =264
-<L27>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L27>
-               	str	wzr, [x1]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, x20
-               	b.lo	 <L28>
-               	b	 <L29>
-<L28>:
-               	add	x1, x24, x0, lsl #2
-               	mov	w17, #0xaaaa            // =43690
-               	movk	w17, #0xaaaa, lsl #16
-               	str	w17, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
-               	b.lo	 <L28>
-<L29>:
-               	mov	x0, #0x0                // =0
-               	cmp	x0, x20
-               	b.lo	 <L30>
-               	b	 <L31>
-<L30>:
-               	add	x1, x23, x0, lsl #2
-               	ldr	w2, [x1]
-               	mov	w16, #0x1               // =1
-               	eor	w1, w2, w16
-               	add	x2, x24, x0, lsl #2
-               	str	w1, [x2]
-               	add	x0, x0, #0x2
-               	cmp	x0, x20
-               	b.lo	 <L30>
-<L31>:
-               	mov	x23, #0x0               // =0
-               	cmp	x23, x20
-               	b.lo	 <L32>
-               	b	 <L34>
-<L32>:
-               	add	x0, x24, x23, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L33>:
-               	bl	 <L33>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, x20
-               	b.lo	 <L32>
-<L34>:
-               	sub	x23, x29, #0x648
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x108              // =264
-<L35>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L35>
-               	str	wzr, [x1]
-               	add	x0, x19, #0x0
-               	ldr	w1, [x0]
-               	add	x0, x23, #0x0
-               	str	w1, [x0]
-               	mov	x0, #0x1                // =1
-               	cmp	x0, x20
-               	b.lo	 <L36>
-               	b	 <L37>
-<L36>:
-               	sub	x1, x0, #0x1
-               	add	x2, x23, x1, lsl #2
-               	ldr	w1, [x2]
-               	mov	w16, #0x1f              // =31
-               	mul	w2, w1, w16
-               	add	x1, x19, x0, lsl #2
-               	ldr	w3, [x1]
-               	add	w1, w2, w3
-               	add	x2, x23, x0, lsl #2
-               	str	w1, [x2]
-               	add	x0, x0, #0x1
-               	cmp	x0, x20
-               	b.lo	 <L36>
-<L37>:
-               	mov	x19, #0x0               // =0
-               	cmp	x19, x20
-               	b.lo	 <L38>
-               	b	 <L40>
-<L38>:
-               	add	x0, x23, x19, lsl #2
-               	ldr	w1, [x0]
-               	mov	x0, x22
-<L39>:
-               	bl	 <L39>
-               	add	x19, x19, #0x1
-               	mov	x22, x0
-               	cmp	x19, x20
-               	b.lo	 <L38>
-<L40>:
-               	sub	x19, x29, #0x6dc
-               	add	x0, x19, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               // =144
-<L41>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L41>
-               	str	wzr, [x1]
-               	sub	x20, x29, #0x770
-               	add	x0, x20, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               // =144
-<L42>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L42>
-               	str	wzr, [x1]
-               	mov	x0, #0x0                // =0
-               	cmp	x0, x21
-               	b.lo	 <L43>
-               	b	 <L44>
-<L43>:
-               	ucvtf	s0, x0
-               	fadd	s1, s0, s8
-               	add	x1, x19, x0, lsl #2
-               	str	s1, [x1]
-               	fmov	s31, #1.25000000
-               	fsub	s1, s31, s0
-               	add	x1, x20, x0, lsl #2
-               	str	s1, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L43>
-<L44>:
-               	sub	x23, x29, #0x804
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               // =144
-<L45>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L45>
-               	str	wzr, [x1]
-               	mov	x16, #0xffff            // =65535
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xfffe, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	cmp	x21, x16
-               	cset	w0, ls
-               	mov	w16, #0x1               // =1
-               	and	w1, w0, w16
-               	mov	w16, #0x1               // =1
-               	and	w0, w1, w16
-               	mov	w16, #0x1               // =1
-               	and	w1, w0, w16
-               	mov	w16, #0x1               // =1
-               	and	w0, w1, w16
-               	add	x1, x19, #0x0
-               	add	x2, x19, x21, lsl #2
-               	add	x3, x20, #0x0
-               	add	x4, x20, x21, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x21, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
-               	cset	w1, ls
-               	orr	w2, w7, w1
-               	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	and	w2, w0, w1
-               	cbnz	w2,  <L47>
-               	mov	x0, #0x0                // =0
-               	cmp	x0, x21
-               	b.lo	 <L46>
-               	b	 <L51>
-<L46>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L46>
-               	b	 <L51>
+               	sub	x1, x29, #0x44c
+               	add	x2, x1, #0x0
+               	add	x4, x2, #0x0
+               	mov	x2, #0x90               // =144
 <L47>:
-               	mov	x0, #0x0                // =0
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L48>
+               	str	xzr, [x4]
+               	add	x4, x4, #0x8
+               	sub	x2, x2, #0x8
+               	cmp	x2, #0x0
+               	b.ne	 <L47>
+               	str	wzr, [x4]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, x3
+               	b.lo	 <L48>
                	b	 <L49>
 <L48>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	q0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	q1, [x1]
-               	fmul	v2.4s, v0.4s, v1.4s
-               	add	x1, x23, x0, lsl #2
-               	str	q2, [x1]
-               	add	x0, x0, #0x4
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L48>
+               	ucvtf	s1, x2
+               	fadd	s2, s1, s0
+               	add	x4, x0, x2, lsl #2
+               	str	s2, [x4]
+               	fmov	s31, #1.25000000
+               	fsub	s2, s31, s1
+               	add	x4, x1, x2, lsl #2
+               	str	s2, [x4]
+               	add	x2, x2, #0x1
+               	cmp	x2, x3
+               	b.lo	 <L48>
 <L49>:
-               	cmp	x0, x21
-               	b.lo	 <L50>
-               	b	 <L51>
+               	sub	x2, x29, #0x4e0
+               	add	x4, x2, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x90               // =144
 <L50>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L50>
-<L51>:
-               	mov	x24, #0x0               // =0
-               	cmp	x24, x21
-               	b.lo	 <L52>
-               	b	 <L54>
-<L52>:
-               	add	x0, x23, x24, lsl #2
-               	ldr	s0, [x0]
-               	mov	x0, x22
-<L53>:
-               	bl	 <L53>
-               	add	x24, x24, #0x1
-               	mov	x22, x0
-               	cmp	x24, x21
-               	b.lo	 <L52>
-<L54>:
-               	sub	x23, x29, #0x898
-               	add	x0, x23, #0x0
-               	add	x1, x0, #0x0
-               	mov	x0, #0x90               // =144
-<L55>:
-               	str	xzr, [x1]
-               	add	x1, x1, #0x8
-               	sub	x0, x0, #0x8
-               	cmp	x0, #0x0
-               	b.ne	 <L55>
-               	str	wzr, [x1]
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L50>
+               	str	wzr, [x6]
                	mov	x16, #0xffff            // =65535
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xfffe, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	cmp	x21, x16
-               	cset	w0, ls
+               	cmp	x3, x16
+               	cset	w4, ls
                	mov	w16, #0x1               // =1
-               	and	w1, w0, w16
+               	and	w6, w4, w16
                	mov	w16, #0x1               // =1
-               	and	w0, w1, w16
+               	and	w4, w6, w16
                	mov	w16, #0x1               // =1
-               	and	w1, w0, w16
+               	and	w6, w4, w16
                	mov	w16, #0x1               // =1
-               	and	w0, w1, w16
-               	add	x1, x19, #0x0
-               	add	x2, x19, x21, lsl #2
-               	add	x3, x20, #0x0
-               	add	x4, x20, x21, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x21, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
-               	cset	w1, ls
-               	orr	w2, w7, w1
+               	and	w4, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x3, lsl #2
+               	add	x8, x1, #0x0
+               	add	x12, x1, x3, lsl #2
+               	add	x13, x2, #0x0
+               	add	x14, x2, x3, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
+               	cset	w8, ls
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w4, w6
+               	cbnz	w7,  <L52>
+               	mov	x4, #0x0                // =0
+               	cmp	x4, x3
+               	b.lo	 <L51>
+               	b	 <L56>
+<L51>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fmul	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L51>
+               	b	 <L56>
+<L52>:
+               	mov	x4, #0x0                // =0
+               	add	x6, x4, #0x4
                	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	and	w2, w0, w1
-               	cbnz	w2,  <L57>
-               	mov	x0, #0x0                // =0
-               	cmp	x0, x21
-               	b.lo	 <L56>
-               	b	 <L61>
+               	b.ls	 <L53>
+               	b	 <L54>
+<L53>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	q0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	q1, [x6]
+               	fmul	v2.4s, v0.4s, v1.4s
+               	add	x6, x2, x4, lsl #2
+               	str	q2, [x6]
+               	add	x4, x4, #0x4
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L53>
+<L54>:
+               	cmp	x4, x3
+               	b.lo	 <L55>
+               	b	 <L56>
+<L55>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fmul	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L55>
 <L56>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L56>
-               	b	 <L61>
+               	mov	x4, #0x0                // =0
+               	cmp	x4, x3
+               	b.lo	 <L57>
+               	b	 <L60>
 <L57>:
-               	mov	x0, #0x0                // =0
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L58>
+               	add	x6, x2, x4, lsl #2
+               	ldr	s0, [x6]
+               	fmov	w6, s0
+               	mov	w7, w6
+               	mov	x6, x5
+               	mov	x8, #0x0                // =0
+               	cmp	x8, #0x8
+               	b.lo	 <L58>
                	b	 <L59>
 <L58>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	q0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	q1, [x1]
-               	fdiv	v2.4s, v0.4s, v1.4s
-               	add	x1, x23, x0, lsl #2
-               	str	q2, [x1]
-               	add	x0, x0, #0x4
-               	add	x1, x0, #0x4
-               	cmp	x1, x21
-               	b.ls	 <L58>
+               	mov	x16, #0x8               // =8
+               	mul	x12, x8, x16
+               	lsr	x13, x7, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x13, x16
+               	eor	x13, x6, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x6, x13, x16
+               	add	x8, x8, #0x1
+               	cmp	x8, #0x8
+               	b.lo	 <L58>
 <L59>:
-               	cmp	x0, x21
-               	b.lo	 <L60>
-               	b	 <L61>
+               	add	x4, x4, #0x1
+               	mov	x5, x6
+               	cmp	x4, x3
+               	b.lo	 <L57>
 <L60>:
-               	add	x1, x19, x0, lsl #2
-               	ldr	s0, [x1]
-               	add	x1, x20, x0, lsl #2
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	add	x1, x23, x0, lsl #2
-               	str	s2, [x1]
-               	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L60>
+               	sub	x2, x29, #0x574
+               	add	x4, x2, #0x0
+               	add	x6, x4, #0x0
+               	mov	x4, #0x90               // =144
 <L61>:
-               	mov	x19, #0x0               // =0
-               	cmp	x19, x21
+               	str	xzr, [x6]
+               	add	x6, x6, #0x8
+               	sub	x4, x4, #0x8
+               	cmp	x4, #0x0
+               	b.ne	 <L61>
+               	str	wzr, [x6]
+               	mov	x16, #0xffff            // =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x3, x16
+               	cset	w4, ls
+               	mov	w16, #0x1               // =1
+               	and	w6, w4, w16
+               	mov	w16, #0x1               // =1
+               	and	w4, w6, w16
+               	mov	w16, #0x1               // =1
+               	and	w6, w4, w16
+               	mov	w16, #0x1               // =1
+               	and	w4, w6, w16
+               	add	x6, x0, #0x0
+               	add	x7, x0, x3, lsl #2
+               	add	x8, x1, #0x0
+               	add	x12, x1, x3, lsl #2
+               	add	x13, x2, #0x0
+               	add	x14, x2, x3, lsl #2
+               	cmp	x14, x6
+               	cset	w15, ls
+               	cmp	x7, x13
+               	cset	w6, ls
+               	orr	w7, w15, w6
+               	cmp	x14, x8
+               	cset	w6, ls
+               	cmp	x12, x13
+               	cset	w8, ls
+               	orr	w12, w6, w8
+               	and	w6, w7, w12
+               	and	w7, w4, w6
+               	cbnz	w7,  <L63>
+               	mov	x4, #0x0                // =0
+               	cmp	x4, x3
                	b.lo	 <L62>
-               	b	 <L64>
+               	b	 <L67>
 <L62>:
-               	add	x0, x23, x19, lsl #2
-               	ldr	s0, [x0]
-               	mov	x0, x22
-<L63>:
-               	bl	 <L63>
-               	add	x19, x19, #0x1
-               	mov	x22, x0
-               	cmp	x19, x21
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fdiv	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
                	b.lo	 <L62>
+               	b	 <L67>
+<L63>:
+               	mov	x4, #0x0                // =0
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L64>
+               	b	 <L65>
 <L64>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	q0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	q1, [x6]
+               	fdiv	v2.4s, v0.4s, v1.4s
+               	add	x6, x2, x4, lsl #2
+               	str	q2, [x6]
+               	add	x4, x4, #0x4
+               	add	x6, x4, #0x4
+               	cmp	x6, x3
+               	b.ls	 <L64>
+<L65>:
+               	cmp	x4, x3
+               	b.lo	 <L66>
+               	b	 <L67>
+<L66>:
+               	add	x6, x0, x4, lsl #2
+               	ldr	s0, [x6]
+               	add	x6, x1, x4, lsl #2
+               	ldr	s1, [x6]
+               	fdiv	s2, s0, s1
+               	add	x6, x2, x4, lsl #2
+               	str	s2, [x6]
+               	add	x4, x4, #0x1
+               	cmp	x4, x3
+               	b.lo	 <L66>
+<L67>:
+               	mov	x0, #0x0                // =0
+               	cmp	x0, x3
+               	b.lo	 <L68>
+               	b	 <L71>
+<L68>:
+               	add	x1, x2, x0, lsl #2
+               	ldr	s0, [x1]
+               	fmov	w1, s0
+               	mov	w4, w1
+               	mov	x1, x5
+               	mov	x6, #0x0                // =0
+               	cmp	x6, #0x8
+               	b.lo	 <L69>
+               	b	 <L70>
+<L69>:
+               	mov	x16, #0x8               // =8
+               	mul	x7, x6, x16
+               	lsr	x8, x4, x7
+               	mov	x16, #0xff              // =255
+               	and	x7, x8, x16
+               	eor	x8, x1, x7
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x8, x16
+               	add	x6, x6, #0x1
+               	cmp	x6, #0x8
+               	b.lo	 <L69>
+<L70>:
+               	add	x0, x0, #0x1
+               	mov	x5, x1
+               	cmp	x0, x3
+               	b.lo	 <L68>
+<L71>:
                	mov	x0, #0x0                // =0
                	fmov	s0, wzr
-               	cmp	x0, x21
-               	b.lo	 <L65>
-               	b	 <L66>
-<L65>:
-               	add	x1, x23, x0, lsl #2
+               	cmp	x0, x3
+               	b.lo	 <L72>
+               	b	 <L73>
+<L72>:
+               	add	x1, x2, x0, lsl #2
                	ldr	s1, [x1]
                	fadd	s0, s0, s1
                	add	x0, x0, #0x1
-               	cmp	x0, x21
-               	b.lo	 <L65>
-<L66>:
-               	mov	x0, x22
-<L67>:
-               	bl	 <L67>
-               	sub	x16, x29, #0x8f8
-               	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x8c0
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldp	x23, x24, [x16, #-0x20]
-               	ldur	x25, [x16, #-0x28]
+               	cmp	x0, x3
+               	b.lo	 <L72>
+<L73>:
+               	fmov	w0, s0
+               	mov	w1, w0
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L74>
+               	b	 <L75>
+<L74>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x0, x16
+               	lsr	x3, x1, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x5, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x5, x3, x16
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x8
+               	b.lo	 <L74>
+<L75>:
+               	mov	x0, x5
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/aarch64-linux/vec/vec_cmp_i64.dis
@@ -3,243 +3,280 @@ vec/vec_cmp_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, v0.d[0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x1, v0.d[1]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, v0.d[0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x1, v0.d[1]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x410
-               	sub	x16, x29, #0x3f0
+               	sub	sp, sp, #0x350
+               	sub	x16, x29, #0x330
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stur	x23, [x16, #-0x18]
                	mov	x19, x0
+               	sub	x20, x29, #0x1a0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               // =96
 <L0>:
-               	bl	 <L0>
-               	sub	x20, x29, #0x60
-               	add	x1, x20, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               // =96
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	sub	x21, x29, #0x200
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x60               // =96
 <L1>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
                	b.ne	 <L1>
-               	sub	x21, x29, #0xc0
-               	add	x1, x21, #0x0
-               	add	x2, x1, #0x0
-               	mov	x1, #0x60               // =96
-<L2>:
-               	str	xzr, [x2]
-               	add	x2, x2, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L2>
-               	sub	x1, x29, #0xd0
-               	add	x2, x1, #0x0
+               	sub	x0, x29, #0x210
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x1               // =1
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x0
-               	str	q0, [x1]
-               	sub	x1, x29, #0xe0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x220
+               	add	x1, x0, #0x0
                	mov	x17, #0x1               // =1
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x0
-               	str	q0, [x1]
-               	sub	x1, x29, #0xf0
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x230
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff00000000    // =281470681743360
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x10
-               	str	q0, [x1]
-               	sub	x1, x29, #0x100
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x240
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff00000000    // =281470681743360
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x10
-               	str	q0, [x1]
-               	sub	x1, x29, #0x110
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x250
+               	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x20
-               	str	q0, [x1]
-               	sub	x1, x29, #0x120
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x260
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0x7fff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x20
-               	str	q0, [x1]
-               	sub	x1, x29, #0x130
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x270
+               	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xdef0            // =57072
                	movk	x17, #0x9abc, lsl #16
                	movk	x17, #0x5678, lsl #32
                	movk	x17, #0x1234, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x30
-               	str	q0, [x1]
-               	sub	x1, x29, #0x140
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x280
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xdef0            // =57072
                	movk	x17, #0x9abc, lsl #16
                	movk	x17, #0x5678, lsl #32
                	movk	x17, #0x1234, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x30
-               	str	q0, [x1]
-               	sub	x1, x29, #0x150
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x290
+               	add	x1, x0, #0x0
                	mov	x17, #0x200000000       // =8589934592
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x40
-               	str	q0, [x1]
-               	sub	x1, x29, #0x160
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2a0
+               	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0x1, lsl #32
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x40
-               	str	q0, [x1]
-               	sub	x1, x29, #0x170
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2b0
+               	add	x1, x0, #0x0
                	mov	x17, #0x10a             // =266
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
                	movk	x17, #0xffff, lsl #48
-               	str	x17, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x20, #0x50
-               	str	q0, [x1]
-               	sub	x1, x29, #0x180
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x50
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2c0
+               	add	x1, x0, #0x0
                	mov	x17, #0xa               // =10
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
-               	str	xzr, [x2]
-               	ldr	q0, [x1]
-               	add	x1, x21, #0x50
-               	str	q0, [x1]
-               	mov	x22, x0
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x50
+               	str	q0, [x0]
+               	mov	x22, #0x2325            // =8997
+               	movk	x22, #0x8422, lsl #16
+               	movk	x22, #0x9ce4, lsl #32
+               	movk	x22, #0xcbf2, lsl #48
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x6
-               	b.lo	 <L3>
-               	b	 <L18>
-<L3>:
+               	b.lo	 <L2>
+               	b	 <L13>
+<L2>:
                	mov	x16, #0x10              // =16
                	mul	x0, x23, x16
                	add	x1, x20, x0
@@ -282,23 +319,14 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd10            // =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
                	mov	x0, x22
-<L4>:
-               	bl	 <L4>
                	mov	x16, #0xfd10            // =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L5>:
-               	bl	 <L5>
+               	ldr	q0, [x29, x16]
+<L3>:
+               	bl	 <L3>
                	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -309,26 +337,46 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmge	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            // =64768
+               	cmge	v0.2d, v31.2d, v30.2d
+<L4>:
+               	bl	 <L4>
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt	v0.2d, v31.2d, v30.2d
+<L5>:
+               	bl	 <L5>
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge	v0.2d, v31.2d, v30.2d
 <L6>:
                	bl	 <L6>
-               	mov	x16, #0xfd00            // =64768
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v0.2d, v31.2d, v30.2d
 <L7>:
                	bl	 <L7>
                	mov	x16, #0xfd30            // =64816
@@ -341,197 +389,98 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmgt	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	cmeq	v0.2d, v31.2d, v30.2d
+               	mvn	v0.16b, v0.16b
 <L8>:
                	bl	 <L8>
-               	mov	x16, #0xfcf0            // =64752
+               	mov	x16, #0xfd10            // =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v31.16b, v30.16b
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn	v1.16b, v31.16b
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v2.16b, v1.16b, v30.16b
+               	orr	v1.16b, v0.16b, v2.16b
+               	mov	x1, v1.d[0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
+               	b	 <L10>
 <L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfd30            // =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmge	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L9>
 <L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
+               	mov	x1, v1.d[1]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
+               	b	 <L12>
 <L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfd30            // =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L11>
 <L12>:
-               	bl	 <L12>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfd30            // =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq	v31.2d, v31.2d, v30.2d
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfcc0            // =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmgt	v0.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd30            // =64816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mvn	v2.16b, v0.16b
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v0.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v0.16b
-               	mov	x16, #0xfcb0            // =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfcb0            // =64688
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L17>:
-               	bl	 <L17>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x6
-               	b.lo	 <L3>
-<L18>:
-               	sub	x20, x29, #0x1d0
+               	b.lo	 <L2>
+<L13>:
+               	sub	x20, x29, #0x50
                	add	x0, x20, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x50               // =80
-<L19>:
+<L14>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L19>
-               	sub	x21, x29, #0x220
+               	b.ne	 <L14>
+               	sub	x21, x29, #0xa0
                	add	x0, x21, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x50               // =80
-<L20>:
+<L15>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L20>
-               	sub	x0, x29, #0x230
+               	b.ne	 <L15>
+               	sub	x0, x29, #0xb0
                	add	x1, x0, #0x0
                	mov	x17, #-0x8000000000000000 // =-9223372036854775808
                	str	x17, [x1]
@@ -544,7 +493,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x0
                	str	q0, [x0]
-               	sub	x0, x29, #0x240
+               	sub	x0, x29, #0xc0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
@@ -557,7 +506,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x0
                	str	q0, [x0]
-               	sub	x0, x29, #0x250
+               	sub	x0, x29, #0xd0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
@@ -570,7 +519,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	sub	x0, x29, #0x260
+               	sub	x0, x29, #0xe0
                	add	x1, x0, #0x0
                	mov	x17, #0x1               // =1
                	movk	x17, #0x1, lsl #32
@@ -583,7 +532,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x10
                	str	q0, [x0]
-               	sub	x0, x29, #0x270
+               	sub	x0, x29, #0xf0
                	add	x1, x0, #0x0
                	mov	x17, #0xffff            // =65535
                	movk	x17, #0xffff, lsl #16
@@ -595,7 +544,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x20
                	str	q0, [x0]
-               	sub	x0, x29, #0x280
+               	sub	x0, x29, #0x100
                	add	x1, x0, #0x0
                	str	xzr, [x1]
                	add	x1, x0, #0x8
@@ -607,7 +556,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x20
                	str	q0, [x0]
-               	sub	x0, x29, #0x290
+               	sub	x0, x29, #0x110
                	add	x1, x0, #0x0
                	mov	x17, #0x80000000        // =2147483648
                	movk	x17, #0x8000, lsl #48
@@ -619,7 +568,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x30
                	str	q0, [x0]
-               	sub	x0, x29, #0x2a0
+               	sub	x0, x29, #0x120
                	add	x1, x0, #0x0
                	mov	x17, #0x80000000        // =2147483648
                	movk	x17, #0x8000, lsl #48
@@ -633,7 +582,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x21, #0x30
                	str	q0, [x0]
-               	sub	x0, x29, #0x2b0
+               	sub	x0, x29, #0x130
                	add	x1, x0, #0x0
                	mov	x17, #0x10a             // =266
                	str	x17, [x1]
@@ -646,7 +595,7 @@ Disassembly of section .text:
                	ldr	q0, [x0]
                	add	x0, x20, #0x40
                	str	q0, [x0]
-               	sub	x0, x29, #0x2c0
+               	sub	x0, x29, #0x140
                	add	x1, x0, #0x0
                	mov	x17, #0xa               // =10
                	str	x17, [x1]
@@ -657,9 +606,9 @@ Disassembly of section .text:
                	str	q0, [x0]
                	mov	x23, #0x0               // =0
                	cmp	x23, #0x5
-               	b.lo	 <L21>
-               	b	 <L36>
-<L21>:
+               	b.lo	 <L16>
+               	b	 <L24>
+<L16>:
                	mov	x16, #0x10              // =16
                	mul	x0, x23, x16
                	add	x1, x20, x0
@@ -672,7 +621,7 @@ Disassembly of section .text:
                	add	x1, x0, x19
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], x1
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -681,258 +630,135 @@ Disassembly of section .text:
                	add	x1, x0, x19
                	mov	v30.16b, v1.16b
                	mov	v30.d[1], x1
-               	mov	x16, #0xfc90            // =64656
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfc80            // =64640
+               	mov	x16, #0xfce0            // =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfc80            // =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
                	mov	x0, x22
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfc80            // =64640
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L17>:
+               	bl	 <L17>
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmhs	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfc70            // =64624
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc70            // =64624
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfc70            // =64624
+               	cmhs	v0.2d, v31.2d, v30.2d
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfc60            // =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc60            // =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfc60            // =64608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhs	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfc50            // =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc50            // =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfc50            // =64592
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfc40            // =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc40            // =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfc40            // =64576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq	v31.2d, v31.2d, v30.2d
-               	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfc30            // =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc30            // =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfc30            // =64560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v0.2d, v31.2d, v30.2d
-               	mov	x16, #0xfca0            // =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mvn	v2.16b, v0.16b
-               	mov	x16, #0xfc90            // =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v0.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v0.16b
-               	mov	x16, #0xfc20            // =64544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc20            // =64544
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfc20            // =64544
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs	v0.2d, v31.2d, v30.2d
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L35>:
-               	bl	 <L35>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v0.2d, v31.2d, v30.2d
+<L21>:
+               	bl	 <L21>
+               	mov	x16, #0xfd00            // =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v0.2d, v31.2d, v30.2d
+               	mvn	v0.16b, v0.16b
+<L22>:
+               	bl	 <L22>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd00            // =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v31.16b, v30.16b
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn	v1.16b, v31.16b
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v2.16b, v1.16b, v30.16b
+               	orr	v1.16b, v0.16b, v2.16b
+               	mov	v0.16b, v1.16b
+<L23>:
+               	bl	 <L23>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x5
-               	b.lo	 <L21>
-<L36>:
+               	b.lo	 <L16>
+<L24>:
                	mov	x0, x22
-               	sub	x16, x29, #0x3f0
+               	sub	x16, x29, #0x330
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldur	x23, [x16, #-0x18]

--- a/test/golden/aarch64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/aarch64-linux/vec/vec_cmp_select.dis
@@ -3,184 +3,378 @@ vec/vec_cmp_select.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_cmp_select.fold_u8x16>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[0]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[1]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[2]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[3]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[4]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[5]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[6]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[7]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.b[8]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov	w1, v0.b[9]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov	w1, v0.b[10]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov	w1, v0.b[11]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov	w1, v0.b[12]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov	w1, v0.b[13]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov	w1, v0.b[14]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov	w1, v0.b[15]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_cmp_select.fold_u16x8>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[0]
-               	mov	x0, x1
+               	umov	w1, v31.h[0]
+               	uxth	w2, w1
                	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[1]
-               	mov	x0, x1
+               	umov	w1, v31.h[1]
+               	uxth	w2, w1
                	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[2]
-               	mov	x0, x1
+               	umov	w1, v31.h[2]
+               	uxth	w2, w1
                	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[3]
-               	mov	x0, x1
+               	umov	w1, v31.h[3]
+               	uxth	w2, w1
                	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[4]
-               	mov	x0, x1
+               	umov	w1, v31.h[4]
+               	uxth	w2, w1
                	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[5]
-               	mov	x0, x1
+               	umov	w1, v31.h[5]
+               	uxth	w2, w1
                	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[6]
-               	mov	x0, x1
+               	umov	w1, v31.h[6]
+               	uxth	w2, w1
                	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[7]
-               	mov	x0, x1
+               	umov	w1, v31.h[7]
+               	uxth	w2, w1
                	mov	x1, x2
 <L7>:
                	bl	 <L7>
@@ -192,33 +386,29 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
                	mov	sp, x29
@@ -252,29 +442,33 @@ Disassembly of section .text:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
                	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
                	mov	sp, x29
@@ -284,98 +478,115 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x390
-               	sub	x16, x29, #0x370
+               	sub	sp, sp, #0x350
+               	sub	x16, x29, #0x330
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
-               	sub	x16, x29, #0x390
+               	sub	x16, x29, #0x350
                	str	d8, [x16, #0x8]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
                	mov	w20, w19
                	ucvtf	s8, x19
                	mov	w21, w19
                	mov	w22, w19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	sub	x0, x29, #0x10
+               	add	x1, x0, #0x0
                	mov	w17, #0xa               // =10
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x14              // =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x1e              // =30
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x2]
-               	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x20
+               	add	x1, x0, #0x0
                	mov	w17, #0x14              // =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x14              // =20
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0xa               // =10
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x1               // =1
-               	str	w17, [x2]
-               	ldr	q1, [x1]
-               	mov	w1, v0.s[0]
-               	add	w2, w1, w20
+               	str	w17, [x1]
+               	ldr	q1, [x0]
+               	mov	w0, v0.s[0]
+               	add	w1, w0, w20
                	mov	v30.16b, v0.16b
-               	mov	v30.s[0], w2
+               	mov	v30.s[0], w1
                	stur	q30, [x29, #-0xd0]
-               	mov	w1, v1.s[3]
-               	add	w2, w1, w20
+               	mov	w0, v1.s[3]
+               	add	w1, w0, w20
                	mov	v30.16b, v1.16b
-               	mov	v30.s[3], w2
+               	mov	v30.s[3], w1
                	stur	q30, [x29, #-0xe0]
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhi	v31.4s, v31.4s, v30.4s
                	stur	q31, [x29, #-0xf0]
                	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
+               	mov	w0, v31.s[0]
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+<L0>:
+               	bl	 <L0>
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L2>:
                	bl	 <L2>
                	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmhi	v31.4s, v31.4s, v30.4s
                	stur	q31, [x29, #-0x100]
                	ldur	q31, [x29, #-0x100]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0x100]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
                	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
                	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmeq	v31.4s, v31.4s, v30.4s
@@ -390,6 +601,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L9>:
                	bl	 <L9>
                	mov	x16, #0xfef0            // =65264
@@ -397,7 +620,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L10>:
                	bl	 <L10>
                	mov	x16, #0xfef0            // =65264
@@ -405,17 +630,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L11>:
                	bl	 <L11>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L12>:
-               	bl	 <L12>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmeq	v31.4s, v31.4s, v30.4s
@@ -431,6 +650,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L13>:
                	bl	 <L13>
                	mov	x16, #0xfee0            // =65248
@@ -438,7 +669,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L14>:
                	bl	 <L14>
                	mov	x16, #0xfee0            // =65248
@@ -446,17 +679,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L15>:
                	bl	 <L15>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhs	v31.4s, v31.4s, v30.4s
@@ -471,6 +698,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L17>:
                	bl	 <L17>
                	mov	x16, #0xfed0            // =65232
@@ -478,7 +717,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L18>:
                	bl	 <L18>
                	mov	x16, #0xfed0            // =65232
@@ -486,17 +727,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L19>:
                	bl	 <L19>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L20>:
-               	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	cmhs	v31.4s, v31.4s, v30.4s
@@ -511,6 +746,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L21>:
                	bl	 <L21>
                	mov	x16, #0xfec0            // =65216
@@ -518,7 +765,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L22>:
                	bl	 <L22>
                	mov	x16, #0xfec0            // =65216
@@ -526,17 +775,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L24>:
-               	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xd0]
                	cmhi	v31.4s, v31.4s, v30.4s
@@ -572,6 +815,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L25>:
                	bl	 <L25>
                	mov	x16, #0xfea0            // =65184
@@ -579,7 +834,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L26>:
                	bl	 <L26>
                	mov	x16, #0xfea0            // =65184
@@ -587,17 +844,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L28>:
-               	bl	 <L28>
                	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -625,6 +876,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L29>:
                	bl	 <L29>
                	mov	x16, #0xfe90            // =65168
@@ -632,7 +895,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
                	mov	x16, #0xfe90            // =65168
@@ -640,17 +905,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L31>:
                	bl	 <L31>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L32>:
-               	bl	 <L32>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	add	v0.4s, v31.4s, v30.4s
@@ -671,6 +930,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe80            // =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L33>:
                	bl	 <L33>
                	mov	x16, #0xfe80            // =65152
@@ -678,7 +949,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L34>:
                	bl	 <L34>
                	mov	x16, #0xfe80            // =65152
@@ -686,17 +959,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L36>:
-               	bl	 <L36>
                	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -718,6 +985,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L36>:
+               	bl	 <L36>
+               	mov	x16, #0xfe70            // =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L37>:
                	bl	 <L37>
                	mov	x16, #0xfe70            // =65136
@@ -725,7 +1004,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L38>:
                	bl	 <L38>
                	mov	x16, #0xfe70            // =65136
@@ -733,17 +1014,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L39>:
                	bl	 <L39>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L40>:
-               	bl	 <L40>
                	sub	x1, x29, #0x30
                	add	x2, x1, #0x0
                	mov	w17, #0xffff            // =65535
@@ -816,6 +1091,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L40>:
+               	bl	 <L40>
+               	mov	x16, #0xfe40            // =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L41>:
                	bl	 <L41>
                	mov	x16, #0xfe40            // =65088
@@ -823,7 +1110,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L42>:
                	bl	 <L42>
                	mov	x16, #0xfe40            // =65088
@@ -831,17 +1120,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L43>:
                	bl	 <L43>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L44>:
-               	bl	 <L44>
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -864,6 +1147,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L44>:
+               	bl	 <L44>
+               	mov	x16, #0xfe30            // =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L45>:
                	bl	 <L45>
                	mov	x16, #0xfe30            // =65072
@@ -871,7 +1166,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L46>:
                	bl	 <L46>
                	mov	x16, #0xfe30            // =65072
@@ -879,17 +1176,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L47>:
                	bl	 <L47>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L48>:
-               	bl	 <L48>
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -912,6 +1203,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L48>:
+               	bl	 <L48>
+               	mov	x16, #0xfe20            // =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe20            // =65056
@@ -919,7 +1222,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L50>:
                	bl	 <L50>
                	mov	x16, #0xfe20            // =65056
@@ -927,17 +1232,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L51>:
                	bl	 <L51>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L52>:
-               	bl	 <L52>
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -961,6 +1260,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L52>:
+               	bl	 <L52>
+               	mov	x16, #0xfe10            // =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L53>:
                	bl	 <L53>
                	mov	x16, #0xfe10            // =65040
@@ -968,7 +1279,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L54>:
                	bl	 <L54>
                	mov	x16, #0xfe10            // =65040
@@ -976,17 +1289,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L56>:
-               	bl	 <L56>
                	mov	x16, #0xfe50            // =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1009,6 +1316,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L56>:
+               	bl	 <L56>
+               	mov	x16, #0xfe00            // =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L57>:
                	bl	 <L57>
                	mov	x16, #0xfe00            // =65024
@@ -1016,7 +1335,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L58>:
                	bl	 <L58>
                	mov	x16, #0xfe00            // =65024
@@ -1024,17 +1345,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L60>:
-               	bl	 <L60>
                	mov	x16, #0xfe60            // =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1057,6 +1372,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L60>:
+               	bl	 <L60>
+               	mov	x16, #0xfdf0            // =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	mov	w2, w1
+               	mov	x1, x2
 <L61>:
                	bl	 <L61>
                	mov	x16, #0xfdf0            // =65008
@@ -1064,7 +1391,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	mov	w1, v31.s[2]
+               	mov	w2, w1
+               	mov	x1, x2
 <L62>:
                	bl	 <L62>
                	mov	x16, #0xfdf0            // =65008
@@ -1072,17 +1401,11 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	mov	w1, v31.s[3]
+               	mov	w2, w1
+               	mov	x1, x2
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L64>:
-               	bl	 <L64>
                	sub	x1, x29, #0x50
                	add	x2, x1, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
@@ -1131,66 +1454,16 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	ldr	q0, [x29, x16]
+<L64>:
+               	bl	 <L64>
+               	mov	x16, #0xfde0            // =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L72>:
-               	bl	 <L72>
                	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1212,8 +1485,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L73>:
-               	bl	 <L73>
+<L66>:
+               	bl	 <L66>
                	mov	x16, #0xfdd0            // =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1225,8 +1498,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt	v0.4s, v31.4s, v30.4s
-<L74>:
-               	bl	 <L74>
+<L67>:
+               	bl	 <L67>
                	mov	x16, #0xfdd0            // =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1238,8 +1511,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq	v0.4s, v31.4s, v30.4s
-<L75>:
-               	bl	 <L75>
+<L68>:
+               	bl	 <L68>
                	mov	x16, #0xfdd0            // =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1252,8 +1525,8 @@ Disassembly of section .text:
                	ldr	q30, [x29, x16]
                	fcmeq	v0.4s, v31.4s, v30.4s
                	mvn	v0.16b, v0.16b
-<L76>:
-               	bl	 <L76>
+<L69>:
+               	bl	 <L69>
                	mov	x16, #0xfde0            // =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1265,8 +1538,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge	v0.4s, v31.4s, v30.4s
-<L77>:
-               	bl	 <L77>
+<L70>:
+               	bl	 <L70>
                	mov	x16, #0xfdd0            // =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1278,8 +1551,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge	v0.4s, v31.4s, v30.4s
-<L78>:
-               	bl	 <L78>
+<L71>:
+               	bl	 <L71>
                	mov	x16, #0xfdc0            // =64960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1336,66 +1609,16 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfdb0            // =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L82>:
-               	bl	 <L82>
+               	ldr	q0, [x29, x16]
+<L72>:
+               	bl	 <L72>
                	mov	x16, #0xfda0            // =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfda0            // =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L86>:
-               	bl	 <L86>
+               	ldr	q0, [x29, x16]
+<L73>:
+               	bl	 <L73>
                	mov	x16, #0xfda0            // =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1406,44 +1629,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfd90            // =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L90>:
-               	bl	 <L90>
+               	fsub	v0.4s, v31.4s, v30.4s
+<L74>:
+               	bl	 <L74>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 // =4609434218613702656
@@ -1459,7 +1647,7 @@ Disassembly of section .text:
                	add	x2, x1, #0x8
                	str	xzr, [x2]
                	ldr	q31, [x1]
-               	mov	x16, #0xfd80            // =64896
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1469,140 +1657,140 @@ Disassembly of section .text:
                	fadd	d3, d1, d2
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], v3.d[0]
-               	mov	x16, #0xfd70            // =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
                	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfd90            // =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd70            // =64880
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd60            // =64864
+               	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfd60            // =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L92>:
-               	bl	 <L92>
                	mov	x16, #0xfd70            // =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfd70            // =64880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L76>:
+               	bl	 <L76>
                	mov	x16, #0xfd80            // =64896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd50            // =64848
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd50            // =64848
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfd50            // =64848
+<L77>:
+               	bl	 <L77>
+               	mov	x16, #0xfd60            // =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd70            // =64880
+<L78>:
+               	bl	 <L78>
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd80            // =64896
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq	v31.2d, v31.2d, v30.2d
                	mvn	v31.16b, v31.16b
-               	mov	x16, #0xfd40            // =64832
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd40            // =64832
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd40            // =64832
+<L79>:
+               	bl	 <L79>
+               	mov	x16, #0xfd50            // =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfd70            // =64880
+<L80>:
+               	bl	 <L80>
+               	mov	x16, #0xfd80            // =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd80            // =64896
+               	mov	x16, #0xfd90            // =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd30            // =64816
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfd30            // =64816
+<L81>:
+               	bl	 <L81>
+               	mov	x16, #0xfd40            // =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	x1, v31.d[1]
-<L98>:
-               	bl	 <L98>
+<L82>:
+               	bl	 <L82>
                	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	w17, #0x1               // =1
@@ -1658,7 +1846,7 @@ Disassembly of section .text:
                	add	w2, w1, w21
                	mov	v30.16b, v0.16b
                	mov	v30.h[0], w2
-               	mov	x16, #0xfd20            // =64800
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1667,252 +1855,48 @@ Disassembly of section .text:
                	add	w2, w1, w21
                	mov	v30.16b, v1.16b
                	mov	v30.h[7], w2
-               	mov	x16, #0xfd10            // =64784
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfd10            // =64784
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            // =64800
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfd00            // =64768
+               	mov	x16, #0xfd10            // =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            // =64768
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L83>:
+               	bl	 <L83>
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfd00            // =64768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L106>:
-               	bl	 <L106>
                	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd10            // =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	cmeq	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfcf0            // =64752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfd20            // =64800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd10            // =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfce0            // =64736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfd10            // =64784
+               	cmeq	v0.8h, v31.8h, v30.8h
+<L84>:
+               	bl	 <L84>
+               	mov	x16, #0xfd30            // =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1923,89 +1907,35 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v0.8h, v31.8h, v30.8h
+<L85>:
+               	bl	 <L85>
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v31.16b, v30.16b
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn	v1.16b, v31.16b
                	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	and	v1.16b, v0.16b, v30.16b
-               	mvn	v2.16b, v0.16b
-               	mov	x16, #0xfd10            // =64784
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and	v0.16b, v2.16b, v30.16b
-               	orr	v31.16b, v1.16b, v0.16b
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfcd0            // =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L130>:
-               	bl	 <L130>
+               	and	v2.16b, v1.16b, v30.16b
+               	orr	v1.16b, v0.16b, v2.16b
+               	mov	v0.16b, v1.16b
+<L86>:
+               	bl	 <L86>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	w17, #0x1               // =1
@@ -2109,7 +2039,7 @@ Disassembly of section .text:
                	add	w2, w1, w22
                	mov	v30.16b, v0.16b
                	mov	v30.b[0], w2
-               	mov	x16, #0xfcc0            // =64704
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2118,78 +2048,78 @@ Disassembly of section .text:
                	add	w2, w1, w22
                	mov	v30.16b, v1.16b
                	mov	v30.b[15], w2
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfce0            // =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfce0            // =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfcc0            // =64704
+<L87>:
+               	bl	 <L87>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmeq	v0.16b, v31.16b, v30.16b
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfcc0            // =64704
+<L88>:
+               	bl	 <L88>
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhs	v0.16b, v31.16b, v30.16b
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfca0            // =64672
+<L89>:
+               	bl	 <L89>
+               	mov	x16, #0xfce0            // =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            // =64704
+               	mov	x16, #0xfd00            // =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	and	v0.16b, v31.16b, v30.16b
-               	mov	x16, #0xfca0            // =64672
+               	mov	x16, #0xfce0            // =64736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mvn	v1.16b, v31.16b
-               	mov	x16, #0xfcb0            // =64688
+               	mov	x16, #0xfcf0            // =64752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2197,11 +2127,11 @@ Disassembly of section .text:
                	and	v2.16b, v1.16b, v30.16b
                	orr	v1.16b, v0.16b, v2.16b
                	mov	v0.16b, v1.16b
-<L134>:
-               	bl	 <L134>
-               	sub	x16, x29, #0x390
+<L90>:
+               	bl	 <L90>
+               	sub	x16, x29, #0x350
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x370
+               	sub	x16, x29, #0x330
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	mov	sp, x29

--- a/test/golden/aarch64-linux/vec/vec_f32x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_f32x2.dis
@@ -3,65 +3,82 @@ vec/vec_f32x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_f32x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0x8
-               	add	x2, x1, #0x0
+               	sub	sp, sp, #0x100
+               	stp	x19, x20, [x29, #-0xf0]
+               	stur	x21, [x29, #-0xf8]
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x48
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	ldr	d1, [x1]
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	ldr	d1, [x0]
+               	sub	x0, x29, #0x50
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x2]
-               	ldr	d2, [x1]
-               	sub	x1, x29, #0x18
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	d2, [x0]
+               	sub	x0, x29, #0x58
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f800000        // =1065353216
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x41d80000        // =1104674816
-               	str	w17, [x2]
-               	ldr	d31, [x1]
+               	str	w17, [x1]
+               	ldr	d31, [x0]
                	stur	d31, [x29, #-0x70]
                	mov	s3, v1.s[0]
                	fadd	s4, s3, s0
@@ -73,154 +90,61 @@ Disassembly of section .text:
                	mov	v30.16b, v2.16b
                	mov	v30.s[1], v3.s[0]
                	stur	q30, [x29, #-0x90]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0x80]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0x90]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[1]
+               	ldur	q30, [x29, #-0x90]
+               	fadd	v0.4s, v31.4s, v30.4s
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0x90]
-               	mov	s0, v31.s[0]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	fsub	v0.4s, v31.4s, v30.4s
 <L3>:
                	bl	 <L3>
                	ldur	q31, [x29, #-0x90]
-               	mov	s0, v31.s[1]
+               	ldur	q30, [x29, #-0x80]
+               	fsub	v0.4s, v31.4s, v30.4s
 <L4>:
                	bl	 <L4>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0x90]
-               	fadd	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0xa0]
-               	mov	s0, v31.s[0]
+               	fmul	v0.4s, v31.4s, v30.4s
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xa0]
-               	mov	s0, v31.s[1]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	fdiv	v0.4s, v31.4s, v30.4s
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xb0]
-               	ldur	q31, [x29, #-0xb0]
-               	mov	s0, v31.s[0]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0x80]
+               	fdiv	v0.4s, v31.4s, v30.4s
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0xb0]
-               	mov	s0, v31.s[1]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x80]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xc0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	s0, v31.s[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xc0]
-               	mov	s0, v31.s[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xd0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[0]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[0]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x80]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[0]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[1]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0x70]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[1]
-<L18>:
-               	bl	 <L18>
+               	fmul	v0.4s, v31.4s, v30.4s
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0x70]
                	ldur	q30, [x29, #-0x90]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L20>:
-               	bl	 <L20>
+               	fsub	v0.4s, v31.4s, v30.4s
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0x70]
                	ldur	q30, [x29, #-0x80]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L22>:
-               	bl	 <L22>
+               	fdiv	v0.4s, v31.4s, v30.4s
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0x60
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -229,136 +153,45 @@ Disassembly of section .text:
                	ldr	d0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
+               	stur	q31, [x29, #-0xb0]
+               	stur	q0, [x29, #-0xc0]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-               	b	 <L30>
-<L23>:
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x70]
                	fmul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	stur	q31, [x29, #-0xa0]
                	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q0, [x29, #-0xa0]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xc0]
+               	ldur	q30, [x29, #-0xa0]
                	fadd	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	stur	q31, [x29, #-0xd0]
+               	ldur	q0, [x29, #-0xd0]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x90]
                	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L29>:
-               	bl	 <L29>
+               	stur	q31, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xe0]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
+               	stur	q31, [x29, #-0xb0]
+               	ldur	q31, [x29, #-0xd0]
+               	stur	q31, [x29, #-0xc0]
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-<L30>:
-               	sub	x20, x29, #0x48
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -366,43 +199,23 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xb0]
                	str	d31, [x0]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x90]
                	fadd	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xb0]
                	ldur	q30, [x29, #-0x70]
                	fmul	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xc0]
                	str	d31, [x0]
                	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xb0]
                	fsub	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x20
                	str	d0, [x0]
@@ -411,39 +224,20 @@ Disassembly of section .text:
                	str	d31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x6
-               	b.lo	 <L31>
-               	b	 <L34>
-<L31>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	add	x0, x20, x21, lsl #3
-               	ldr	d31, [x0]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L33>:
-               	bl	 <L33>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L31>
-<L34>:
-               	sub	x21, x29, #0x58
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	add	x0, x21, #0x0
@@ -452,49 +246,60 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x10
                	ldr	d0, [x1]
-               	add	x20, x21, #0x4
-               	str	d0, [x20]
+               	add	x1, x21, #0x4
+               	str	d0, [x1]
                	add	x1, x21, #0xc
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x4
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L35>:
-               	bl	 <L35>
-               	ldr	d31, [x20]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L37>:
-               	bl	 <L37>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0xc
                	ldr	w2, [x1]
                	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            // =65112
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x21, [x29, x16]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldur	x21, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_f32x3.dis
+++ b/test/golden/aarch64-linux/vec/vec_f32x3.dis
@@ -3,82 +3,118 @@ vec/vec_f32x3.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x3.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.vec.vec_f32x3.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            // =65112
+               	sub	sp, sp, #0x160
+               	stp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0xc
-               	add	x2, x1, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x50
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x2]
-               	stur	xzr, [x29, #-0x1c]
-               	stur	xzr, [x29, #-0x14]
-               	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x1c]
-               	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x14]
-               	ldur	q1, [x29, #-0x1c]
-               	sub	x1, x29, #0x28
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	stur	xzr, [x29, #-0x60]
+               	stur	xzr, [x29, #-0x58]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0x60]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0x58]
+               	ldur	q1, [x29, #-0x60]
+               	sub	x0, x29, #0x6c
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x2, x1, #0x8
-               	str	s2, [x2]
-               	stur	xzr, [x29, #-0x38]
-               	stur	xzr, [x29, #-0x30]
-               	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x38]
-               	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x30]
-               	ldur	q2, [x29, #-0x38]
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	stur	xzr, [x29, #-0x7c]
+               	stur	xzr, [x29, #-0x74]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0x7c]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0x74]
+               	ldur	q2, [x29, #-0x7c]
                	mov	s3, v1.s[0]
                	fadd	s4, s3, s0
                	mov	v30.16b, v1.16b
@@ -97,54 +133,24 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	ldr	q0, [x29, x16]
+<L0>:
+               	bl	 <L0>
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L1>:
                	bl	 <L1>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L2>:
-               	bl	 <L2>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L3>:
-               	bl	 <L3>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L4>:
-               	bl	 <L4>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L5>:
-               	bl	 <L5>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L6>:
-               	bl	 <L6>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -165,26 +171,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L8>:
-               	bl	 <L8>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L9>:
-               	bl	 <L9>
+               	ldr	q0, [x29, x16]
+<L2>:
+               	bl	 <L2>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -195,36 +184,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L12>:
-               	bl	 <L12>
+               	fsub	v0.4s, v31.4s, v30.4s
+<L3>:
+               	bl	 <L3>
                	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -235,36 +197,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L15>:
-               	bl	 <L15>
+               	fsub	v0.4s, v31.4s, v30.4s
+<L4>:
+               	bl	 <L4>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -276,35 +211,18 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fmul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L16>:
-               	bl	 <L16>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L18>:
-               	bl	 <L18>
+               	ldr	q0, [x29, x16]
+<L5>:
+               	bl	 <L5>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -315,37 +233,10 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L21>:
-               	bl	 <L21>
-               	sub	x19, x29, #0xbc
+               	fdiv	v0.4s, v31.4s, v30.4s
+<L6>:
+               	bl	 <L6>
+               	sub	x19, x29, #0xac
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
                	str	xzr, [x19, #0x10]
@@ -358,44 +249,32 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
+               	stur	q31, [x29, #-0xbc]
+               	ldur	x2, [x29, #-0xbc]
+               	str	x2, [x1]
+               	ldur	w2, [x29, #-0xb4]
+               	str	w2, [x1, #0x8]
+               	add	x1, x19, #0xc
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	stur	q31, [x29, #-0xcc]
                	ldur	x2, [x29, #-0xcc]
                	str	x2, [x1]
                	ldur	w2, [x29, #-0xc4]
                	str	w2, [x1, #0x8]
-               	mov	x16, #0xfef0            // =65264
+               	add	x1, x19, #0x18
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fadd	v0.4s, v31.4s, v30.4s
-               	add	x1, x19, #0xc
-               	stur	q0, [x29, #-0xdc]
+               	stur	q31, [x29, #-0xdc]
                	ldur	x2, [x29, #-0xdc]
                	str	x2, [x1]
                	ldur	w2, [x29, #-0xd4]
-               	str	w2, [x1, #0x8]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fmul	v0.4s, v31.4s, v30.4s
-               	add	x1, x19, #0x18
-               	stur	q0, [x29, #-0xec]
-               	ldur	x2, [x29, #-0xec]
-               	str	x2, [x1]
-               	ldur	w2, [x29, #-0xe4]
                	str	w2, [x1, #0x8]
                	add	x1, x19, #0x24
                	mov	x16, #0xfee0            // =65248
@@ -403,63 +282,36 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	stur	q31, [x29, #-0xfc]
-               	ldur	x2, [x29, #-0xfc]
+               	stur	q31, [x29, #-0xec]
+               	ldur	x2, [x29, #-0xec]
                	str	x2, [x1]
-               	ldur	w2, [x29, #-0xf4]
+               	ldur	w2, [x29, #-0xe4]
                	str	w2, [x1, #0x8]
                	mov	x20, x0
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L22>
-               	b	 <L26>
-<L22>:
+               	b.lo	 <L7>
+               	b	 <L9>
+<L7>:
                	mov	x16, #0xc               // =12
                	mul	x0, x21, x16
                	add	x1, x19, x0
-               	stur	xzr, [x29, #-0x48]
-               	stur	xzr, [x29, #-0x40]
+               	stur	xzr, [x29, #-0x10]
+               	stur	xzr, [x29, #-0x8]
                	ldr	x0, [x1]
-               	stur	x0, [x29, #-0x48]
+               	stur	x0, [x29, #-0x10]
                	ldr	w0, [x1, #0x8]
-               	stur	w0, [x29, #-0x40]
-               	ldur	q31, [x29, #-0x48]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	stur	w0, [x29, #-0x8]
+               	ldur	q0, [x29, #-0x10]
                	mov	x0, x20
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L25>:
-               	bl	 <L25>
+<L8>:
+               	bl	 <L8>
                	add	x21, x21, #0x1
                	mov	x20, x0
                	cmp	x21, #0x4
-               	b.lo	 <L22>
-<L26>:
-               	sub	x21, x29, #0x5c
+               	b.lo	 <L7>
+<L9>:
+               	sub	x21, x29, #0x24
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	wzr, [x21, #0x10]
@@ -468,70 +320,77 @@ Disassembly of section .text:
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
                	add	x1, x19, #0x18
-               	stur	xzr, [x29, #-0x6c]
-               	stur	xzr, [x29, #-0x64]
+               	stur	xzr, [x29, #-0x34]
+               	stur	xzr, [x29, #-0x2c]
                	ldr	x2, [x1]
-               	stur	x2, [x29, #-0x6c]
+               	stur	x2, [x29, #-0x34]
                	ldr	w2, [x1, #0x8]
-               	stur	w2, [x29, #-0x64]
-               	ldur	q0, [x29, #-0x6c]
-               	add	x19, x21, #0x4
-               	stur	q0, [x29, #-0x7c]
-               	ldur	x1, [x29, #-0x7c]
-               	str	x1, [x19]
-               	ldur	w1, [x29, #-0x74]
-               	str	w1, [x19, #0x8]
+               	stur	w2, [x29, #-0x2c]
+               	ldur	q0, [x29, #-0x34]
+               	add	x1, x21, #0x4
+               	stur	q0, [x29, #-0x44]
+               	ldur	x2, [x29, #-0x44]
+               	str	x2, [x1]
+               	ldur	w2, [x29, #-0x3c]
+               	str	w2, [x1, #0x8]
                	add	x1, x21, #0x10
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x20, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x20, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x0, x21, #0x4
+               	stur	xzr, [x29, #-0xfc]
+               	stur	xzr, [x29, #-0xf4]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0xfc]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0xf4]
+               	ldur	q0, [x29, #-0xfc]
                	mov	x0, x20
-<L27>:
-               	bl	 <L27>
-               	stur	xzr, [x29, #-0x8c]
-               	stur	xzr, [x29, #-0x84]
-               	ldr	x1, [x19]
-               	stur	x1, [x29, #-0x8c]
-               	ldr	w1, [x19, #0x8]
-               	stur	w1, [x29, #-0x84]
-               	ldur	q31, [x29, #-0x8c]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L30>:
-               	bl	 <L30>
+<L12>:
+               	bl	 <L12>
                	add	x1, x21, #0x10
                	ldr	w2, [x1]
                	mov	w1, w2
-<L31>:
-               	bl	 <L31>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	mov	x16, #0xfe58            // =65112
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	ldp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/vec/vec_f32x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_f32x4.dis
@@ -3,97 +3,148 @@ vec/vec_f32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0.s[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_f32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            // =65032
+               	sub	sp, sp, #0x150
+               	stp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x80
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x2, x1, #0x4
-               	str	s1, [x2]
-               	add	x2, x1, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x2, x1, #0xc
-               	str	s1, [x2]
-               	ldr	q1, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	add	x1, x0, #0xc
+               	str	s1, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x90
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x2]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x2, x1, #0x8
-               	str	s2, [x2]
-               	add	x2, x1, #0xc
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41000000        // =1090519040
-               	str	w17, [x2]
-               	ldr	q2, [x1]
-               	sub	x1, x29, #0x30
-               	add	x2, x1, #0x0
+               	str	w17, [x1]
+               	ldr	q2, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f800000        // =1065353216
-               	str	w17, [x2]
-               	add	x2, x1, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40400000        // =1077936128
-               	str	w17, [x2]
-               	add	x2, x1, #0x8
+               	str	w17, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x41100000        // =1091567616
-               	str	w17, [x2]
-               	add	x2, x1, #0xc
+               	str	w17, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41d80000        // =1104674816
-               	str	w17, [x2]
-               	ldr	q31, [x1]
+               	str	w17, [x1]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
                	mov	s3, v1.s[0]
                	fadd	s4, s3, s0
@@ -113,358 +164,61 @@ Disassembly of section .text:
                	mov	v30.16b, v1.16b
                	mov	v30.s[2], v3.s[0]
                	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xd0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xe0]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[1]
+               	ldur	q30, [x29, #-0xe0]
+               	fadd	v0.4s, v31.4s, v30.4s
 <L2>:
                	bl	 <L2>
                	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[2]
+               	ldur	q30, [x29, #-0xe0]
+               	fsub	v0.4s, v31.4s, v30.4s
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xd0]
-               	mov	s0, v31.s[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xd0]
+               	fsub	v0.4s, v31.4s, v30.4s
 <L4>:
                	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[0]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fmul	v0.4s, v31.4s, v30.4s
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[1]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fdiv	v0.4s, v31.4s, v30.4s
 <L6>:
                	bl	 <L6>
                	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[2]
+               	ldur	q30, [x29, #-0xd0]
+               	fdiv	v0.4s, v31.4s, v30.4s
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[3]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fadd	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[0]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[2]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0x100]
-               	mov	s0, v31.s[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L32>:
-               	bl	 <L32>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xc0]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L36>:
-               	bl	 <L36>
+               	fmul	v0.4s, v31.4s, v30.4s
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xe0]
-               	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L40>:
-               	bl	 <L40>
+               	fsub	v0.4s, v31.4s, v30.4s
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xd0]
-               	fdiv	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L44>:
-               	bl	 <L44>
+               	fdiv	v0.4s, v31.4s, v30.4s
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -477,184 +231,81 @@ Disassembly of section .text:
                	ldr	q0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L45>
-               	b	 <L58>
-<L45>:
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	stur	q31, [x29, #-0xf0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            // =65152
+               	ldur	q0, [x29, #-0xf0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	fadd	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fsub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L57>:
-               	bl	 <L57>
+               	ldr	q0, [x29, x16]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L45>
-<L58>:
-               	sub	x20, x29, #0x70
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -664,32 +315,20 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	str	q31, [x0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fadd	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -697,57 +336,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L59>
-               	b	 <L64>
-<L59>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L63>:
-               	bl	 <L63>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L59>
-<L64>:
-               	sub	x21, x29, #0xa0
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -760,61 +364,60 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L65>:
-               	bl	 <L65>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L69>:
-               	bl	 <L69>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L70>:
-               	bl	 <L70>
-               	ldp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            // =65032
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/vec/vec_f32x5.dis
+++ b/test/golden/aarch64-linux/vec/vec_f32x5.dis
@@ -5,45 +5,122 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x5.fold_vec>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stur	x19, [x29, #-0x78]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x14
-               	sub	x1, x29, #0x28
-               	sub	x1, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x70
+               	sub	x2, x29, #0x14
+               	sub	x2, x29, #0x28
+               	sub	x2, x29, #0x3c
+               	sub	x2, x29, #0x50
+               	sub	x2, x29, #0x64
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldur	x19, [x29, #-0x78]
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	x2, x1, #0xc
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -51,1269 +128,803 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x5.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xd80
-               	sub	x16, x29, #0xd40
+               	sub	sp, sp, #0x720
+               	sub	x16, x29, #0x6e0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-               	sub	x20, x29, #0x14
-               	sub	x21, x29, #0x28
-               	sub	x22, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	sub	x23, x29, #0x78
-               	sub	x1, x29, #0x8c
-               	sub	x1, x29, #0xa0
-               	sub	x24, x29, #0xb4
-               	sub	x1, x29, #0xc8
-               	sub	x1, x29, #0xdc
-               	sub	x25, x29, #0xf0
-               	sub	x1, x29, #0x104
-               	sub	x1, x29, #0x118
-               	sub	x1, x29, #0x12c
-               	sub	x1, x29, #0x140
-               	sub	x26, x29, #0x154
-               	sub	x1, x29, #0x168
-               	sub	x1, x29, #0x17c
-               	sub	x27, x29, #0x190
-               	sub	x1, x29, #0x1a4
-               	sub	x1, x29, #0x1b8
-               	sub	x28, x29, #0x1cc
-               	sub	x1, x29, #0x1e0
-               	sub	x1, x29, #0x1f4
-               	sub	x9, x29, #0x208
-               	mov	x16, #0xf330            // =62256
+               	sub	x1, x29, #0x14
+               	sub	x9, x29, #0x28
+               	mov	x16, #0xf988            // =63880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x2, x29, #0x21c
-               	sub	x2, x29, #0x230
-               	sub	x9, x29, #0x244
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x3, x29, #0x258
-               	sub	x3, x29, #0x26c
-               	sub	x9, x29, #0x280
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x19, x29, #0x3c
+               	sub	x3, x29, #0x50
+               	sub	x3, x29, #0x64
+               	sub	x3, x29, #0x78
+               	sub	x4, x29, #0x8c
+               	sub	x4, x29, #0xa0
+               	sub	x20, x29, #0xb4
+               	sub	x4, x29, #0xc8
+               	sub	x4, x29, #0xdc
+               	sub	x21, x29, #0xf0
+               	sub	x4, x29, #0x104
+               	sub	x4, x29, #0x118
+               	sub	x4, x29, #0x12c
+               	sub	x4, x29, #0x140
+               	sub	x22, x29, #0x154
+               	sub	x4, x29, #0x168
+               	sub	x4, x29, #0x17c
+               	sub	x23, x29, #0x190
+               	sub	x4, x29, #0x1a4
+               	sub	x4, x29, #0x1b8
+               	sub	x24, x29, #0x1cc
+               	sub	x4, x29, #0x1e0
+               	sub	x4, x29, #0x1f4
+               	sub	x25, x29, #0x208
+               	sub	x4, x29, #0x21c
+               	sub	x4, x29, #0x230
+               	sub	x26, x29, #0x244
+               	sub	x4, x29, #0x258
+               	sub	x4, x29, #0x26c
+               	sub	x27, x29, #0x280
                	sub	x4, x29, #0x294
                	sub	x4, x29, #0x2a8
-               	sub	x9, x29, #0x2bc
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x5, x29, #0x2d0
-               	sub	x5, x29, #0x2e4
+               	sub	x28, x29, #0x2bc
+               	sub	x4, x29, #0x2d0
+               	sub	x4, x29, #0x2e4
                	sub	x9, x29, #0x2f8
-               	mov	x16, #0xf310            // =62224
+               	mov	x16, #0xf980            // =63872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x6, x29, #0x30c
-               	sub	x6, x29, #0x320
+               	sub	x5, x29, #0x30c
+               	sub	x5, x29, #0x320
                	sub	x9, x29, #0x334
-               	mov	x16, #0xf308            // =62216
+               	mov	x16, #0xf978            // =63864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x348
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x35c
-               	sub	x8, x29, #0x370
+               	sub	x7, x29, #0x35c
+               	sub	x7, x29, #0x370
                	sub	x9, x29, #0x384
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x12, x29, #0x398
-               	sub	x12, x29, #0x3ac
-               	sub	x12, x29, #0x3c0
+               	sub	x8, x29, #0x398
+               	sub	x8, x29, #0x3ac
+               	sub	x8, x29, #0x3c0
                	sub	x9, x29, #0x3d4
-               	mov	x16, #0xf2f8            // =62200
+               	mov	x16, #0xf960            // =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x13, x29, #0x3e8
-               	sub	x13, x29, #0x3fc
-               	sub	x13, x29, #0x410
+               	sub	x12, x29, #0x3e8
+               	sub	x12, x29, #0x3fc
+               	sub	x12, x29, #0x410
                	sub	x9, x29, #0x424
-               	mov	x16, #0xf2f0            // =62192
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x14, x29, #0x438
-               	sub	x14, x29, #0x44c
-               	sub	x14, x29, #0x460
-               	sub	x14, x29, #0x474
+               	sub	x13, x29, #0x438
+               	sub	x13, x29, #0x44c
+               	sub	x13, x29, #0x460
+               	sub	x13, x29, #0x474
                	sub	x9, x29, #0x488
-               	mov	x16, #0xf2e8            // =62184
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x49c
-               	sub	x15, x29, #0x4b0
+               	sub	x14, x29, #0x49c
+               	sub	x14, x29, #0x4b0
                	sub	x9, x29, #0x4c4
-               	mov	x16, #0xf338            // =62264
+               	mov	x16, #0xf948            // =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x4d8
-               	sub	x18, x29, #0x4ec
-               	sub	x18, x29, #0x500
+               	sub	x15, x29, #0x4d8
+               	sub	x15, x29, #0x4ec
+               	sub	x15, x29, #0x500
                	sub	x9, x29, #0x514
-               	mov	x16, #0xf2e0            // =62176
+               	mov	x16, #0xf940            // =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x528
+               	sub	x18, x29, #0x528
                	sub	x9, x29, #0x53c
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x550
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x564
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x578
-               	sub	x15, x29, #0x58c
-               	sub	x15, x29, #0x5a0
-               	sub	x15, x29, #0x5b4
-               	sub	x15, x29, #0x5c8
-               	sub	x15, x29, #0x5dc
-               	sub	x15, x29, #0x5f0
-               	sub	x15, x29, #0x604
-               	sub	x15, x29, #0x618
-               	sub	x15, x29, #0x62c
-               	sub	x15, x29, #0x640
-               	sub	x15, x29, #0x654
-               	sub	x15, x29, #0x668
-               	sub	x15, x29, #0x67c
-               	sub	x15, x29, #0x690
-               	sub	x15, x29, #0x6a4
-               	sub	x15, x29, #0x6b8
-               	sub	x15, x29, #0x6cc
-               	sub	x15, x29, #0x6e0
-               	sub	x15, x29, #0x6f4
-               	sub	x15, x29, #0x708
-               	sub	x15, x29, #0x71c
-               	sub	x15, x29, #0x730
-               	sub	x15, x29, #0x744
-               	sub	x15, x29, #0x758
-               	sub	x15, x29, #0x76c
-               	sub	x15, x29, #0x780
-               	sub	x15, x29, #0x794
-               	sub	x15, x29, #0x7a8
-               	sub	x15, x29, #0x7bc
-               	sub	x15, x29, #0x7d0
-               	sub	x15, x29, #0x7e4
-               	sub	x15, x29, #0x7f8
-               	sub	x15, x29, #0x80c
-               	sub	x15, x29, #0x820
-               	sub	x15, x29, #0x834
-               	sub	x15, x29, #0x848
-               	sub	x15, x29, #0x85c
-               	sub	x15, x29, #0x870
-               	sub	x15, x29, #0x884
-               	sub	x15, x29, #0x898
-               	sub	x15, x29, #0x8ac
-               	sub	x15, x29, #0x8c0
-               	sub	x15, x29, #0x8d4
-               	sub	x15, x29, #0x8e8
-               	sub	x15, x29, #0x8fc
-               	sub	x15, x29, #0x910
-               	sub	x15, x29, #0x924
-               	sub	x15, x29, #0x938
-               	sub	x15, x29, #0x94c
-               	sub	x15, x29, #0x960
-               	sub	x15, x29, #0x974
-               	sub	x15, x29, #0x988
-               	sub	x15, x29, #0x99c
-               	sub	x15, x29, #0x9b0
-               	sub	x15, x29, #0x9c4
-               	sub	x15, x29, #0x9d8
-               	sub	x15, x29, #0x9ec
-               	sub	x15, x29, #0xa00
-               	sub	x15, x29, #0xa14
-               	sub	x15, x29, #0xa28
-               	sub	x15, x29, #0xa3c
-               	sub	x15, x29, #0xa50
-               	sub	x15, x29, #0xa64
-               	sub	x15, x29, #0xa78
-               	sub	x15, x29, #0xa8c
-               	sub	x15, x29, #0xaa0
-               	sub	x15, x29, #0xab4
-               	sub	x15, x29, #0xac8
-               	sub	x15, x29, #0xadc
-               	sub	x15, x29, #0xaf0
-               	sub	x15, x29, #0xb04
-               	sub	x15, x29, #0xb18
-               	sub	x15, x29, #0xb2c
-               	sub	x15, x29, #0xb40
-               	sub	x15, x29, #0xb54
-               	sub	x15, x29, #0xb68
-               	sub	x15, x29, #0xb7c
-               	sub	x15, x29, #0xb90
-               	sub	x15, x29, #0xba4
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	sub	x15, x29, #0xbb8
-               	add	x19, x15, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x624
+               	add	x2, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x15, #0x4
-               	str	s1, [x19]
-               	add	x19, x15, #0x8
+               	add	x2, x0, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x15, #0xc
-               	str	s1, [x19]
-               	add	x19, x15, #0x10
+               	add	x2, x0, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
                	mov	w17, #0x40c80000        // =1086849024
-               	str	w17, [x19]
-               	add	x19, x15, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x0
-               	str	s1, [x19]
-               	add	x19, x15, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x4
-               	str	s1, [x19]
-               	add	x19, x15, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x8
-               	str	s1, [x19]
-               	add	x19, x15, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x20, #0xc
-               	str	s1, [x19]
-               	add	x19, x15, #0x10
-               	ldr	s1, [x19]
-               	add	x15, x20, #0x10
-               	str	s1, [x15]
-               	sub	x15, x29, #0xbcc
-               	add	x19, x15, #0x0
+               	str	w17, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	add	x2, x1, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	add	x2, x1, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	add	x0, x1, #0x10
+               	str	s1, [x0]
+               	sub	x0, x29, #0x638
+               	add	x2, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x19]
-               	add	x19, x15, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x15, #0x8
-               	str	s1, [x19]
-               	add	x19, x15, #0xc
+               	add	x2, x0, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x41000000        // =1090519040
-               	str	w17, [x19]
+               	str	w17, [x2]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x15, #0x10
-               	str	s1, [x19]
-               	add	x19, x15, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x0
-               	str	s1, [x19]
-               	add	x19, x15, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x4
-               	str	s1, [x19]
-               	add	x19, x15, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x8
-               	str	s1, [x19]
-               	add	x19, x15, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x21, #0xc
-               	str	s1, [x19]
-               	add	x19, x15, #0x10
-               	ldr	s1, [x19]
-               	add	x15, x21, #0x10
-               	str	s1, [x15]
-               	sub	x15, x29, #0xbe0
-               	add	x19, x15, #0x0
+               	add	x2, x0, #0x10
+               	str	s1, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s1, [x0]
+               	sub	x0, x29, #0x64c
+               	add	x2, x0, #0x0
                	mov	w17, #0x3f800000        // =1065353216
-               	str	w17, [x19]
-               	add	x19, x15, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x40400000        // =1077936128
-               	str	w17, [x19]
-               	add	x19, x15, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x41100000        // =1091567616
-               	str	w17, [x19]
-               	add	x19, x15, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x41d80000        // =1104674816
-               	str	w17, [x19]
-               	add	x19, x15, #0x10
+               	str	w17, [x2]
+               	add	x2, x0, #0x10
                	mov	w17, #0x42a20000        // =1117913088
-               	str	w17, [x19]
-               	add	x19, x15, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x0
-               	str	s1, [x19]
-               	add	x19, x15, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x4
-               	str	s1, [x19]
-               	add	x19, x15, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x8
-               	str	s1, [x19]
-               	add	x19, x15, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x22, #0xc
-               	str	s1, [x19]
-               	add	x19, x15, #0x10
-               	ldr	s1, [x19]
-               	add	x15, x22, #0x10
-               	str	s1, [x15]
-               	add	x15, x20, #0x0
-               	ldr	s1, [x15]
+               	str	w17, [x2]
+               	add	x2, x0, #0x0
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x0
+               	str	s1, [x2]
+               	add	x2, x0, #0x4
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x4
+               	str	s1, [x2]
+               	add	x2, x0, #0x8
+               	ldr	s1, [x2]
+               	add	x2, x19, #0x8
+               	str	s1, [x2]
+               	add	x2, x0, #0xc
+               	ldr	s1, [x2]
+               	add	x2, x19, #0xc
+               	str	s1, [x2]
+               	add	x2, x0, #0x10
+               	ldr	s1, [x2]
+               	add	x0, x19, #0x10
+               	str	s1, [x0]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x15, x20, #0x0
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x0
-               	str	s1, [x15]
-               	add	x15, x20, #0x4
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x4
-               	str	s1, [x15]
-               	add	x15, x20, #0x8
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x8
-               	str	s1, [x15]
-               	add	x15, x20, #0xc
-               	ldr	s1, [x15]
-               	add	x15, x23, #0xc
-               	str	s1, [x15]
-               	add	x15, x20, #0x10
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x10
-               	str	s1, [x15]
-               	add	x15, x23, #0x0
-               	str	s2, [x15]
-               	add	x15, x23, #0x10
-               	ldr	s1, [x15]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s1, [x0]
+               	add	x0, x1, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x4
+               	str	s1, [x0]
+               	add	x0, x1, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x8
+               	str	s1, [x0]
+               	add	x0, x1, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x3, #0xc
+               	str	s1, [x0]
+               	add	x0, x1, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x10
+               	str	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s2, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x15, x23, #0x0
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x0
-               	str	s1, [x15]
-               	add	x15, x23, #0x4
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x4
-               	str	s1, [x15]
-               	add	x15, x23, #0x8
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x8
-               	str	s1, [x15]
-               	add	x15, x23, #0xc
-               	ldr	s1, [x15]
-               	add	x15, x24, #0xc
-               	str	s1, [x15]
-               	add	x15, x23, #0x10
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x10
-               	str	s1, [x15]
-               	add	x15, x24, #0x10
-               	str	s2, [x15]
-               	add	x15, x21, #0x8
-               	ldr	s1, [x15]
+               	add	x0, x3, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x0
+               	str	s1, [x0]
+               	add	x0, x3, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x4
+               	str	s1, [x0]
+               	add	x0, x3, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x8
+               	str	s1, [x0]
+               	add	x0, x3, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x20, #0xc
+               	str	s1, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s2, [x0]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x15, x21, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	str	s0, [x15]
-               	add	x15, x21, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	str	s0, [x15]
-               	add	x15, x21, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	str	s0, [x15]
-               	add	x15, x21, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	str	s0, [x15]
-               	add	x15, x21, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	str	s0, [x15]
-               	add	x15, x25, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	str	s0, [x0]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	str	s0, [x0]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s0, [x0]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	str	s0, [x0]
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s2, [x0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x20
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x21
 <L1>:
                	bl	 <L1>
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x10
+               	str	s2, [x1]
+               	mov	x1, x22
 <L2>:
                	bl	 <L2>
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x10
+               	str	s2, [x1]
+               	mov	x1, x23
 <L3>:
                	bl	 <L3>
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x10
+               	str	s2, [x1]
+               	mov	x1, x24
 <L4>:
                	bl	 <L4>
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x10
+               	str	s2, [x1]
+               	mov	x1, x25
 <L5>:
                	bl	 <L5>
-               	add	x15, x25, #0x0
-               	ldr	s0, [x15]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x10
+               	str	s2, [x1]
+               	mov	x1, x26
 <L6>:
                	bl	 <L6>
-               	add	x15, x25, #0x4
-               	ldr	s0, [x15]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x10
+               	str	s2, [x1]
+               	mov	x1, x27
 <L7>:
                	bl	 <L7>
-               	add	x15, x25, #0x8
-               	ldr	s0, [x15]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x10
+               	str	s2, [x1]
+               	mov	x1, x28
 <L8>:
                	bl	 <L8>
-               	add	x15, x25, #0xc
-               	ldr	s0, [x15]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	add	x15, x25, #0x10
-               	ldr	s0, [x15]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
-               	fadd	s2, s0, s1
-               	add	x15, x26, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
-               	fadd	s2, s0, s1
-               	add	x15, x26, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
-               	fadd	s2, s0, s1
-               	add	x15, x26, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
-               	fadd	s2, s0, s1
-               	add	x15, x26, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
-               	fadd	s2, s0, s1
-               	add	x15, x26, #0x10
-               	str	s2, [x15]
-               	add	x15, x26, #0x0
-               	ldr	s0, [x15]
-<L11>:
-               	bl	 <L11>
-               	add	x15, x26, #0x4
-               	ldr	s0, [x15]
-<L12>:
-               	bl	 <L12>
-               	add	x15, x26, #0x8
-               	ldr	s0, [x15]
-<L13>:
-               	bl	 <L13>
-               	add	x15, x26, #0xc
-               	ldr	s0, [x15]
-<L14>:
-               	bl	 <L14>
-               	add	x15, x26, #0x10
-               	ldr	s0, [x15]
-<L15>:
-               	bl	 <L15>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x27, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x27, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x27, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x27, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x27, #0x10
-               	str	s2, [x15]
-               	add	x15, x27, #0x0
-               	ldr	s0, [x15]
-<L16>:
-               	bl	 <L16>
-               	add	x15, x27, #0x4
-               	ldr	s0, [x15]
-<L17>:
-               	bl	 <L17>
-               	add	x15, x27, #0x8
-               	ldr	s0, [x15]
-<L18>:
-               	bl	 <L18>
-               	add	x15, x27, #0xc
-               	ldr	s0, [x15]
-<L19>:
-               	bl	 <L19>
-               	add	x15, x27, #0x10
-               	ldr	s0, [x15]
-<L20>:
-               	bl	 <L20>
-               	add	x15, x25, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x0
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x28, #0x0
-               	str	s2, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x28, #0x4
-               	str	s2, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x28, #0x8
-               	str	s2, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x28, #0xc
-               	str	s2, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s1, [x15]
-               	fsub	s2, s0, s1
-               	add	x15, x28, #0x10
-               	str	s2, [x15]
-               	add	x15, x28, #0x0
-               	ldr	s0, [x15]
-<L21>:
-               	bl	 <L21>
-               	add	x15, x28, #0x4
-               	ldr	s0, [x15]
-<L22>:
-               	bl	 <L22>
-               	add	x15, x28, #0x8
-               	ldr	s0, [x15]
-<L23>:
-               	bl	 <L23>
-               	add	x15, x28, #0xc
-               	ldr	s0, [x15]
-<L24>:
-               	bl	 <L24>
-               	add	x15, x28, #0x10
-               	ldr	s0, [x15]
-<L25>:
-               	bl	 <L25>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x10
-               	str	s2, [x15]
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x0
-               	ldr	s0, [x15]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x4
-               	ldr	s0, [x15]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x8
-               	ldr	s0, [x15]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0xc
-               	ldr	s0, [x15]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xf330            // =62256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x10
-               	ldr	s0, [x15]
-<L30>:
-               	bl	 <L30>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xf328            // =62248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L35>:
-               	bl	 <L35>
-               	add	x1, x25, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xf320            // =62240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L40>:
-               	bl	 <L40>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xf318            // =62232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L45>:
-               	bl	 <L45>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xf310            // =62224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L50>:
-               	bl	 <L50>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xf308            // =62216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L55>:
-               	bl	 <L55>
-               	sub	x1, x29, #0xca4
+               	sub	x1, x29, #0x660
                	add	x2, x1, #0x0
                	str	wzr, [x2]
                	add	x2, x1, #0x4
@@ -1326,7 +937,7 @@ Disassembly of section .text:
                	str	wzr, [x2]
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1335,7 +946,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1344,7 +955,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1353,7 +964,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1362,134 +973,97 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf350            // =62288
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x19, x0
-               	mov	x16, #0xf350            // =62288
+               	mov	x22, x0
+               	mov	x16, #0xf970            // =63856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x20, x9
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x6
-               	b.lo	 <L56>
-               	b	 <L72>
-<L56>:
-               	add	x0, x24, #0x0
+               	mov	x23, x9
+               	mov	x24, #0x0               // =0
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x22, #0x0
+               	add	x0, x19, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x22, #0x4
+               	add	x0, x19, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x22, #0x8
+               	add	x0, x19, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x22, #0xc
+               	add	x0, x19, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x22, #0x10
+               	add	x0, x19, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	mov	x16, #0xf300            // =62208
+               	mov	x0, x22
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	mov	x1, x9
+<L12>:
+               	bl	 <L12>
+               	add	x1, x23, #0x0
                	ldr	s0, [x1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	add	x1, x20, #0x0
-               	ldr	s0, [x1]
-               	mov	x16, #0xf300            // =62208
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1497,7 +1071,95 @@ Disassembly of section .text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            // =62200
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L13>:
+               	bl	 <L13>
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1506,15 +1168,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	add	x1, x21, #0x4
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            // =62200
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1523,15 +1180,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
+               	add	x1, x21, #0x8
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            // =62200
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1540,15 +1192,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
+               	add	x1, x21, #0xc
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            // =62200
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1557,432 +1204,52 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            // =62208
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
+               	add	x1, x21, #0x10
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            // =62200
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf2f8            // =62200
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xf2f8            // =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xf2f8            // =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xf2f8            // =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xf2f8            // =62200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x25, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x25, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xf2f0            // =62192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x24, x9
-               	mov	x16, #0xf2f8            // =62200
+               	mov	x1, x9
+<L14>:
+               	bl	 <L14>
+               	add	x24, x24, #0x1
+               	mov	x22, x0
+               	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x20, x9
-               	cmp	x21, #0x6
-               	b.lo	 <L56>
-<L72>:
-               	sub	x21, x29, #0xc60
-               	add	x0, x21, #0x0
+               	mov	x16, #0xf960            // =63840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x23, x9
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+<L15>:
+               	sub	x24, x29, #0x5e0
+               	add	x0, x24, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x78               // =120
-<L73>:
+<L16>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L73>
-               	add	x0, x21, #0x0
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
+               	b.ne	 <L16>
                	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x0
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x4
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x8
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x25, #0xc
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x25, #0x10
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x21, #0x14
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf2e8            // =62184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x0
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x4
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x8
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x22, #0xc
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x10
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x21, #0x28
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf338            // =62264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x0, x21, #0x3c
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
@@ -2003,68 +1270,68 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	add	x0, x25, #0x0
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x24, #0x0
+               	add	x0, x21, #0x0
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            // =62176
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x25, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x21, #0x4
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            // =62176
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x25, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x21, #0x8
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            // =62176
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x25, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x21, #0xc
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            // =62176
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x25, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x21, #0x10
                	ldr	s1, [x0]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            // =62176
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	add	x0, x21, #0x50
-               	mov	x16, #0xf2e0            // =62176
+               	add	x0, x24, #0x14
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2073,7 +1340,7 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            // =62176
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2082,7 +1349,7 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            // =62176
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2091,7 +1358,7 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            // =62176
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2100,7 +1367,7 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            // =62176
+               	mov	x16, #0xf950            // =63824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2109,38 +1376,271 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	add	x0, x21, #0x64
-               	add	x1, x25, #0x0
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x0
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x4
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x8
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x19, #0xc
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x10
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x24, #0x28
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	add	x1, x25, #0x4
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	add	x1, x25, #0x8
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	add	x1, x25, #0xc
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	add	x1, x25, #0x10
+               	mov	x16, #0xf948            // =63816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x6
-               	b.lo	 <L74>
-               	b	 <L80>
-<L74>:
+               	add	x0, x24, #0x3c
+               	add	x1, x23, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x0, x21, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x0
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x21, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x21, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x21, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x21, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s1, [x0]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x24, #0x50
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x0, x24, #0x64
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x19, #0x0               // =0
+               	cmp	x19, #0x6
+               	b.lo	 <L17>
+               	b	 <L19>
+<L17>:
                	mov	x16, #0x14              // =20
-               	mul	x0, x20, x16
-               	add	x1, x21, x0
+               	mul	x0, x19, x16
+               	add	x1, x24, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2149,7 +1649,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2158,7 +1658,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2167,7 +1667,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2176,79 +1676,42 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s0, [x0]
-               	mov	x16, #0xf2d8            // =62168
+               	mov	x0, x22
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xf2d8            // =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xf2d8            // =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xf2d8            // =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xf2d8            // =62168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x6
-               	b.lo	 <L74>
-<L80>:
-               	sub	x20, x29, #0xc90
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	add	x0, x20, #0x0
+               	mov	x1, x9
+<L18>:
+               	bl	 <L18>
+               	add	x19, x19, #0x1
+               	mov	x22, x0
+               	cmp	x19, #0x6
+               	b.lo	 <L17>
+<L19>:
+               	sub	x19, x29, #0x610
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	str	xzr, [x19, #0x10]
+               	str	xzr, [x19, #0x18]
+               	str	xzr, [x19, #0x20]
+               	str	xzr, [x19, #0x28]
+               	add	x0, x19, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x21, #0x28
+               	add	x1, x24, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2257,7 +1720,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2266,7 +1729,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2275,7 +1738,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2284,163 +1747,160 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            // =62280
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x21, x20, #0x10
-               	mov	x16, #0xf348            // =62280
+               	add	x1, x19, #0x10
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf348            // =62280
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf348            // =62280
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf348            // =62280
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x21, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf348            // =62280
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf998            // =63896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x10
-               	str	s0, [x1]
-               	add	x1, x20, #0x24
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	add	x1, x19, #0x24
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x19
-<L81>:
-               	bl	 <L81>
-               	add	x1, x21, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x19, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x21, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x21, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x21, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x21, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xf340            // =62272
+               	add	x0, x9, #0x10
+               	str	s0, [x0]
+               	mov	x0, x22
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xf340            // =62272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xf340            // =62272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xf340            // =62272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xf340            // =62272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L86>:
-               	bl	 <L86>
-               	add	x1, x20, #0x24
+               	mov	x1, x9
+<L22>:
+               	bl	 <L22>
+               	add	x1, x19, #0x24
                	ldr	w2, [x1]
                	mov	w1, w2
-<L87>:
-               	bl	 <L87>
-               	sub	x16, x29, #0xd40
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	sub	x16, x29, #0x6e0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/vec/vec_f32x8.dis
+++ b/test/golden/aarch64-linux/vec/vec_f32x8.dis
@@ -5,74 +5,191 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x8.fold_vec>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x110
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x19, [x29, x16]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x20
-               	sub	x1, x29, #0x40
-               	sub	x1, x29, #0x60
-               	sub	x1, x29, #0x80
-               	sub	x1, x29, #0xa0
-               	sub	x1, x29, #0xc0
-               	sub	x1, x29, #0xe0
-               	sub	x1, x29, #0x100
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x100
+               	sub	x2, x29, #0x20
+               	sub	x2, x29, #0x40
+               	sub	x2, x29, #0x60
+               	sub	x2, x29, #0x80
+               	sub	x2, x29, #0xa0
+               	sub	x2, x29, #0xc0
+               	sub	x2, x29, #0xe0
+               	sub	x2, x29, #0x100
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	add	x2, x19, #0x14
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	add	x2, x19, #0x18
+               	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	add	x2, x19, #0x1c
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x16, #0xfef8            // =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x19, [x29, x16]
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	add	x2, x1, #0x14
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	add	x2, x1, #0x18
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	add	x2, x1, #0x1c
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -80,2333 +197,1194 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1, lsl #12   // =0x1000
-               	sub	sp, sp, #0xa90
-               	mov	x16, #0xe5b0            // =58800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
+               	sub	sp, sp, #0xa70
+               	sub	x16, x29, #0xa30
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	mov	x19, x0
-               	sub	x20, x29, #0x20
-               	sub	x21, x29, #0x40
-               	sub	x22, x29, #0x60
-               	sub	x1, x29, #0x80
-               	sub	x1, x29, #0xa0
-               	sub	x23, x29, #0xc0
-               	sub	x1, x29, #0xe0
-               	sub	x1, x29, #0x100
-               	sub	x24, x29, #0x120
-               	sub	x1, x29, #0x140
-               	sub	x1, x29, #0x160
-               	sub	x25, x29, #0x180
-               	sub	x1, x29, #0x1a0
-               	sub	x1, x29, #0x1c0
-               	sub	x26, x29, #0x1e0
-               	sub	x1, x29, #0x200
-               	sub	x1, x29, #0x220
-               	sub	x1, x29, #0x240
-               	sub	x1, x29, #0x260
-               	sub	x27, x29, #0x280
-               	sub	x1, x29, #0x2a0
-               	sub	x1, x29, #0x2c0
-               	sub	x28, x29, #0x2e0
-               	sub	x1, x29, #0x300
-               	sub	x1, x29, #0x320
-               	sub	x9, x29, #0x340
-               	mov	x16, #0xe618            // =58904
+               	sub	x1, x29, #0x20
+               	sub	x2, x29, #0x40
+               	sub	x19, x29, #0x60
+               	sub	x3, x29, #0x80
+               	sub	x3, x29, #0xa0
+               	sub	x3, x29, #0xc0
+               	sub	x4, x29, #0xe0
+               	sub	x4, x29, #0x100
+               	sub	x20, x29, #0x120
+               	sub	x4, x29, #0x140
+               	sub	x4, x29, #0x160
+               	sub	x9, x29, #0x180
+               	mov	x16, #0xf628            // =63016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x2, x29, #0x360
-               	sub	x2, x29, #0x380
-               	sub	x9, x29, #0x3a0
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x3, x29, #0x3c0
-               	sub	x3, x29, #0x3e0
-               	sub	x9, x29, #0x400
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x4, x29, #0x420
-               	sub	x4, x29, #0x440
-               	sub	x9, x29, #0x460
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x5, x29, #0x1a0
+               	sub	x5, x29, #0x1c0
+               	sub	x21, x29, #0x1e0
+               	sub	x5, x29, #0x200
+               	sub	x5, x29, #0x220
+               	sub	x5, x29, #0x240
+               	sub	x5, x29, #0x260
+               	sub	x22, x29, #0x280
+               	sub	x5, x29, #0x2a0
+               	sub	x5, x29, #0x2c0
+               	sub	x23, x29, #0x2e0
+               	sub	x5, x29, #0x300
+               	sub	x5, x29, #0x320
+               	sub	x24, x29, #0x340
+               	sub	x5, x29, #0x360
+               	sub	x5, x29, #0x380
+               	sub	x25, x29, #0x3a0
+               	sub	x5, x29, #0x3c0
+               	sub	x5, x29, #0x3e0
+               	sub	x26, x29, #0x400
+               	sub	x5, x29, #0x420
+               	sub	x5, x29, #0x440
+               	sub	x27, x29, #0x460
                	sub	x5, x29, #0x480
                	sub	x5, x29, #0x4a0
-               	sub	x9, x29, #0x4c0
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x6, x29, #0x4e0
-               	sub	x6, x29, #0x500
+               	sub	x28, x29, #0x4c0
+               	sub	x5, x29, #0x4e0
+               	sub	x5, x29, #0x500
                	sub	x9, x29, #0x520
-               	mov	x16, #0xe5f0            // =58864
+               	mov	x16, #0xf620            // =63008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x540
-               	sub	x7, x29, #0x560
+               	sub	x6, x29, #0x540
+               	sub	x6, x29, #0x560
                	sub	x9, x29, #0x580
-               	mov	x16, #0xe5e8            // =58856
+               	mov	x16, #0xf618            // =63000
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x5a0
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x12, x29, #0x5c0
-               	sub	x12, x29, #0x5e0
+               	sub	x8, x29, #0x5c0
+               	sub	x8, x29, #0x5e0
                	sub	x9, x29, #0x600
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x13, x29, #0x620
-               	sub	x13, x29, #0x640
-               	sub	x13, x29, #0x660
+               	sub	x12, x29, #0x620
+               	sub	x12, x29, #0x640
+               	sub	x12, x29, #0x660
                	sub	x9, x29, #0x680
-               	mov	x16, #0xe5d8            // =58840
+               	mov	x16, #0xf600            // =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x14, x29, #0x6a0
-               	sub	x14, x29, #0x6c0
-               	sub	x14, x29, #0x6e0
+               	sub	x13, x29, #0x6a0
+               	sub	x13, x29, #0x6c0
+               	sub	x13, x29, #0x6e0
                	sub	x9, x29, #0x700
-               	mov	x16, #0xe5d0            // =58832
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x720
-               	sub	x15, x29, #0x740
-               	sub	x15, x29, #0x760
-               	sub	x15, x29, #0x780
+               	sub	x14, x29, #0x720
+               	sub	x14, x29, #0x740
+               	sub	x14, x29, #0x760
+               	sub	x14, x29, #0x780
                	sub	x9, x29, #0x7a0
-               	mov	x16, #0xe5c8            // =58824
+               	mov	x16, #0xf5f0            // =62960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x7c0
-               	sub	x18, x29, #0x7e0
+               	sub	x15, x29, #0x7c0
+               	sub	x15, x29, #0x7e0
                	sub	x9, x29, #0x800
-               	mov	x16, #0xe620            // =58912
+               	mov	x16, #0xf5e8            // =62952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x8, x29, #0x820
+               	sub	x18, x29, #0x820
                	sub	x9, x29, #0x840
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x860
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x880
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x8a0
-               	sub	x18, x29, #0x8c0
-               	sub	x18, x29, #0x8e0
-               	sub	x18, x29, #0x900
-               	sub	x18, x29, #0x920
-               	sub	x18, x29, #0x940
-               	sub	x18, x29, #0x960
-               	sub	x18, x29, #0x980
-               	sub	x18, x29, #0x9a0
-               	sub	x18, x29, #0x9c0
-               	sub	x18, x29, #0x9e0
-               	sub	x18, x29, #0xa00
-               	sub	x18, x29, #0xa20
-               	sub	x18, x29, #0xa40
-               	sub	x18, x29, #0xa60
-               	sub	x18, x29, #0xa80
-               	sub	x18, x29, #0xaa0
-               	sub	x18, x29, #0xac0
-               	sub	x18, x29, #0xae0
-               	sub	x18, x29, #0xb00
-               	sub	x18, x29, #0xb20
-               	sub	x18, x29, #0xb40
-               	sub	x18, x29, #0xb60
-               	sub	x18, x29, #0xb80
-               	sub	x18, x29, #0xba0
-               	sub	x18, x29, #0xbc0
-               	sub	x18, x29, #0xbe0
-               	sub	x18, x29, #0xc00
-               	sub	x18, x29, #0xc20
-               	sub	x18, x29, #0xc40
-               	sub	x18, x29, #0xc60
-               	sub	x18, x29, #0xc80
-               	sub	x18, x29, #0xca0
-               	sub	x18, x29, #0xcc0
-               	sub	x18, x29, #0xce0
-               	sub	x18, x29, #0xd00
-               	sub	x18, x29, #0xd20
-               	sub	x18, x29, #0xd40
-               	sub	x18, x29, #0xd60
-               	sub	x18, x29, #0xd80
-               	sub	x18, x29, #0xda0
-               	sub	x18, x29, #0xdc0
-               	sub	x18, x29, #0xde0
-               	sub	x18, x29, #0xe00
-               	sub	x18, x29, #0xe20
-               	sub	x18, x29, #0xe40
-               	sub	x18, x29, #0xe60
-               	sub	x18, x29, #0xe80
-               	sub	x18, x29, #0xea0
-               	sub	x18, x29, #0xec0
-               	sub	x18, x29, #0xee0
-               	sub	x18, x29, #0xf00
-               	sub	x18, x29, #0xf20
-               	sub	x18, x29, #0xf40
-               	sub	x18, x29, #0xf60
-               	sub	x18, x29, #0xf80
-               	sub	x18, x29, #0xfa0
-               	sub	x18, x29, #0xfc0
-               	sub	x18, x29, #0xfe0
-               	sub	x18, x29, #0x1, lsl #12 // =0x1000
-               	mov	x16, #0xefe0            // =61408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xefc0            // =61376
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xefa0            // =61344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xef80            // =61312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xef60            // =61280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xef40            // =61248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xef20            // =61216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xef00            // =61184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeee0            // =61152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeec0            // =61120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeea0            // =61088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xee80            // =61056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xee60            // =61024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xee40            // =60992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xee20            // =60960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xee00            // =60928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xede0            // =60896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xedc0            // =60864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeda0            // =60832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xed80            // =60800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xed60            // =60768
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xed40            // =60736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xed20            // =60704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xed00            // =60672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xece0            // =60640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xecc0            // =60608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeca0            // =60576
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xec80            // =60544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xec60            // =60512
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xec40            // =60480
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xec20            // =60448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xec00            // =60416
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xebe0            // =60384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xebc0            // =60352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeba0            // =60320
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeb80            // =60288
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeb60            // =60256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeb40            // =60224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeb20            // =60192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeb00            // =60160
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeae0            // =60128
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeac0            // =60096
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xeaa0            // =60064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xea80            // =60032
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xea60            // =60000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xea40            // =59968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xea20            // =59936
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xea00            // =59904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe9e0            // =59872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe9c0            // =59840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe9a0            // =59808
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe980            // =59776
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe960            // =59744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe940            // =59712
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe920            // =59680
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe900            // =59648
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe8e0            // =59616
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe8c0            // =59584
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe8a0            // =59552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe880            // =59520
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe860            // =59488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe840            // =59456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe820            // =59424
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe800            // =59392
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe7e0            // =59360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe7c0            // =59328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe7a0            // =59296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	mov	x16, #0xe780            // =59264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-<L0>:
-               	bl	 <L0>
-               	ucvtf	s0, x19
-               	mov	x16, #0xe760            // =59232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	ucvtf	s0, x0
+               	sub	x0, x29, #0x960
+               	add	x4, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x18, #0x4
-               	str	s1, [x19]
-               	add	x19, x18, #0x8
+               	add	x4, x0, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x18, #0xc
-               	str	s1, [x19]
-               	add	x19, x18, #0x10
+               	add	x4, x0, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
                	mov	w17, #0x40c80000        // =1086849024
-               	str	w17, [x19]
+               	str	w17, [x4]
                	mov	w16, #0x41020000        // =1090650112
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x18, #0x14
-               	str	s1, [x19]
-               	add	x19, x18, #0x18
+               	add	x4, x0, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
                	mov	w17, #0x3f400000        // =1061158912
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #16.00000000
                	fneg	s1, s31
-               	add	x19, x18, #0x1c
-               	str	s1, [x19]
-               	add	x19, x18, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x0
-               	str	s1, [x19]
-               	add	x19, x18, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x4
-               	str	s1, [x19]
-               	add	x19, x18, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x8
-               	str	s1, [x19]
-               	add	x19, x18, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x20, #0xc
-               	str	s1, [x19]
-               	add	x19, x18, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x10
-               	str	s1, [x19]
-               	add	x19, x18, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x14
-               	str	s1, [x19]
-               	add	x19, x18, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x20, #0x18
-               	str	s1, [x19]
-               	add	x19, x18, #0x1c
-               	ldr	s1, [x19]
-               	add	x18, x20, #0x1c
-               	str	s1, [x18]
-               	mov	x16, #0xe740            // =59200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	add	x4, x0, #0x1c
+               	str	s1, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x1, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x1, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x1, #0x1c
+               	str	s1, [x0]
+               	sub	x0, x29, #0x980
+               	add	x4, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x19]
-               	add	x19, x18, #0x4
+               	str	w17, [x4]
+               	add	x4, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x18, #0x8
-               	str	s1, [x19]
-               	add	x19, x18, #0xc
+               	add	x4, x0, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
                	mov	w17, #0x41000000        // =1090519040
-               	str	w17, [x19]
+               	str	w17, [x4]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x18, #0x10
-               	str	s1, [x19]
-               	add	x19, x18, #0x14
+               	add	x4, x0, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
                	mov	w17, #0x3fa00000        // =1067450368
-               	str	w17, [x19]
+               	str	w17, [x4]
                	mov	w16, #0x42000000        // =1107296256
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x18, #0x18
-               	str	s1, [x19]
-               	add	x19, x18, #0x1c
+               	add	x4, x0, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
                	mov	w17, #0x3d800000        // =1031798784
-               	str	w17, [x19]
-               	add	x19, x18, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x0
-               	str	s1, [x19]
-               	add	x19, x18, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x4
-               	str	s1, [x19]
-               	add	x19, x18, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x8
-               	str	s1, [x19]
-               	add	x19, x18, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x21, #0xc
-               	str	s1, [x19]
-               	add	x19, x18, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x10
-               	str	s1, [x19]
-               	add	x19, x18, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x14
-               	str	s1, [x19]
-               	add	x19, x18, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x21, #0x18
-               	str	s1, [x19]
-               	add	x19, x18, #0x1c
-               	ldr	s1, [x19]
-               	add	x18, x21, #0x1c
-               	str	s1, [x18]
-               	mov	x16, #0xe720            // =59168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	str	w17, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x2, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x2, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x2, #0x1c
+               	str	s1, [x0]
+               	sub	x0, x29, #0x9a0
+               	add	x4, x0, #0x0
                	mov	w17, #0x3f800000        // =1065353216
-               	str	w17, [x19]
-               	add	x19, x18, #0x4
+               	str	w17, [x4]
+               	add	x4, x0, #0x4
                	mov	w17, #0x40400000        // =1077936128
-               	str	w17, [x19]
-               	add	x19, x18, #0x8
+               	str	w17, [x4]
+               	add	x4, x0, #0x8
                	mov	w17, #0x41100000        // =1091567616
-               	str	w17, [x19]
-               	add	x19, x18, #0xc
+               	str	w17, [x4]
+               	add	x4, x0, #0xc
                	mov	w17, #0x41d80000        // =1104674816
-               	str	w17, [x19]
-               	add	x19, x18, #0x10
+               	str	w17, [x4]
+               	add	x4, x0, #0x10
                	mov	w17, #0x42a20000        // =1117913088
-               	str	w17, [x19]
-               	add	x19, x18, #0x14
+               	str	w17, [x4]
+               	add	x4, x0, #0x14
                	mov	w17, #0x43730000        // =1131610112
-               	str	w17, [x19]
-               	add	x19, x18, #0x18
+               	str	w17, [x4]
+               	add	x4, x0, #0x18
                	mov	w17, #0x4000            // =16384
                	movk	w17, #0x4436, lsl #16
-               	str	w17, [x19]
-               	add	x19, x18, #0x1c
+               	str	w17, [x4]
+               	add	x4, x0, #0x1c
                	mov	w17, #0xb000            // =45056
                	movk	w17, #0x4508, lsl #16
-               	str	w17, [x19]
-               	add	x19, x18, #0x0
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x0
-               	str	s1, [x19]
-               	add	x19, x18, #0x4
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x4
-               	str	s1, [x19]
-               	add	x19, x18, #0x8
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x8
-               	str	s1, [x19]
-               	add	x19, x18, #0xc
-               	ldr	s1, [x19]
-               	add	x19, x22, #0xc
-               	str	s1, [x19]
-               	add	x19, x18, #0x10
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x10
-               	str	s1, [x19]
-               	add	x19, x18, #0x14
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x14
-               	str	s1, [x19]
-               	add	x19, x18, #0x18
-               	ldr	s1, [x19]
-               	add	x19, x22, #0x18
-               	str	s1, [x19]
-               	add	x19, x18, #0x1c
-               	ldr	s1, [x19]
-               	add	x18, x22, #0x1c
-               	str	s1, [x18]
-               	add	x18, x20, #0x0
-               	ldr	s1, [x18]
+               	str	w17, [x4]
+               	add	x4, x0, #0x0
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x0
+               	str	s1, [x4]
+               	add	x4, x0, #0x4
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x4
+               	str	s1, [x4]
+               	add	x4, x0, #0x8
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x8
+               	str	s1, [x4]
+               	add	x4, x0, #0xc
+               	ldr	s1, [x4]
+               	add	x4, x19, #0xc
+               	str	s1, [x4]
+               	add	x4, x0, #0x10
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x10
+               	str	s1, [x4]
+               	add	x4, x0, #0x14
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x14
+               	str	s1, [x4]
+               	add	x4, x0, #0x18
+               	ldr	s1, [x4]
+               	add	x4, x19, #0x18
+               	str	s1, [x4]
+               	add	x4, x0, #0x1c
+               	ldr	s1, [x4]
+               	add	x0, x19, #0x1c
+               	str	s1, [x0]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x18, x20, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x0
-               	str	s1, [x18]
-               	add	x18, x20, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x4
-               	str	s1, [x18]
-               	add	x18, x20, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x8
-               	str	s1, [x18]
-               	add	x18, x20, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x23, #0xc
-               	str	s1, [x18]
-               	add	x18, x20, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x10
-               	str	s1, [x18]
-               	add	x18, x20, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x14
-               	str	s1, [x18]
-               	add	x18, x20, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x18
-               	str	s1, [x18]
-               	add	x18, x20, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x1c
-               	str	s1, [x18]
-               	add	x18, x23, #0x0
-               	str	s2, [x18]
-               	add	x18, x23, #0x1c
-               	ldr	s1, [x18]
+               	add	x0, x1, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s1, [x0]
+               	add	x0, x1, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x4
+               	str	s1, [x0]
+               	add	x0, x1, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x8
+               	str	s1, [x0]
+               	add	x0, x1, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x3, #0xc
+               	str	s1, [x0]
+               	add	x0, x1, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x10
+               	str	s1, [x0]
+               	add	x0, x1, #0x14
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x14
+               	str	s1, [x0]
+               	add	x0, x1, #0x18
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x18
+               	str	s1, [x0]
+               	add	x0, x1, #0x1c
+               	ldr	s1, [x0]
+               	add	x0, x3, #0x1c
+               	str	s1, [x0]
+               	add	x0, x3, #0x0
+               	str	s2, [x0]
+               	add	x0, x3, #0x1c
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x18, x23, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x0
-               	str	s1, [x18]
-               	add	x18, x23, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x4
-               	str	s1, [x18]
-               	add	x18, x23, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x8
-               	str	s1, [x18]
-               	add	x18, x23, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x24, #0xc
-               	str	s1, [x18]
-               	add	x18, x23, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x10
-               	str	s1, [x18]
-               	add	x18, x23, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x14
-               	str	s1, [x18]
-               	add	x18, x23, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x18
-               	str	s1, [x18]
-               	add	x18, x23, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x1c
-               	str	s1, [x18]
-               	add	x18, x24, #0x1c
-               	str	s2, [x18]
-               	add	x18, x21, #0xc
-               	ldr	s1, [x18]
+               	add	x0, x3, #0x0
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x0
+               	str	s1, [x0]
+               	add	x0, x3, #0x4
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x4
+               	str	s1, [x0]
+               	add	x0, x3, #0x8
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x8
+               	str	s1, [x0]
+               	add	x0, x3, #0xc
+               	ldr	s1, [x0]
+               	add	x0, x20, #0xc
+               	str	s1, [x0]
+               	add	x0, x3, #0x10
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x10
+               	str	s1, [x0]
+               	add	x0, x3, #0x14
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x14
+               	str	s1, [x0]
+               	add	x0, x3, #0x18
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x18
+               	str	s1, [x0]
+               	add	x0, x3, #0x1c
+               	ldr	s1, [x0]
+               	add	x0, x20, #0x1c
+               	str	s1, [x0]
+               	add	x0, x20, #0x1c
+               	str	s2, [x0]
+               	add	x0, x2, #0xc
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x18, x21, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x0
-               	str	s1, [x18]
-               	add	x18, x21, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x4
-               	str	s1, [x18]
-               	add	x18, x21, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x8
-               	str	s1, [x18]
-               	add	x18, x21, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x25, #0xc
-               	str	s1, [x18]
-               	add	x18, x21, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x10
-               	str	s1, [x18]
-               	add	x18, x21, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x14
-               	str	s1, [x18]
-               	add	x18, x21, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x18
-               	str	s1, [x18]
-               	add	x18, x21, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x1c
-               	str	s1, [x18]
-               	add	x18, x25, #0xc
-               	str	s2, [x18]
-               	add	x18, x25, #0x10
-               	ldr	s1, [x18]
+               	add	x0, x2, #0x0
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s1, [x0]
+               	add	x0, x2, #0x4
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s1, [x0]
+               	add	x0, x2, #0x8
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s1, [x0]
+               	add	x0, x2, #0xc
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s1, [x0]
+               	add	x0, x2, #0x10
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s1, [x0]
+               	add	x0, x2, #0x14
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s1, [x0]
+               	add	x0, x2, #0x18
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s1, [x0]
+               	add	x0, x2, #0x1c
+               	ldr	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s1, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s1, [x0]
                	fadd	s2, s1, s0
-               	add	x18, x25, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	str	s0, [x18]
-               	add	x18, x25, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	str	s0, [x18]
-               	add	x18, x25, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	str	s0, [x18]
-               	add	x18, x25, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	str	s0, [x18]
-               	add	x18, x25, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	str	s0, [x18]
-               	add	x18, x25, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	str	s0, [x18]
-               	add	x18, x25, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	str	s0, [x18]
-               	add	x18, x25, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	str	s0, [x18]
-               	add	x18, x26, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x14
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x18
+               	str	s0, [x0]
+               	mov	x16, #0xf628            // =63016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x1c
+               	str	s0, [x0]
+               	add	x0, x21, #0x10
+               	str	s2, [x0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x1, x20
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x21
 <L1>:
                	bl	 <L1>
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	add	x1, x22, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x22
 <L2>:
                	bl	 <L2>
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x23, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x23
 <L3>:
                	bl	 <L3>
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x10
+               	str	s2, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x14
+               	str	s2, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x18
+               	str	s2, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	add	x1, x24, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x24
 <L4>:
                	bl	 <L4>
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x25, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x25
 <L5>:
                	bl	 <L5>
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x26, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x26
 <L6>:
                	bl	 <L6>
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
+               	add	x1, x21, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x0
+               	str	s2, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x4
+               	str	s2, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x8
+               	str	s2, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0xc
+               	str	s2, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x10
+               	str	s2, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x14
+               	str	s2, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x18
+               	str	s2, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	add	x1, x27, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x27
 <L7>:
                	bl	 <L7>
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x0
+               	str	s2, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x4
+               	str	s2, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x8
+               	str	s2, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0xc
+               	str	s2, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x10
+               	str	s2, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x14
+               	str	s2, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x18
+               	str	s2, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s1, [x1]
+               	fmul	s2, s0, s1
+               	add	x1, x28, #0x1c
+               	str	s2, [x1]
+               	mov	x1, x28
 <L8>:
                	bl	 <L8>
-               	add	x18, x26, #0x0
-               	ldr	s0, [x18]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x4
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x8
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x21, #0xc
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x10
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x14
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x18
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x1c
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf620            // =63008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	add	x18, x26, #0x4
-               	ldr	s0, [x18]
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x0
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x4
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x8
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x20, #0xc
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x10
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x19, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x14
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x19, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x18
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x19, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x20, #0x1c
+               	ldr	s1, [x1]
+               	fdiv	s2, s0, s1
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf618            // =63000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	add	x18, x26, #0x8
-               	ldr	s0, [x18]
-<L11>:
-               	bl	 <L11>
-               	add	x18, x26, #0xc
-               	ldr	s0, [x18]
-<L12>:
-               	bl	 <L12>
-               	add	x18, x26, #0x10
-               	ldr	s0, [x18]
-<L13>:
-               	bl	 <L13>
-               	add	x18, x26, #0x14
-               	ldr	s0, [x18]
-<L14>:
-               	bl	 <L14>
-               	add	x18, x26, #0x18
-               	ldr	s0, [x18]
-<L15>:
-               	bl	 <L15>
-               	add	x18, x26, #0x1c
-               	ldr	s0, [x18]
-<L16>:
-               	bl	 <L16>
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x0
-               	str	s2, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x4
-               	str	s2, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x8
-               	str	s2, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0xc
-               	str	s2, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x14
-               	str	s2, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x18
-               	str	s2, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s1, [x18]
-               	fadd	s2, s0, s1
-               	add	x18, x27, #0x1c
-               	str	s2, [x18]
-               	add	x18, x27, #0x0
-               	ldr	s0, [x18]
-<L17>:
-               	bl	 <L17>
-               	add	x18, x27, #0x4
-               	ldr	s0, [x18]
-<L18>:
-               	bl	 <L18>
-               	add	x18, x27, #0x8
-               	ldr	s0, [x18]
-<L19>:
-               	bl	 <L19>
-               	add	x18, x27, #0xc
-               	ldr	s0, [x18]
-<L20>:
-               	bl	 <L20>
-               	add	x18, x27, #0x10
-               	ldr	s0, [x18]
-<L21>:
-               	bl	 <L21>
-               	add	x18, x27, #0x14
-               	ldr	s0, [x18]
-<L22>:
-               	bl	 <L22>
-               	add	x18, x27, #0x18
-               	ldr	s0, [x18]
-<L23>:
-               	bl	 <L23>
-               	add	x18, x27, #0x1c
-               	ldr	s0, [x18]
-<L24>:
-               	bl	 <L24>
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x0
-               	str	s2, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x4
-               	str	s2, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x8
-               	str	s2, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0xc
-               	str	s2, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x14
-               	str	s2, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x18
-               	str	s2, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	add	x18, x28, #0x1c
-               	str	s2, [x18]
-               	add	x18, x28, #0x0
-               	ldr	s0, [x18]
-<L25>:
-               	bl	 <L25>
-               	add	x18, x28, #0x4
-               	ldr	s0, [x18]
-<L26>:
-               	bl	 <L26>
-               	add	x18, x28, #0x8
-               	ldr	s0, [x18]
-<L27>:
-               	bl	 <L27>
-               	add	x18, x28, #0xc
-               	ldr	s0, [x18]
-<L28>:
-               	bl	 <L28>
-               	add	x18, x28, #0x10
-               	ldr	s0, [x18]
-<L29>:
-               	bl	 <L29>
-               	add	x18, x28, #0x14
-               	ldr	s0, [x18]
-<L30>:
-               	bl	 <L30>
-               	add	x18, x28, #0x18
-               	ldr	s0, [x18]
-<L31>:
-               	bl	 <L31>
-               	add	x18, x28, #0x1c
-               	ldr	s0, [x18]
-<L32>:
-               	bl	 <L32>
-               	add	x18, x26, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x0
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x0
-               	str	s2, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x4
-               	str	s2, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x8
-               	str	s2, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0xc
-               	str	s2, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x10
-               	str	s2, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x14
-               	str	s2, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x18
-               	str	s2, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s1, [x18]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x1c
-               	str	s2, [x18]
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x0
-               	ldr	s0, [x18]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x4
-               	ldr	s0, [x18]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x8
-               	ldr	s0, [x18]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0xc
-               	ldr	s0, [x18]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x10
-               	ldr	s0, [x18]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x14
-               	ldr	s0, [x18]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x18
-               	ldr	s0, [x18]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xe618            // =58904
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x1c
-               	ldr	s0, [x18]
-<L40>:
-               	bl	 <L40>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xe610            // =58896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L48>:
-               	bl	 <L48>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xe608            // =58888
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L56>:
-               	bl	 <L56>
-               	add	x1, x26, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xe600            // =58880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L64>:
-               	bl	 <L64>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s1, [x1]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xe5f8            // =58872
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L72>:
-               	bl	 <L72>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xe5f0            // =58864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L80>:
-               	bl	 <L80>
-               	add	x1, x22, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x0
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x22, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x22, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x22, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x22, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x22, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x22, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x22, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s1, [x1]
-               	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xe5e8            // =58856
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xe640            // =58944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x1, x29, x16
+               	sub	x1, x29, #0x9c0
                	add	x2, x1, #0x0
                	str	wzr, [x2]
                	add	x2, x1, #0x4
@@ -2425,7 +1403,7 @@ Disassembly of section .text:
                	str	wzr, [x2]
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2434,7 +1412,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2443,7 +1421,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2452,7 +1430,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2461,7 +1439,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2470,7 +1448,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x14
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2479,7 +1457,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x18
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2488,197 +1466,133 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x1c
                	ldr	s0, [x2]
-               	mov	x16, #0xe638            // =58936
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s0, [x1]
-               	mov	x19, x0
-               	mov	x16, #0xe638            // =58936
+               	mov	x22, x0
+               	mov	x16, #0xf610            // =62992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x20, x9
-               	mov	x21, #0x0               // =0
-               	cmp	x21, #0x6
-               	b.lo	 <L89>
-               	b	 <L114>
-<L89>:
-               	add	x0, x24, #0x0
+               	mov	x23, x9
+               	mov	x24, #0x0               // =0
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	add	x0, x20, #0x0
                	ldr	s0, [x0]
-               	add	x0, x22, #0x0
+               	add	x0, x19, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	str	s2, [x0]
-               	add	x0, x24, #0x4
+               	add	x0, x20, #0x4
                	ldr	s0, [x0]
-               	add	x0, x22, #0x4
+               	add	x0, x19, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x4
                	str	s2, [x0]
-               	add	x0, x24, #0x8
+               	add	x0, x20, #0x8
                	ldr	s0, [x0]
-               	add	x0, x22, #0x8
+               	add	x0, x19, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x8
                	str	s2, [x0]
-               	add	x0, x24, #0xc
+               	add	x0, x20, #0xc
                	ldr	s0, [x0]
-               	add	x0, x22, #0xc
+               	add	x0, x19, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
                	str	s2, [x0]
-               	add	x0, x24, #0x10
+               	add	x0, x20, #0x10
                	ldr	s0, [x0]
-               	add	x0, x22, #0x10
+               	add	x0, x19, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	add	x0, x24, #0x14
+               	add	x0, x20, #0x14
                	ldr	s0, [x0]
-               	add	x0, x22, #0x14
+               	add	x0, x19, #0x14
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x14
                	str	s2, [x0]
-               	add	x0, x24, #0x18
+               	add	x0, x20, #0x18
                	ldr	s0, [x0]
-               	add	x0, x22, #0x18
+               	add	x0, x19, #0x18
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x18
                	str	s2, [x0]
-               	add	x0, x24, #0x1c
+               	add	x0, x20, #0x1c
                	ldr	s0, [x0]
-               	add	x0, x22, #0x1c
+               	add	x0, x19, #0x1c
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s2, [x0]
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x0, x22
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	mov	x1, x9
+<L12>:
+               	bl	 <L12>
+               	add	x1, x23, #0x0
                	ldr	s0, [x1]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L97>:
-               	bl	 <L97>
-               	add	x1, x20, #0x0
-               	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
+               	mov	x16, #0xf608            // =62984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2686,7 +1600,146 @@ Disassembly of section .text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	add	x1, x23, #0x14
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	str	s2, [x1]
+               	add	x1, x23, #0x18
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	str	s2, [x1]
+               	add	x1, x23, #0x1c
+               	ldr	s0, [x1]
+               	mov	x16, #0xf608            // =62984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	str	s2, [x1]
+               	mov	x16, #0xf600            // =62976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L13>:
+               	bl	 <L13>
+               	add	x1, x20, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x21, #0x0
+               	ldr	s1, [x1]
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2695,15 +1748,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
+               	add	x1, x21, #0x4
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2712,15 +1760,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
+               	add	x1, x21, #0x8
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2729,15 +1772,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
+               	add	x1, x21, #0xc
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2746,15 +1784,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
+               	add	x1, x21, #0x10
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2763,15 +1796,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
+               	add	x1, x21, #0x14
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2780,15 +1808,10 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
+               	add	x1, x21, #0x18
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2797,664 +1820,52 @@ Disassembly of section .text:
                	str	s2, [x1]
                	add	x1, x20, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            // =58848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
+               	add	x1, x21, #0x1c
                	ldr	s1, [x1]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            // =58840
+               	fsub	s2, s0, s1
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5d8            // =58840
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xe5d8            // =58840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L105>:
-               	bl	 <L105>
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x0
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	str	s2, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x4
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	str	s2, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x8
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	str	s2, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x26, #0xc
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	str	s2, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x10
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s2, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x14
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	str	s2, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x18
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	str	s2, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x26, #0x1c
-               	ldr	s1, [x1]
-               	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s2, [x1]
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L113>:
-               	bl	 <L113>
-               	add	x21, x21, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xe5d0            // =58832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x24, x9
-               	mov	x16, #0xe5d8            // =58840
+               	mov	x1, x9
+<L14>:
+               	bl	 <L14>
+               	add	x24, x24, #0x1
+               	mov	x22, x0
+               	mov	x16, #0xf5f8            // =62968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x20, x9
-               	cmp	x21, #0x6
-               	b.lo	 <L89>
-<L114>:
-               	mov	x16, #0xe6a0            // =59040
+               	mov	x16, #0xf600            // =62976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x21, x29, x16
-               	add	x0, x21, #0x0
+               	ldr	x9, [x29, x16]
+               	mov	x23, x9
+               	cmp	x24, #0x6
+               	b.lo	 <L11>
+<L15>:
+               	sub	x24, x29, #0x900
+               	add	x0, x24, #0x0
                	add	x1, x0, #0x0
                	mov	x0, #0x80               // =128
-<L115>:
+<L16>:
                	str	xzr, [x1]
                	add	x1, x1, #0x8
                	sub	x0, x0, #0x8
                	cmp	x0, #0x0
-               	b.ne	 <L115>
-               	add	x0, x21, #0x0
-               	add	x1, x24, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x24, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	add	x1, x24, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	add	x1, x24, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	add	x1, x24, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	add	x1, x24, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	add	x1, x24, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	add	x1, x24, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
+               	b.ne	 <L16>
                	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x0
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x4
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x8
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x26, #0xc
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x10
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x24, #0x14
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x14
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x14
-               	str	s2, [x0]
-               	add	x0, x24, #0x18
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x18
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x18
-               	str	s2, [x0]
-               	add	x0, x24, #0x1c
-               	ldr	s0, [x0]
-               	add	x0, x26, #0x1c
-               	ldr	s1, [x0]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x1c
-               	str	s2, [x0]
-               	add	x0, x21, #0x20
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe5c8            // =58824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
-               	add	x0, x24, #0x0
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x0
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	str	s2, [x0]
-               	add	x0, x24, #0x4
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x4
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	str	s2, [x0]
-               	add	x0, x24, #0x8
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x8
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x8
-               	str	s2, [x0]
-               	add	x0, x24, #0xc
-               	ldr	s0, [x0]
-               	add	x0, x22, #0xc
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0xc
-               	str	s2, [x0]
-               	add	x0, x24, #0x10
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x10
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x10
-               	str	s2, [x0]
-               	add	x0, x24, #0x14
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x14
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x14
-               	str	s2, [x0]
-               	add	x0, x24, #0x18
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x18
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x18
-               	str	s2, [x0]
-               	add	x0, x24, #0x1c
-               	ldr	s0, [x0]
-               	add	x0, x22, #0x1c
-               	ldr	s1, [x0]
-               	fmul	s2, s0, s1
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x1c
-               	str	s2, [x0]
-               	add	x0, x21, #0x40
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x0, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe620            // =58912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x0, #0x1c
-               	str	s0, [x1]
-               	add	x0, x21, #0x60
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
@@ -3487,17 +1898,388 @@ Disassembly of section .text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x1c
                	str	s0, [x1]
-               	mov	x20, #0x0               // =0
-               	cmp	x20, #0x4
-               	b.lo	 <L116>
-               	b	 <L125>
-<L116>:
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x0
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x4
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x8
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x21, #0xc
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x10
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x20, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x14
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s2, [x0]
+               	add	x0, x20, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x18
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s2, [x0]
+               	add	x0, x20, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x21, #0x1c
+               	ldr	s1, [x0]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s2, [x0]
+               	add	x0, x24, #0x20
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	mov	x16, #0xf5f0            // =62960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	add	x0, x20, #0x0
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x0
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	str	s2, [x0]
+               	add	x0, x20, #0x4
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x4
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	str	s2, [x0]
+               	add	x0, x20, #0x8
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x8
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x8
+               	str	s2, [x0]
+               	add	x0, x20, #0xc
+               	ldr	s0, [x0]
+               	add	x0, x19, #0xc
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	str	s2, [x0]
+               	add	x0, x20, #0x10
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x10
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	str	s2, [x0]
+               	add	x0, x20, #0x14
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x14
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x14
+               	str	s2, [x0]
+               	add	x0, x20, #0x18
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x18
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x18
+               	str	s2, [x0]
+               	add	x0, x20, #0x1c
+               	ldr	s0, [x0]
+               	add	x0, x19, #0x1c
+               	ldr	s1, [x0]
+               	fmul	s2, s0, s1
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1c
+               	str	s2, [x0]
+               	add	x0, x24, #0x40
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	mov	x16, #0xf5e8            // =62952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	add	x0, x24, #0x60
+               	add	x1, x23, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x23, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x23, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x23, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	add	x1, x23, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x10
+               	str	s0, [x1]
+               	add	x1, x23, #0x14
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x14
+               	str	s0, [x1]
+               	add	x1, x23, #0x18
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x18
+               	str	s0, [x1]
+               	add	x1, x23, #0x1c
+               	ldr	s0, [x1]
+               	add	x1, x0, #0x1c
+               	str	s0, [x1]
+               	mov	x19, #0x0               // =0
+               	cmp	x19, #0x4
+               	b.lo	 <L17>
+               	b	 <L19>
+<L17>:
                	mov	x16, #0x20              // =32
-               	mul	x0, x20, x16
-               	add	x1, x21, x0
+               	mul	x0, x19, x16
+               	add	x1, x24, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3506,7 +2288,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3515,7 +2297,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3524,7 +2306,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3533,7 +2315,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3542,7 +2324,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x14
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3551,7 +2333,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x18
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3560,112 +2342,44 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x1c
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s0, [x0]
-               	mov	x16, #0xe5c0            // =58816
+               	mov	x0, x22
+               	mov	x16, #0xf5e0            // =62944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x19
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xe5c0            // =58816
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L124>:
-               	bl	 <L124>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	cmp	x20, #0x4
-               	b.lo	 <L116>
-<L125>:
-               	mov	x16, #0xe660            // =58976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x20, x29, x16
-               	str	xzr, [x20]
-               	str	xzr, [x20, #0x8]
-               	str	xzr, [x20, #0x10]
-               	str	xzr, [x20, #0x18]
-               	str	xzr, [x20, #0x20]
-               	str	xzr, [x20, #0x28]
-               	str	xzr, [x20, #0x30]
-               	str	xzr, [x20, #0x38]
-               	add	x0, x20, #0x0
+               	mov	x1, x9
+<L18>:
+               	bl	 <L18>
+               	add	x19, x19, #0x1
+               	mov	x22, x0
+               	cmp	x19, #0x4
+               	b.lo	 <L17>
+<L19>:
+               	sub	x19, x29, #0x940
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	str	xzr, [x19, #0x10]
+               	str	xzr, [x19, #0x18]
+               	str	xzr, [x19, #0x20]
+               	str	xzr, [x19, #0x28]
+               	str	xzr, [x19, #0x30]
+               	str	xzr, [x19, #0x38]
+               	add	x0, x19, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x21, #0x40
+               	add	x1, x24, #0x40
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3674,7 +2388,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3683,7 +2397,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3692,7 +2406,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3701,7 +2415,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3710,7 +2424,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x14
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3719,7 +2433,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x18
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3728,248 +2442,214 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x1c
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            // =58928
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s0, [x1]
-               	add	x21, x20, #0x10
-               	mov	x16, #0xe630            // =58928
+               	add	x1, x19, #0x10
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x21, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x14
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x14
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x14
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x18
-               	str	s0, [x1]
-               	mov	x16, #0xe630            // =58928
+               	add	x2, x9, #0x18
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x18
+               	str	s0, [x2]
+               	mov	x16, #0xf638            // =63032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-               	add	x1, x21, #0x1c
-               	str	s0, [x1]
-               	add	x1, x20, #0x30
+               	add	x2, x9, #0x1c
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x1c
+               	str	s0, [x2]
+               	add	x1, x19, #0x30
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x19
-<L126>:
-               	bl	 <L126>
-               	add	x1, x21, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x22, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x22, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	add	x0, x19, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x21, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x21, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x21, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x21, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x1, x21, #0x14
+               	add	x1, x0, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x14
                	str	s0, [x1]
-               	add	x1, x21, #0x18
+               	add	x1, x0, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x18
                	str	s0, [x1]
-               	add	x1, x21, #0x1c
+               	add	x1, x0, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	str	s0, [x1]
-               	mov	x16, #0xe628            // =58920
+               	add	x0, x9, #0x1c
+               	str	s0, [x0]
+               	mov	x0, x22
+               	mov	x16, #0xf630            // =63024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x14
-               	ldr	s0, [x1]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x18
-               	ldr	s0, [x1]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xe628            // =58920
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x1c
-               	ldr	s0, [x1]
-<L134>:
-               	bl	 <L134>
-               	add	x1, x20, #0x30
+               	mov	x1, x9
+<L22>:
+               	bl	 <L22>
+               	add	x1, x19, #0x30
                	ldr	w2, [x1]
                	mov	w1, w2
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xe5b0            // =58800
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	add	x16, x29, x16
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	sub	x16, x29, #0xa30
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/vec/vec_f64x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_f64x2.dis
@@ -3,64 +3,83 @@ vec/vec_f64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[0]
-               	mov	x0, x1
+               	mov	d1, v0.d[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0.d[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_f64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            // =65032
+               	sub	sp, sp, #0x150
+               	stp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	ucvtf	d0, x19
-               	sub	x1, x29, #0x10
-               	add	x2, x1, #0x0
+               	ucvtf	d0, x0
+               	sub	x0, x29, #0x80
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff8000000000000 // =4609434218613702656
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #-0x3ffe000000000000 // =-4611123068473966592
-               	str	x17, [x2]
-               	ldr	q1, [x1]
-               	sub	x1, x29, #0x20
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x90
+               	add	x1, x0, #0x0
                	mov	x17, #0x3fe0000000000000 // =4602678819172646912
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x4010000000000000 // =4616189618054758400
-               	str	x17, [x2]
-               	ldr	q2, [x1]
-               	sub	x1, x29, #0x30
-               	add	x2, x1, #0x0
+               	str	x17, [x1]
+               	ldr	q2, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x1, x0, #0x0
                	mov	x17, #0x3ff0000000000000 // =4607182418800017408
-               	str	x17, [x2]
-               	add	x2, x1, #0x8
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
                	mov	x17, #0x403b000000000000 // =4628293042053316608
-               	str	x17, [x2]
-               	ldr	q31, [x1]
+               	str	x17, [x1]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
                	mov	d3, v1.d[0]
                	fadd	d4, d3, d0
@@ -72,214 +91,61 @@ Disassembly of section .text:
                	mov	v30.16b, v2.16b
                	mov	v30.d[1], v3.d[0]
                	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	d0, v31.d[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xd0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xe0]
 <L1>:
                	bl	 <L1>
                	ldur	q31, [x29, #-0xd0]
-               	mov	d0, v31.d[1]
+               	ldur	q30, [x29, #-0xe0]
+               	fadd	v0.2d, v31.2d, v30.2d
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	d0, v31.d[0]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fsub	v0.2d, v31.2d, v30.2d
 <L3>:
                	bl	 <L3>
                	ldur	q31, [x29, #-0xe0]
-               	mov	d0, v31.d[1]
+               	ldur	q30, [x29, #-0xd0]
+               	fsub	v0.2d, v31.2d, v30.2d
 <L4>:
                	bl	 <L4>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	fadd	v31.2d, v31.2d, v30.2d
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	d0, v31.d[0]
+               	fmul	v0.2d, v31.2d, v30.2d
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	d0, v31.d[1]
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	fdiv	v0.2d, v31.2d, v30.2d
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fsub	v31.2d, v31.2d, v30.2d
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	d0, v31.d[0]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xd0]
+               	fdiv	v0.2d, v31.2d, v30.2d
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov	d0, v31.d[1]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fsub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fmul	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	fdiv	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xd0]
-               	fdiv	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xc0]
-               	fmul	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L18>:
-               	bl	 <L18>
+               	fmul	v0.2d, v31.2d, v30.2d
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xe0]
-               	fsub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L20>:
-               	bl	 <L20>
+               	fsub	v0.2d, v31.2d, v30.2d
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xc0]
                	ldur	q30, [x29, #-0xd0]
-               	fdiv	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L22>:
-               	bl	 <L22>
+               	fdiv	v0.2d, v31.2d, v30.2d
+<L10>:
+               	bl	 <L10>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
@@ -288,136 +154,81 @@ Disassembly of section .text:
                	ldr	q0, [x1]
                	mov	x19, x0
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-               	b	 <L30>
-<L23>:
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L11>
+               	b	 <L15>
+<L11>:
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
+               	stur	q31, [x29, #-0xf0]
                	mov	x0, x19
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xfe80            // =65152
+               	ldur	q0, [x29, #-0xf0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	fadd	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L13>:
+               	bl	 <L13>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fsub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L29>:
-               	bl	 <L29>
+               	ldr	q0, [x29, x16]
+<L14>:
+               	bl	 <L14>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L23>
-<L30>:
-               	sub	x20, x29, #0x70
+               	b.lo	 <L11>
+<L15>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -427,32 +238,20 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	str	q31, [x0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xe0]
                	fadd	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	fmul	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -460,41 +259,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L31>
-               	b	 <L34>
-<L31>:
+               	b.lo	 <L16>
+               	b	 <L18>
+<L16>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L33>:
-               	bl	 <L33>
+<L17>:
+               	bl	 <L17>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L31>
-<L34>:
-               	sub	x21, x29, #0xa0
+               	b.lo	 <L16>
+<L18>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -507,45 +287,60 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+               	b	 <L20>
+<L19>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L19>
+<L20>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L35>:
-               	bl	 <L35>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L37>:
-               	bl	 <L37>
+<L21>:
+               	bl	 <L21>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L38>:
-               	bl	 <L38>
-               	ldp	x19, x20, [x29, #-0x1f0]
-               	mov	x16, #0xfe08            // =65032
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	ldp	x19, x20, [x29, #-0x140]
+               	mov	x16, #0xfeb8            // =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/vec/vec_i16x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_i16x4.dis
@@ -3,668 +3,361 @@ vec/vec_i16x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i16x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[0]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[1]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.h[2]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	umov	w1, v0.h[3]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_i16x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1f0
-               	stp	x19, x20, [x29, #-0x1e0]
-               	mov	x16, #0xfe18            // =65048
+               	sub	sp, sp, #0x160
+               	stp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x44
+               	add	x2, x0, #0x0
+               	mov	w17, #0x3e9             // =1001
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfbb1            // =64433
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x4b7             // =1207
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfaeb            // =64235
+               	strh	w17, [x2]
+               	ldr	d0, [x0]
+               	sub	x0, x29, #0x4c
+               	add	x2, x0, #0x0
+               	mov	w17, #0xd               // =13
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfff5            // =65525
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               // =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfff9            // =65529
+               	strh	w17, [x2]
+               	ldr	d1, [x0]
+               	sub	x0, x29, #0x54
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               // =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x2               // =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x3               // =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x4               // =4
+               	strh	w17, [x2]
+               	ldr	d31, [x0]
+               	stur	d31, [x29, #-0x70]
+               	sub	x0, x29, #0x5c
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	ldr	d31, [x0]
+               	stur	d31, [x29, #-0x80]
+               	umov	w0, v0.h[0]
+               	add	w2, w0, w1
+               	mov	v2.16b, v0.16b
+               	mov	v2.h[0], w2
+               	umov	w0, v2.h[3]
+               	add	w2, w0, w1
+               	mov	v30.16b, v2.16b
+               	mov	v30.h[3], w2
+               	stur	q30, [x29, #-0x90]
+               	umov	w0, v1.h[1]
+               	add	w2, w0, w1
+               	mov	v0.16b, v1.16b
+               	mov	v0.h[1], w2
+               	umov	w0, v0.h[2]
+               	add	w2, w0, w1
+               	mov	v30.16b, v0.16b
+               	mov	v30.h[2], w2
+               	stur	q30, [x29, #-0xa0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0x90]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x8
-               	add	x3, x2, #0x0
-               	mov	w17, #0x3e9             // =1001
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfbb1            // =64433
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x4b7             // =1207
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfaeb            // =64235
-               	strh	w17, [x3]
-               	ldr	d0, [x2]
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0xd               // =13
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfff5            // =65525
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               // =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfff9            // =65529
-               	strh	w17, [x3]
-               	ldr	d1, [x2]
-               	sub	x2, x29, #0x18
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               // =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x2               // =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x3               // =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x4               // =4
-               	strh	w17, [x3]
-               	ldr	d31, [x2]
-               	stur	d31, [x29, #-0x70]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	ldr	d31, [x2]
-               	stur	d31, [x29, #-0x80]
-               	umov	w2, v0.h[0]
-               	add	w3, w2, w1
-               	mov	v2.16b, v0.16b
-               	mov	v2.h[0], w3
-               	umov	w2, v2.h[3]
-               	add	w3, w2, w1
-               	mov	v30.16b, v2.16b
-               	mov	v30.h[3], w3
-               	stur	q30, [x29, #-0x90]
-               	umov	w2, v1.h[1]
-               	add	w3, w2, w1
-               	mov	v0.16b, v1.16b
-               	mov	v0.h[1], w3
-               	umov	w2, v0.h[2]
-               	add	w3, w2, w1
-               	mov	v30.16b, v0.16b
-               	mov	v30.h[2], w3
-               	stur	q30, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0x90]
-               	umov	w1, v31.h[0]
+               	ldur	q0, [x29, #-0xa0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0x90]
-               	umov	w1, v31.h[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0x90]
-               	umov	w1, v31.h[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0x90]
-               	umov	w1, v31.h[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xa0]
-               	umov	w1, v31.h[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xa0]
-               	umov	w1, v31.h[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xa0]
-               	umov	w1, v31.h[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xa0]
-               	umov	w1, v31.h[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	add	v31.8h, v31.8h, v30.8h
                	stur	q31, [x29, #-0xb0]
+               	ldur	q0, [x29, #-0xb0]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	sub	v0.8h, v31.8h, v30.8h
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x90]
+               	sub	v0.8h, v31.8h, v30.8h
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	mul	v0.8h, v31.8h, v30.8h
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0x70]
+               	mul	v0.8h, v31.8h, v30.8h
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x70]
+               	mul	v0.8h, v31.8h, v30.8h
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0xb0]
-               	umov	w1, v31.h[0]
+               	ldur	q30, [x29, #-0x70]
+               	mul	v0.8h, v31.8h, v30.8h
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0x90]
+               	sub	v0.8h, v31.8h, v30.8h
 <L9>:
                	bl	 <L9>
-               	ldur	q31, [x29, #-0xb0]
-               	umov	w1, v31.h[1]
+               	ldur	q31, [x29, #-0x80]
+               	ldur	q30, [x29, #-0xa0]
+               	sub	v0.8h, v31.8h, v30.8h
 <L10>:
                	bl	 <L10>
-               	ldur	q31, [x29, #-0xb0]
-               	umov	w1, v31.h[2]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	and	v31.16b, v31.16b, v30.16b
+               	stur	q31, [x29, #-0xc0]
+               	ldur	q0, [x29, #-0xc0]
 <L11>:
                	bl	 <L11>
-               	ldur	q31, [x29, #-0xb0]
-               	umov	w1, v31.h[3]
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	orr	v31.16b, v31.16b, v30.16b
+               	stur	q31, [x29, #-0xd0]
+               	ldur	q0, [x29, #-0xd0]
 <L12>:
                	bl	 <L12>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	stur	q31, [x29, #-0xc0]
-               	ldur	q31, [x29, #-0xc0]
-               	umov	w1, v31.h[0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L13>:
                	bl	 <L13>
-               	ldur	q31, [x29, #-0xc0]
-               	umov	w1, v31.h[1]
+               	ldur	q31, [x29, #-0x90]
+               	mvn	v0.16b, v31.16b
 <L14>:
                	bl	 <L14>
-               	ldur	q31, [x29, #-0xc0]
-               	umov	w1, v31.h[2]
+               	ldur	q31, [x29, #-0xa0]
+               	mvn	v0.16b, v31.16b
 <L15>:
                	bl	 <L15>
                	ldur	q31, [x29, #-0xc0]
-               	umov	w1, v31.h[3]
+               	ldur	q30, [x29, #-0xd0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L16>:
                	bl	 <L16>
-               	ldur	q31, [x29, #-0xa0]
-               	ldur	q30, [x29, #-0x90]
-               	sub	v31.8h, v31.8h, v30.8h
-               	stur	q31, [x29, #-0xd0]
-               	ldur	q31, [x29, #-0xd0]
-               	umov	w1, v31.h[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0xd0]
-               	umov	w1, v31.h[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0xd0]
-               	umov	w1, v31.h[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0xd0]
-               	umov	w1, v31.h[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	stur	q31, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[0]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[1]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[2]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0x70]
-               	mul	v31.8h, v31.8h, v30.8h
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[0]
-<L25>:
-               	bl	 <L25>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[2]
-<L27>:
-               	bl	 <L27>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xa0]
-               	ldur	q30, [x29, #-0x70]
-               	mul	v31.8h, v31.8h, v30.8h
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[0]
-<L29>:
-               	bl	 <L29>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[2]
-<L31>:
-               	bl	 <L31>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	add	v0.8h, v31.8h, v30.8h
-               	ldur	q30, [x29, #-0x70]
-               	mul	v31.8h, v0.8h, v30.8h
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0x90]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0x80]
-               	ldur	q30, [x29, #-0xa0]
-               	sub	v0.8h, v31.8h, v30.8h
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	eor	v0.16b, v31.16b, v30.16b
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0x90]
-               	mvn	v0.16b, v31.16b
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xa0]
-               	mvn	v0.16b, v31.16b
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor	v0.16b, v31.16b, v30.16b
-<L47>:
-               	bl	 <L47>
                	mov	x19, x0
                	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0xf0]
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0x100]
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0x70]
                	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	stur	q31, [x29, #-0xe0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q0, [x29, #-0xe0]
+<L18>:
+               	bl	 <L18>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xe0]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	stur	q31, [x29, #-0xf0]
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	stur	q31, [x29, #-0x100]
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x50
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x30
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -672,104 +365,49 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0xf0]
                	str	d31, [x0]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0x70]
                	mul	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	d31, [x29, x16]
+               	ldur	d31, [x29, #-0x100]
                	str	d31, [x0]
                	add	x0, x20, #0x20
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xa0]
                	eor	v0.16b, v31.16b, v30.16b
                	add	x0, x20, #0x28
                	str	d0, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x6
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	add	x0, x20, x21, lsl #3
-               	ldr	d31, [x0]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0x5c
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x3c
                	str	xzr, [x21]
                	str	wzr, [x21, #0x8]
                	add	x0, x21, #0x0
@@ -777,60 +415,59 @@ Disassembly of section .text:
                	strb	w17, [x0]
                	add	x1, x20, #0x10
                	ldr	d0, [x1]
-               	add	x20, x21, #0x2
-               	str	d0, [x20]
+               	add	x1, x21, #0x2
+               	str	d0, [x1]
                	add	x1, x21, #0xa
                	mov	w17, #0xad              // =173
                	strb	w17, [x1]
                	ldrb	w1, [x0]
+               	uxtb	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x2
+               	ldr	d0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	d31, [x20]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0xa
                	ldrb	w2, [x1]
-               	mov	x1, x2
-<L77>:
-               	bl	 <L77>
-               	ldp	x19, x20, [x29, #-0x1e0]
-               	mov	x16, #0xfe18            // =65048
+               	uxtb	w1, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x150]
+               	mov	x16, #0xfea8            // =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-linux/vec/vec_i16x8.dis
+++ b/test/golden/aarch64-linux/vec/vec_i16x8.dis
@@ -3,1237 +3,553 @@ vec/vec_i16x8.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i16x8.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[0]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[1]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[2]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[3]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.h[4]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	umov	w1, v0.h[5]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	umov	w1, v0.h[6]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	umov	w1, v0.h[7]
+               	sxth	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.vec.vec_i16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0x3e9             // =1001
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfbb1            // =64433
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x4b7             // =1207
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfaeb            // =64235
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x581             // =1409
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfa19            // =64025
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x641             // =1601
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xf953            // =63827
+               	strh	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0xd               // =13
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfff5            // =65525
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               // =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfff9            // =65529
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x5               // =5
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfffd            // =65533
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x2               // =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xffff            // =65535
+               	strh	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               // =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x2               // =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x3               // =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x4               // =4
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x5               // =5
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x6               // =6
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x7               // =7
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x8               // =8
+               	strh	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strh	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov	w0, v0.h[0]
+               	add	w2, w0, w1
+               	mov	v2.16b, v0.16b
+               	mov	v2.h[0], w2
+               	umov	w0, v2.h[6]
+               	add	w2, w0, w1
+               	mov	v30.16b, v2.16b
+               	mov	v30.h[6], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov	w0, v1.h[2]
+               	add	w2, w0, w1
+               	mov	v0.16b, v1.16b
+               	mov	v0.h[2], w2
+               	umov	w0, v0.h[7]
+               	add	w2, w0, w1
+               	mov	v30.16b, v0.16b
+               	mov	v30.h[7], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0x3e9             // =1001
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfbb1            // =64433
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x4b7             // =1207
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfaeb            // =64235
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x581             // =1409
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xfa19            // =64025
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x641             // =1601
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xf953            // =63827
-               	strh	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	mov	w17, #0xd               // =13
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xfff5            // =65525
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               // =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xfff9            // =65529
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x5               // =5
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xfffd            // =65533
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x2               // =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xffff            // =65535
-               	strh	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               // =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x2               // =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x3               // =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x4               // =4
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x5               // =5
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x6               // =6
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x7               // =7
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x8               // =8
-               	strh	w17, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x8
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xa
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xc
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xe
-               	strh	wzr, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xd0]
-               	umov	w2, v0.h[0]
-               	add	w3, w2, w1
-               	mov	v2.16b, v0.16b
-               	mov	v2.h[0], w3
-               	umov	w2, v2.h[6]
-               	add	w3, w2, w1
-               	mov	v30.16b, v2.16b
-               	mov	v30.h[6], w3
-               	stur	q30, [x29, #-0xe0]
-               	umov	w2, v1.h[2]
-               	add	w3, w2, w1
-               	mov	v0.16b, v1.16b
-               	mov	v0.h[2], w3
-               	umov	w2, v0.h[7]
-               	add	w3, w2, w1
-               	mov	v30.16b, v0.16b
-               	mov	v30.h[7], w3
-               	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[4]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[5]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[6]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[7]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[4]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[5]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[6]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[7]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.8h, v31.8h, v30.8h
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[4]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[5]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[6]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[7]
-<L24>:
-               	bl	 <L24>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L32>:
-               	bl	 <L32>
+               	sub	v0.8h, v31.8h, v30.8h
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L40>:
-               	bl	 <L40>
+               	sub	v0.8h, v31.8h, v30.8h
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L48>:
-               	bl	 <L48>
+               	mul	v0.8h, v31.8h, v30.8h
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L56>:
-               	bl	 <L56>
+               	mul	v0.8h, v31.8h, v30.8h
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L64>:
-               	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.8h, v31.8h, v30.8h
+               	mul	v0.8h, v31.8h, v30.8h
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v0.8h, v30.8h
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L72>:
-               	bl	 <L72>
+               	mul	v0.8h, v31.8h, v30.8h
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L80>:
-               	bl	 <L80>
+               	sub	v0.8h, v31.8h, v30.8h
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.8h, v31.8h, v30.8h
-<L81>:
-               	bl	 <L81>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L82>:
-               	bl	 <L82>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L83>:
-               	bl	 <L83>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-<L84>:
-               	bl	 <L84>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-<L85>:
-               	bl	 <L85>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfe80            // =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L87>:
-               	bl	 <L87>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-               	b	 <L121>
-<L88>:
-               	mov	x16, #0xfe50            // =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
                	mov	x0, x19
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfe50            // =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L120>:
-               	bl	 <L120>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-<L121>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1243,13 +559,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1258,7 +574,7 @@ Disassembly of section .text:
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1268,7 +584,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1276,89 +592,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-               	b	 <L131>
-<L122>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L130>:
-               	bl	 <L130>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-<L131>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -1371,94 +620,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L140>:
-               	bl	 <L140>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L141>:
-               	bl	 <L141>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_i32x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_i32x4.dis
@@ -3,184 +3,235 @@ vec/vec_i32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_i32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x230
-               	sub	x16, x29, #0x220
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1a0
+               	stp	x19, x20, [x29, #-0x190]
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
                	mov	w17, #0x2717            // =10007
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0xb1d5            // =45525
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x753d            // =30013
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x8000            // =32768
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
                	mov	w17, #0xfff9            // =65529
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x83              // =131
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0xfc0f            // =64527
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
                	mov	w17, #0x1               // =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x9               // =9
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1b              // =27
-               	str	w17, [x3]
-               	ldr	q31, [x2]
+               	str	w17, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	str	wzr, [x3]
-               	add	x3, x2, #0x4
-               	str	wzr, [x3]
-               	add	x3, x2, #0x8
-               	str	wzr, [x3]
-               	add	x3, x2, #0xc
-               	str	wzr, [x3]
-               	ldr	q31, [x2]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	str	wzr, [x2]
+               	add	x2, x0, #0x4
+               	str	wzr, [x2]
+               	add	x2, x0, #0x8
+               	str	wzr, [x2]
+               	add	x2, x0, #0xc
+               	str	wzr, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xd0]
-               	mov	w2, v0.s[0]
-               	add	w3, w2, w1
+               	mov	w0, v0.s[0]
+               	add	w2, w0, w1
                	mov	v2.16b, v0.16b
-               	mov	v2.s[0], w3
-               	mov	w2, v2.s[2]
-               	add	w3, w2, w1
+               	mov	v2.s[0], w2
+               	mov	w0, v2.s[2]
+               	add	w2, w0, w1
                	mov	v30.16b, v2.16b
-               	mov	v30.s[2], w3
+               	mov	v30.s[2], w2
                	stur	q30, [x29, #-0xe0]
-               	mov	w2, v1.s[1]
-               	add	w3, w2, w1
+               	mov	w0, v1.s[1]
+               	add	w2, w0, w1
                	mov	v0.16b, v1.16b
-               	mov	v0.s[1], w3
-               	mov	w2, v0.s[3]
-               	add	w3, w2, w1
+               	mov	v0.s[1], w2
+               	mov	w0, v0.s[3]
+               	add	w2, w0, w1
                	mov	v30.16b, v0.16b
-               	mov	v30.s[3], w3
+               	mov	v30.s[3], w2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.4s, v31.4s, v30.4s
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[3]
-<L12>:
-               	bl	 <L12>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.4s, v31.4s, v30.4s
+               	sub	v0.4s, v31.4s, v30.4s
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L9>:
+               	bl	 <L9>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L10>:
+               	bl	 <L10>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -190,24 +241,35 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L13>:
                	bl	 <L13>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
 <L15>:
                	bl	 <L15>
                	mov	x16, #0xfef0            // =65264
@@ -215,537 +277,139 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.4s, v31.4s, v30.4s
                	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.4s, v31.4s, v30.4s
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub	v0.4s, v31.4s, v30.4s
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v0.16b, v31.16b, v30.16b
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v0.16b, v31.16b
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v0.16b, v31.16b
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L47>:
-               	bl	 <L47>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfe50            // =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe30            // =65072
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe50            // =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -755,13 +419,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -770,7 +434,7 @@ Disassembly of section .text:
                	add	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -780,7 +444,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -788,57 +452,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -851,62 +480,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
-               	sub	x16, x29, #0x220
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x190]
+               	mov	x16, #0xfe68            // =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_i64x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_i64x2.dis
@@ -3,39 +3,57 @@ vec/vec_i64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, v0.d[0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x1, v0.d[1]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_i64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0x10
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	x17, #0xca07            // =51719
                	movk	x17, #0x3b9a, lsl #16
@@ -47,7 +65,7 @@ Disassembly of section .text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
+               	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	x17, #0x5e13            // =24083
                	movk	x17, #0xb2d0, lsl #16
@@ -59,7 +77,7 @@ Disassembly of section .text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q1, [x1]
-               	sub	x1, x29, #0x30
+               	sub	x1, x29, #0xa0
                	add	x2, x1, #0x0
                	mov	x17, #0x1               // =1
                	str	x17, [x2]
@@ -68,7 +86,7 @@ Disassembly of section .text:
                	str	x17, [x2]
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xc0]
-               	sub	x1, x29, #0x40
+               	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
                	add	x2, x1, #0x8
@@ -76,345 +94,205 @@ Disassembly of section .text:
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xd0]
                	mov	x1, v0.d[0]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], x2
                	stur	q30, [x29, #-0xe0]
                	mov	x1, v1.d[1]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov	v30.16b, v1.16b
                	mov	v30.d[1], x2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[0]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[1]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub	v0.2d, v31.2d, v30.2d
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.2d, v31.2d, v30.2d
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
                	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
                	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L7>:
                	bl	 <L7>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
+               	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0x100]
                	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0x100]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.2d, v31.2d, v30.2d
-               	mov	x1, v0.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	mov	x1, v0.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	mov	v1.16b, v0.16b
-               	mov	v1.d[0], x3
-               	mov	v30.16b, v1.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L18>:
-               	bl	 <L18>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L20>:
-               	bl	 <L20>
+               	sub	v0.2d, v31.2d, v30.2d
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.2d, v31.2d, v30.2d
-<L21>:
-               	bl	 <L21>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L23>:
-               	bl	 <L23>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-<L24>:
-               	bl	 <L24>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-<L25>:
-               	bl	 <L25>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe80            // =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L27>:
-               	bl	 <L27>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-               	b	 <L37>
-<L28>:
-               	mov	x16, #0xfe60            // =65120
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -423,7 +301,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -432,7 +310,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -441,156 +319,120 @@ Disassembly of section .text:
                	mov	v0.d[0], x2
                	mov	v30.16b, v0.16b
                	mov	v30.d[1], x3
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
                	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe60            // =65120
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L36>:
-               	bl	 <L36>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-<L37>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -600,13 +442,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -615,7 +457,7 @@ Disassembly of section .text:
                	add	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -624,7 +466,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -633,7 +475,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -645,7 +487,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -653,41 +495,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-               	b	 <L41>
-<L38>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L40>:
-               	bl	 <L40>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-<L41>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -700,46 +523,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L44>:
-               	bl	 <L44>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L45>:
-               	bl	 <L45>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_i8x16.dis
+++ b/test/golden/aarch64-linux/vec/vec_i8x16.dis
@@ -3,124 +3,326 @@ vec/vec_i8x16.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i8x16.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[0]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[1]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[2]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[3]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[4]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[5]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[6]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[7]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.b[8]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov	w1, v0.b[9]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov	w1, v0.b[10]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov	w1, v0.b[11]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov	w1, v0.b[12]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov	w1, v0.b[13]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov	w1, v0.b[14]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov	w1, v0.b[15]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_i8x16.checksum>:
@@ -133,290 +335,268 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xf7              // =247
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x7               // =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xfb              // =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0xff              // =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xfc              // =252
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x6               // =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xf8              // =248
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x9               // =9
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfd              // =253
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0xfe              // =254
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x4               // =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xfa              // =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x8               // =8
+               	strb	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0xfd              // =253
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x4               // =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0xfb              // =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x6               // =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0xf9              // =249
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x8               // =8
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0xf7              // =247
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0xfe              // =254
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0xfc              // =252
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x5               // =5
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0xfa              // =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x7               // =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xff              // =255
+               	strb	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x1
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x3
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x5
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x7
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xb
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xd
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xf
+               	strb	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov	w0, v0.b[0]
+               	add	w2, w0, w1
+               	mov	v2.16b, v0.16b
+               	mov	v2.b[0], w2
+               	umov	w0, v2.b[7]
+               	add	w2, w0, w1
+               	mov	v30.16b, v2.16b
+               	mov	v30.b[7], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov	w0, v1.b[3]
+               	add	w2, w0, w1
+               	mov	v0.16b, v1.16b
+               	mov	v0.b[3], w2
+               	umov	w0, v0.b[12]
+               	add	w2, w0, w1
+               	mov	v30.16b, v0.16b
+               	mov	v30.b[12], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	sub	x3, x29, #0x10
-               	add	x4, x3, #0x0
-               	mov	w17, #0xf7              // =247
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x7               // =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0xfb              // =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0xff              // =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0xfc              // =252
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x6               // =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0xf8              // =248
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x9               // =9
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0xfd              // =253
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0xfe              // =254
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x4               // =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0xfa              // =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x8               // =8
-               	strb	w17, [x4]
-               	ldr	q0, [x3]
-               	sub	x3, x29, #0x20
-               	add	x4, x3, #0x0
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0xfd              // =253
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x4               // =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0xfb              // =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x6               // =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0xf9              // =249
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x8               // =8
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0xf7              // =247
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0xfe              // =254
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0xfc              // =252
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x5               // =5
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0xfa              // =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x7               // =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xff              // =255
-               	strb	w17, [x4]
-               	ldr	q1, [x3]
-               	sub	x3, x29, #0x30
-               	add	x4, x3, #0x0
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x3, x29, #0x40
-               	add	x4, x3, #0x0
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x1
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x2
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x3
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x4
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x5
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x6
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x7
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xa
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xb
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xc
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xd
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xe
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xf
-               	strb	wzr, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xd0]
-               	umov	w3, v0.b[0]
-               	add	w4, w3, w2
-               	mov	v2.16b, v0.16b
-               	mov	v2.b[0], w4
-               	umov	w3, v2.b[7]
-               	add	w4, w3, w2
-               	mov	v30.16b, v2.16b
-               	mov	v30.b[7], w4
-               	stur	q30, [x29, #-0xe0]
-               	umov	w3, v1.b[3]
-               	add	w4, w3, w2
-               	mov	v0.16b, v1.16b
-               	mov	v0.b[3], w4
-               	umov	w3, v0.b[12]
-               	add	w4, w3, w2
-               	mov	v30.16b, v0.16b
-               	mov	v30.b[12], w4
-               	stur	q30, [x29, #-0xf0]
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xf0]
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.16b, v31.16b, v30.16b
                	stur	q31, [x29, #-0x100]
-               	mov	x0, x1
                	ldur	q0, [x29, #-0x100]
-<L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
@@ -425,15 +605,13 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
@@ -442,34 +620,26 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-               	mov	x0, x1
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-               	mov	x0, x1
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -481,9 +651,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfec0            // =65216
@@ -505,9 +674,9 @@ Disassembly of section .text:
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x3
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
                	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -526,8 +695,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -549,8 +718,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -572,8 +741,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -591,8 +760,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
                	mov	x16, #0xfe70            // =65136
@@ -626,9 +795,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x3
-               	b.lo	 <L18>
-<L23>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -671,51 +840,55 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q0, [x1]
                	mov	x0, x19
-<L25>:
-               	bl	 <L25>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-<L26>:
-               	sub	x0, x29, #0xb0
-               	str	xzr, [x0]
-               	str	xzr, [x0, #0x8]
-               	str	xzr, [x0, #0x10]
-               	str	xzr, [x0, #0x18]
-               	str	xzr, [x0, #0x20]
-               	str	xzr, [x0, #0x28]
-               	add	x1, x0, #0x0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
+               	str	xzr, [x21]
+               	str	xzr, [x21, #0x8]
+               	str	xzr, [x21, #0x10]
+               	str	xzr, [x21, #0x18]
+               	str	xzr, [x21, #0x20]
+               	str	xzr, [x21, #0x28]
+               	add	x0, x21, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x2, x20, #0x20
-               	ldr	q0, [x2]
-               	add	x20, x0, #0x10
-               	str	q0, [x20]
-               	add	x21, x0, #0x20
+               	str	w17, [x0]
+               	add	x1, x20, #0x20
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x21]
-               	ldr	w2, [x1]
+               	str	w17, [x1]
+               	ldr	w1, [x0]
+               	mov	w2, w1
                	mov	x0, x19
-               	mov	w1, w2
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	add	x1, x21, #0x10
+               	ldr	q0, [x1]
 <L27>:
                	bl	 <L27>
-               	ldr	q0, [x20]
+               	add	x1, x21, #0x20
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L28>:
                	bl	 <L28>
-               	ldr	w1, [x21]
-<L29>:
-               	bl	 <L29>
                	ldp	x19, x20, [x29, #-0x1a0]
                	mov	x16, #0xfe58            // =65112
                	movk	x16, #0xffff, lsl #16

--- a/test/golden/aarch64-linux/vec/vec_lane_ops.dis
+++ b/test/golden/aarch64-linux/vec/vec_lane_ops.dis
@@ -3,213 +3,409 @@ vec/vec_lane_ops.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_lane_ops.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0.s[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f64x2>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[0]
-               	mov	x0, x1
+               	mov	d1, v0.d[0]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	d0, v31.d[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	d1, v0.d[1]
+               	fmov	x1, d1
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_i8x16>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
                	sub	sp, sp, #0x10
-               	mov	x1, x0
                	stur	q0, [x29, #-0x10]
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[0]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[1]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[2]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[3]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[4]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v31.b[5]
+               	sxtb	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[12]
-               	mov	x0, x1
+               	umov	w1, v31.b[6]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L12>:
                	bl	 <L12>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[13]
-               	mov	x0, x1
+               	umov	w1, v31.b[7]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L13>:
                	bl	 <L13>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[14]
-               	mov	x0, x1
+               	umov	w1, v31.b[8]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L14>:
                	bl	 <L14>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[15]
-               	mov	x0, x1
+               	umov	w1, v31.b[9]
+               	sxtb	x2, w1
                	mov	x1, x2
 <L15>:
                	bl	 <L15>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[10]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L16>:
+               	bl	 <L16>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[11]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L17>:
+               	bl	 <L17>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[12]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L18>:
+               	bl	 <L18>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[13]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L19>:
+               	bl	 <L19>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[14]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	ldur	q31, [x29, #-0x10]
+               	umov	w1, v31.b[15]
+               	sxtb	x2, w1
+               	mov	x1, x2
+<L21>:
+               	bl	 <L21>
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -217,390 +413,165 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x260
-               	stp	x19, x20, [x16]
-               	stp	x21, x22, [x16, #-0x10]
-               	stur	x23, [x16, #-0x18]
-               	sub	x16, x29, #0x288
-               	stp	d8, d9, [x16]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	ucvtf	s8, x19
-               	ucvtf	d9, x19
-               	mov	w20, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1c0
+               	stp	x19, x20, [x29, #-0x170]
+               	stp	x21, x22, [x29, #-0x180]
+               	stp	x23, x24, [x29, #-0x190]
+               	stp	x25, x26, [x29, #-0x1a0]
+               	stp	d8, d9, [x29, #-0x1b0]
+               	stp	d10, d11, [x29, #-0x1c0]
+               	mov	w1, w0
+               	ucvtf	s8, x0
+               	ucvtf	d9, x0
+               	mov	w19, w0
+               	sub	x0, x29, #0x10
+               	add	x2, x0, #0x0
                	mov	w17, #0x1111            // =4369
                	movk	w17, #0x1111, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x2222            // =8738
                	movk	w17, #0x2222, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x3333            // =13107
                	movk	w17, #0x3333, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x4444            // =17476
                	movk	w17, #0x4444, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	mov	w2, v0.s[0]
-               	add	w3, w2, w1
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	mov	w0, v0.s[0]
+               	add	w2, w0, w1
                	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w3
-               	mov	w2, v1.s[3]
-               	add	w3, w2, w1
+               	mov	v1.s[0], w2
+               	mov	w0, v1.s[3]
+               	add	w2, w0, w1
                	mov	v30.16b, v1.16b
-               	mov	v30.s[3], w3
+               	mov	v30.s[3], w2
                	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xf0]
+<L0>:
+               	bl	 <L0>
+               	sub	x20, x29, #0x20
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
                	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
+               	mov	w21, v31.s[3]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[0], w21
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w22, v31.s[2]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], w22
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w23, v31.s[1]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[2], w23
+               	str	q1, [x20]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w24, v31.s[0]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[3], w24
+               	str	q1, [x20]
+               	ldr	q0, [x20]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
+               	sub	x25, x29, #0x30
+               	str	xzr, [x25]
+               	str	xzr, [x25, #0x8]
+               	ldr	q0, [x25]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[0], w23
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], w22
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[2], w21
+               	str	q1, [x25]
+               	ldr	q0, [x25]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[3], w24
+               	str	q1, [x25]
+               	ldr	q0, [x25]
 <L2>:
                	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
+               	sub	x26, x29, #0x40
+               	str	xzr, [x26]
+               	str	xzr, [x26, #0x8]
+               	ldr	q0, [x26]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[0], w22
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], w21
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[2], w24
+               	str	q1, [x26]
+               	ldr	q0, [x26]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[3], w23
+               	str	q1, [x26]
+               	ldr	q0, [x26]
 <L3>:
                	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-<L4>:
-               	bl	 <L4>
-               	sub	x19, x29, #0x20
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-               	ldr	q0, [x19]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
-               	ldr	q0, [x19]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
-               	ldr	q0, [x19]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[2], w1
-               	str	q1, [x19]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-               	ldr	q0, [x19]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[3], w1
-               	str	q1, [x19]
-               	ldr	q31, [x19]
-               	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[3]
-<L8>:
-               	bl	 <L8>
-               	sub	x21, x29, #0x30
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
-               	ldr	q0, [x21]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
-               	ldr	q0, [x21]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-               	ldr	q0, [x21]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[2], w1
-               	str	q1, [x21]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-               	ldr	q0, [x21]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[3], w1
-               	str	q1, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L10>:
-               	bl	 <L10>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L12>:
-               	bl	 <L12>
-               	sub	x22, x29, #0x40
-               	str	xzr, [x22]
-               	str	xzr, [x22, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
-               	ldr	q0, [x22]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-               	ldr	q0, [x22]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-               	ldr	q0, [x22]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[2], w1
-               	str	q1, [x22]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
-               	ldr	q0, [x22]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[3], w1
-               	str	q1, [x22]
-               	ldr	q31, [x22]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L14>:
-               	bl	 <L14>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L16>:
-               	bl	 <L16>
                	sub	x1, x29, #0x50
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w2, v31.s[2]
                	ldr	q0, [x1]
                	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w2
+               	mov	v1.s[0], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w2
+               	mov	v1.s[1], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov	v1.16b, v0.16b
-               	mov	v1.s[2], w2
+               	mov	v1.s[2], w22
                	str	q1, [x1]
                	ldr	q0, [x1]
                	mov	v1.16b, v0.16b
-               	mov	v1.s[3], w2
+               	mov	v1.s[3], w22
                	str	q1, [x1]
-               	ldr	q31, [x1]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L20>:
-               	bl	 <L20>
+               	ldr	q0, [x1]
+<L4>:
+               	bl	 <L4>
                	sub	x1, x29, #0x60
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w2, v31.s[0]
                	ldr	q0, [x1]
                	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w2
+               	mov	v1.s[1], w24
                	str	q1, [x1]
-               	ldr	q31, [x1]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x1]
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xf0]
                	mov	v0.16b, v31.16b
-               	mov	v0.s[1], w1
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-               	mov	v30.16b, v0.16b
-               	mov	v30.s[1], w1
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L28>:
-               	bl	 <L28>
+               	mov	v0.s[1], w24
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], w21
+               	mov	v0.16b, v1.16b
+<L6>:
+               	bl	 <L6>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	str	wzr, [x2]
@@ -611,288 +582,132 @@ Disassembly of section .text:
                	add	x2, x1, #0xc
                	str	wzr, [x2]
                	ldr	q0, [x1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-               	add	w2, w1, #0x1
+               	add	w1, w24, #0x1
                	mov	v30.16b, v0.16b
-               	mov	v30.s[0], w2
-               	mov	x16, #0xfea0            // =65184
+               	mov	v30.s[0], w1
+               	stur	q30, [x29, #-0x100]
+               	ldur	q31, [x29, #-0x100]
+               	mov	w1, v31.s[0]
+               	mov	w2, w1
+               	mov	x1, x2
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	mov	w1, v31.s[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w2, v31.s[1]
+               	add	w3, w1, w2
+               	ldur	q31, [x29, #-0x100]
+               	mov	v30.16b, v31.16b
+               	mov	v30.s[1], w3
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w23, v31.s[0]
-               	mov	w1, w23
-<L29>:
-               	bl	 <L29>
-               	ldur	q31, [x29, #-0xf0]
                	mov	w1, v31.s[1]
-               	add	w2, w23, w1
-               	mov	x16, #0xfea0            // =65184
+               	mov	w2, w1
+               	mov	x1, x2
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfef0            // =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w2, v31.s[2]
+               	eor	w3, w1, w2
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	v30.16b, v31.16b
-               	mov	v30.s[1], w2
-               	mov	x16, #0xfe90            // =65168
+               	mov	v30.s[2], w3
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w23, v31.s[1]
-               	mov	w1, w23
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
                	mov	w1, v31.s[2]
-               	eor	w2, w23, w1
-               	mov	x16, #0xfe90            // =65168
+               	mov	w2, w1
+               	mov	x1, x2
+<L9>:
+               	bl	 <L9>
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	w1, v31.s[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	w2, v31.s[3]
+               	sub	w3, w1, w2
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	v30.16b, v31.16b
-               	mov	v30.s[2], w2
-               	mov	x16, #0xfe80            // =65152
+               	mov	v30.s[3], w3
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w23, v31.s[2]
-               	mov	w1, w23
-<L31>:
-               	bl	 <L31>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-               	sub	w2, w23, w1
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	v30.16b, v31.16b
-               	mov	v30.s[3], w2
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	w1, v31.s[3]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe70            // =65136
+               	mov	w2, w1
+               	mov	x1, x2
+<L10>:
+               	bl	 <L10>
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L36>:
-               	bl	 <L36>
-               	ldr	q0, [x19]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldr	q0, [x20]
                	ldur	q30, [x29, #-0xf0]
-               	add	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L40>:
-               	bl	 <L40>
-               	ldr	q0, [x21]
+               	add	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L12>:
+               	bl	 <L12>
+               	ldr	q0, [x25]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L44>:
-               	bl	 <L44>
-               	ldr	q0, [x22]
+               	sub	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L13>:
+               	bl	 <L13>
+               	ldr	q0, [x26]
                	ldur	q30, [x29, #-0xf0]
-               	mul	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L48>:
-               	bl	 <L48>
-               	ldr	q0, [x19]
-               	ldr	q1, [x21]
-               	eor	v31.16b, v0.16b, v1.16b
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L52>:
-               	bl	 <L52>
+               	mul	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L14>:
+               	bl	 <L14>
+               	ldr	q0, [x20]
+               	ldr	q1, [x25]
+               	eor	v2.16b, v0.16b, v1.16b
+               	mov	v0.16b, v2.16b
+<L15>:
+               	bl	 <L15>
                	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
@@ -913,261 +728,118 @@ Disassembly of section .text:
                	fadd	s2, s1, s8
                	mov	v30.16b, v0.16b
                	mov	v30.s[1], v2.s[0]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe20            // =65056
+               	ldr	q0, [x29, x16]
+<L16>:
+               	bl	 <L16>
+               	sub	x20, x29, #0x90
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31.s[3]
-<L56>:
-               	bl	 <L56>
-               	sub	x19, x29, #0x90
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	v2.16b, v1.16b
                	mov	v2.s[0], v0.s[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            // =65056
+               	str	q2, [x20]
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-               	ldr	q1, [x19]
-               	mov	v2.16b, v1.16b
-               	mov	v2.s[1], v0.s[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            // =65056
+               	mov	s10, v31.s[2]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], v10.s[0]
+               	str	q1, [x20]
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31.s[1]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	v2.16b, v1.16b
                	mov	v2.s[2], v0.s[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfe20            // =65056
+               	str	q2, [x20]
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	ldr	q1, [x19]
-               	mov	v2.16b, v1.16b
-               	mov	v2.s[3], v0.s[0]
-               	str	q2, [x19]
-               	ldr	q31, [x19]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L60>:
-               	bl	 <L60>
+               	mov	s11, v31.s[0]
+               	ldr	q0, [x20]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[3], v11.s[0]
+               	str	q1, [x20]
+               	ldr	q0, [x20]
+<L17>:
+               	bl	 <L17>
                	sub	x21, x29, #0xa0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	ldr	q1, [x21]
-               	mov	v2.16b, v1.16b
-               	mov	v2.s[0], v0.s[0]
-               	str	q2, [x21]
-               	ldr	q0, [x19]
+               	ldr	q0, [x21]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[0], v11.s[0]
+               	str	q1, [x21]
+               	ldr	q0, [x20]
                	mov	s1, v0.s[1]
                	ldr	q0, [x21]
                	mov	v2.16b, v0.16b
                	mov	v2.s[1], v1.s[0]
                	str	q2, [x21]
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-               	ldr	q1, [x21]
-               	mov	v2.16b, v1.16b
-               	mov	v2.s[2], v0.s[0]
-               	str	q2, [x21]
-               	ldr	q0, [x19]
+               	ldr	q0, [x21]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[2], v10.s[0]
+               	str	q1, [x21]
+               	ldr	q0, [x20]
                	mov	s1, v0.s[3]
                	ldr	q0, [x21]
                	mov	v2.16b, v0.16b
                	mov	v2.s[3], v1.s[0]
                	str	q2, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L64>:
-               	bl	 <L64>
                	ldr	q0, [x21]
-               	ldr	q1, [x19]
-               	fmul	v31.4s, v0.4s, v1.4s
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdf0            // =65008
+<L18>:
+               	bl	 <L18>
+               	ldr	q0, [x21]
+               	ldr	q1, [x20]
+               	fmul	v2.4s, v0.4s, v1.4s
+               	mov	v0.16b, v2.16b
+<L19>:
+               	bl	 <L19>
+               	ldr	q0, [x20]
+               	mov	s1, v0.s[0]
+               	fsub	s0, s11, s1
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, x2
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	s0, v31.s[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	ldr	q1, [x19]
-               	mov	s2, v1.s[0]
-               	fsub	s1, s0, s2
-               	fmov	s0, s1
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	s2, v1.s[3]
                	fsub	s1, s0, s2
-               	fmov	s0, s1
-<L70>:
-               	bl	 <L70>
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, x2
+<L21>:
+               	bl	 <L21>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 // =4609434218613702656
@@ -1180,100 +852,54 @@ Disassembly of section .text:
                	fadd	d2, d1, d9
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], v2.d[0]
-               	mov	x16, #0xfde0            // =64992
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	sub	x19, x29, #0xc0
-               	str	xzr, [x19]
-               	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfde0            // =64992
+               	sub	x20, x29, #0xc0
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	d0, v31.d[1]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	v2.16b, v1.16b
                	mov	v2.d[0], v0.d[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfde0            // =64992
+               	str	q2, [x20]
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov	d0, v31.d[0]
-               	ldr	q1, [x19]
+               	ldr	q1, [x20]
                	mov	v2.16b, v1.16b
                	mov	v2.d[1], v0.d[0]
-               	str	q2, [x19]
-               	mov	x16, #0xfde0            // =64992
+               	str	q2, [x20]
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x19]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdd0            // =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L74>:
-               	bl	 <L74>
-               	ldr	q0, [x19]
-               	mov	x16, #0xfde0            // =64992
+               	ldr	q0, [x29, x16]
+<L22>:
+               	bl	 <L22>
+               	ldr	q0, [x20]
+<L23>:
+               	bl	 <L23>
+               	ldr	q0, [x20]
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fsub	v31.2d, v0.2d, v30.2d
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[0]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdc0            // =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	d0, v31.d[1]
-<L76>:
-               	bl	 <L76>
+               	fsub	v1.2d, v0.2d, v30.2d
+               	mov	v0.16b, v1.16b
+<L24>:
+               	bl	 <L24>
                	sub	x1, x29, #0xd0
                	add	x2, x1, #0x0
                	mov	w17, #0xf7              // =247
@@ -1325,29 +951,29 @@ Disassembly of section .text:
                	strb	w17, [x2]
                	ldr	q0, [x1]
                	umov	w1, v0.b[0]
-               	add	w2, w1, w20
+               	add	w2, w1, w19
                	mov	v1.16b, v0.16b
                	mov	v1.b[0], w2
                	umov	w1, v1.b[15]
-               	add	w2, w1, w20
+               	add	w2, w1, w19
                	mov	v30.16b, v1.16b
                	mov	v30.b[15], w2
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L77>:
-               	bl	 <L77>
+<L25>:
+               	bl	 <L25>
                	sub	x19, x29, #0xe0
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1357,7 +983,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[0], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1367,7 +993,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[1], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1377,7 +1003,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[2], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1387,7 +1013,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[3], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1397,7 +1023,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[4], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1407,7 +1033,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[5], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1417,7 +1043,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[6], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1427,7 +1053,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[7], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1437,7 +1063,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[8], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1447,7 +1073,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[9], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1457,7 +1083,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[10], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1467,7 +1093,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[11], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1477,7 +1103,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[12], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1487,7 +1113,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[13], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1497,7 +1123,7 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.b[14], w1
                	str	q1, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1508,34 +1134,34 @@ Disassembly of section .text:
                	mov	v1.b[15], w1
                	str	q1, [x19]
                	ldr	q0, [x19]
-<L78>:
-               	bl	 <L78>
+<L26>:
+               	bl	 <L26>
                	ldr	q0, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v1.16b, v0.16b, v30.16b
                	mov	v0.16b, v1.16b
-<L79>:
-               	bl	 <L79>
+<L27>:
+               	bl	 <L27>
                	ldr	q0, [x19]
-               	mov	x16, #0xfdb0            // =64944
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v1.16b, v0.16b, v30.16b
                	mov	v0.16b, v1.16b
-<L80>:
-               	bl	 <L80>
-               	sub	x16, x29, #0x288
-               	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x260
-               	ldp	x19, x20, [x16]
-               	ldp	x21, x22, [x16, #-0x10]
-               	ldur	x23, [x16, #-0x18]
+<L28>:
+               	bl	 <L28>
+               	ldp	d8, d9, [x29, #-0x1b0]
+               	ldp	d10, d11, [x29, #-0x1c0]
+               	ldp	x19, x20, [x29, #-0x170]
+               	ldp	x21, x22, [x29, #-0x180]
+               	ldp	x23, x24, [x29, #-0x190]
+               	ldp	x25, x26, [x29, #-0x1a0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_mem.dis
+++ b/test/golden/aarch64-linux/vec/vec_mem.dis
@@ -3,74 +3,190 @@ vec/vec_mem.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_mem.fold3>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+<L3>:
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
                	ret
 
 <corpus.cases.vec.vec_mem.fold5>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x80
-               	stur	x19, [x29, #-0x78]
-               	mov	x2, x0
-               	mov	x19, x1
-               	sub	x1, x29, #0x14
-               	sub	x1, x29, #0x28
-               	sub	x1, x29, #0x3c
-               	sub	x1, x29, #0x50
-               	sub	x1, x29, #0x64
-               	add	x1, x19, #0x0
-               	ldr	s0, [x1]
-               	mov	x0, x2
+               	sub	sp, sp, #0x70
+               	sub	x2, x29, #0x14
+               	sub	x2, x29, #0x28
+               	sub	x2, x29, #0x3c
+               	sub	x2, x29, #0x50
+               	sub	x2, x29, #0x64
+               	add	x2, x1, #0x0
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	add	x2, x19, #0x4
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	add	x2, x19, #0x8
+               	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	add	x2, x19, #0xc
-               	ldr	s0, [x2]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	add	x2, x19, #0x10
+               	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x0, x1
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	ldur	x19, [x29, #-0x78]
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	add	x2, x1, #0xc
+               	ldr	s0, [x2]
+               	fmov	w2, s0
+               	mov	w3, w2
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x4, x2, x16
+               	lsr	x5, x3, x4
+               	mov	x16, #0xff              // =255
+               	and	x4, x5, x16
+               	eor	x5, x0, x4
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x5, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L6>
+<L7>:
+               	add	x2, x1, #0x10
+               	ldr	s0, [x2]
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret
@@ -78,640 +194,622 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x9b0
-               	sub	x16, x29, #0x960
+               	sub	sp, sp, #0x800
+               	sub	x16, x29, #0x7b0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x9b0
+               	sub	x16, x29, #0x800
                	str	d8, [x16, #0x8]
-               	mov	x19, x0
-               	sub	x20, x29, #0x14
-               	sub	x21, x29, #0x28
-               	sub	x22, x29, #0x3c
-               	sub	x23, x29, #0x50
-               	sub	x24, x29, #0x64
-               	sub	x25, x29, #0x78
-               	sub	x26, x29, #0x8c
-               	sub	x27, x29, #0xa0
-               	sub	x28, x29, #0xb4
-               	sub	x9, x29, #0xc8
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	sub	x19, x29, #0x14
+               	sub	x20, x29, #0x28
+               	sub	x21, x29, #0x3c
+               	sub	x22, x29, #0x50
+               	sub	x23, x29, #0x64
+               	sub	x24, x29, #0x78
+               	sub	x25, x29, #0x8c
+               	sub	x26, x29, #0xa0
+               	sub	x27, x29, #0xb4
+               	sub	x28, x29, #0xc8
                	sub	x9, x29, #0xdc
-               	mov	x16, #0xf808            // =63496
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0xf0
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x104
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x118
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x12c
-               	mov	x16, #0xf7e8            // =63464
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x140
-               	mov	x16, #0xf7e0            // =63456
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x154
-               	mov	x16, #0xf7d8            // =63448
+               	mov	x16, #0xf8e0            // =63712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x168
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x17c
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x190
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x1, x29, #0x1a4
-               	sub	x1, x29, #0x1b8
-               	sub	x1, x29, #0x1cc
-               	sub	x1, x29, #0x1e0
-               	sub	x1, x29, #0x1f4
-               	sub	x1, x29, #0x208
-               	sub	x1, x29, #0x21c
-               	sub	x1, x29, #0x230
-               	sub	x1, x29, #0x244
-               	sub	x1, x29, #0x258
-               	sub	x1, x29, #0x26c
-               	sub	x1, x29, #0x280
-               	sub	x1, x29, #0x294
-               	sub	x1, x29, #0x2a8
-               	sub	x1, x29, #0x2bc
-               	sub	x1, x29, #0x2d0
-               	sub	x1, x29, #0x2e4
-               	sub	x1, x29, #0x2f8
-               	sub	x1, x29, #0x30c
-               	sub	x1, x29, #0x320
-               	sub	x1, x29, #0x334
-               	sub	x1, x29, #0x348
-               	sub	x1, x29, #0x35c
-               	sub	x1, x29, #0x370
-               	sub	x1, x29, #0x384
-<L0>:
-               	bl	 <L0>
-               	mov	x9, x0
-               	mov	x16, #0xf878            // =63608
+               	ucvtf	s8, x0
+               	sub	x9, x29, #0x384
+               	mov	x16, #0xf930            // =63792
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf878            // =63608
+               	mov	x16, #0xf930            // =63792
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ucvtf	s8, x19
-               	sub	x19, x29, #0x3d8
-               	add	x1, x19, #0x0
-               	add	x18, x1, #0x0
-               	mov	x1, #0x50               // =80
+               	add	x0, x9, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               // =80
+<L0>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L0>
+               	str	wzr, [x1]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x7
+               	b.lo	 <L1>
+               	b	 <L2>
 <L1>:
-               	str	xzr, [x18]
-               	add	x18, x18, #0x8
-               	sub	x1, x1, #0x8
-               	cmp	x1, #0x0
-               	b.ne	 <L1>
-               	str	wzr, [x18]
-               	mov	x1, #0x0                // =0
-               	cmp	x1, #0x7
-               	b.lo	 <L2>
-               	b	 <L3>
-<L2>:
-               	ucvtf	s0, x1
-               	sub	x18, x29, #0x3e4
-               	str	xzr, [x18]
-               	str	wzr, [x18, #0x8]
+               	ucvtf	s0, x0
+               	sub	x1, x29, #0x19c
+               	str	xzr, [x1]
+               	str	wzr, [x1, #0x8]
                	fadd	s1, s0, s8
-               	mov	x16, #0xfc0c            // =64524
+               	mov	x16, #0xfe54            // =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfc14            // =64532
+               	mov	x16, #0xfe5c            // =65116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
-               	mov	x16, #0xfc0c            // =64524
+               	ldr	x18, [x1]
+               	mov	x16, #0xfe54            // =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
-               	mov	x16, #0xfc14            // =64532
+               	str	x18, [x29, x16]
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfe5c            // =65116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
-               	mov	x16, #0xfc0c            // =64524
+               	str	w18, [x29, x16]
+               	mov	x16, #0xfe54            // =65108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
                	mov	v3.16b, v2.16b
                	mov	v3.s[0], v1.s[0]
-               	mov	x16, #0xfbfc            // =64508
+               	mov	x16, #0xfe44            // =65092
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q3, [x29, x16]
-               	mov	x16, #0xfbfc            // =64508
+               	mov	x16, #0xfe44            // =65092
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
-               	mov	x16, #0xfc04            // =64516
+               	ldr	x18, [x29, x16]
+               	str	x18, [x1]
+               	mov	x16, #0xfe4c            // =65100
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	ldr	w18, [x29, x16]
+               	str	w18, [x1, #0x8]
                	fmov	s30, #1.25000000
                	fsub	s1, s0, s30
-               	mov	x16, #0xfbec            // =64492
+               	mov	x16, #0xfe34            // =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfbf4            // =64500
+               	mov	x16, #0xfe3c            // =65084
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
-               	mov	x16, #0xfbec            // =64492
+               	ldr	x18, [x1]
+               	mov	x16, #0xfe34            // =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
-               	mov	x16, #0xfbf4            // =64500
+               	str	x18, [x29, x16]
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfe3c            // =65084
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
-               	mov	x16, #0xfbec            // =64492
+               	str	w18, [x29, x16]
+               	mov	x16, #0xfe34            // =65076
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
                	mov	v3.16b, v2.16b
                	mov	v3.s[1], v1.s[0]
-               	mov	x16, #0xfbdc            // =64476
+               	mov	x16, #0xfe24            // =65060
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q3, [x29, x16]
-               	mov	x16, #0xfbdc            // =64476
+               	mov	x16, #0xfe24            // =65060
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
-               	mov	x16, #0xfbe4            // =64484
+               	ldr	x18, [x29, x16]
+               	str	x18, [x1]
+               	mov	x16, #0xfe2c            // =65068
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	ldr	w18, [x29, x16]
+               	str	w18, [x1, #0x8]
                	mov	w16, #0x42c80000        // =1120403456
                	fmov	s31, w16
                	fsub	s1, s31, s0
-               	mov	x16, #0xfbcc            // =64460
+               	mov	x16, #0xfe14            // =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfbd4            // =64468
+               	mov	x16, #0xfe1c            // =65052
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
-               	mov	x16, #0xfbcc            // =64460
+               	ldr	x18, [x1]
+               	mov	x16, #0xfe14            // =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
-               	mov	x16, #0xfbd4            // =64468
+               	str	x18, [x29, x16]
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfe1c            // =65052
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
-               	mov	x16, #0xfbcc            // =64460
+               	str	w18, [x29, x16]
+               	mov	x16, #0xfe14            // =65044
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
                	mov	v2.16b, v0.16b
                	mov	v2.s[2], v1.s[0]
-               	mov	x16, #0xfbbc            // =64444
+               	mov	x16, #0xfe04            // =65028
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q2, [x29, x16]
-               	mov	x16, #0xfbbc            // =64444
+               	mov	x16, #0xfe04            // =65028
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
-               	mov	x16, #0xfbc4            // =64452
+               	ldr	x18, [x29, x16]
+               	str	x18, [x1]
+               	mov	x16, #0xfe0c            // =65036
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
-               	mov	x16, #0xfbac            // =64428
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfbb4            // =64436
+               	ldr	w18, [x29, x16]
+               	str	w18, [x1, #0x8]
+               	mov	x16, #0xfdf4            // =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
-               	mov	x16, #0xfbac            // =64428
+               	mov	x16, #0xfdfc            // =65020
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
-               	mov	x16, #0xfbb4            // =64436
+               	str	xzr, [x29, x16]
+               	ldr	x18, [x1]
+               	mov	x16, #0xfdf4            // =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
-               	mov	x16, #0xfbac            // =64428
+               	str	x18, [x29, x16]
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfdfc            // =65020
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w18, [x29, x16]
+               	mov	x16, #0xfdf4            // =65012
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
                	mov	x16, #0xc               // =12
-               	mul	x0, x1, x16
-               	add	x18, x19, x0
-               	mov	x16, #0xfb9c            // =64412
+               	mul	x1, x0, x16
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x18, x9, x1
+               	mov	x16, #0xfde4            // =64996
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xfb9c            // =64412
+               	mov	x16, #0xfde4            // =64996
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
-               	mov	x16, #0xfba4            // =64420
+               	ldr	x1, [x29, x16]
+               	str	x1, [x18]
+               	mov	x16, #0xfdec            // =65004
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x7
-               	b.lo	 <L2>
-<L3>:
-               	mov	x16, #0xf878            // =63608
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	mov	x9, x10
-               	mov	x16, #0xf7a8            // =63400
+               	ldr	w1, [x29, x16]
+               	str	w1, [x18, #0x8]
+               	add	x0, x0, #0x1
+               	cmp	x0, #0x7
+               	b.lo	 <L1>
+<L2>:
+               	mov	x9, #0x2325             // =8997
+               	movk	x9, #0x8422, lsl #16
+               	movk	x9, #0x9ce4, lsl #32
+               	movk	x9, #0xcbf2, lsl #48
+               	mov	x16, #0xf920            // =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x7                // =7
-               	mov	x16, #0xf7a0            // =63392
+               	mov	x16, #0xf918            // =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7a0            // =63392
+               	mov	x16, #0xf918            // =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x17, #0x0               // =0
                	cmp	x17, x9
-               	b.lo	 <L4>
-               	b	 <L8>
-<L4>:
-               	mov	x16, #0xf7a0            // =63392
+               	b.lo	 <L3>
+               	b	 <L5>
+<L3>:
+               	mov	x16, #0xf918            // =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	sub	x9, x10, #0x1
-               	mov	x16, #0xf7c8            // =63432
+               	mov	x16, #0xf928            // =63784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7c8            // =63432
+               	mov	x16, #0xf928            // =63784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               // =12
                	mul	x0, x9, x16
-               	add	x9, x19, x0
-               	mov	x16, #0xf868            // =63592
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xfa60            // =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfb8c            // =64396
+               	mov	x16, #0xfdd4            // =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfb94            // =64404
+               	mov	x16, #0xfddc            // =64988
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf868            // =63592
+               	mov	x16, #0xfa60            // =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfb8c            // =64396
+               	mov	x16, #0xfdd4            // =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf868            // =63592
+               	mov	x16, #0xfa60            // =64096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfb94            // =64404
+               	mov	x16, #0xfddc            // =64988
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfb8c            // =64396
+               	mov	x16, #0xfdd4            // =64980
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf7b0            // =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf7b0            // =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	mov	x16, #0xf7a8            // =63400
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf920            // =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-<L5>:
-               	bl	 <L5>
-               	mov	x16, #0xf7b0            // =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L6>:
-               	bl	 <L6>
-               	mov	x16, #0xf7b0            // =63408
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L7>:
-               	bl	 <L7>
+<L4>:
+               	bl	 <L4>
                	mov	x9, x0
-               	mov	x16, #0xf7a8            // =63400
+               	mov	x16, #0xf920            // =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7c8            // =63432
+               	mov	x16, #0xf928            // =63784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	mov	x16, #0xf7a0            // =63392
+               	mov	x16, #0xf918            // =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7a0            // =63392
+               	mov	x16, #0xf918            // =63768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x17, #0x0               // =0
                	cmp	x17, x9
-               	b.lo	 <L4>
-<L8>:
-               	sub	x9, x29, #0x4b4
-               	mov	x16, #0xf798            // =63384
+               	b.lo	 <L3>
+<L5>:
+               	sub	x9, x29, #0x26c
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x10]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x18]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x20]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x28]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x30]
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x38]
                	mov	x9, #0x0                // =0
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L9>
-               	b	 <L10>
-<L9>:
-               	mov	x16, #0xf860            // =63584
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               // =12
-               	mul	x18, x9, x16
-               	add	x0, x19, x18
-               	mov	x16, #0xfb3c            // =64316
+               	mul	x0, x9, x16
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xfa50            // =64080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfd84            // =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfb44            // =64324
+               	mov	x16, #0xfd8c            // =64908
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
-               	mov	x16, #0xfb3c            // =64316
+               	mov	x16, #0xfa50            // =64080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
-               	mov	x16, #0xfb44            // =64324
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfd84            // =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
-               	mov	x16, #0xfb3c            // =64316
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfa50            // =64080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfd8c            // =64908
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfd84            // =64900
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0x10              // =16
                	mul	x0, x9, x16
-               	mov	x16, #0xf798            // =63384
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	add	x9, x10, x0
-               	mov	x16, #0xf858            // =63576
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf858            // =63576
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	mov	x16, #0xfb2c            // =64300
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xfa40            // =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfd74            // =64884
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xfb2c            // =64300
+               	mov	x16, #0xfd74            // =64884
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x18, [x29, x16]
-               	str	x18, [x0]
-               	mov	x16, #0xfb34            // =64308
+               	ldr	x0, [x29, x16]
+               	mov	x16, #0xfa40            // =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w18, [x29, x16]
-               	str	w18, [x0, #0x8]
-               	mov	x16, #0xf860            // =63584
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfd7c            // =64892
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w0, [x29, x16]
+               	mov	x16, #0xfa40            // =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w0, [x9, #0x8]
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -719,485 +817,84 @@ Disassembly of section .text:
                	mov	w0, w9
                	mov	w17, #0xaaaa            // =43690
                	movk	w17, #0xaaaa, lsl #16
-               	sub	w18, w17, w0
-               	mov	x16, #0xf858            // =63576
+               	sub	w9, w17, w0
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa48            // =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
-               	str	w18, [x0]
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa38            // =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w9, [x0]
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1
                	mov	x9, x0
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf860            // =63584
+               	mov	x16, #0xfa58            // =64088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L9>
-<L10>:
-               	mov	x16, #0xf7a8            // =63400
+               	b.lo	 <L6>
+<L7>:
+               	mov	x16, #0xf920            // =63776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	mov	x16, #0xf778            // =63352
+               	mov	x16, #0xf8c0            // =63680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x0                // =0
-               	mov	x16, #0xf770            // =63344
+               	mov	x16, #0xf8b8            // =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf770            // =63344
+               	mov	x16, #0xf8b8            // =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x4
-               	b.lo	 <L11>
-               	b	 <L16>
-<L11>:
-               	mov	x16, #0xf770            // =63344
+               	b.lo	 <L8>
+               	b	 <L12>
+<L8>:
+               	mov	x16, #0xf8b8            // =63672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0x10              // =16
                	mul	x0, x9, x16
-               	mov	x16, #0xf798            // =63384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, x0
-               	add	x0, x1, #0x0
-               	mov	x16, #0xfb1c            // =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfb24            // =64292
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x1, [x0]
-               	mov	x16, #0xfb1c            // =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	ldr	w1, [x0, #0x8]
-               	mov	x16, #0xfb24            // =64292
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xfb1c            // =64284
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf780            // =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf780            // =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	mov	x16, #0xf778            // =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-<L12>:
-               	bl	 <L12>
-               	mov	x16, #0xf780            // =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xf780            // =63360
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L14>:
-               	bl	 <L14>
-               	mov	x9, x0
-               	mov	x16, #0xf848            // =63560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf848            // =63560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xf770            // =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0x10              // =16
-               	mul	x1, x9, x16
-               	mov	x16, #0xf798            // =63384
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, x1
-               	add	x1, x0, #0xc
-               	ldr	w9, [x1]
-               	mov	x16, #0xf840            // =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf848            // =63560
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	x16, #0xf840            // =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	w1, w9
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xf770            // =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x1
-               	mov	x9, x0
-               	mov	x16, #0xf778            // =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x9, x14
-               	mov	x16, #0xf770            // =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf770            // =63344
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	cmp	x9, #0x4
-               	b.lo	 <L11>
-<L16>:
-               	sub	x9, x29, #0x4f8
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	xzr, [x9]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	wzr, [x9, #0x10]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	mov	w17, #0xdb              // =219
-               	strb	w17, [x0]
-               	add	x1, x19, #0x3c
-               	mov	x16, #0xfaf8            // =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfb00            // =64256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x14, [x1]
-               	mov	x16, #0xfaf8            // =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x1, #0x8]
-               	mov	x16, #0xfb00            // =64256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xfaf8            // =64248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	mov	x16, #0xf768            // =63336
+               	mov	x16, #0xf8c8            // =63688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	add	x9, x10, #0x4
-               	mov	x16, #0xf760            // =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xfae8            // =64232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
-               	mov	x16, #0xfae8            // =64232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x1, [x29, x16]
-               	mov	x16, #0xf760            // =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x1, [x9]
-               	mov	x16, #0xfaf0            // =64240
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w1, [x29, x16]
-               	mov	x16, #0xf760            // =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	w1, [x9, #0x8]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	mov	w17, #0xad              // =173
-               	strb	w17, [x1]
-               	ldrb	w1, [x0]
-               	mov	x16, #0xf778            // =63352
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfad8            // =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfae0            // =64224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf760            // =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
-               	mov	x16, #0xfad8            // =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	mov	x16, #0xf760            // =63328
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	w1, [x9, #0x8]
-               	mov	x16, #0xfae0            // =64224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xfad8            // =64216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf750            // =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf750            // =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xf750            // =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xf750            // =63312
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L20>:
-               	bl	 <L20>
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L21>:
-               	bl	 <L21>
-               	mov	x9, x0
-               	mov	x16, #0xf838            // =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf838            // =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	sub	x9, x29, #0x5b4
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x1, x29, #0x5c8
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x18, [x9]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x0, [x9, #0x8]
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldr	w9, [x10, #0x10]
-               	mov	x16, #0xf830            // =63536
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	str	x18, [x1]
-               	str	x0, [x1, #0x8]
-               	mov	x16, #0xf830            // =63536
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	w9, [x1, #0x10]
-               	ldr	x0, [x1]
-               	ldr	x18, [x1, #0x8]
-               	ldr	w9, [x1, #0x10]
-               	mov	x16, #0xf828            // =63528
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x0, [x9]
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	str	x18, [x9, #0x8]
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x16, #0xf828            // =63528
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	str	w10, [x9, #0x10]
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	add	x9, x10, #0x4
-               	mov	x16, #0xf740            // =63296
+               	add	x9, x10, x0
+               	mov	x16, #0xfa28            // =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1206,475 +903,1161 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfa30            // =64048
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xfa20            // =64032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfd64            // =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf740            // =63296
+               	mov	x16, #0xfd6c            // =64876
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfa20            // =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfa28            // =64040
+               	mov	x16, #0xfd64            // =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf740            // =63296
+               	mov	x16, #0xfa20            // =64032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfa30            // =64048
+               	mov	x16, #0xfd6c            // =64876
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfa28            // =64040
+               	mov	x16, #0xfd64            // =64868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	add	x0, x19, #0xc
+               	mov	x16, #0xf8c0            // =63680
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L9>:
+               	bl	 <L9>
+               	mov	x9, x0
                	mov	x16, #0xfa18            // =64024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa18            // =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xfa28            // =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0xc
+               	ldr	w9, [x0]
+               	mov	x16, #0xfa10            // =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa10            // =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	w9, w10
+               	mov	x16, #0xfa00            // =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfa18            // =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, #0x0                // =0
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x8               // =8
+               	mul	x0, x9, x16
+               	mov	x16, #0xfa00            // =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	lsr	x9, x10, x0
+               	mov	x16, #0xf9f0            // =63984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9f0            // =63984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xff              // =255
+               	and	x0, x9, x16
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	eor	x9, x10, x0
+               	mov	x16, #0xf9e8            // =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9e8            // =63976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x9, x16
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x1
+               	mov	x16, #0xf9e0            // =63968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9e0            // =63968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9f8            // =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	mov	x16, #0xf8b8            // =63672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x1
+               	mov	x16, #0xfa08            // =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf8c0            // =63680
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x1
+               	mov	x16, #0xf8b8            // =63672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8b8            // =63672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x4
+               	b.lo	 <L8>
+<L12>:
+               	sub	x9, x29, #0x2b0
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	xzr, [x9]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	xzr, [x9, #0x8]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	wzr, [x9, #0x10]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
+               	mov	x16, #0xf9d8            // =63960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9d8            // =63960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w17, #0xdb              // =219
+               	strb	w17, [x9]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x3c
+               	mov	x16, #0xfd40            // =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfa20            // =64032
+               	mov	x16, #0xfd48            // =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x1]
+               	mov	x16, #0xfd40            // =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x1, #0x8]
+               	mov	x16, #0xfd48            // =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfd40            // =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q0, [x29, x16]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x1, [x29, x16]
+               	str	x1, [x0]
+               	mov	x16, #0xfd38            // =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	str	w1, [x0, #0x8]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x10
+               	mov	w17, #0xad              // =173
+               	strb	w17, [x0]
+               	mov	x16, #0xf9d8            // =63960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldrb	w0, [x9]
+               	uxtb	w9, w0
+               	mov	x16, #0xf9d0            // =63952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8c0            // =63680
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf9c8            // =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x0, #0x0                // =0
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+               	b	 <L14>
+<L13>:
+               	mov	x16, #0x8               // =8
+               	mul	x1, x0, x16
+               	mov	x16, #0xf9d0            // =63952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x12, x9, x1
+               	mov	x16, #0xff              // =255
+               	and	x1, x12, x16
+               	mov	x16, #0xf9c8            // =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x12, x9, x1
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x1, x12, x16
+               	add	x0, x0, #0x1
+               	mov	x9, x1
+               	mov	x16, #0xf9c8            // =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x0, #0x8
+               	b.lo	 <L13>
+<L14>:
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfc6c            // =64620
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc74            // =64628
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
                	ldr	x1, [x0]
-               	mov	x16, #0xfa18            // =64024
+               	mov	x16, #0xfc6c            // =64620
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x1, [x29, x16]
                	ldr	w1, [x0, #0x8]
-               	mov	x16, #0xfa20            // =64032
+               	mov	x16, #0xfc74            // =64628
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w1, [x29, x16]
-               	mov	x16, #0xfa18            // =64024
+               	mov	x16, #0xfc6c            // =64620
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf9c8            // =63944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldrb	w12, [x1]
+               	uxtb	w9, w12
+               	mov	x16, #0xf9b8            // =63928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf9c0            // =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x0, x12, x16
+               	mov	x16, #0xf9b8            // =63928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x1, x9, x0
+               	mov	x16, #0xff              // =255
+               	and	x0, x1, x16
+               	mov	x16, #0xf9c0            // =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x0
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x1, x16
+               	add	x12, x12, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xf9c0            // =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x12, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	sub	x9, x29, #0x4a4
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x0, x29, #0x4b8
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x12, [x9]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	ldr	x9, [x10, #0x8]
+               	mov	x16, #0xf9b0            // =63920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8b0            // =63664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	ldr	w9, [x10, #0x10]
+               	mov	x16, #0xf9a8            // =63912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	str	x12, [x0]
+               	mov	x16, #0xf9b0            // =63920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x9, [x0, #0x8]
+               	mov	x16, #0xf9a8            // =63912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w9, [x0, #0x10]
+               	ldr	x12, [x0]
+               	ldr	x9, [x0, #0x8]
+               	mov	x16, #0xf9a0            // =63904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldr	w9, [x0, #0x10]
+               	mov	x16, #0xf998            // =63896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x12, [x9]
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf9a0            // =63904
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	x10, [x9, #0x8]
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf998            // =63896
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	str	w10, [x9, #0x10]
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x4
+               	mov	x16, #0xf990            // =63888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfb38            // =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb40            // =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf990            // =63888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x12, [x9]
+               	mov	x16, #0xfb38            // =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x12, [x29, x16]
+               	mov	x16, #0xf990            // =63888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w12, [x9, #0x8]
+               	mov	x16, #0xfb40            // =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w12, [x29, x16]
+               	mov	x16, #0xfb38            // =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x12, x9, #0xc
+               	mov	x16, #0xfb28            // =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb30            // =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x12]
+               	mov	x16, #0xfb28            // =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x12, #0x8]
+               	mov	x16, #0xfb30            // =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfb28            // =64296
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q1, [x29, x16]
                	fadd	v2.4s, v0.4s, v1.4s
-               	mov	x16, #0xfa08            // =64008
+               	mov	x16, #0xfb18            // =64280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q2, [x29, x16]
-               	mov	x16, #0xfa08            // =64008
+               	mov	x16, #0xfb18            // =64280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
-               	mov	x16, #0xf740            // =63296
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	x0, [x9]
-               	mov	x16, #0xfa10            // =64016
+               	mov	x16, #0xfb20            // =64288
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
-               	mov	x16, #0xf740            // =63296
+               	mov	x16, #0xf990            // =63888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	w0, [x9, #0x8]
-               	mov	x16, #0xf748            // =63304
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x0
+               	ldrb	w12, [x0]
+               	uxtb	w9, w12
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf9c0            // =63936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, #0x0                // =0
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0x8               // =8
+               	mul	x12, x9, x16
+               	mov	x16, #0xf988            // =63880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x0, x16
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x12, x0, x16
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1
+               	mov	x9, x12
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf978            // =63864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	mov	x16, #0xfb08            // =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfb10            // =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x12, [x0]
+               	mov	x16, #0xfb08            // =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x12, [x29, x16]
+               	ldr	w12, [x0, #0x8]
+               	mov	x16, #0xfb10            // =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w12, [x29, x16]
+               	mov	x16, #0xfb08            // =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf980            // =63872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xf8a8            // =63656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x12, x9, #0x10
+               	ldrb	w1, [x12]
+               	uxtb	w9, w1
+               	mov	x16, #0xf970            // =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x0
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+               	b	 <L22>
+<L21>:
+               	mov	x16, #0x8               // =8
+               	mul	x12, x1, x16
+               	mov	x16, #0xf970            // =63856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	lsr	x0, x9, x12
+               	mov	x16, #0xff              // =255
+               	and	x12, x0, x16
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x0, x9, x12
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x12, x0, x16
+               	add	x1, x1, #0x1
+               	mov	x9, x12
+               	mov	x16, #0xf968            // =63848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x1, #0x8
+               	b.lo	 <L21>
+<L22>:
+               	mov	x16, #0xf8b0            // =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	ldrb	w1, [x0]
-               	mov	x16, #0xf838            // =63544
+               	uxtb	w12, w1
+               	mov	x16, #0xf968            // =63848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xf9f8            // =63992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfa00            // =64000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf740            // =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	x1, [x9]
-               	mov	x16, #0xf9f8            // =63992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x1, [x29, x16]
-               	mov	x16, #0xf740            // =63296
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	ldr	w1, [x9, #0x8]
-               	mov	x16, #0xfa00            // =64000
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w1, [x29, x16]
-               	mov	x16, #0xf9f8            // =63992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf730            // =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf730            // =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	mov	x1, x12
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xf730            // =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L24>:
-               	bl	 <L24>
-               	mov	x16, #0xf730            // =63280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xf748            // =63304
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xf768            // =63336
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldrb	w14, [x1]
-               	mov	x1, x14
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xf768            // =63336
+               	mov	x16, #0xf8b0            // =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
-               	mov	x16, #0xf9e8            // =63976
+               	mov	x16, #0xfaf8            // =64248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf9f0            // =63984
+               	mov	x16, #0xfb00            // =64256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x14, [x1]
-               	mov	x16, #0xf9e8            // =63976
+               	ldr	x12, [x1]
+               	mov	x16, #0xfaf8            // =64248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x1, #0x8]
-               	mov	x16, #0xf9f0            // =63984
+               	str	x12, [x29, x16]
+               	ldr	w12, [x1, #0x8]
+               	mov	x16, #0xfb00            // =64256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xf9e8            // =63976
+               	str	w12, [x29, x16]
+               	mov	x16, #0xfaf8            // =64248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf720            // =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf720            // =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xf720            // =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xf720            // =63264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xf768            // =63336
+               	ldr	q0, [x29, x16]
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xf8b0            // =63664
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
-               	ldrb	w13, [x1]
-               	mov	x1, x13
-<L31>:
-               	bl	 <L31>
+               	ldrb	w12, [x1]
+               	uxtb	w1, w12
+<L25>:
+               	bl	 <L25>
                	mov	x9, x0
-               	mov	x16, #0xf820            // =63520
+               	mov	x16, #0xf960            // =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf820            // =63520
+               	mov	x16, #0xf960            // =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	sub	x9, x29, #0x690
-               	mov	x16, #0xf718            // =63256
+               	sub	x9, x29, #0x534
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x8]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x10]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x18]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x20]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	str	wzr, [x9, #0x28]
-               	mov	x16, #0xf718            // =63256
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	mov	w17, #0xffff            // =65535
-               	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x14, x19, #0x0
-               	mov	x16, #0xf960            // =63840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf968            // =63848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x18, [x14]
-               	mov	x16, #0xf960            // =63840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x14, #0x8]
-               	mov	x16, #0xf968            // =63848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
-               	mov	x16, #0xf960            // =63840
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	mov	x16, #0xf718            // =63256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	add	x18, x14, #0x0
-               	mov	x16, #0xf950            // =63824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q0, [x29, x16]
-               	mov	x16, #0xf950            // =63824
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x0
                	mov	x16, #0xf958            // =63832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
-               	add	x0, x19, #0x24
-               	mov	x16, #0xf940            // =63808
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf958            // =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	w17, #0xffff            // =65535
+               	movk	w17, #0xffff, lsl #16
+               	str	w17, [x9]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x18, x9, #0x0
+               	mov	x16, #0xfabc            // =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf948            // =63816
+               	mov	x16, #0xfac4            // =64196
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
-               	mov	x16, #0xf940            // =63808
+               	ldr	x0, [x18]
+               	mov	x16, #0xfabc            // =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
-               	mov	x16, #0xf948            // =63816
+               	str	x0, [x29, x16]
+               	ldr	w0, [x18, #0x8]
+               	mov	x16, #0xfac4            // =64196
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
-               	mov	x16, #0xf940            // =63808
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfabc            // =64188
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	add	x0, x14, #0xc
-               	mov	x16, #0xf930            // =63792
+               	mov	x16, #0xf8a0            // =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x4
+               	add	x18, x0, #0x0
+               	mov	x16, #0xfaac            // =64172
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
+               	mov	x16, #0xfaac            // =64172
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x1, [x29, x16]
+               	str	x1, [x18]
+               	mov	x16, #0xfab4            // =64180
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w1, [x29, x16]
+               	str	w1, [x18, #0x8]
                	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x24
+               	mov	x16, #0xfa9c            // =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfaa4            // =64164
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x18, [x1]
+               	mov	x16, #0xfa9c            // =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x18, [x29, x16]
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfaa4            // =64164
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w18, [x29, x16]
+               	mov	x16, #0xfa9c            // =64156
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	add	x1, x0, #0xc
+               	mov	x16, #0xfa8c            // =64140
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q0, [x29, x16]
+               	mov	x16, #0xfa8c            // =64140
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x18, [x29, x16]
-               	str	x18, [x0]
-               	mov	x16, #0xf938            // =63800
+               	str	x18, [x1]
+               	mov	x16, #0xfa94            // =64148
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w18, [x29, x16]
-               	str	w18, [x0, #0x8]
-               	add	x0, x19, #0x48
-               	mov	x16, #0xf920            // =63776
+               	str	w18, [x1, #0x8]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x48
+               	mov	x16, #0xfa7c            // =64124
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf928            // =63784
+               	mov	x16, #0xfa84            // =64132
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
-               	mov	x16, #0xf920            // =63776
+               	ldr	x18, [x1]
+               	mov	x16, #0xfa7c            // =64124
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
-               	mov	x16, #0xf928            // =63784
+               	ldr	w18, [x1, #0x8]
+               	mov	x16, #0xfa84            // =64132
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w18, [x29, x16]
-               	mov	x16, #0xf920            // =63776
+               	mov	x16, #0xfa7c            // =64124
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	add	x0, x14, #0x18
-               	mov	x16, #0xf910            // =63760
+               	add	x1, x0, #0x18
+               	mov	x16, #0xfa6c            // =64108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q0, [x29, x16]
-               	mov	x16, #0xf910            // =63760
+               	mov	x16, #0xfa6c            // =64108
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x14, [x29, x16]
-               	str	x14, [x0]
-               	mov	x16, #0xf918            // =63768
+               	ldr	x0, [x29, x16]
+               	str	x0, [x1]
+               	mov	x16, #0xfa74            // =64116
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w14, [x29, x16]
-               	str	w14, [x0, #0x8]
-               	mov	x16, #0xf718            // =63256
+               	ldr	w0, [x29, x16]
+               	str	w0, [x1, #0x8]
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1683,105 +2066,474 @@ Disassembly of section .text:
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x0]
-               	ldr	w14, [x1]
-               	mov	x16, #0xf820            // =63520
+               	mov	x16, #0xf958            // =63832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9]
+               	mov	w1, w0
+               	mov	x16, #0xf960            // =63840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	w1, w14
-<L32>:
-               	bl	 <L32>
+<L26>:
+               	bl	 <L26>
                	mov	x9, x0
-               	mov	x16, #0xf6f8            // =63224
+               	mov	x16, #0xf898            // =63640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mov	x9, #0x0                // =0
-               	mov	x16, #0xf6f0            // =63216
+               	mov	x16, #0xf890            // =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf6f0            // =63216
+               	mov	x16, #0xf890            // =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	cmp	x9, #0x3
-               	b.lo	 <L33>
-               	b	 <L37>
-<L33>:
-               	mov	x16, #0xf718            // =63256
+               	b.lo	 <L27>
+               	b	 <L29>
+<L27>:
+               	mov	x16, #0xf8a0            // =63648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x4
-               	mov	x16, #0xf6f0            // =63216
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x4
+               	mov	x16, #0xf950            // =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf890            // =63632
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               // =12
-               	mul	x18, x9, x16
-               	add	x9, x0, x18
-               	mov	x16, #0xf818            // =63512
+               	mul	x0, x9, x16
+               	mov	x16, #0xf950            // =63824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, x0
+               	mov	x16, #0xf948            // =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfac8            // =64200
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xfad0            // =64208
+               	mov	x16, #0xfd28            // =64808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf818            // =63512
+               	mov	x16, #0xf948            // =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
-               	mov	x16, #0xfac8            // =64200
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf818            // =63512
+               	mov	x16, #0xf948            // =63816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	w0, [x9, #0x8]
-               	mov	x16, #0xfad0            // =64208
+               	mov	x16, #0xfd28            // =64808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	w0, [x29, x16]
-               	mov	x16, #0xfac8            // =64200
+               	mov	x16, #0xfd20            // =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf700            // =63232
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf898            // =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xf890            // =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x18, x9, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xf898            // =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x9, x18
+               	mov	x16, #0xf890            // =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf890            // =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x3
+               	b.lo	 <L27>
+<L29>:
+               	mov	x16, #0xf8a0            // =63648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x28
+               	ldr	w12, [x0]
+               	mov	w0, w12
+               	mov	x16, #0xf898            // =63640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x12, #0x0               // =0
+               	cmp	x12, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x18, x12, x16
+               	lsr	x1, x0, x18
+               	mov	x16, #0xff              // =255
+               	and	x18, x1, x16
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	eor	x1, x9, x18
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x18, x1, x16
+               	add	x12, x12, #0x1
+               	mov	x9, x18
+               	mov	x16, #0xf940            // =63808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	cmp	x12, #0x8
+               	b.lo	 <L30>
+<L31>:
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x18
+               	mov	x16, #0xf888            // =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc5c            // =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc64            // =64612
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf888            // =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc5c            // =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf888            // =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc64            // =64612
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc5c            // =64604
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x30
+               	mov	x16, #0xf880            // =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc4c            // =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc54            // =64596
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf880            // =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc4c            // =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf880            // =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc54            // =64596
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc4c            // =64588
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q1, [x29, x16]
+               	fadd	v31.4s, v0.4s, v1.4s
+               	mov	x16, #0xf870            // =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xf700            // =63232
+               	mov	x16, #0xf940            // =63808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-               	mov	x16, #0xf6f8            // =63224
+               	ldr	x9, [x29, x16]
+               	mov	x0, x9
+               	mov	x16, #0xf870            // =63600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xf870            // =63600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L33>:
+               	bl	 <L33>
+               	mov	x9, x0
+               	mov	x16, #0xf938            // =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf938            // =63800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x16, #0xf930            // =63792
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	add	x9, x10, #0x24
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfc3c            // =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc44            // =64580
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc3c            // =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w15, [x9, #0x8]
+               	mov	x16, #0xfc44            // =64580
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w15, [x29, x16]
+               	mov	x16, #0xfc3c            // =64572
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	sub	x15, x29, #0x3d0
+               	add	x0, x15, #0x0
+               	mov	w17, #0x40000000        // =1073741824
+               	str	w17, [x0]
+               	add	x0, x15, #0x4
+               	mov	w17, #0x40800000        // =1082130432
+               	str	w17, [x0]
+               	add	x0, x15, #0x8
+               	mov	w17, #0x41000000        // =1090519040
+               	str	w17, [x0]
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc28            // =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	ldr	x0, [x15]
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	w0, [x15, #0x8]
+               	mov	x16, #0xfc28            // =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q1, [x29, x16]
+               	fmul	v2.4s, v0.4s, v1.4s
+               	mov	x16, #0xfc10            // =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q2, [x29, x16]
+               	mov	x16, #0xfc10            // =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x0, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	x0, [x9]
+               	mov	x16, #0xfc18            // =64536
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	w0, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	str	w0, [x9, #0x8]
+               	mov	x16, #0xfc00            // =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfc08            // =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf888            // =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9]
+               	mov	x16, #0xfc00            // =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xf888            // =63624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w0, [x9, #0x8]
+               	mov	x16, #0xfc08            // =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w0, [x29, x16]
+               	mov	x16, #0xfc00            // =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+               	mov	x16, #0xf938            // =63800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1789,935 +2541,556 @@ Disassembly of section .text:
                	mov	x0, x9
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0xf700            // =63232
+               	mov	x16, #0xfbf0            // =64496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfbf8            // =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	x16, #0xfbf0            // =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf868            // =63592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w1, [x9, #0x8]
+               	mov	x16, #0xfbf8            // =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w1, [x29, x16]
+               	mov	x16, #0xfbf0            // =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xf700            // =63232
+               	mov	x16, #0xfbe0            // =64480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xfbe8            // =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	xzr, [x29, x16]
+               	mov	x16, #0xf880            // =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x1, [x9]
+               	mov	x16, #0xfbe0            // =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	mov	x16, #0xf880            // =63616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	w1, [x9, #0x8]
+               	mov	x16, #0xfbe8            // =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	w1, [x29, x16]
+               	mov	x16, #0xfbe0            // =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L36>:
                	bl	 <L36>
-               	mov	x16, #0xf6f0            // =63216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x1
-               	mov	x9, x0
-               	mov	x16, #0xf6f8            // =63224
+               	sub	x9, x29, #0x490
+               	mov	x16, #0xf860            // =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x14
-               	mov	x16, #0xf6f0            // =63216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x16, #0xf6f0            // =63216
+               	mov	x16, #0xf860            // =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	cmp	x9, #0x3
-               	b.lo	 <L33>
-<L37>:
-               	mov	x16, #0xf718            // =63256
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x28
-               	ldr	w13, [x0]
-               	mov	x16, #0xf6f8            // =63224
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x0, x9
-               	mov	w1, w13
-<L38>:
-               	bl	 <L38>
-               	add	x1, x19, #0x18
-               	mov	x16, #0xfab8            // =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfac0            // =64192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xfab8            // =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xfac0            // =64192
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xfab8            // =64184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	add	x1, x19, #0x30
-               	mov	x16, #0xfaa8            // =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xfab0            // =64176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xfaa8            // =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xfab0            // =64176
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xfaa8            // =64168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q1, [x29, x16]
-               	fadd	v31.4s, v0.4s, v1.4s
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xf6e0            // =63200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L44>:
-               	bl	 <L44>
-               	add	x1, x19, #0x24
-               	mov	x16, #0xf9d8            // =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9e0            // =63968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf9d8            // =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf9e0            // =63968
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf9d8            // =63960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-               	sub	x13, x29, #0x634
-               	add	x14, x13, #0x0
-               	mov	w17, #0x40000000        // =1073741824
-               	str	w17, [x14]
-               	add	x14, x13, #0x4
-               	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x14]
-               	add	x14, x13, #0x8
-               	mov	w17, #0x41000000        // =1090519040
-               	str	w17, [x14]
-               	mov	x16, #0xf9bc            // =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9c4            // =63940
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x14, [x13]
-               	mov	x16, #0xf9bc            // =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x13, #0x8]
-               	mov	x16, #0xf9c4            // =63940
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
-               	mov	x16, #0xf9bc            // =63932
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q1, [x29, x16]
-               	fmul	v2.4s, v0.4s, v1.4s
-               	mov	x16, #0xf9ac            // =63916
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q2, [x29, x16]
-               	mov	x16, #0xf9ac            // =63916
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x13, [x29, x16]
-               	str	x13, [x1]
-               	mov	x16, #0xf9b4            // =63924
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	w13, [x29, x16]
-               	str	w13, [x1, #0x8]
-               	add	x1, x19, #0x18
-               	mov	x16, #0xf99c            // =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf9a4            // =63908
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf99c            // =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf9a4            // =63908
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf99c            // =63900
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6d0            // =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6d0            // =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xf6d0            // =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xf6d0            // =63184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L47>:
-               	bl	 <L47>
-               	add	x1, x19, #0x24
-               	mov	x16, #0xf900            // =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf908            // =63752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf900            // =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf908            // =63752
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf900            // =63744
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6c0            // =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6c0            // =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xf6c0            // =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xf6c0            // =63168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L50>:
-               	bl	 <L50>
-               	add	x1, x19, #0x30
-               	mov	x16, #0xf8f0            // =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	mov	x16, #0xf8f8            // =63736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	xzr, [x29, x16]
-               	ldr	x13, [x1]
-               	mov	x16, #0xf8f0            // =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x13, [x29, x16]
-               	ldr	w13, [x1, #0x8]
-               	mov	x16, #0xf8f8            // =63736
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	w13, [x29, x16]
-               	mov	x16, #0xf8f0            // =63728
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xf6b0            // =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xf6b0            // =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xf6b0            // =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xf6b0            // =63152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L53>:
-               	bl	 <L53>
-               	sub	x19, x29, #0x780
-               	add	x1, x19, #0x0
-               	add	x13, x1, #0x0
+               	add	x1, x9, #0x0
+               	add	x15, x1, #0x0
                	mov	x1, #0x60               // =96
-<L54>:
-               	str	xzr, [x13]
-               	add	x13, x13, #0x8
+<L37>:
+               	str	xzr, [x15]
+               	add	x15, x15, #0x8
                	sub	x1, x1, #0x8
                	cmp	x1, #0x0
-               	b.ne	 <L54>
-               	str	wzr, [x13]
+               	b.ne	 <L37>
+               	str	wzr, [x15]
                	mov	x1, #0x0                // =0
                	cmp	x1, #0x5
-               	b.lo	 <L55>
-               	b	 <L56>
-<L55>:
+               	b.lo	 <L38>
+               	b	 <L39>
+<L38>:
                	ucvtf	s0, x1
-               	sub	x13, x29, #0x56c
-               	str	xzr, [x13]
-               	str	xzr, [x13, #0x8]
-               	str	wzr, [x13, #0x10]
+               	sub	x15, x29, #0x2f4
+               	str	xzr, [x15]
+               	str	xzr, [x15, #0x8]
+               	str	wzr, [x15, #0x10]
                	fadd	s1, s0, s8
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x20, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x20, #0x10
-               	str	s2, [x14]
-               	add	x14, x20, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x0
-               	str	s2, [x14]
-               	add	x14, x20, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x4
-               	str	s2, [x14]
-               	add	x14, x20, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x8
-               	str	s2, [x14]
-               	add	x14, x20, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x21, #0xc
-               	str	s2, [x14]
-               	add	x14, x20, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x21, #0x10
-               	str	s2, [x14]
-               	add	x14, x21, #0x0
-               	str	s1, [x14]
-               	add	x14, x21, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x21, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x21, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x21, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x21, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x18, x15, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x19, #0x0
+               	str	s2, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x19, #0x4
+               	str	s2, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x19, #0x8
+               	str	s2, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x19, #0xc
+               	str	s2, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x19, #0x10
+               	str	s2, [x18]
+               	add	x18, x19, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x20, #0x0
+               	str	s2, [x18]
+               	add	x18, x19, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x20, #0x4
+               	str	s2, [x18]
+               	add	x18, x19, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x20, #0x8
+               	str	s2, [x18]
+               	add	x18, x19, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x20, #0xc
+               	str	s2, [x18]
+               	add	x18, x19, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x20, #0x10
+               	str	s2, [x18]
+               	add	x18, x20, #0x0
+               	str	s1, [x18]
+               	add	x18, x20, #0x0
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x0
+               	str	s1, [x18]
+               	add	x18, x20, #0x4
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x4
+               	str	s1, [x18]
+               	add	x18, x20, #0x8
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x8
+               	str	s1, [x18]
+               	add	x18, x20, #0xc
+               	ldr	s1, [x18]
+               	add	x18, x15, #0xc
+               	str	s1, [x18]
+               	add	x18, x20, #0x10
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x10
+               	str	s1, [x18]
                	fmov	s30, #1.25000000
                	fsub	s1, s0, s30
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x22, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x22, #0x10
-               	str	s2, [x14]
-               	add	x14, x22, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x0
-               	str	s2, [x14]
-               	add	x14, x22, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x4
-               	str	s2, [x14]
-               	add	x14, x22, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x8
-               	str	s2, [x14]
-               	add	x14, x22, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x23, #0xc
-               	str	s2, [x14]
-               	add	x14, x22, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x23, #0x10
-               	str	s2, [x14]
-               	add	x14, x23, #0x4
-               	str	s1, [x14]
-               	add	x14, x23, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x23, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x23, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x23, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x23, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x18, x15, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x21, #0x0
+               	str	s2, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x21, #0x4
+               	str	s2, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x21, #0x8
+               	str	s2, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x21, #0xc
+               	str	s2, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x21, #0x10
+               	str	s2, [x18]
+               	add	x18, x21, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x22, #0x0
+               	str	s2, [x18]
+               	add	x18, x21, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x22, #0x4
+               	str	s2, [x18]
+               	add	x18, x21, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x22, #0x8
+               	str	s2, [x18]
+               	add	x18, x21, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x22, #0xc
+               	str	s2, [x18]
+               	add	x18, x21, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x22, #0x10
+               	str	s2, [x18]
+               	add	x18, x22, #0x4
+               	str	s1, [x18]
+               	add	x18, x22, #0x0
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x0
+               	str	s1, [x18]
+               	add	x18, x22, #0x4
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x4
+               	str	s1, [x18]
+               	add	x18, x22, #0x8
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x8
+               	str	s1, [x18]
+               	add	x18, x22, #0xc
+               	ldr	s1, [x18]
+               	add	x18, x15, #0xc
+               	str	s1, [x18]
+               	add	x18, x22, #0x10
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x10
+               	str	s1, [x18]
                	mov	w16, #0x42c80000        // =1120403456
                	fmov	s31, w16
                	fsub	s1, s31, s0
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x24, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x24, #0x10
-               	str	s2, [x14]
-               	add	x14, x24, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x0
-               	str	s2, [x14]
-               	add	x14, x24, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x4
-               	str	s2, [x14]
-               	add	x14, x24, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x8
-               	str	s2, [x14]
-               	add	x14, x24, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x25, #0xc
-               	str	s2, [x14]
-               	add	x14, x24, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x25, #0x10
-               	str	s2, [x14]
-               	add	x14, x25, #0x8
-               	str	s1, [x14]
-               	add	x14, x25, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x25, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x25, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x25, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x25, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x18, x15, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x23, #0x0
+               	str	s2, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x23, #0x4
+               	str	s2, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x23, #0x8
+               	str	s2, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x23, #0xc
+               	str	s2, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x23, #0x10
+               	str	s2, [x18]
+               	add	x18, x23, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x24, #0x0
+               	str	s2, [x18]
+               	add	x18, x23, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x24, #0x4
+               	str	s2, [x18]
+               	add	x18, x23, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x24, #0x8
+               	str	s2, [x18]
+               	add	x18, x23, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x24, #0xc
+               	str	s2, [x18]
+               	add	x18, x23, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x24, #0x10
+               	str	s2, [x18]
+               	add	x18, x24, #0x8
+               	str	s1, [x18]
+               	add	x18, x24, #0x0
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x0
+               	str	s1, [x18]
+               	add	x18, x24, #0x4
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x4
+               	str	s1, [x18]
+               	add	x18, x24, #0x8
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x8
+               	str	s1, [x18]
+               	add	x18, x24, #0xc
+               	ldr	s1, [x18]
+               	add	x18, x15, #0xc
+               	str	s1, [x18]
+               	add	x18, x24, #0x10
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x10
+               	str	s1, [x18]
                	fmov	s30, #7.50000000
                	fadd	s1, s0, s30
-               	add	x14, x13, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x0
-               	str	s2, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x4
-               	str	s2, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x8
-               	str	s2, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x26, #0xc
-               	str	s2, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x26, #0x10
-               	str	s2, [x14]
-               	add	x14, x26, #0x0
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x0
-               	str	s2, [x14]
-               	add	x14, x26, #0x4
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x4
-               	str	s2, [x14]
-               	add	x14, x26, #0x8
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x8
-               	str	s2, [x14]
-               	add	x14, x26, #0xc
-               	ldr	s2, [x14]
-               	add	x14, x27, #0xc
-               	str	s2, [x14]
-               	add	x14, x26, #0x10
-               	ldr	s2, [x14]
-               	add	x14, x27, #0x10
-               	str	s2, [x14]
-               	add	x14, x27, #0xc
-               	str	s1, [x14]
-               	add	x14, x27, #0x0
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x0
-               	str	s1, [x14]
-               	add	x14, x27, #0x4
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x4
-               	str	s1, [x14]
-               	add	x14, x27, #0x8
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x8
-               	str	s1, [x14]
-               	add	x14, x27, #0xc
-               	ldr	s1, [x14]
-               	add	x14, x13, #0xc
-               	str	s1, [x14]
-               	add	x14, x27, #0x10
-               	ldr	s1, [x14]
-               	add	x14, x13, #0x10
-               	str	s1, [x14]
+               	add	x18, x15, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x25, #0x0
+               	str	s2, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x25, #0x4
+               	str	s2, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x25, #0x8
+               	str	s2, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x25, #0xc
+               	str	s2, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x25, #0x10
+               	str	s2, [x18]
+               	add	x18, x25, #0x0
+               	ldr	s2, [x18]
+               	add	x18, x26, #0x0
+               	str	s2, [x18]
+               	add	x18, x25, #0x4
+               	ldr	s2, [x18]
+               	add	x18, x26, #0x4
+               	str	s2, [x18]
+               	add	x18, x25, #0x8
+               	ldr	s2, [x18]
+               	add	x18, x26, #0x8
+               	str	s2, [x18]
+               	add	x18, x25, #0xc
+               	ldr	s2, [x18]
+               	add	x18, x26, #0xc
+               	str	s2, [x18]
+               	add	x18, x25, #0x10
+               	ldr	s2, [x18]
+               	add	x18, x26, #0x10
+               	str	s2, [x18]
+               	add	x18, x26, #0xc
+               	str	s1, [x18]
+               	add	x18, x26, #0x0
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x0
+               	str	s1, [x18]
+               	add	x18, x26, #0x4
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x4
+               	str	s1, [x18]
+               	add	x18, x26, #0x8
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x8
+               	str	s1, [x18]
+               	add	x18, x26, #0xc
+               	ldr	s1, [x18]
+               	add	x18, x15, #0xc
+               	str	s1, [x18]
+               	add	x18, x26, #0x10
+               	ldr	s1, [x18]
+               	add	x18, x15, #0x10
+               	str	s1, [x18]
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-               	add	x14, x13, #0x0
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x0
-               	str	s0, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x4
-               	str	s0, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x8
-               	str	s0, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s0, [x14]
-               	add	x14, x28, #0xc
-               	str	s0, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s0, [x14]
-               	add	x14, x28, #0x10
-               	str	s0, [x14]
-               	add	x14, x28, #0x0
-               	ldr	s0, [x14]
-               	mov	x16, #0xf810            // =63504
+               	add	x18, x15, #0x0
+               	ldr	s0, [x18]
+               	add	x18, x27, #0x0
+               	str	s0, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s0, [x18]
+               	add	x18, x27, #0x4
+               	str	s0, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s0, [x18]
+               	add	x18, x27, #0x8
+               	str	s0, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s0, [x18]
+               	add	x18, x27, #0xc
+               	str	s0, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s0, [x18]
+               	add	x18, x27, #0x10
+               	str	s0, [x18]
+               	add	x18, x27, #0x0
+               	ldr	s0, [x18]
+               	add	x18, x28, #0x0
+               	str	s0, [x18]
+               	add	x18, x27, #0x4
+               	ldr	s0, [x18]
+               	add	x18, x28, #0x4
+               	str	s0, [x18]
+               	add	x18, x27, #0x8
+               	ldr	s0, [x18]
+               	add	x18, x28, #0x8
+               	str	s0, [x18]
+               	add	x18, x27, #0xc
+               	ldr	s0, [x18]
+               	add	x18, x28, #0xc
+               	str	s0, [x18]
+               	add	x18, x27, #0x10
+               	ldr	s0, [x18]
+               	add	x18, x28, #0x10
+               	str	s0, [x18]
+               	add	x18, x28, #0x10
+               	str	s1, [x18]
+               	add	x18, x28, #0x0
+               	ldr	s0, [x18]
+               	add	x18, x15, #0x0
+               	str	s0, [x18]
+               	add	x18, x28, #0x4
+               	ldr	s0, [x18]
+               	add	x18, x15, #0x4
+               	str	s0, [x18]
+               	add	x18, x28, #0x8
+               	ldr	s0, [x18]
+               	add	x18, x15, #0x8
+               	str	s0, [x18]
+               	add	x18, x28, #0xc
+               	ldr	s0, [x18]
+               	add	x18, x15, #0xc
+               	str	s0, [x18]
+               	add	x18, x28, #0x10
+               	ldr	s0, [x18]
+               	add	x18, x15, #0x10
+               	str	s0, [x18]
+               	add	x18, x15, #0x0
+               	ldr	s0, [x18]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	str	s0, [x14]
-               	add	x14, x28, #0x4
-               	ldr	s0, [x14]
-               	mov	x16, #0xf810            // =63504
+               	add	x18, x9, #0x0
+               	str	s0, [x18]
+               	add	x18, x15, #0x4
+               	ldr	s0, [x18]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	str	s0, [x14]
-               	add	x14, x28, #0x8
-               	ldr	s0, [x14]
-               	mov	x16, #0xf810            // =63504
+               	add	x18, x9, #0x4
+               	str	s0, [x18]
+               	add	x18, x15, #0x8
+               	ldr	s0, [x18]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	str	s0, [x14]
-               	add	x14, x28, #0xc
-               	ldr	s0, [x14]
-               	mov	x16, #0xf810            // =63504
+               	add	x18, x9, #0x8
+               	str	s0, [x18]
+               	add	x18, x15, #0xc
+               	ldr	s0, [x18]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	str	s0, [x14]
-               	add	x14, x28, #0x10
-               	ldr	s0, [x14]
-               	mov	x16, #0xf810            // =63504
+               	add	x18, x9, #0xc
+               	str	s0, [x18]
+               	add	x18, x15, #0x10
+               	ldr	s0, [x18]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	str	s0, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	str	s1, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x0
-               	str	s0, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x4
-               	str	s0, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x8
-               	str	s0, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	ldr	s0, [x14]
-               	add	x14, x13, #0xc
-               	str	s0, [x14]
-               	mov	x16, #0xf810            // =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x10
-               	ldr	s0, [x14]
-               	add	x14, x13, #0x10
-               	str	s0, [x14]
-               	add	x14, x13, #0x0
-               	ldr	s0, [x14]
-               	mov	x16, #0xf808            // =63496
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x0
-               	str	s0, [x14]
-               	add	x14, x13, #0x4
-               	ldr	s0, [x14]
-               	mov	x16, #0xf808            // =63496
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x4
-               	str	s0, [x14]
-               	add	x14, x13, #0x8
-               	ldr	s0, [x14]
-               	mov	x16, #0xf808            // =63496
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x8
-               	str	s0, [x14]
-               	add	x14, x13, #0xc
-               	ldr	s0, [x14]
-               	mov	x16, #0xf808            // =63496
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x14, x9, #0xc
-               	str	s0, [x14]
-               	add	x14, x13, #0x10
-               	ldr	s0, [x14]
-               	mov	x16, #0xf808            // =63496
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x13, x9, #0x10
-               	str	s0, [x13]
+               	add	x15, x9, #0x10
+               	str	s0, [x15]
                	mov	x16, #0x14              // =20
-               	mul	x13, x1, x16
-               	add	x14, x19, x13
-               	mov	x16, #0xf808            // =63496
+               	mul	x15, x1, x16
+               	mov	x16, #0xf860            // =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x13, x9, #0x0
-               	ldr	s0, [x13]
-               	add	x13, x14, #0x0
-               	str	s0, [x13]
-               	mov	x16, #0xf808            // =63496
+               	add	x18, x9, x15
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x13, x9, #0x4
-               	ldr	s0, [x13]
-               	add	x13, x14, #0x4
-               	str	s0, [x13]
-               	mov	x16, #0xf808            // =63496
+               	add	x15, x9, #0x0
+               	ldr	s0, [x15]
+               	add	x15, x18, #0x0
+               	str	s0, [x15]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x13, x9, #0x8
-               	ldr	s0, [x13]
-               	add	x13, x14, #0x8
-               	str	s0, [x13]
-               	mov	x16, #0xf808            // =63496
+               	add	x15, x9, #0x4
+               	ldr	s0, [x15]
+               	add	x15, x18, #0x4
+               	str	s0, [x15]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x13, x9, #0xc
-               	ldr	s0, [x13]
-               	add	x13, x14, #0xc
-               	str	s0, [x13]
-               	mov	x16, #0xf808            // =63496
+               	add	x15, x9, #0x8
+               	ldr	s0, [x15]
+               	add	x15, x18, #0x8
+               	str	s0, [x15]
+               	mov	x16, #0xf910            // =63760
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x13, x9, #0x10
-               	ldr	s0, [x13]
-               	add	x13, x14, #0x10
-               	str	s0, [x13]
+               	add	x15, x9, #0xc
+               	ldr	s0, [x15]
+               	add	x15, x18, #0xc
+               	str	s0, [x15]
+               	mov	x16, #0xf910            // =63760
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x15, x9, #0x10
+               	ldr	s0, [x15]
+               	add	x15, x18, #0x10
+               	str	s0, [x15]
                	add	x1, x1, #0x1
                	cmp	x1, #0x5
-               	b.lo	 <L55>
-<L56>:
-               	mov	x20, x0
-               	mov	x21, #0x5               // =5
+               	b.lo	 <L38>
+<L39>:
+               	mov	x19, x0
+               	mov	x20, #0x5               // =5
                	mov	x17, #0x0               // =0
-               	cmp	x17, x21
-               	b.lo	 <L57>
-               	b	 <L63>
-<L57>:
-               	sub	x22, x21, #0x1
+               	cmp	x17, x20
+               	b.lo	 <L40>
+               	b	 <L42>
+<L40>:
+               	sub	x20, x20, #0x1
                	mov	x16, #0x14              // =20
-               	mul	x0, x22, x16
-               	add	x1, x19, x0
+               	mul	x0, x20, x16
+               	mov	x16, #0xf860            // =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2726,7 +3099,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2735,7 +3108,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2744,7 +3117,7 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2753,80 +3126,47 @@ Disassembly of section .text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s0, [x0]
-               	mov	x16, #0xf800            // =63488
+               	mov	x0, x19
+               	mov	x16, #0xf908            // =63752
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x0, x9, #0x0
-               	ldr	s0, [x0]
-               	mov	x0, x20
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xf800            // =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xf800            // =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xf800            // =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xf800            // =63488
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L62>:
-               	bl	 <L62>
-               	mov	x20, x0
-               	mov	x21, x22
+               	mov	x1, x9
+<L41>:
+               	bl	 <L41>
+               	mov	x19, x0
                	mov	x17, #0x0               // =0
-               	cmp	x17, x21
-               	b.lo	 <L57>
-<L63>:
-               	sub	x21, x29, #0x5a0
-               	str	xzr, [x21]
-               	str	xzr, [x21, #0x8]
-               	str	xzr, [x21, #0x10]
-               	str	xzr, [x21, #0x18]
-               	str	xzr, [x21, #0x20]
-               	str	xzr, [x21, #0x28]
-               	add	x0, x21, #0x0
+               	cmp	x17, x20
+               	b.lo	 <L40>
+<L42>:
+               	sub	x20, x29, #0x330
+               	str	xzr, [x20]
+               	str	xzr, [x20, #0x8]
+               	str	xzr, [x20, #0x10]
+               	str	xzr, [x20, #0x18]
+               	str	xzr, [x20, #0x20]
+               	str	xzr, [x20, #0x28]
+               	add	x0, x20, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
                	str	w17, [x0]
-               	add	x1, x19, #0x3c
+               	mov	x16, #0xf860            // =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x3c
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2835,7 +3175,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2844,7 +3184,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2853,7 +3193,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2862,413 +3202,219 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf7f8            // =63480
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	add	x22, x21, #0x10
-               	mov	x16, #0xf7f8            // =63480
+               	add	x1, x20, #0x10
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x0
-               	str	s0, [x1]
-               	mov	x16, #0xf7f8            // =63480
+               	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x0
+               	str	s0, [x2]
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x4
-               	str	s0, [x1]
-               	mov	x16, #0xf7f8            // =63480
+               	add	x2, x9, #0x4
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x4
+               	str	s0, [x2]
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x8
-               	str	s0, [x1]
-               	mov	x16, #0xf7f8            // =63480
+               	add	x2, x9, #0x8
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x8
+               	str	s0, [x2]
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-               	add	x1, x22, #0xc
-               	str	s0, [x1]
-               	mov	x16, #0xf7f8            // =63480
+               	add	x2, x9, #0xc
+               	ldr	s0, [x2]
+               	add	x2, x1, #0xc
+               	str	s0, [x2]
+               	mov	x16, #0xf900            // =63744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-               	add	x1, x22, #0x10
-               	str	s0, [x1]
-               	add	x1, x21, #0x24
+               	add	x2, x9, #0x10
+               	ldr	s0, [x2]
+               	add	x2, x1, #0x10
+               	str	s0, [x2]
+               	add	x1, x20, #0x24
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
-               	mov	x0, x20
-<L64>:
-               	bl	 <L64>
-               	add	x1, x22, #0x0
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L43>
+               	b	 <L44>
+<L43>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L43>
+<L44>:
+               	add	x0, x20, #0x10
+               	add	x1, x0, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	str	s0, [x1]
-               	add	x1, x22, #0x4
+               	add	x1, x0, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	str	s0, [x1]
-               	add	x1, x22, #0x8
+               	add	x1, x0, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	str	s0, [x1]
-               	add	x1, x22, #0xc
+               	add	x1, x0, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	str	s0, [x1]
-               	add	x1, x22, #0x10
+               	add	x1, x0, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	str	s0, [x1]
-               	mov	x16, #0xf7f0            // =63472
+               	add	x0, x9, #0x10
+               	str	s0, [x0]
+               	mov	x0, x19
+               	mov	x16, #0xf8f8            // =63736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xf7f0            // =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xf7f0            // =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xf7f0            // =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xf7f0            // =63472
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L69>:
-               	bl	 <L69>
-               	add	x1, x21, #0x24
+               	mov	x1, x9
+<L45>:
+               	bl	 <L45>
+               	add	x1, x20, #0x24
                	ldr	w2, [x1]
                	mov	w1, w2
-<L70>:
-               	bl	 <L70>
-               	add	x1, x19, #0x14
-               	add	x2, x1, #0x0
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L46>
+               	b	 <L47>
+<L46>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L46>
+<L47>:
+               	mov	x16, #0xf860            // =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	str	s0, [x2]
-               	add	x2, x1, #0x4
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	str	s0, [x2]
-               	add	x2, x1, #0x8
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	str	s0, [x2]
-               	add	x2, x1, #0xc
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	str	s0, [x2]
-               	add	x2, x1, #0x10
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s0, [x2]
-               	add	x2, x19, #0x50
-               	add	x3, x2, #0x0
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x0
-               	str	s0, [x3]
-               	add	x3, x2, #0x4
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x4
-               	str	s0, [x3]
-               	add	x3, x2, #0x8
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0x8
-               	str	s0, [x3]
-               	add	x3, x2, #0xc
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x3, x9, #0xc
-               	str	s0, [x3]
-               	add	x3, x2, #0x10
-               	ldr	s0, [x3]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s0, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	str	s2, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	str	s2, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	str	s2, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	str	s2, [x2]
-               	mov	x16, #0xf7e8            // =63464
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s0, [x2]
-               	mov	x16, #0xf7e0            // =63456
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	str	s2, [x2]
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x0
-               	str	s0, [x2]
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x4
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x4
-               	str	s0, [x2]
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x8
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x8
-               	str	s0, [x2]
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0xc
-               	ldr	s0, [x2]
-               	add	x2, x1, #0xc
-               	str	s0, [x2]
-               	mov	x16, #0xf7d8            // =63448
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x10
-               	ldr	s0, [x2]
-               	add	x2, x1, #0x10
-               	str	s0, [x2]
+               	add	x19, x9, #0x14
                	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8f0            // =63728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s0, [x1]
+               	add	x1, x19, #0x4
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8f0            // =63728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s0, [x1]
+               	add	x1, x19, #0x8
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8f0            // =63728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s0, [x1]
+               	add	x1, x19, #0xc
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8f0            // =63728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s0, [x1]
+               	add	x1, x19, #0x10
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8f0            // =63728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf860            // =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x50
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3277,7 +3423,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3286,7 +3432,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3295,7 +3441,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3304,62 +3450,177 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
                	ldr	s0, [x1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	str	s2, [x1]
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
                	ldr	s0, [x1]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	str	s2, [x1]
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
                	ldr	s0, [x1]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	str	s2, [x1]
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
                	ldr	s0, [x1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xf870            // =63600
+               	mov	x16, #0xf8e8            // =63720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	str	s2, [x1]
+               	mov	x16, #0xf8f0            // =63728
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	ldr	s0, [x1]
-<L75>:
-               	bl	 <L75>
-               	add	x1, x19, #0x14
+               	mov	x16, #0xf8e8            // =63720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s1, [x1]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	str	s2, [x1]
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x0
+               	str	s0, [x1]
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x4
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x4
+               	str	s0, [x1]
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x8
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x8
+               	str	s0, [x1]
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0xc
+               	ldr	s0, [x1]
+               	add	x1, x19, #0xc
+               	str	s0, [x1]
+               	mov	x16, #0xf8e0            // =63712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x10
+               	ldr	s0, [x1]
+               	add	x1, x19, #0x10
+               	str	s0, [x1]
+               	mov	x16, #0xf860            // =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x0
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3368,7 +3629,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3377,7 +3638,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3386,7 +3647,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3395,62 +3656,83 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xfa30            // =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L48>:
+               	bl	 <L48>
+               	add	x1, x19, #0x0
+               	ldr	s0, [x1]
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x0
+               	str	s0, [x1]
+               	add	x1, x19, #0x4
                	ldr	s0, [x1]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x4
+               	str	s0, [x1]
+               	add	x1, x19, #0x8
                	ldr	s0, [x1]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x8
+               	str	s0, [x1]
+               	add	x1, x19, #0xc
                	ldr	s0, [x1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0xc
+               	str	s0, [x1]
+               	add	x1, x19, #0x10
                	ldr	s0, [x1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xf850            // =63568
+               	mov	x16, #0xf8d8            // =63704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L80>:
-               	bl	 <L80>
-               	add	x1, x19, #0x28
+               	str	s0, [x1]
+               	mov	x16, #0xf8d8            // =63704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L49>:
+               	bl	 <L49>
+               	mov	x16, #0xf860            // =63584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x1, x9, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3459,7 +3741,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3468,7 +3750,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3477,7 +3759,7 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3486,61 +3768,24 @@ Disassembly of section .text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf7d0            // =63440
+               	mov	x16, #0xf8d0            // =63696
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x0
-               	ldr	s0, [x1]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xf7d0            // =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x4
-               	ldr	s0, [x1]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xf7d0            // =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x8
-               	ldr	s0, [x1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xf7d0            // =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0xc
-               	ldr	s0, [x1]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xf7d0            // =63440
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x1, x9, #0x10
-               	ldr	s0, [x1]
-<L85>:
-               	bl	 <L85>
-               	sub	x16, x29, #0x9b0
+               	mov	x1, x9
+<L50>:
+               	bl	 <L50>
+               	sub	x16, x29, #0x800
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x960
+               	sub	x16, x29, #0x7b0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-linux/vec/vec_scalar_mix.dis
+++ b/test/golden/aarch64-linux/vec/vec_scalar_mix.dis
@@ -3,165 +3,305 @@ vec/vec_scalar_mix.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_scalar_mix.fold_f32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[0]
-               	mov	x0, x1
+               	mov	s1, v0.s[0]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[1]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[2]
-               	mov	x0, x1
+               	mov	s1, v0.s[1]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	s0, v31.s[3]
-               	mov	x0, x1
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	s1, v0.s[2]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	s1, v0.s[3]
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_i32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	sxtw	x2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_u32x4>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x200
-               	stp	x19, x20, [x29, #-0x1b0]
-               	stp	x21, x22, [x29, #-0x1c0]
-               	mov	x16, #0xfe38            // =65080
+               	sub	sp, sp, #0x120
+               	stp	x19, x20, [x29, #-0xf0]
+               	stur	x21, [x29, #-0xf8]
+               	stp	d10, d11, [x29, #-0x108]
+               	stp	d12, d13, [x29, #-0x118]
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x23, [x29, x16]
-               	sub	x16, x29, #0x1d8
-               	stp	d9, d10, [x16]
-               	stp	d11, d12, [x16, #-0x10]
-               	stp	d13, d14, [x16, #-0x20]
-               	stur	d15, [x16, #-0x28]
+               	str	d14, [x29, x16]
                	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	x1, x0
                	ucvtf	s0, x19
                	mov	w20, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	x0, x29, #0x10
+               	add	x1, x0, #0x0
                	mov	w17, #0x3fc00000        // =1069547520
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x3, x2, #0x4
-               	str	s1, [x3]
-               	add	x3, x2, #0x8
+               	add	x1, x0, #0x4
+               	str	s1, [x1]
+               	add	x1, x0, #0x8
                	mov	w17, #0x40700000        // =1081081856
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x3, x2, #0xc
-               	str	s1, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	add	x1, x0, #0xc
+               	str	s1, [x1]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0x20
+               	add	x1, x0, #0x0
                	mov	w17, #0x3f000000        // =1056964608
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x1]
+               	add	x1, x0, #0x4
                	mov	w17, #0x40800000        // =1082130432
-               	str	w17, [x3]
+               	str	w17, [x1]
                	fmov	s31, #0.12500000
                	fneg	s2, s31
-               	add	x3, x2, #0x8
-               	str	s2, [x3]
-               	add	x3, x2, #0xc
+               	add	x1, x0, #0x8
+               	str	s2, [x1]
+               	add	x1, x0, #0xc
                	mov	w17, #0x41000000        // =1090519040
-               	str	w17, [x3]
-               	ldr	q2, [x2]
+               	str	w17, [x1]
+               	ldr	q2, [x0]
                	mov	s3, v1.s[0]
                	fadd	s4, s3, s0
                	mov	v30.16b, v1.16b
@@ -175,194 +315,235 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[0]
                	ldur	q31, [x29, #-0x90]
-               	mov	s10, v31.s[0]
-               	fmul	s11, s0, s10
+               	mov	s1, v31.s[0]
+               	fmul	s10, s0, s1
                	ldur	q31, [x29, #-0x80]
-               	mov	s12, v31.s[1]
+               	mov	s0, v31.s[1]
                	ldur	q31, [x29, #-0x90]
-               	mov	s13, v31.s[1]
-               	fmul	s14, s12, s13
+               	mov	s1, v31.s[1]
+               	fmul	s11, s0, s1
                	ldur	q31, [x29, #-0x80]
-               	mov	s15, v31.s[2]
-               	ldur	q31, [x29, #-0x90]
                	mov	s0, v31.s[2]
-               	fmul	s31, s15, s0
-               	stur	s31, [x29, #-0xa0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s30, v31.s[3]
-               	stur	s30, [x29, #-0xb0]
                	ldur	q31, [x29, #-0x90]
+               	mov	s1, v31.s[2]
+               	fmul	s12, s0, s1
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[3]
-               	ldur	s31, [x29, #-0xb0]
-               	fmul	s31, s31, s0
-               	stur	s31, [x29, #-0xc0]
-               	mov	x0, x1
-               	fmov	s0, s11
+               	ldur	q31, [x29, #-0x90]
+               	mov	s1, v31.s[3]
+               	fmul	s13, s0, s1
+               	fmov	w0, s10
+               	mov	w1, w0
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
+<L0>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xa0]
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xc0]
+               	fmov	w1, s12
+               	mov	w2, w1
+               	mov	x1, x2
 <L4>:
                	bl	 <L4>
-               	mov	x1, x0
-               	fadd	s31, s11, s14
-               	stur	s31, [x29, #-0xd0]
-               	mov	x0, x1
-               	ldur	s0, [x29, #-0xd0]
+               	fmov	w1, s13
+               	mov	w2, w1
+               	mov	x1, x2
 <L5>:
                	bl	 <L5>
-               	mov	x1, x0
-               	ldur	s31, [x29, #-0xd0]
-               	ldur	s30, [x29, #-0xa0]
-               	fadd	s11, s31, s30
-               	mov	x0, x1
-               	fmov	s0, s11
+               	fadd	s14, s10, s11
+               	fmov	w1, s14
+               	mov	w2, w1
+               	mov	x1, x2
 <L6>:
                	bl	 <L6>
-               	mov	x1, x0
-               	ldur	s30, [x29, #-0xc0]
-               	fadd	s14, s11, s30
-               	mov	x0, x1
-               	fmov	s0, s14
+               	fadd	s10, s14, s12
+               	fmov	w1, s10
+               	mov	w2, w1
+               	mov	x1, x2
 <L7>:
                	bl	 <L7>
-               	ldur	q31, [x29, #-0x80]
-               	mov	v0.16b, v31.16b
-               	mov	v0.s[0], v14.s[0]
-               	ldur	s31, [x29, #-0xb0]
-               	fsub	s1, s31, s10
-               	mov	v2.16b, v0.16b
-               	mov	v2.s[1], v1.s[0]
-               	fadd	s0, s13, s15
-               	mov	v1.16b, v2.16b
-               	mov	v1.s[2], v0.s[0]
-               	fmov	s31, wzr
-               	fsub	s0, s31, s12
-               	mov	v30.16b, v1.16b
-               	mov	v30.s[3], v0.s[0]
-               	stur	q30, [x29, #-0xe0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[0]
+               	fadd	s11, s10, s13
+               	fmov	w1, s11
+               	mov	w2, w1
+               	mov	x1, x2
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xe0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	v0.16b, v31.16b
+               	mov	v0.s[0], v11.s[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s1, v31.s[3]
+               	ldur	q31, [x29, #-0x90]
+               	mov	s2, v31.s[0]
+               	fsub	s3, s1, s2
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], v3.s[0]
+               	ldur	q31, [x29, #-0x90]
                	mov	s0, v31.s[1]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s2, v31.s[2]
+               	fadd	s3, s0, s2
+               	mov	v0.16b, v1.16b
+               	mov	v0.s[2], v3.s[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s10, v31.s[1]
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+               	mov	v30.16b, v0.16b
+               	mov	v30.s[3], v1.s[0]
+               	stur	q30, [x29, #-0xa0]
+               	ldur	q0, [x29, #-0xa0]
 <L9>:
                	bl	 <L9>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[2]
+               	ldur	q31, [x29, #-0xa0]
+               	ldur	q30, [x29, #-0x90]
+               	fmul	v0.4s, v31.4s, v30.4s
 <L10>:
                	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	s0, v31.s[3]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0x90]
-               	fmul	v31.4s, v31.4s, v30.4s
-               	stur	q31, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xf0]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[0]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
+               	fcmp	s0, s10
+               	cset	w1, mi
+               	cbnz	w1,  <L11>
+               	b	 <L12>
+<L11>:
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[1]
+<L12>:
+               	ldur	q31, [x29, #-0x80]
+               	mov	s1, v31.s[2]
+               	fcmp	s0, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L13>
+               	b	 <L14>
 <L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
+               	ldur	q31, [x29, #-0x80]
                	mov	s0, v31.s[2]
 <L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	s0, v31.s[3]
-<L15>:
-               	bl	 <L15>
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31.s[1]
+               	mov	s1, v31.s[3]
                	fcmp	s0, s1
                	cset	w1, mi
-               	cbnz	w1,  <L16>
-               	b	 <L17>
+               	cbnz	w1,  <L15>
+               	b	 <L16>
+<L15>:
+               	ldur	q31, [x29, #-0x80]
+               	mov	s0, v31.s[3]
 <L16>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[1]
+               	mov	s1, v31.s[0]
+               	ldur	q31, [x29, #-0x80]
+               	mov	s2, v31.s[1]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L17>
+               	b	 <L18>
 <L17>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31.s[2]
-               	fcmp	s0, s1
-               	cset	w1, mi
-               	cbnz	w1,  <L18>
-               	b	 <L19>
+               	mov	s1, v31.s[1]
 <L18>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[2]
+               	mov	s2, v31.s[2]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L19>
+               	b	 <L20>
 <L19>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31.s[3]
-               	fcmp	s0, s1
-               	cset	w1, mi
-               	cbnz	w1,  <L20>
-               	fmov	d9, d0
-               	b	 <L21>
+               	mov	s1, v31.s[2]
 <L20>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s9, v31.s[3]
+               	mov	s2, v31.s[3]
+               	fcmp	s2, s1
+               	cset	w1, mi
+               	cbnz	w1,  <L21>
+               	b	 <L22>
 <L21>:
                	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[0]
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31.s[1]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L22>
-               	b	 <L23>
-<L22>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[1]
-<L23>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s1, v31.s[2]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L24>
-               	b	 <L25>
-<L24>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s0, v31.s[2]
-<L25>:
-               	ldur	q31, [x29, #-0x80]
                	mov	s1, v31.s[3]
-               	fcmp	s1, s0
-               	cset	w1, mi
-               	cbnz	w1,  <L26>
-               	fmov	d10, d0
-               	b	 <L27>
+<L22>:
+               	fmov	w1, s0
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+               	b	 <L24>
+<L23>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L23>
+<L24>:
+               	fmov	w1, s1
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L25>
+               	b	 <L26>
+<L25>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L25>
 <L26>:
-               	ldur	q31, [x29, #-0x80]
-               	mov	s10, v31.s[3]
+               	fsub	s2, s0, s1
+               	fmov	w1, s2
+               	mov	w2, w1
+               	mov	x1, x2
 <L27>:
-               	fmov	s0, s9
-<L28>:
-               	bl	 <L28>
-               	fmov	s0, s10
-<L29>:
-               	bl	 <L29>
-               	fsub	s0, s9, s10
-<L30>:
-               	bl	 <L30>
+               	bl	 <L27>
                	sub	x1, x29, #0x30
                	add	x2, x1, #0x0
                	mov	w17, #0x7               // =7
@@ -384,116 +565,47 @@ Disassembly of section .text:
                	add	w3, w1, w2
                	mov	v30.16b, v0.16b
                	mov	v30.s[1], w3
-               	stur	q30, [x29, #-0x100]
+               	stur	q30, [x29, #-0xb0]
                	sub	x19, x29, #0x40
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov	w1, v31.s[0]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov	v2.16b, v1.16b
                	mov	v2.s[0], v0.s[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov	w1, v31.s[1]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov	v2.16b, v1.16b
                	mov	v2.s[1], v0.s[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov	w1, v31.s[2]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov	v2.16b, v1.16b
                	mov	v2.s[2], v0.s[0]
                	str	q2, [x19]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xb0]
                	mov	w1, v31.s[3]
                	scvtf	s0, w1
                	ldr	q1, [x19]
                	mov	v2.16b, v1.16b
                	mov	v2.s[3], v0.s[0]
                	str	q2, [x19]
-               	ldr	q31, [x19]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L34>:
-               	bl	 <L34>
+               	ldr	q0, [x19]
+<L28>:
+               	bl	 <L28>
                	ldr	q0, [x19]
                	ldur	q30, [x29, #-0x80]
-               	fmul	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L38>:
-               	bl	 <L38>
+               	fmul	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L29>:
+               	bl	 <L29>
                	sub	x21, x29, #0x50
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -533,124 +645,21 @@ Disassembly of section .text:
                	mov	v1.16b, v0.16b
                	mov	v1.s[3], w1
                	str	q1, [x21]
-               	ldr	q31, [x21]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L42>:
-               	bl	 <L42>
                	ldr	q0, [x21]
-               	ldur	q30, [x29, #-0x100]
-               	mul	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L46>:
-               	bl	 <L46>
+<L30>:
+               	bl	 <L30>
                	ldr	q0, [x21]
-               	ldur	q30, [x29, #-0x100]
-               	sub	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L48>:
-               	bl	 <L48>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L50>:
-               	bl	 <L50>
+               	ldur	q30, [x29, #-0xb0]
+               	mul	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L31>:
+               	bl	 <L31>
+               	ldr	q0, [x21]
+               	ldur	q30, [x29, #-0xb0]
+               	sub	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L32>:
+               	bl	 <L32>
                	sub	x1, x29, #0x60
                	add	x2, x1, #0x0
                	mov	w17, #0xffff            // =65535
@@ -672,201 +681,90 @@ Disassembly of section .text:
                	add	w2, w1, w20
                	mov	v30.16b, v0.16b
                	mov	v30.s[3], w2
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	stur	q30, [x29, #-0xc0]
+               	ldur	q31, [x29, #-0xc0]
                	mov	w19, v31.s[0]
                	mov	w1, w19
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w20, v31.s[1]
-               	eor	w21, w19, w20
-               	mov	w1, w21
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w22, v31.s[2]
-               	mul	w23, w21, w22
-               	mov	w1, w23
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-               	sub	w21, w23, w1
-               	mov	w1, w21
-<L54>:
-               	bl	 <L54>
-               	sub	x23, x29, #0x70
-               	str	xzr, [x23]
-               	str	xzr, [x23, #0x8]
-               	ldr	q0, [x23]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[0], w21
-               	str	q1, [x23]
-               	eor	w1, w21, w19
-               	ldr	q0, [x23]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[1], w1
-               	str	q1, [x23]
-               	add	w1, w21, w20
-               	ldr	q0, [x23]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[2], w1
-               	str	q1, [x23]
-               	sub	w1, w21, w22
-               	ldr	q0, [x23]
-               	mov	v1.16b, v0.16b
-               	mov	v1.s[3], w1
-               	str	q1, [x23]
-               	ldr	q31, [x23]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+<L33>:
+               	bl	 <L33>
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[1]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	eor	w20, w19, w1
+               	mov	w1, w20
+<L34>:
+               	bl	 <L34>
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[2]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	mul	w19, w20, w1
+               	mov	w1, w19
+<L35>:
+               	bl	 <L35>
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[3]
-<L58>:
-               	bl	 <L58>
-               	ldr	q0, [x23]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	sub	w20, w19, w1
+               	mov	w1, w20
+<L36>:
+               	bl	 <L36>
+               	sub	x19, x29, #0x70
+               	str	xzr, [x19]
+               	str	xzr, [x19, #0x8]
+               	ldr	q0, [x19]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[0], w20
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[0]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	eor	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[1], w2
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[1]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	add	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[2], w2
+               	str	q1, [x19]
+               	ldur	q31, [x29, #-0xc0]
                	mov	w1, v31.s[2]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L62>:
-               	bl	 <L62>
+               	sub	w2, w20, w1
+               	ldr	q0, [x19]
+               	mov	v1.16b, v0.16b
+               	mov	v1.s[3], w2
+               	str	q1, [x19]
+               	ldr	q0, [x19]
+<L37>:
+               	bl	 <L37>
+               	ldr	q0, [x19]
+               	ldur	q30, [x29, #-0xc0]
+               	add	v1.4s, v0.4s, v30.4s
+               	mov	v0.16b, v1.16b
+<L38>:
+               	bl	 <L38>
                	mov	x19, x0
                	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	stur	q31, [x29, #-0xe0]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x4
-               	b.lo	 <L63>
-               	b	 <L68>
-<L63>:
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	b.lo	 <L39>
+               	b	 <L41>
+<L39>:
+               	ldur	q31, [x29, #-0xe0]
                	mov	s0, v31.s[0]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s1, v31.s[3]
                	fadd	s2, s0, s1
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s0, v31.s[1]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	s3, v31.s[2]
                	fsub	s4, s0, s3
                	fmov	s30, #0.50000000
                	fmul	s0, s3, s30
                	fmov	s30, #1.25000000
                	fadd	s3, s1, s30
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xe0]
                	mov	v1.16b, v31.16b
                	mov	v1.s[0], v2.s[0]
                	mov	v2.16b, v1.16b
@@ -875,72 +773,28 @@ Disassembly of section .text:
                	mov	v1.s[2], v0.s[0]
                	mov	v30.16b, v1.16b
                	mov	v30.s[3], v3.s[0]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[0]
+               	stur	q30, [x29, #-0xd0]
                	mov	x0, x19
-<L64>:
-               	bl	 <L64>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[1]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[2]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31.s[3]
-<L67>:
-               	bl	 <L67>
+               	ldur	q0, [x29, #-0xd0]
+<L40>:
+               	bl	 <L40>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	stur	q31, [x29, #-0xe0]
                	cmp	x20, #0x4
-               	b.lo	 <L63>
-<L68>:
+               	b.lo	 <L39>
+<L41>:
                	mov	x0, x19
-               	sub	x16, x29, #0x1d8
-               	ldp	d9, d10, [x16]
-               	ldp	d11, d12, [x16, #-0x10]
-               	ldp	d13, d14, [x16, #-0x20]
-               	ldur	d15, [x16, #-0x28]
-               	ldp	x19, x20, [x29, #-0x1b0]
-               	ldp	x21, x22, [x29, #-0x1c0]
-               	mov	x16, #0xfe38            // =65080
+               	ldp	d10, d11, [x29, #-0x108]
+               	ldp	d12, d13, [x29, #-0x118]
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x23, [x29, x16]
+               	ldr	d14, [x29, x16]
+               	ldp	x19, x20, [x29, #-0xf0]
+               	ldur	x21, [x29, #-0xf8]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_u16x8.dis
+++ b/test/golden/aarch64-linux/vec/vec_u16x8.dis
@@ -3,1237 +3,553 @@ vec/vec_u16x8.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u16x8.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[0]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[1]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[2]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.h[3]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.h[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.h[4]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
+<L8>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+<L9>:
+               	umov	w1, v0.h[5]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
+<L10>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+<L11>:
+               	umov	w1, v0.h[6]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
+<L12>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+<L13>:
+               	umov	w1, v0.h[7]
+               	uxth	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
+<L14>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+<L15>:
                	ret
 
 <corpus.cases.vec.vec_u16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xfff0            // =65520
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x1               // =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x8000            // =32768
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xffff            // =65535
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x1001            // =4097
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x2               // =2
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x9c40            // =40000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x3039            // =12345
+               	strh	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x11              // =17
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0xffff            // =65535
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x8001            // =32769
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x1               // =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xea60            // =60000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x7530            // =30000
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x63c1            // =25537
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xd431            // =54321
+               	strh	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               // =1
+               	strh	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x3               // =3
+               	strh	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x9               // =9
+               	strh	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x1b              // =27
+               	strh	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x51              // =81
+               	strh	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xf3              // =243
+               	strh	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x2d9             // =729
+               	strh	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x88b             // =2187
+               	strh	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strh	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strh	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strh	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov	w0, v0.h[0]
+               	add	w2, w0, w1
+               	mov	v2.16b, v0.16b
+               	mov	v2.h[0], w2
+               	umov	w0, v2.h[6]
+               	add	w2, w0, w1
+               	mov	v30.16b, v2.16b
+               	mov	v30.h[6], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov	w0, v1.h[2]
+               	add	w2, w0, w1
+               	mov	v0.16b, v1.16b
+               	mov	v0.h[2], w2
+               	umov	w0, v0.h[7]
+               	add	w2, w0, w1
+               	mov	v30.16b, v0.16b
+               	mov	v30.h[7], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
-               	mov	w17, #0xfff0            // =65520
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x1               // =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x8000            // =32768
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0xffff            // =65535
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x1001            // =4097
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x2               // =2
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x9c40            // =40000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x3039            // =12345
-               	strh	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
-               	mov	w17, #0x11              // =17
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0xffff            // =65535
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x8001            // =32769
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x1               // =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0xea60            // =60000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0x7530            // =30000
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x63c1            // =25537
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0xd431            // =54321
-               	strh	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
-               	mov	w17, #0x1               // =1
-               	strh	w17, [x3]
-               	add	x3, x2, #0x2
-               	mov	w17, #0x3               // =3
-               	strh	w17, [x3]
-               	add	x3, x2, #0x4
-               	mov	w17, #0x9               // =9
-               	strh	w17, [x3]
-               	add	x3, x2, #0x6
-               	mov	w17, #0x1b              // =27
-               	strh	w17, [x3]
-               	add	x3, x2, #0x8
-               	mov	w17, #0x51              // =81
-               	strh	w17, [x3]
-               	add	x3, x2, #0xa
-               	mov	w17, #0xf3              // =243
-               	strh	w17, [x3]
-               	add	x3, x2, #0xc
-               	mov	w17, #0x2d9             // =729
-               	strh	w17, [x3]
-               	add	x3, x2, #0xe
-               	mov	w17, #0x88b             // =2187
-               	strh	w17, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x2
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x4
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x6
-               	strh	wzr, [x3]
-               	add	x3, x2, #0x8
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xa
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xc
-               	strh	wzr, [x3]
-               	add	x3, x2, #0xe
-               	strh	wzr, [x3]
-               	ldr	q31, [x2]
-               	stur	q31, [x29, #-0xd0]
-               	umov	w2, v0.h[0]
-               	add	w3, w2, w1
-               	mov	v2.16b, v0.16b
-               	mov	v2.h[0], w3
-               	umov	w2, v2.h[6]
-               	add	w3, w2, w1
-               	mov	v30.16b, v2.16b
-               	mov	v30.h[6], w3
-               	stur	q30, [x29, #-0xe0]
-               	umov	w2, v1.h[2]
-               	add	w3, w2, w1
-               	mov	v0.16b, v1.16b
-               	mov	v0.h[2], w3
-               	umov	w2, v0.h[7]
-               	add	w3, w2, w1
-               	mov	v30.16b, v0.16b
-               	mov	v30.h[7], w3
-               	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[4]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[5]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[6]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xe0]
-               	umov	w1, v31.h[7]
-<L8>:
-               	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[3]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[4]
-<L13>:
-               	bl	 <L13>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[5]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[6]
-<L15>:
-               	bl	 <L15>
-               	ldur	q31, [x29, #-0xf0]
-               	umov	w1, v31.h[7]
-<L16>:
-               	bl	 <L16>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.8h, v31.8h, v30.8h
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[0]
-<L17>:
-               	bl	 <L17>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[1]
-<L18>:
-               	bl	 <L18>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[2]
-<L19>:
-               	bl	 <L19>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[4]
-<L21>:
-               	bl	 <L21>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[5]
-<L22>:
-               	bl	 <L22>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[6]
-<L23>:
-               	bl	 <L23>
-               	ldur	q31, [x29, #-0x100]
-               	umov	w1, v31.h[7]
-<L24>:
-               	bl	 <L24>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L28>:
-               	bl	 <L28>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L32>:
-               	bl	 <L32>
+               	sub	v0.8h, v31.8h, v30.8h
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L40>:
-               	bl	 <L40>
+               	sub	v0.8h, v31.8h, v30.8h
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L44>:
-               	bl	 <L44>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L48>:
-               	bl	 <L48>
+               	mul	v0.8h, v31.8h, v30.8h
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L56>:
-               	bl	 <L56>
+               	mul	v0.8h, v31.8h, v30.8h
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L64>:
-               	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.8h, v31.8h, v30.8h
+               	mul	v0.8h, v31.8h, v30.8h
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
-               	mul	v31.8h, v0.8h, v30.8h
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L72>:
-               	bl	 <L72>
+               	mul	v0.8h, v31.8h, v30.8h
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L80>:
-               	bl	 <L80>
+               	sub	v0.8h, v31.8h, v30.8h
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.8h, v31.8h, v30.8h
-<L81>:
-               	bl	 <L81>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L82>:
-               	bl	 <L82>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L83>:
-               	bl	 <L83>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-<L84>:
-               	bl	 <L84>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-<L85>:
-               	bl	 <L85>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfe80            // =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L87>:
-               	bl	 <L87>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-               	b	 <L121>
-<L88>:
-               	mov	x16, #0xfe50            // =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
                	mov	x0, x19
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L108>:
-               	bl	 <L108>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfe50            // =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.8h, v31.8h, v30.8h
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L116>:
-               	bl	 <L116>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L120>:
-               	bl	 <L120>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L88>
-<L121>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1243,13 +559,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1258,7 +574,7 @@ Disassembly of section .text:
                	add	v0.8h, v31.8h, v30.8h
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1268,7 +584,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1276,89 +592,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-               	b	 <L131>
-<L122>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L128>:
-               	bl	 <L128>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L130>:
-               	bl	 <L130>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L122>
-<L131>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -1371,94 +620,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov	w1, v31.h[7]
-<L140>:
-               	bl	 <L140>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L141>:
-               	bl	 <L141>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_u32x4.dis
+++ b/test/golden/aarch64-linux/vec/vec_u32x4.dis
@@ -3,184 +3,235 @@ vec/vec_u32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u32x4.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[0]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[0]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[1]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[2]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	w1, v0.s[1]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	w2, v31.s[3]
-               	mov	x0, x1
-               	mov	w1, w2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	w1, v0.s[2]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
+<L4>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+<L5>:
+               	mov	w1, v0.s[3]
+               	mov	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
+<L6>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+<L7>:
                	ret
 
 <corpus.cases.vec.vec_u32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	mov	w1, w19
-               	sub	x2, x29, #0x10
-               	add	x3, x2, #0x0
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
                	mov	w17, #0xfff0            // =65520
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x1               // =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #-0x80000000       // =-2147483648
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	sub	x2, x29, #0x20
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
                	mov	w17, #0x11              // =17
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x1               // =1
                	movk	w17, #0x8000, lsl #16
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1               // =1
-               	str	w17, [x3]
-               	ldr	q1, [x2]
-               	sub	x2, x29, #0x30
-               	add	x3, x2, #0x0
+               	str	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
                	mov	w17, #0x1               // =1
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x0, #0x4
                	mov	w17, #0x3               // =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x0, #0x8
                	mov	w17, #0x9               // =9
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x0, #0xc
                	mov	w17, #0x1b              // =27
-               	str	w17, [x3]
-               	ldr	q31, [x2]
+               	str	w17, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xc0]
-               	sub	x2, x29, #0x40
-               	add	x3, x2, #0x0
-               	str	wzr, [x3]
-               	add	x3, x2, #0x4
-               	str	wzr, [x3]
-               	add	x3, x2, #0x8
-               	str	wzr, [x3]
-               	add	x3, x2, #0xc
-               	str	wzr, [x3]
-               	ldr	q31, [x2]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	str	wzr, [x2]
+               	add	x2, x0, #0x4
+               	str	wzr, [x2]
+               	add	x2, x0, #0x8
+               	str	wzr, [x2]
+               	add	x2, x0, #0xc
+               	str	wzr, [x2]
+               	ldr	q31, [x0]
                	stur	q31, [x29, #-0xd0]
-               	mov	w2, v0.s[0]
-               	add	w3, w2, w1
+               	mov	w0, v0.s[0]
+               	add	w2, w0, w1
                	mov	v2.16b, v0.16b
-               	mov	v2.s[0], w3
-               	mov	w2, v2.s[2]
-               	add	w3, w2, w1
+               	mov	v2.s[0], w2
+               	mov	w0, v2.s[2]
+               	add	w2, w0, w1
                	mov	v30.16b, v2.16b
-               	mov	v30.s[2], w3
+               	mov	v30.s[2], w2
                	stur	q30, [x29, #-0xe0]
-               	mov	w2, v1.s[1]
-               	add	w3, w2, w1
+               	mov	w0, v1.s[1]
+               	add	w2, w0, w1
                	mov	v0.16b, v1.16b
-               	mov	v0.s[1], w3
-               	mov	w2, v0.s[3]
-               	add	w3, w2, w1
+               	mov	v0.s[1], w2
+               	mov	w0, v0.s[3]
+               	add	w2, w0, w1
                	mov	v30.16b, v0.16b
-               	mov	v30.s[3], w3
+               	mov	v30.s[3], w2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[2]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	w1, v31.s[3]
-<L4>:
-               	bl	 <L4>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[0]
-<L5>:
-               	bl	 <L5>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[1]
-<L6>:
-               	bl	 <L6>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[2]
-<L7>:
-               	bl	 <L7>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	w1, v31.s[3]
-<L8>:
-               	bl	 <L8>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.4s, v31.4s, v30.4s
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[0]
-<L9>:
-               	bl	 <L9>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[2]
-<L11>:
-               	bl	 <L11>
-               	ldur	q31, [x29, #-0x100]
-               	mov	w1, v31.s[3]
-<L12>:
-               	bl	 <L12>
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	sub	v31.4s, v31.4s, v30.4s
+               	sub	v0.4s, v31.4s, v30.4s
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L5>:
+               	bl	 <L5>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L6>:
+               	bl	 <L6>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L7>:
+               	bl	 <L7>
+               	ldur	q31, [x29, #-0x100]
+               	ldur	q30, [x29, #-0xc0]
+               	mul	v0.4s, v31.4s, v30.4s
+<L8>:
+               	bl	 <L8>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L9>:
+               	bl	 <L9>
+               	ldur	q31, [x29, #-0xd0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub	v0.4s, v31.4s, v30.4s
+<L10>:
+               	bl	 <L10>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and	v31.16b, v31.16b, v30.16b
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -190,24 +241,35 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x29, x16]
+<L11>:
+               	bl	 <L11>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr	v31.16b, v31.16b, v30.16b
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfee0            // =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L12>:
+               	bl	 <L12>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor	v0.16b, v31.16b, v30.16b
 <L13>:
                	bl	 <L13>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn	v0.16b, v31.16b
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn	v0.16b, v31.16b
 <L15>:
                	bl	 <L15>
                	mov	x16, #0xfef0            // =65264
@@ -215,557 +277,159 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.4s, v31.4s, v30.4s
                	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L18>:
-               	bl	 <L18>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L20>:
-               	bl	 <L20>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L22>:
-               	bl	 <L22>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L23>:
-               	bl	 <L23>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L24>:
-               	bl	 <L24>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L25>:
-               	bl	 <L25>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.4s, v31.4s, v30.4s
-               	ldur	q30, [x29, #-0xc0]
-               	mul	v31.4s, v0.4s, v30.4s
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L36>:
-               	bl	 <L36>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L40>:
-               	bl	 <L40>
-               	ldur	q31, [x29, #-0xd0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub	v0.4s, v31.4s, v30.4s
-<L41>:
-               	bl	 <L41>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L42>:
-               	bl	 <L42>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q0, [x29, x16]
-<L43>:
-               	bl	 <L43>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor	v0.16b, v31.16b, v30.16b
-<L44>:
-               	bl	 <L44>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn	v0.16b, v31.16b
-<L45>:
-               	bl	 <L45>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn	v0.16b, v31.16b
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe80            // =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L47>:
-               	bl	 <L47>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-               	b	 <L65>
-<L48>:
-               	mov	x16, #0xfe50            // =65104
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xc0]
                	mul	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L51>:
-               	bl	 <L51>
-               	mov	x16, #0xfe60            // =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L52>:
-               	bl	 <L52>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L53>:
-               	bl	 <L53>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L54>:
-               	bl	 <L54>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L55>:
-               	bl	 <L55>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L56>:
-               	bl	 <L56>
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L57>:
-               	bl	 <L57>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L58>:
-               	bl	 <L58>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L59>:
-               	bl	 <L59>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L60>:
-               	bl	 <L60>
-               	mov	x16, #0xfe50            // =65104
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.4s, v31.4s, v30.4s
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L61>:
-               	bl	 <L61>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L62>:
-               	bl	 <L62>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L63>:
-               	bl	 <L63>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L64>:
-               	bl	 <L64>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L48>
-<L65>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -775,13 +439,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -790,7 +454,7 @@ Disassembly of section .text:
                	add	v0.4s, v31.4s, v30.4s
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -800,7 +464,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -808,57 +472,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-               	b	 <L71>
-<L66>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L68>:
-               	bl	 <L68>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L69>:
-               	bl	 <L69>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L70>:
-               	bl	 <L70>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L66>
-<L71>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -871,62 +500,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L72>:
-               	bl	 <L72>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[0]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	w1, v31.s[3]
-<L76>:
-               	bl	 <L76>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L77>:
-               	bl	 <L77>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_u64x2.dis
+++ b/test/golden/aarch64-linux/vec/vec_u64x2.dis
@@ -3,39 +3,57 @@ vec/vec_u64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u64x2.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x1, v0.d[0]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	mov	x2, v31.d[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	mov	x1, v0.d[1]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
+<L2>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L2>
+<L3>:
                	ret
 
 <corpus.cases.vec.vec_u64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
-               	mov	x19, x0
-<L0>:
-               	bl	 <L0>
-               	sub	x1, x29, #0x10
+               	sub	sp, sp, #0x1b0
+               	stp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
+               	sub	x1, x29, #0x80
                	add	x2, x1, #0x0
                	mov	x17, #0xfff0            // =65520
                	movk	x17, #0xffff, lsl #16
@@ -47,7 +65,7 @@ Disassembly of section .text:
                	movk	x17, #0x1234, lsl #16
                	str	x17, [x2]
                	ldr	q0, [x1]
-               	sub	x1, x29, #0x20
+               	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	x17, #0x11              // =17
                	str	x17, [x2]
@@ -58,7 +76,7 @@ Disassembly of section .text:
                	movk	x17, #0xffff, lsl #48
                	str	x17, [x2]
                	ldr	q1, [x1]
-               	sub	x1, x29, #0x30
+               	sub	x1, x29, #0xa0
                	add	x2, x1, #0x0
                	mov	x17, #0x1               // =1
                	str	x17, [x2]
@@ -67,7 +85,7 @@ Disassembly of section .text:
                	str	x17, [x2]
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xc0]
-               	sub	x1, x29, #0x40
+               	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	str	xzr, [x2]
                	add	x2, x1, #0x8
@@ -75,345 +93,205 @@ Disassembly of section .text:
                	ldr	q31, [x1]
                	stur	q31, [x29, #-0xd0]
                	mov	x1, v0.d[0]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov	v30.16b, v0.16b
                	mov	v30.d[0], x2
                	stur	q30, [x29, #-0xe0]
                	mov	x1, v1.d[1]
-               	add	x2, x1, x19
+               	add	x2, x1, x0
                	mov	v30.16b, v1.16b
                	mov	v30.d[1], x2
                	stur	q30, [x29, #-0xf0]
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
+<L0>:
+               	bl	 <L0>
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-<L2>:
-               	bl	 <L2>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[0]
-<L3>:
-               	bl	 <L3>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[1]
-<L4>:
-               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
                	stur	q31, [x29, #-0x100]
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q0, [x29, #-0x100]
+<L2>:
+               	bl	 <L2>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	sub	v0.2d, v31.2d, v30.2d
+<L3>:
+               	bl	 <L3>
+               	ldur	q31, [x29, #-0xf0]
+               	ldur	q30, [x29, #-0xe0]
+               	sub	v0.2d, v31.2d, v30.2d
+<L4>:
+               	bl	 <L4>
+               	ldur	q31, [x29, #-0xe0]
                	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L5>:
                	bl	 <L5>
-               	ldur	q31, [x29, #-0x100]
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xe0]
                	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xe0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L6>:
                	bl	 <L6>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xf0]
                	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0xf0]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L7>:
                	bl	 <L7>
-               	mov	x16, #0xfef0            // =65264
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x100]
+               	mov	x1, v31.d[0]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[0]
+               	mul	x3, x1, x2
+               	ldur	q31, [x29, #-0x100]
                	mov	x1, v31.d[1]
+               	ldur	q31, [x29, #-0xc0]
+               	mov	x2, v31.d[1]
+               	mul	x4, x1, x2
+               	ldur	q31, [x29, #-0x100]
+               	mov	v0.16b, v31.16b
+               	mov	v0.d[0], x3
+               	mov	v1.16b, v0.16b
+               	mov	v1.d[1], x4
+               	mov	v0.16b, v1.16b
 <L8>:
                	bl	 <L8>
-               	ldur	q31, [x29, #-0xf0]
-               	ldur	q30, [x29, #-0xe0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L9>:
-               	bl	 <L9>
-               	mov	x16, #0xfee0            // =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L10>:
-               	bl	 <L10>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L11>:
-               	bl	 <L11>
-               	mov	x16, #0xfed0            // =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L12>:
-               	bl	 <L12>
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xe0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L13>:
-               	bl	 <L13>
-               	mov	x16, #0xfec0            // =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L14>:
-               	bl	 <L14>
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov	x1, v31.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	ldur	q31, [x29, #-0xf0]
-               	mov	v0.16b, v31.16b
-               	mov	v0.d[0], x3
-               	mov	v30.16b, v0.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L15>:
-               	bl	 <L15>
-               	mov	x16, #0xfeb0            // =65200
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L16>:
-               	bl	 <L16>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	add	v0.2d, v31.2d, v30.2d
-               	mov	x1, v0.d[0]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[0]
-               	mul	x3, x1, x2
-               	mov	x1, v0.d[1]
-               	ldur	q31, [x29, #-0xc0]
-               	mov	x2, v31.d[1]
-               	mul	x4, x1, x2
-               	mov	v1.16b, v0.16b
-               	mov	v1.d[0], x3
-               	mov	v30.16b, v1.16b
-               	mov	v30.d[1], x4
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q30, [x29, x16]
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L17>:
-               	bl	 <L17>
-               	mov	x16, #0xfea0            // =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L18>:
-               	bl	 <L18>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
-               	sub	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L19>:
-               	bl	 <L19>
-               	mov	x16, #0xfe90            // =65168
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L20>:
-               	bl	 <L20>
+               	sub	v0.2d, v31.2d, v30.2d
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.2d, v31.2d, v30.2d
-<L21>:
-               	bl	 <L21>
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            // =65152
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L23>:
-               	bl	 <L23>
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-<L24>:
-               	bl	 <L24>
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-<L25>:
-               	bl	 <L25>
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-<L26>:
-               	bl	 <L26>
-               	mov	x16, #0xfe80            // =65152
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe70            // =65136
+               	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-<L27>:
-               	bl	 <L27>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-               	b	 <L37>
-<L28>:
-               	mov	x16, #0xfe60            // =65120
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -422,7 +300,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -431,7 +309,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -440,156 +318,120 @@ Disassembly of section .text:
                	mov	v0.d[0], x2
                	mov	v30.16b, v0.16b
                	mov	v30.d[1], x3
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
                	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L18>:
+               	bl	 <L18>
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L30>:
-               	bl	 <L30>
-               	mov	x16, #0xfe50            // =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            // =65072
+               	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v31.16b, v31.16b, v30.16b
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L19>:
+               	bl	 <L19>
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe20            // =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L32>:
-               	bl	 <L32>
-               	mov	x16, #0xfe40            // =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe10            // =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x16, #0xfe60            // =65120
+               	ldr	q0, [x29, x16]
+<L20>:
+               	bl	 <L20>
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.2d, v31.2d, v30.2d
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L35>:
-               	bl	 <L35>
-               	mov	x16, #0xfe00            // =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L36>:
-               	bl	 <L36>
+               	ldr	q0, [x29, x16]
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            // =65024
+               	mov	x16, #0xfe70            // =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            // =65056
+               	mov	x16, #0xfe90            // =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            // =65040
+               	mov	x16, #0xfe80            // =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            // =65088
+               	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L28>
-<L37>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -599,13 +441,13 @@ Disassembly of section .text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -614,7 +456,7 @@ Disassembly of section .text:
                	add	v0.2d, v31.2d, v30.2d
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -623,7 +465,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -632,7 +474,7 @@ Disassembly of section .text:
                	ldur	q31, [x29, #-0xc0]
                	mov	x1, v31.d[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe60            // =65120
+               	mov	x16, #0xfed0            // =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -644,7 +486,7 @@ Disassembly of section .text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe50            // =65104
+               	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -652,41 +494,22 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-               	b	 <L41>
-<L38>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
-               	ldr	q31, [x1]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
+               	ldr	q0, [x1]
                	mov	x0, x19
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            // =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L40>:
-               	bl	 <L40>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L38>
-<L41>:
-               	sub	x21, x29, #0xb0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
                	str	xzr, [x21, #0x10]
@@ -699,46 +522,64 @@ Disassembly of section .text:
                	str	w17, [x0]
                	add	x1, x20, #0x20
                	ldr	q0, [x1]
-               	add	x20, x21, #0x10
-               	str	q0, [x20]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
                	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x1]
                	ldr	w1, [x0]
+               	mov	w0, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x2, x1, x16
+               	lsr	x3, x0, x2
+               	mov	x16, #0xff              // =255
+               	and	x2, x3, x16
+               	eor	x3, x19, x2
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x19, x3, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	add	x0, x21, #0x10
+               	ldr	q0, [x0]
                	mov	x0, x19
-<L42>:
-               	bl	 <L42>
-               	ldr	q31, [x20]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[0]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfde0            // =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x1, v31.d[1]
-<L44>:
-               	bl	 <L44>
+<L28>:
+               	bl	 <L28>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L45>:
-               	bl	 <L45>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+               	mov	x2, #0x0                // =0
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+               	b	 <L30>
+<L29>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x2, x16
+               	lsr	x4, x1, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x8
+               	b.lo	 <L29>
+<L30>:
+               	ldp	x19, x20, [x29, #-0x1a0]
+               	mov	x16, #0xfe58            // =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-linux/vec/vec_u8x16.dis
+++ b/test/golden/aarch64-linux/vec/vec_u8x16.dis
@@ -3,124 +3,326 @@ vec/vec_u8x16.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u8x16.fold_vec>:
-               	stp	x29, x30, [sp, #-0x10]!
-               	mov	x29, sp
-               	sub	sp, sp, #0x10
-               	mov	x1, x0
-               	stur	q0, [x29, #-0x10]
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[0]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[0]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
+               	b	 <L1>
 <L0>:
-               	bl	 <L0>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[1]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L0>
 <L1>:
-               	bl	 <L1>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[2]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[1]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
+               	b	 <L3>
 <L2>:
-               	bl	 <L2>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[3]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L2>
 <L3>:
-               	bl	 <L3>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[4]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[2]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
+               	b	 <L5>
 <L4>:
-               	bl	 <L4>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[5]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L4>
 <L5>:
-               	bl	 <L5>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[6]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[3]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
+               	b	 <L7>
 <L6>:
-               	bl	 <L6>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[7]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L6>
 <L7>:
-               	bl	 <L7>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[8]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[4]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
+               	b	 <L9>
 <L8>:
-               	bl	 <L8>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[9]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L8>
 <L9>:
-               	bl	 <L9>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[10]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[5]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
+               	b	 <L11>
 <L10>:
-               	bl	 <L10>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[11]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L10>
 <L11>:
-               	bl	 <L11>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[12]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[6]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
+               	b	 <L13>
 <L12>:
-               	bl	 <L12>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[13]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L12>
 <L13>:
-               	bl	 <L13>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[14]
-               	mov	x0, x1
-               	mov	x1, x2
+               	umov	w1, v0.b[7]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
+               	b	 <L15>
 <L14>:
-               	bl	 <L14>
-               	mov	x1, x0
-               	ldur	q31, [x29, #-0x10]
-               	umov	w2, v31.b[15]
-               	mov	x0, x1
-               	mov	x1, x2
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L14>
 <L15>:
-               	bl	 <L15>
-               	mov	sp, x29
-               	ldp	x29, x30, [sp], #0x10
+               	umov	w1, v0.b[8]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+               	b	 <L17>
+<L16>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L16>
+<L17>:
+               	umov	w1, v0.b[9]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+               	b	 <L19>
+<L18>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L18>
+<L19>:
+               	umov	w1, v0.b[10]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+               	b	 <L21>
+<L20>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L20>
+<L21>:
+               	umov	w1, v0.b[11]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+               	b	 <L23>
+<L22>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L22>
+<L23>:
+               	umov	w1, v0.b[12]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+               	b	 <L25>
+<L24>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L24>
+<L25>:
+               	umov	w1, v0.b[13]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+               	b	 <L27>
+<L26>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L26>
+<L27>:
+               	umov	w1, v0.b[14]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+               	b	 <L29>
+<L28>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L28>
+<L29>:
+               	umov	w1, v0.b[15]
+               	uxtb	w2, w1
+               	mov	x1, #0x0                // =0
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+               	b	 <L31>
+<L30>:
+               	mov	x16, #0x8               // =8
+               	mul	x3, x1, x16
+               	lsr	x4, x2, x3
+               	mov	x16, #0xff              // =255
+               	and	x3, x4, x16
+               	eor	x4, x0, x3
+               	mov	x16, #0x1b3             // =435
+               	movk	x16, #0x100, lsl #32
+               	mul	x0, x4, x16
+               	add	x1, x1, #0x1
+               	cmp	x1, #0x8
+               	b.lo	 <L30>
+<L31>:
                	ret
 
 <corpus.cases.vec.vec_u8x16.checksum>:
@@ -133,289 +335,267 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x21, [x29, x16]
-               	mov	x19, x0
+               	mov	w1, w0
+               	sub	x0, x29, #0x80
+               	add	x2, x0, #0x0
+               	mov	w17, #0xf0              // =240
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x80              // =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0xff              // =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x11              // =17
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0xc8              // =200
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x63              // =99
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x7               // =7
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0xfa              // =250
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x21              // =33
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x80              // =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x40              // =64
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x5               // =5
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xc7              // =199
+               	strb	w17, [x2]
+               	ldr	q0, [x0]
+               	sub	x0, x29, #0x90
+               	add	x2, x0, #0x0
+               	mov	w17, #0x11              // =17
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0xff              // =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x81              // =129
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0xc8              // =200
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x64              // =100
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x39              // =57
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x15              // =21
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0xff              // =255
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x6               // =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0xde              // =222
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x80              // =128
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0xc0              // =192
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0xfb              // =251
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0x39              // =57
+               	strb	w17, [x2]
+               	ldr	q1, [x0]
+               	sub	x0, x29, #0xa0
+               	add	x2, x0, #0x0
+               	mov	w17, #0x1               // =1
+               	strb	w17, [x2]
+               	add	x2, x0, #0x1
+               	mov	w17, #0x3               // =3
+               	strb	w17, [x2]
+               	add	x2, x0, #0x2
+               	mov	w17, #0x9               // =9
+               	strb	w17, [x2]
+               	add	x2, x0, #0x3
+               	mov	w17, #0x1b              // =27
+               	strb	w17, [x2]
+               	add	x2, x0, #0x4
+               	mov	w17, #0x2               // =2
+               	strb	w17, [x2]
+               	add	x2, x0, #0x5
+               	mov	w17, #0x6               // =6
+               	strb	w17, [x2]
+               	add	x2, x0, #0x6
+               	mov	w17, #0x12              // =18
+               	strb	w17, [x2]
+               	add	x2, x0, #0x7
+               	mov	w17, #0x36              // =54
+               	strb	w17, [x2]
+               	add	x2, x0, #0x8
+               	mov	w17, #0x4               // =4
+               	strb	w17, [x2]
+               	add	x2, x0, #0x9
+               	mov	w17, #0xc               // =12
+               	strb	w17, [x2]
+               	add	x2, x0, #0xa
+               	mov	w17, #0x24              // =36
+               	strb	w17, [x2]
+               	add	x2, x0, #0xb
+               	mov	w17, #0x6c              // =108
+               	strb	w17, [x2]
+               	add	x2, x0, #0xc
+               	mov	w17, #0x8               // =8
+               	strb	w17, [x2]
+               	add	x2, x0, #0xd
+               	mov	w17, #0x18              // =24
+               	strb	w17, [x2]
+               	add	x2, x0, #0xe
+               	mov	w17, #0x48              // =72
+               	strb	w17, [x2]
+               	add	x2, x0, #0xf
+               	mov	w17, #0xd8              // =216
+               	strb	w17, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xc0]
+               	sub	x0, x29, #0xb0
+               	add	x2, x0, #0x0
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x1
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x2
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x3
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x4
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x5
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x6
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x7
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x8
+               	strb	wzr, [x2]
+               	add	x2, x0, #0x9
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xa
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xb
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xc
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xd
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xe
+               	strb	wzr, [x2]
+               	add	x2, x0, #0xf
+               	strb	wzr, [x2]
+               	ldr	q31, [x0]
+               	stur	q31, [x29, #-0xd0]
+               	umov	w0, v0.b[0]
+               	add	w2, w0, w1
+               	mov	v2.16b, v0.16b
+               	mov	v2.b[0], w2
+               	umov	w0, v2.b[7]
+               	add	w2, w0, w1
+               	mov	v30.16b, v2.16b
+               	mov	v30.b[7], w2
+               	stur	q30, [x29, #-0xe0]
+               	umov	w0, v1.b[3]
+               	add	w2, w0, w1
+               	mov	v0.16b, v1.16b
+               	mov	v0.b[3], w2
+               	umov	w0, v0.b[12]
+               	add	w2, w0, w1
+               	mov	v30.16b, v0.16b
+               	mov	v30.b[12], w2
+               	stur	q30, [x29, #-0xf0]
+               	mov	x0, #0x2325             // =8997
+               	movk	x0, #0x8422, lsl #16
+               	movk	x0, #0x9ce4, lsl #32
+               	movk	x0, #0xcbf2, lsl #48
+               	ldur	q0, [x29, #-0xe0]
 <L0>:
                	bl	 <L0>
-               	mov	x1, x0
-               	mov	w2, w19
-               	sub	x3, x29, #0x10
-               	add	x4, x3, #0x0
-               	mov	w17, #0xf0              // =240
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x80              // =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0xff              // =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x11              // =17
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0xc8              // =200
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x63              // =99
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x7               // =7
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0xfa              // =250
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x21              // =33
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x80              // =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x40              // =64
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x5               // =5
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xc7              // =199
-               	strb	w17, [x4]
-               	ldr	q0, [x3]
-               	sub	x3, x29, #0x20
-               	add	x4, x3, #0x0
-               	mov	w17, #0x11              // =17
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0xff              // =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x81              // =129
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0xc8              // =200
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x64              // =100
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x39              // =57
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x15              // =21
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0xff              // =255
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x6               // =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0xde              // =222
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x80              // =128
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0xc0              // =192
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0xfb              // =251
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0x39              // =57
-               	strb	w17, [x4]
-               	ldr	q1, [x3]
-               	sub	x3, x29, #0x30
-               	add	x4, x3, #0x0
-               	mov	w17, #0x1               // =1
-               	strb	w17, [x4]
-               	add	x4, x3, #0x1
-               	mov	w17, #0x3               // =3
-               	strb	w17, [x4]
-               	add	x4, x3, #0x2
-               	mov	w17, #0x9               // =9
-               	strb	w17, [x4]
-               	add	x4, x3, #0x3
-               	mov	w17, #0x1b              // =27
-               	strb	w17, [x4]
-               	add	x4, x3, #0x4
-               	mov	w17, #0x2               // =2
-               	strb	w17, [x4]
-               	add	x4, x3, #0x5
-               	mov	w17, #0x6               // =6
-               	strb	w17, [x4]
-               	add	x4, x3, #0x6
-               	mov	w17, #0x12              // =18
-               	strb	w17, [x4]
-               	add	x4, x3, #0x7
-               	mov	w17, #0x36              // =54
-               	strb	w17, [x4]
-               	add	x4, x3, #0x8
-               	mov	w17, #0x4               // =4
-               	strb	w17, [x4]
-               	add	x4, x3, #0x9
-               	mov	w17, #0xc               // =12
-               	strb	w17, [x4]
-               	add	x4, x3, #0xa
-               	mov	w17, #0x24              // =36
-               	strb	w17, [x4]
-               	add	x4, x3, #0xb
-               	mov	w17, #0x6c              // =108
-               	strb	w17, [x4]
-               	add	x4, x3, #0xc
-               	mov	w17, #0x8               // =8
-               	strb	w17, [x4]
-               	add	x4, x3, #0xd
-               	mov	w17, #0x18              // =24
-               	strb	w17, [x4]
-               	add	x4, x3, #0xe
-               	mov	w17, #0x48              // =72
-               	strb	w17, [x4]
-               	add	x4, x3, #0xf
-               	mov	w17, #0xd8              // =216
-               	strb	w17, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xc0]
-               	sub	x3, x29, #0x40
-               	add	x4, x3, #0x0
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x1
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x2
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x3
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x4
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x5
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x6
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x7
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x8
-               	strb	wzr, [x4]
-               	add	x4, x3, #0x9
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xa
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xb
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xc
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xd
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xe
-               	strb	wzr, [x4]
-               	add	x4, x3, #0xf
-               	strb	wzr, [x4]
-               	ldr	q31, [x3]
-               	stur	q31, [x29, #-0xd0]
-               	umov	w3, v0.b[0]
-               	add	w4, w3, w2
-               	mov	v2.16b, v0.16b
-               	mov	v2.b[0], w4
-               	umov	w3, v2.b[7]
-               	add	w4, w3, w2
-               	mov	v30.16b, v2.16b
-               	mov	v30.b[7], w4
-               	stur	q30, [x29, #-0xe0]
-               	umov	w3, v1.b[3]
-               	add	w4, w3, w2
-               	mov	v0.16b, v1.16b
-               	mov	v0.b[3], w4
-               	umov	w3, v0.b[12]
-               	add	w4, w3, w2
-               	mov	v30.16b, v0.16b
-               	mov	v30.b[12], w4
-               	stur	q30, [x29, #-0xf0]
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xe0]
+               	ldur	q0, [x29, #-0xf0]
 <L1>:
                	bl	 <L1>
-               	mov	x1, x0
-               	mov	x0, x1
-               	ldur	q0, [x29, #-0xf0]
-<L2>:
-               	bl	 <L2>
-               	mov	x1, x0
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	add	v31.16b, v31.16b, v30.16b
                	stur	q31, [x29, #-0x100]
-               	mov	x0, x1
                	ldur	q0, [x29, #-0x100]
-<L3>:
-               	bl	 <L3>
-               	mov	x1, x0
+<L2>:
+               	bl	 <L2>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L4>:
-               	bl	 <L4>
-               	mov	x1, x0
+<L3>:
+               	bl	 <L3>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xe0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L5>:
-               	bl	 <L5>
-               	mov	x1, x0
+<L4>:
+               	bl	 <L4>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L6>:
-               	bl	 <L6>
-               	mov	x1, x0
+<L5>:
+               	bl	 <L5>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L7>:
-               	bl	 <L7>
-               	mov	x1, x0
+<L6>:
+               	bl	 <L6>
                	ldur	q31, [x29, #-0xf0]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L8>:
-               	bl	 <L8>
-               	mov	x1, x0
+<L7>:
+               	bl	 <L7>
                	ldur	q31, [x29, #-0x100]
                	ldur	q30, [x29, #-0xc0]
                	mul	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L9>:
-               	bl	 <L9>
-               	mov	x1, x0
+<L8>:
+               	bl	 <L8>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xe0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L10>:
-               	bl	 <L10>
-               	mov	x1, x0
+<L9>:
+               	bl	 <L9>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
                	sub	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L11>:
-               	bl	 <L11>
-               	mov	x1, x0
+<L10>:
+               	bl	 <L10>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and	v31.16b, v31.16b, v30.16b
@@ -424,15 +604,13 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x0
+<L11>:
+               	bl	 <L11>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr	v31.16b, v31.16b, v30.16b
@@ -441,34 +619,26 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x0, x1
                	mov	x16, #0xfee0            // =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L13>:
-               	bl	 <L13>
-               	mov	x1, x0
+<L12>:
+               	bl	 <L12>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	eor	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L14>:
-               	bl	 <L14>
-               	mov	x1, x0
+<L13>:
+               	bl	 <L13>
                	ldur	q31, [x29, #-0xe0]
                	mvn	v0.16b, v31.16b
-               	mov	x0, x1
-<L15>:
-               	bl	 <L15>
-               	mov	x1, x0
+<L14>:
+               	bl	 <L14>
                	ldur	q31, [x29, #-0xf0]
                	mvn	v0.16b, v31.16b
-               	mov	x0, x1
-<L16>:
-               	bl	 <L16>
-               	mov	x1, x0
+<L15>:
+               	bl	 <L15>
                	mov	x16, #0xfef0            // =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -480,9 +650,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor	v0.16b, v31.16b, v30.16b
-               	mov	x0, x1
-<L17>:
-               	bl	 <L17>
+<L16>:
+               	bl	 <L16>
                	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfec0            // =65216
@@ -504,9 +673,9 @@ Disassembly of section .text:
                	str	q31, [x29, x16]
                	mov	x20, #0x0               // =0
                	cmp	x20, #0x6
-               	b.lo	 <L18>
-               	b	 <L23>
-<L18>:
+               	b.lo	 <L17>
+               	b	 <L22>
+<L17>:
                	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -525,8 +694,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L19>:
-               	bl	 <L19>
+<L18>:
+               	bl	 <L18>
                	mov	x16, #0xfeb0            // =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -548,8 +717,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L20>:
-               	bl	 <L20>
+<L19>:
+               	bl	 <L19>
                	mov	x16, #0xfea0            // =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -571,8 +740,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L21>:
-               	bl	 <L21>
+<L20>:
+               	bl	 <L20>
                	mov	x16, #0xfec0            // =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -590,8 +759,8 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L22>:
-               	bl	 <L22>
+<L21>:
+               	bl	 <L21>
                	add	x20, x20, #0x1
                	mov	x19, x0
                	mov	x16, #0xfe70            // =65136
@@ -625,9 +794,9 @@ Disassembly of section .text:
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L18>
-<L23>:
-               	sub	x20, x29, #0x80
+               	b.lo	 <L17>
+<L22>:
+               	sub	x20, x29, #0x40
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -670,51 +839,55 @@ Disassembly of section .text:
                	str	q31, [x0]
                	mov	x21, #0x0               // =0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-               	b	 <L26>
-<L24>:
+               	b.lo	 <L23>
+               	b	 <L25>
+<L23>:
                	mov	x16, #0x10              // =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q0, [x1]
                	mov	x0, x19
-<L25>:
-               	bl	 <L25>
+<L24>:
+               	bl	 <L24>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L24>
-<L26>:
-               	sub	x0, x29, #0xb0
-               	str	xzr, [x0]
-               	str	xzr, [x0, #0x8]
-               	str	xzr, [x0, #0x10]
-               	str	xzr, [x0, #0x18]
-               	str	xzr, [x0, #0x20]
-               	str	xzr, [x0, #0x28]
-               	add	x1, x0, #0x0
+               	b.lo	 <L23>
+<L25>:
+               	sub	x21, x29, #0x70
+               	str	xzr, [x21]
+               	str	xzr, [x21, #0x8]
+               	str	xzr, [x21, #0x10]
+               	str	xzr, [x21, #0x18]
+               	str	xzr, [x21, #0x20]
+               	str	xzr, [x21, #0x28]
+               	add	x0, x21, #0x0
                	mov	w17, #0xffff            // =65535
                	movk	w17, #0xffff, lsl #16
-               	str	w17, [x1]
-               	add	x2, x20, #0x20
-               	ldr	q0, [x2]
-               	add	x20, x0, #0x10
-               	str	q0, [x20]
-               	add	x21, x0, #0x20
+               	str	w17, [x0]
+               	add	x1, x20, #0x20
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	add	x1, x21, #0x20
                	mov	w17, #0x5678            // =22136
                	movk	w17, #0x1234, lsl #16
-               	str	w17, [x21]
-               	ldr	w2, [x1]
+               	str	w17, [x1]
+               	ldr	w1, [x0]
+               	mov	w2, w1
                	mov	x0, x19
-               	mov	w1, w2
+               	mov	x1, x2
+<L26>:
+               	bl	 <L26>
+               	add	x1, x21, #0x10
+               	ldr	q0, [x1]
 <L27>:
                	bl	 <L27>
-               	ldr	q0, [x20]
+               	add	x1, x21, #0x20
+               	ldr	w2, [x1]
+               	mov	w1, w2
 <L28>:
                	bl	 <L28>
-               	ldr	w1, [x21]
-<L29>:
-               	bl	 <L29>
                	ldp	x19, x20, [x29, #-0x1a0]
                	mov	x16, #0xfe58            // =65112
                	movk	x16, #0xffff, lsl #16

--- a/test/golden/riscv64-linux/bits/logic_u32.dis
+++ b/test/golden/riscv64-linux/bits/logic_u32.dis
@@ -3,173 +3,393 @@ bits/logic_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.logic_u32.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	sd	s8, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x34>
-               	mv	a1, a0
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	sd	s2, 0x20(sp)
+               	sd	s3, 0x18(sp)
+               	sd	s4, 0x10(sp)
+               	sd	s5, 0x8(sp)
+               	sd	s6, 0x0(sp)
+               	sext.w	s1, a0
                	li	t1, -0x1
-               	xor	s1, t1, s2
+               	xor	s2, t1, s1
                	lui	t1, 0xaaaab
                	addiw	t1, t1, -0x556
-               	xor	s3, t1, s2
+               	xor	s3, t1, s1
                	lui	t1, 0x55555
                	addiw	t1, t1, 0x555
-               	xor	s4, t1, s2
-               	and	s5, s2, s1
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x70>
-               	mv	a1, a0
-               	or	s6, s2, s1
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x88>
-               	mv	a1, a0
-               	xor	a2, s2, s1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0xa0>
-               	mv	a1, a0
-               	not	a2, s2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0xb8>
-               	mv	a1, a0
-               	not	a2, s1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0xd0>
-               	mv	a1, a0
-               	and	a2, s3, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0xe8>
-               	mv	a1, a0
-               	or	a2, s3, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x100>
-               	mv	a1, a0
-               	xor	s7, s3, s4
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x118>
-               	mv	a1, a0
-               	not	a2, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x130>
-               	mv	a1, a0
-               	not	a2, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x148>
-               	mv	a1, a0
-               	and	a2, s2, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x160>
-               	mv	a1, a0
-               	or	a2, s1, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x178>
-               	mv	a1, a0
-               	and	a2, s2, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x190>
-               	mv	a1, a0
-               	or	a2, s1, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x1a8>
-               	mv	a1, a0
-               	or	a2, s5, s7
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x1c0>
-               	mv	a1, a0
-               	not	a2, s6
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x1d8>
-               	mv	a1, a0
-               	not	a2, s5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x1f0>
-               	mv	a1, a0
-               	not	a2, s7
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x208>
-               	mv	s5, a0
-               	li	s6, 0x0
+               	xor	s4, t1, s1
+               	and	a0, s1, s2
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	s6, t0, 0x224 <corpus.cases.bits.logic_u32.checksum+0x224>
-               	j	0x274 <corpus.cases.bits.logic_u32.checksum+0x274>
-               	xor	s7, s2, s6
-               	or	a0, s1, s6
-               	xor	a1, s4, s6
-               	and	s8, s3, a1
-               	and	a1, s7, a0
-               	mv	a0, s5
+               	bltu	a2, t0, 0x88 <corpus.cases.bits.logic_u32.checksum+0x88>
+               	j	0xbc <corpus.cases.bits.logic_u32.checksum+0xbc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x88 <corpus.cases.bits.logic_u32.checksum+0x88>
+               	or	a1, s1, s2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd8 <corpus.cases.bits.logic_u32.checksum+0xd8>
+               	j	0x10c <corpus.cases.bits.logic_u32.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd8 <corpus.cases.bits.logic_u32.checksum+0xd8>
+               	xor	a1, s1, s2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x128 <corpus.cases.bits.logic_u32.checksum+0x128>
+               	j	0x15c <corpus.cases.bits.logic_u32.checksum+0x15c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x128 <corpus.cases.bits.logic_u32.checksum+0x128>
+               	not	a1, s1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.logic_u32.checksum+0x178>
+               	j	0x1ac <corpus.cases.bits.logic_u32.checksum+0x1ac>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.logic_u32.checksum+0x178>
+               	not	a1, s2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c8 <corpus.cases.bits.logic_u32.checksum+0x1c8>
+               	j	0x1fc <corpus.cases.bits.logic_u32.checksum+0x1fc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c8 <corpus.cases.bits.logic_u32.checksum+0x1c8>
+               	and	a1, s3, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x218 <corpus.cases.bits.logic_u32.checksum+0x218>
+               	j	0x24c <corpus.cases.bits.logic_u32.checksum+0x24c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x218 <corpus.cases.bits.logic_u32.checksum+0x218>
+               	or	a1, s3, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x268 <corpus.cases.bits.logic_u32.checksum+0x268>
+               	j	0x29c <corpus.cases.bits.logic_u32.checksum+0x29c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x268 <corpus.cases.bits.logic_u32.checksum+0x268>
+               	xor	a1, s3, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2b8 <corpus.cases.bits.logic_u32.checksum+0x2b8>
+               	j	0x2ec <corpus.cases.bits.logic_u32.checksum+0x2ec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2b8 <corpus.cases.bits.logic_u32.checksum+0x2b8>
+               	not	a1, s3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x308 <corpus.cases.bits.logic_u32.checksum+0x308>
+               	j	0x33c <corpus.cases.bits.logic_u32.checksum+0x33c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x308 <corpus.cases.bits.logic_u32.checksum+0x308>
+               	not	a1, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x358 <corpus.cases.bits.logic_u32.checksum+0x358>
+               	j	0x38c <corpus.cases.bits.logic_u32.checksum+0x38c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x358 <corpus.cases.bits.logic_u32.checksum+0x358>
+               	and	a1, s1, s3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3a8 <corpus.cases.bits.logic_u32.checksum+0x3a8>
+               	j	0x3dc <corpus.cases.bits.logic_u32.checksum+0x3dc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3a8 <corpus.cases.bits.logic_u32.checksum+0x3a8>
+               	or	a1, s2, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3f8 <corpus.cases.bits.logic_u32.checksum+0x3f8>
+               	j	0x42c <corpus.cases.bits.logic_u32.checksum+0x42c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3f8 <corpus.cases.bits.logic_u32.checksum+0x3f8>
+               	and	a1, s1, s4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x448 <corpus.cases.bits.logic_u32.checksum+0x448>
+               	j	0x47c <corpus.cases.bits.logic_u32.checksum+0x47c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x448 <corpus.cases.bits.logic_u32.checksum+0x448>
+               	or	a1, s2, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x23c>
-               	or	a1, s7, s8
+               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x480>
+               	and	s5, s1, s2
+               	xor	s6, s3, s4
+               	or	a1, s5, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x248>
-               	xor	a1, s7, s8
+               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x494>
+               	or	a1, s1, s2
                	not	a2, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x25c>
-               	addiw	s6, s6, 0x1
-               	mv	s5, a0
+               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x4a8>
+               	not	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x4b4>
+               	not	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.logic_u32.checksum+0x4c0>
+               	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	s6, t0, 0x224 <corpus.cases.bits.logic_u32.checksum+0x224>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	s8, 0x0(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x4d8 <corpus.cases.bits.logic_u32.checksum+0x4d8>
+               	j	0x5f0 <corpus.cases.bits.logic_u32.checksum+0x5f0>
+               	xor	a2, s1, a1
+               	or	a3, s2, a1
+               	xor	a4, s4, a1
+               	and	a5, s3, a4
+               	and	a4, a2, a3
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a4, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x508 <corpus.cases.bits.logic_u32.checksum+0x508>
+               	j	0x53c <corpus.cases.bits.logic_u32.checksum+0x53c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a3, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x508 <corpus.cases.bits.logic_u32.checksum+0x508>
+               	or	a3, a2, a5
+               	slli	a6, a3, 0x20
+               	srli	a6, a6, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x558 <corpus.cases.bits.logic_u32.checksum+0x558>
+               	j	0x58c <corpus.cases.bits.logic_u32.checksum+0x58c>
+               	li	t0, 0x8
+               	mul	a7, a3, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x558 <corpus.cases.bits.logic_u32.checksum+0x558>
+               	xor	a3, a2, a5
+               	not	a2, a3
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5ac <corpus.cases.bits.logic_u32.checksum+0x5ac>
+               	j	0x5e0 <corpus.cases.bits.logic_u32.checksum+0x5e0>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a4, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5ac <corpus.cases.bits.logic_u32.checksum+0x5ac>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a4
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d8 <corpus.cases.bits.logic_u32.checksum+0x4d8>
+               	ld	s1, 0x28(sp)
+               	ld	s2, 0x20(sp)
+               	ld	s3, 0x18(sp)
+               	ld	s4, 0x10(sp)
+               	ld	s5, 0x8(sp)
+               	ld	s6, 0x0(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret

--- a/test/golden/riscv64-linux/bits/logic_u64.dis
+++ b/test/golden/riscv64-linux/bits/logic_u64.dis
@@ -3,22 +3,17 @@ bits/logic_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.logic_u64.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	sd	s8, 0x0(sp)
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	sd	s2, 0x20(sp)
+               	sd	s3, 0x18(sp)
+               	sd	s4, 0x10(sp)
+               	sd	s5, 0x8(sp)
+               	sd	s6, 0x0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x34>
-               	mv	a1, a0
                	li	t1, -0x1
                	xor	s2, t1, s1
                	lui	t1, 0xfaaab
@@ -39,148 +34,344 @@ Disassembly of section .text:
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x555
                	xor	s4, t1, s1
-               	and	s5, s1, s2
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x9c>
-               	mv	a1, a0
-               	or	s6, s1, s2
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0xb4>
-               	mv	a1, a0
-               	xor	a2, s1, s2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0xcc>
-               	mv	a1, a0
-               	not	a2, s1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0xe4>
-               	mv	a1, a0
-               	not	a2, s2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0xfc>
-               	mv	a1, a0
-               	and	a2, s3, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x114>
-               	mv	a1, a0
-               	or	a2, s3, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x12c>
-               	mv	a1, a0
-               	xor	s7, s3, s4
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x144>
-               	mv	a1, a0
-               	not	a2, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x15c>
-               	mv	a1, a0
-               	not	a2, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x174>
-               	mv	a1, a0
-               	and	a2, s1, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x18c>
-               	mv	a1, a0
-               	or	a2, s2, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x1a4>
-               	mv	a1, a0
-               	and	a2, s1, s4
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x1bc>
-               	mv	a1, a0
+               	and	a0, s1, s2
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb0 <corpus.cases.bits.logic_u64.checksum+0xb0>
+               	j	0xe4 <corpus.cases.bits.logic_u64.checksum+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb0 <corpus.cases.bits.logic_u64.checksum+0xb0>
+               	or	a0, s1, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8 <corpus.cases.bits.logic_u64.checksum+0xf8>
+               	j	0x12c <corpus.cases.bits.logic_u64.checksum+0x12c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8 <corpus.cases.bits.logic_u64.checksum+0xf8>
+               	xor	a0, s1, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x140 <corpus.cases.bits.logic_u64.checksum+0x140>
+               	j	0x174 <corpus.cases.bits.logic_u64.checksum+0x174>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x140 <corpus.cases.bits.logic_u64.checksum+0x140>
+               	not	a0, s1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x188 <corpus.cases.bits.logic_u64.checksum+0x188>
+               	j	0x1bc <corpus.cases.bits.logic_u64.checksum+0x1bc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x188 <corpus.cases.bits.logic_u64.checksum+0x188>
+               	not	a0, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1d0 <corpus.cases.bits.logic_u64.checksum+0x1d0>
+               	j	0x204 <corpus.cases.bits.logic_u64.checksum+0x204>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1d0 <corpus.cases.bits.logic_u64.checksum+0x1d0>
+               	and	a0, s3, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x218 <corpus.cases.bits.logic_u64.checksum+0x218>
+               	j	0x24c <corpus.cases.bits.logic_u64.checksum+0x24c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x218 <corpus.cases.bits.logic_u64.checksum+0x218>
+               	or	a0, s3, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.bits.logic_u64.checksum+0x260>
+               	j	0x294 <corpus.cases.bits.logic_u64.checksum+0x294>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.bits.logic_u64.checksum+0x260>
+               	xor	a0, s3, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2a8 <corpus.cases.bits.logic_u64.checksum+0x2a8>
+               	j	0x2dc <corpus.cases.bits.logic_u64.checksum+0x2dc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2a8 <corpus.cases.bits.logic_u64.checksum+0x2a8>
+               	not	a0, s3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2f0 <corpus.cases.bits.logic_u64.checksum+0x2f0>
+               	j	0x324 <corpus.cases.bits.logic_u64.checksum+0x324>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2f0 <corpus.cases.bits.logic_u64.checksum+0x2f0>
+               	not	a0, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x338 <corpus.cases.bits.logic_u64.checksum+0x338>
+               	j	0x36c <corpus.cases.bits.logic_u64.checksum+0x36c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x338 <corpus.cases.bits.logic_u64.checksum+0x338>
+               	and	a0, s1, s3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x380 <corpus.cases.bits.logic_u64.checksum+0x380>
+               	j	0x3b4 <corpus.cases.bits.logic_u64.checksum+0x3b4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x380 <corpus.cases.bits.logic_u64.checksum+0x380>
+               	or	a0, s2, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c8 <corpus.cases.bits.logic_u64.checksum+0x3c8>
+               	j	0x3fc <corpus.cases.bits.logic_u64.checksum+0x3fc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c8 <corpus.cases.bits.logic_u64.checksum+0x3c8>
+               	and	a0, s1, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x410 <corpus.cases.bits.logic_u64.checksum+0x410>
+               	j	0x444 <corpus.cases.bits.logic_u64.checksum+0x444>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x410 <corpus.cases.bits.logic_u64.checksum+0x410>
                	or	a2, s2, s3
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x1d4>
-               	mv	a1, a0
-               	or	a2, s5, s7
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x450>
+               	and	s5, s1, s2
+               	xor	s6, s3, s4
+               	or	a1, s5, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x1ec>
-               	mv	a1, a0
-               	not	a2, s6
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x204>
-               	mv	a1, a0
-               	not	a2, s5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x21c>
-               	mv	a1, a0
-               	not	a2, s7
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x234>
-               	mv	s5, a0
-               	li	s6, 0x0
-               	li	t0, 0x8
-               	bltu	s6, t0, 0x250 <corpus.cases.bits.logic_u64.checksum+0x250>
-               	j	0x2a0 <corpus.cases.bits.logic_u64.checksum+0x2a0>
-               	xor	s7, s1, s6
-               	or	a0, s2, s6
-               	xor	a1, s4, s6
-               	and	s8, s3, a1
-               	and	a1, s7, a0
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x268>
-               	or	a1, s7, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x274>
-               	xor	a1, s7, s8
+               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x464>
+               	or	a1, s1, s2
                	not	a2, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x288>
-               	addi	s6, s6, 0x1
-               	mv	s5, a0
+               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x478>
+               	not	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x484>
+               	not	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.logic_u64.checksum+0x490>
+               	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	s6, t0, 0x250 <corpus.cases.bits.logic_u64.checksum+0x250>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	s8, 0x0(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x4a8 <corpus.cases.bits.logic_u64.checksum+0x4a8>
+               	j	0x5a8 <corpus.cases.bits.logic_u64.checksum+0x5a8>
+               	xor	a2, s1, a1
+               	or	a3, s2, a1
+               	xor	a4, s4, a1
+               	and	a5, s3, a4
+               	and	a4, a2, a3
+               	mv	a3, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x4d0 <corpus.cases.bits.logic_u64.checksum+0x4d0>
+               	j	0x504 <corpus.cases.bits.logic_u64.checksum+0x504>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a3, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x4d0 <corpus.cases.bits.logic_u64.checksum+0x4d0>
+               	or	a4, a2, a5
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x518 <corpus.cases.bits.logic_u64.checksum+0x518>
+               	j	0x54c <corpus.cases.bits.logic_u64.checksum+0x54c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a3, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x518 <corpus.cases.bits.logic_u64.checksum+0x518>
+               	xor	a4, a2, a5
+               	not	a2, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x564 <corpus.cases.bits.logic_u64.checksum+0x564>
+               	j	0x598 <corpus.cases.bits.logic_u64.checksum+0x598>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x564 <corpus.cases.bits.logic_u64.checksum+0x564>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4a8 <corpus.cases.bits.logic_u64.checksum+0x4a8>
+               	ld	s1, 0x28(sp)
+               	ld	s2, 0x20(sp)
+               	ld	s3, 0x18(sp)
+               	ld	s4, 0x10(sp)
+               	ld	s5, 0x8(sp)
+               	ld	s6, 0x0(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret

--- a/test/golden/riscv64-linux/bits/shift_i32.dis
+++ b/test/golden/riscv64-linux/bits/shift_i32.dis
@@ -3,201 +3,395 @@ bits/shift_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.shift_i32.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x30>
-               	mv	a1, a0
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
+               	sd	s4, 0x0(sp)
+               	sext.w	s1, a0
                	li	t1, -0x1
-               	xor	s1, t1, s2
+               	xor	s2, t1, s1
                	lui	t1, 0xaaaab
                	addiw	t1, t1, -0x556
-               	xor	s3, t1, s2
+               	xor	s3, t1, s1
                	lui	t1, 0x55555
                	addiw	t1, t1, 0x555
-               	xor	s4, t1, s2
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x68>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x80>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x98>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0xac>
-               	mv	a1, a0
-               	sraiw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0xc4>
-               	mv	a1, a0
-               	sraiw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0xdc>
-               	mv	a1, a0
-               	slliw	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0xf4>
-               	mv	a1, a0
-               	sraiw	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x10c>
-               	mv	a1, a0
-               	sraiw	a2, s3, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x124>
-               	mv	a1, a0
-               	slliw	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x13c>
-               	mv	a1, a0
+               	xor	s4, t1, s1
+               	sext.w	a0, s2
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x78 <corpus.cases.bits.shift_i32.checksum+0x78>
+               	j	0xac <corpus.cases.bits.shift_i32.checksum+0xac>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x78 <corpus.cases.bits.shift_i32.checksum+0x78>
+               	slliw	a0, s2, 0x1
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc4 <corpus.cases.bits.shift_i32.checksum+0xc4>
+               	j	0xf8 <corpus.cases.bits.shift_i32.checksum+0xf8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc4 <corpus.cases.bits.shift_i32.checksum+0xc4>
+               	slliw	a0, s2, 0x1f
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x110 <corpus.cases.bits.shift_i32.checksum+0x110>
+               	j	0x144 <corpus.cases.bits.shift_i32.checksum+0x144>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x110 <corpus.cases.bits.shift_i32.checksum+0x110>
+               	sext.w	a0, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x158 <corpus.cases.bits.shift_i32.checksum+0x158>
+               	j	0x18c <corpus.cases.bits.shift_i32.checksum+0x18c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x158 <corpus.cases.bits.shift_i32.checksum+0x158>
+               	sraiw	a0, s2, 0x1
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1a4 <corpus.cases.bits.shift_i32.checksum+0x1a4>
+               	j	0x1d8 <corpus.cases.bits.shift_i32.checksum+0x1d8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1a4 <corpus.cases.bits.shift_i32.checksum+0x1a4>
+               	sraiw	a0, s2, 0x1f
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1f0 <corpus.cases.bits.shift_i32.checksum+0x1f0>
+               	j	0x224 <corpus.cases.bits.shift_i32.checksum+0x224>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1f0 <corpus.cases.bits.shift_i32.checksum+0x1f0>
+               	slliw	a0, s3, 0x1
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x23c <corpus.cases.bits.shift_i32.checksum+0x23c>
+               	j	0x270 <corpus.cases.bits.shift_i32.checksum+0x270>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x23c <corpus.cases.bits.shift_i32.checksum+0x23c>
+               	sraiw	a0, s3, 0x1
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x288 <corpus.cases.bits.shift_i32.checksum+0x288>
+               	j	0x2bc <corpus.cases.bits.shift_i32.checksum+0x2bc>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x288 <corpus.cases.bits.shift_i32.checksum+0x288>
+               	sraiw	a0, s3, 0x1f
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2d4 <corpus.cases.bits.shift_i32.checksum+0x2d4>
+               	j	0x308 <corpus.cases.bits.shift_i32.checksum+0x308>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2d4 <corpus.cases.bits.shift_i32.checksum+0x2d4>
+               	slliw	a0, s4, 0x1
+               	sext.w	a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x320 <corpus.cases.bits.shift_i32.checksum+0x320>
+               	j	0x354 <corpus.cases.bits.shift_i32.checksum+0x354>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x320 <corpus.cases.bits.shift_i32.checksum+0x320>
                	sraiw	a2, s4, 0x1
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x154>
-               	mv	a1, a0
-               	slliw	a2, s2, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x360>
+               	slliw	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x16c>
-               	mv	a1, a0
-               	sraiw	a2, s2, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x36c>
+               	sraiw	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x184>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x378>
+               	slliw	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x19c>
-               	mv	a1, a0
-               	sraiw	a2, s1, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x384>
+               	sraiw	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x1b4>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x390>
+               	slliw	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x1cc>
-               	mv	a1, a0
-               	sraiw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x39c>
+               	sraiw	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x1e4>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x3a8>
+               	slliw	a1, s2, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x1fc>
-               	mv	a1, a0
-               	sraiw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x3b4>
+               	sraiw	a1, s2, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x214>
-               	mv	a1, a0
-               	slliw	a2, s3, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x3c0>
+               	slliw	a1, s3, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x22c>
-               	mv	a1, a0
-               	sraiw	a2, s3, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x3cc>
+               	sraiw	a1, s3, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x244>
-               	mv	s5, a0
-               	li	s6, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x3d8>
+               	li	a1, 0x0
                	li	t0, 0x20
-               	bltu	s6, t0, 0x260 <corpus.cases.bits.shift_i32.checksum+0x260>
-               	j	0x2a8 <corpus.cases.bits.shift_i32.checksum+0x2a8>
-               	sllw	a1, s1, s6
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x268>
-               	sraw	a1, s1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x274>
-               	addw	s7, s6, s2
-               	sllw	a1, s3, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x284>
-               	sraw	a1, s4, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x290>
-               	addiw	s6, s6, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x3f0 <corpus.cases.bits.shift_i32.checksum+0x3f0>
+               	j	0x53c <corpus.cases.bits.shift_i32.checksum+0x53c>
+               	sllw	a2, s2, a1
+               	sext.w	a3, a2
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x40c <corpus.cases.bits.shift_i32.checksum+0x40c>
+               	j	0x440 <corpus.cases.bits.shift_i32.checksum+0x440>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x40c <corpus.cases.bits.shift_i32.checksum+0x40c>
+               	sraw	a3, s2, a1
+               	sext.w	a4, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x458 <corpus.cases.bits.shift_i32.checksum+0x458>
+               	j	0x48c <corpus.cases.bits.shift_i32.checksum+0x48c>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x458 <corpus.cases.bits.shift_i32.checksum+0x458>
+               	addw	a3, a1, s1
+               	sllw	a4, s3, a3
+               	sext.w	a3, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4a8 <corpus.cases.bits.shift_i32.checksum+0x4a8>
+               	j	0x4dc <corpus.cases.bits.shift_i32.checksum+0x4dc>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4a8 <corpus.cases.bits.shift_i32.checksum+0x4a8>
+               	addw	a3, a1, s1
+               	sraw	a4, s4, a3
+               	sext.w	a3, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4f8 <corpus.cases.bits.shift_i32.checksum+0x4f8>
+               	j	0x52c <corpus.cases.bits.shift_i32.checksum+0x52c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4f8 <corpus.cases.bits.shift_i32.checksum+0x4f8>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a2
                	li	t0, 0x20
-               	bltu	s6, t0, 0x260 <corpus.cases.bits.shift_i32.checksum+0x260>
-               	li	s3, 0x1e
+               	bltu	a1, t0, 0x3f0 <corpus.cases.bits.shift_i32.checksum+0x3f0>
+               	li	a1, 0x1e
                	li	t0, 0x28
-               	bltu	s3, t0, 0x2b8 <corpus.cases.bits.shift_i32.checksum+0x2b8>
-               	j	0x2e8 <corpus.cases.bits.shift_i32.checksum+0x2e8>
-               	addw	s4, s3, s2
-               	sllw	a1, s1, s4
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x2c4>
-               	sraw	a1, s1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i32.checksum+0x2d0>
-               	addiw	s3, s3, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x54c <corpus.cases.bits.shift_i32.checksum+0x54c>
+               	j	0x600 <corpus.cases.bits.shift_i32.checksum+0x600>
+               	addw	a2, a1, s1
+               	sllw	a3, s2, a2
+               	sext.w	a2, a3
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x56c <corpus.cases.bits.shift_i32.checksum+0x56c>
+               	j	0x5a0 <corpus.cases.bits.shift_i32.checksum+0x5a0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x56c <corpus.cases.bits.shift_i32.checksum+0x56c>
+               	addw	a2, a1, s1
+               	sraw	a4, s2, a2
+               	sext.w	a2, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x5bc <corpus.cases.bits.shift_i32.checksum+0x5bc>
+               	j	0x5f0 <corpus.cases.bits.shift_i32.checksum+0x5f0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x5bc <corpus.cases.bits.shift_i32.checksum+0x5bc>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x28
-               	bltu	s3, t0, 0x2b8 <corpus.cases.bits.shift_i32.checksum+0x2b8>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x54c <corpus.cases.bits.shift_i32.checksum+0x54c>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	s4, 0x0(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/bits/shift_i64.dis
+++ b/test/golden/riscv64-linux/bits/shift_i64.dis
@@ -3,21 +3,15 @@ bits/shift_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.shift_i64.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
+               	sd	s4, 0x0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x30>
-               	mv	a1, a0
                	li	t1, -0x1
                	xor	s2, t1, s1
                	lui	t1, 0xfaaab
@@ -38,177 +32,360 @@ Disassembly of section .text:
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x555
                	xor	s4, t1, s1
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x94>
-               	mv	a1, a0
-               	slli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0xac>
-               	mv	a1, a0
-               	slli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0xc4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0xd8>
-               	mv	a1, a0
-               	srai	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0xf0>
-               	mv	a1, a0
-               	srai	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x108>
-               	mv	a1, a0
-               	slli	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x120>
-               	mv	a1, a0
-               	srai	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x138>
-               	mv	a1, a0
-               	srai	a2, s3, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x150>
-               	mv	a1, a0
-               	slli	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x168>
-               	mv	a1, a0
-               	srai	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x180>
-               	mv	a1, a0
-               	slli	a2, s1, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x198>
-               	mv	a1, a0
-               	srai	a2, s1, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x1b0>
-               	mv	a1, a0
-               	slli	a2, s2, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x1c8>
-               	mv	a1, a0
-               	srai	a2, s2, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x1e0>
-               	mv	a1, a0
-               	slli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x1f8>
-               	mv	a1, a0
-               	srai	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x210>
-               	mv	a1, a0
-               	slli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x228>
-               	mv	a1, a0
-               	srai	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x240>
-               	mv	a1, a0
-               	slli	a2, s3, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x258>
-               	mv	a1, a0
-               	srai	a2, s3, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x270>
-               	mv	s5, a0
-               	li	s6, 0x0
-               	li	t0, 0x40
-               	bltu	s6, t0, 0x28c <corpus.cases.bits.shift_i64.checksum+0x28c>
-               	j	0x2d4 <corpus.cases.bits.shift_i64.checksum+0x2d4>
-               	sll	a1, s2, s6
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x294>
-               	sra	a1, s2, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x2a0>
-               	add	s7, s6, s1
-               	sll	a1, s3, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x2b0>
-               	sra	a1, s4, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x2bc>
-               	addi	s6, s6, 0x1
-               	mv	s5, a0
-               	li	t0, 0x40
-               	bltu	s6, t0, 0x28c <corpus.cases.bits.shift_i64.checksum+0x28c>
-               	li	s3, 0x3c
-               	li	t0, 0x48
-               	bltu	s3, t0, 0x2e4 <corpus.cases.bits.shift_i64.checksum+0x2e4>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa4 <corpus.cases.bits.shift_i64.checksum+0xa4>
+               	j	0xd8 <corpus.cases.bits.shift_i64.checksum+0xd8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s2, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa4 <corpus.cases.bits.shift_i64.checksum+0xa4>
+               	slli	a1, s2, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xec <corpus.cases.bits.shift_i64.checksum+0xec>
+               	j	0x120 <corpus.cases.bits.shift_i64.checksum+0x120>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xec <corpus.cases.bits.shift_i64.checksum+0xec>
+               	slli	a1, s2, 0x3f
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.bits.shift_i64.checksum+0x134>
+               	j	0x168 <corpus.cases.bits.shift_i64.checksum+0x168>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.bits.shift_i64.checksum+0x134>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.shift_i64.checksum+0x178>
+               	j	0x1ac <corpus.cases.bits.shift_i64.checksum+0x1ac>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s2, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.shift_i64.checksum+0x178>
+               	srai	a1, s2, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c0 <corpus.cases.bits.shift_i64.checksum+0x1c0>
+               	j	0x1f4 <corpus.cases.bits.shift_i64.checksum+0x1f4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c0 <corpus.cases.bits.shift_i64.checksum+0x1c0>
+               	srai	a1, s2, 0x3f
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.bits.shift_i64.checksum+0x208>
+               	j	0x23c <corpus.cases.bits.shift_i64.checksum+0x23c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.bits.shift_i64.checksum+0x208>
+               	slli	a1, s3, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x250 <corpus.cases.bits.shift_i64.checksum+0x250>
+               	j	0x284 <corpus.cases.bits.shift_i64.checksum+0x284>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x250 <corpus.cases.bits.shift_i64.checksum+0x250>
+               	srai	a1, s3, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x298 <corpus.cases.bits.shift_i64.checksum+0x298>
+               	j	0x2cc <corpus.cases.bits.shift_i64.checksum+0x2cc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x298 <corpus.cases.bits.shift_i64.checksum+0x298>
+               	srai	a1, s3, 0x3f
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <corpus.cases.bits.shift_i64.checksum+0x2e0>
                	j	0x314 <corpus.cases.bits.shift_i64.checksum+0x314>
-               	add	s4, s3, s1
-               	sll	a1, s2, s4
-               	mv	a0, s5
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <corpus.cases.bits.shift_i64.checksum+0x2e0>
+               	slli	a1, s4, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.bits.shift_i64.checksum+0x328>
+               	j	0x35c <corpus.cases.bits.shift_i64.checksum+0x35c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.bits.shift_i64.checksum+0x328>
+               	srai	a1, s4, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x2f0>
-               	sra	a1, s2, s4
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x360>
+               	slli	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x2fc>
-               	addi	s3, s3, 0x1
-               	mv	s5, a0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x36c>
+               	srai	a1, s1, 0x5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x378>
+               	slli	a1, s2, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x384>
+               	srai	a1, s2, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x390>
+               	slli	a1, s2, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x39c>
+               	srai	a1, s2, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x3a8>
+               	slli	a1, s2, 0x3f
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x3b4>
+               	srai	a1, s2, 0x3f
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x3c0>
+               	slli	a1, s3, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x3cc>
+               	srai	a1, s3, 0x3f
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.bits.shift_i64.checksum+0x3d8>
+               	li	a1, 0x0
+               	li	t0, 0x40
+               	bltu	a1, t0, 0x3f0 <corpus.cases.bits.shift_i64.checksum+0x3f0>
+               	j	0x52c <corpus.cases.bits.shift_i64.checksum+0x52c>
+               	sll	a2, s2, a1
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x408 <corpus.cases.bits.shift_i64.checksum+0x408>
+               	j	0x43c <corpus.cases.bits.shift_i64.checksum+0x43c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x408 <corpus.cases.bits.shift_i64.checksum+0x408>
+               	sra	a2, s2, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x450 <corpus.cases.bits.shift_i64.checksum+0x450>
+               	j	0x484 <corpus.cases.bits.shift_i64.checksum+0x484>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x450 <corpus.cases.bits.shift_i64.checksum+0x450>
+               	add	a2, a1, s1
+               	sll	a4, s3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.bits.shift_i64.checksum+0x49c>
+               	j	0x4d0 <corpus.cases.bits.shift_i64.checksum+0x4d0>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.bits.shift_i64.checksum+0x49c>
+               	add	a2, a1, s1
+               	sra	a4, s4, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.bits.shift_i64.checksum+0x4e8>
+               	j	0x51c <corpus.cases.bits.shift_i64.checksum+0x51c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.bits.shift_i64.checksum+0x4e8>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
+               	li	t0, 0x40
+               	bltu	a1, t0, 0x3f0 <corpus.cases.bits.shift_i64.checksum+0x3f0>
+               	li	a1, 0x3c
                	li	t0, 0x48
-               	bltu	s3, t0, 0x2e4 <corpus.cases.bits.shift_i64.checksum+0x2e4>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x53c <corpus.cases.bits.shift_i64.checksum+0x53c>
+               	j	0x5e8 <corpus.cases.bits.shift_i64.checksum+0x5e8>
+               	add	a2, a1, s1
+               	sll	a3, s2, a2
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x558 <corpus.cases.bits.shift_i64.checksum+0x558>
+               	j	0x58c <corpus.cases.bits.shift_i64.checksum+0x58c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x558 <corpus.cases.bits.shift_i64.checksum+0x558>
+               	add	a3, a1, s1
+               	sra	a4, s2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x5a4 <corpus.cases.bits.shift_i64.checksum+0x5a4>
+               	j	0x5d8 <corpus.cases.bits.shift_i64.checksum+0x5d8>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x5a4 <corpus.cases.bits.shift_i64.checksum+0x5a4>
+               	addi	a1, a1, 0x1
+               	mv	a0, a2
+               	li	t0, 0x48
+               	bltu	a1, t0, 0x53c <corpus.cases.bits.shift_i64.checksum+0x53c>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	s4, 0x0(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/bits/shift_u32.dis
+++ b/test/golden/riscv64-linux/bits/shift_u32.dis
@@ -3,195 +3,408 @@ bits/shift_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.shift_u32.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x30>
-               	mv	a1, a0
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
+               	sd	s4, 0x0(sp)
+               	sext.w	s1, a0
                	li	t1, -0x1
-               	xor	s1, t1, s2
+               	xor	s2, t1, s1
                	lui	t1, 0xaaaab
                	addiw	t1, t1, -0x556
-               	xor	s3, t1, s2
+               	xor	s3, t1, s1
                	lui	t1, 0x55555
                	addiw	t1, t1, 0x555
-               	xor	s4, t1, s2
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x68>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1
+               	xor	s4, t1, s1
+               	slli	a0, s2, 0x20
+               	srli	a0, a0, 0x20
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.bits.shift_u32.checksum+0x7c>
+               	j	0xb0 <corpus.cases.bits.shift_u32.checksum+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.bits.shift_u32.checksum+0x7c>
+               	slliw	a0, s2, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xcc <corpus.cases.bits.shift_u32.checksum+0xcc>
+               	j	0x100 <corpus.cases.bits.shift_u32.checksum+0x100>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xcc <corpus.cases.bits.shift_u32.checksum+0xcc>
+               	slliw	a0, s2, 0x1f
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x11c <corpus.cases.bits.shift_u32.checksum+0x11c>
+               	j	0x150 <corpus.cases.bits.shift_u32.checksum+0x150>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x11c <corpus.cases.bits.shift_u32.checksum+0x11c>
+               	slli	a0, s2, 0x20
+               	srli	a0, a0, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x168 <corpus.cases.bits.shift_u32.checksum+0x168>
+               	j	0x19c <corpus.cases.bits.shift_u32.checksum+0x19c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x168 <corpus.cases.bits.shift_u32.checksum+0x168>
+               	srliw	a0, s2, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1b8 <corpus.cases.bits.shift_u32.checksum+0x1b8>
+               	j	0x1ec <corpus.cases.bits.shift_u32.checksum+0x1ec>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1b8 <corpus.cases.bits.shift_u32.checksum+0x1b8>
+               	srliw	a0, s2, 0x1f
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x208 <corpus.cases.bits.shift_u32.checksum+0x208>
+               	j	0x23c <corpus.cases.bits.shift_u32.checksum+0x23c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x208 <corpus.cases.bits.shift_u32.checksum+0x208>
+               	slliw	a0, s3, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x258 <corpus.cases.bits.shift_u32.checksum+0x258>
+               	j	0x28c <corpus.cases.bits.shift_u32.checksum+0x28c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x258 <corpus.cases.bits.shift_u32.checksum+0x258>
+               	srliw	a0, s3, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2a8 <corpus.cases.bits.shift_u32.checksum+0x2a8>
+               	j	0x2dc <corpus.cases.bits.shift_u32.checksum+0x2dc>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2a8 <corpus.cases.bits.shift_u32.checksum+0x2a8>
+               	slliw	a0, s4, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2f8 <corpus.cases.bits.shift_u32.checksum+0x2f8>
+               	j	0x32c <corpus.cases.bits.shift_u32.checksum+0x32c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2f8 <corpus.cases.bits.shift_u32.checksum+0x2f8>
+               	srliw	a0, s4, 0x1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x348 <corpus.cases.bits.shift_u32.checksum+0x348>
+               	j	0x37c <corpus.cases.bits.shift_u32.checksum+0x37c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x348 <corpus.cases.bits.shift_u32.checksum+0x348>
+               	slliw	a2, s1, 0x5
                	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x80>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x388>
+               	srliw	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x98>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x394>
+               	slliw	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0xac>
-               	mv	a1, a0
-               	srliw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3a0>
+               	srliw	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0xc4>
-               	mv	a1, a0
-               	srliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3ac>
+               	slliw	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0xdc>
-               	mv	a1, a0
-               	slliw	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3b8>
+               	srliw	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0xf4>
-               	mv	a1, a0
-               	srliw	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3c4>
+               	slliw	a1, s2, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x10c>
-               	mv	a1, a0
-               	slliw	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3d0>
+               	srliw	a1, s2, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x124>
-               	mv	a1, a0
-               	srliw	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3dc>
+               	slliw	a1, s3, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x13c>
-               	mv	a1, a0
-               	slliw	a2, s2, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3e8>
+               	srliw	a1, s3, 0x1f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x154>
-               	mv	a1, a0
-               	srliw	a2, s2, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x16c>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x184>
-               	mv	a1, a0
-               	srliw	a2, s1, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x19c>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x1b4>
-               	mv	a1, a0
-               	srliw	a2, s1, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x1cc>
-               	mv	a1, a0
-               	slliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x1e4>
-               	mv	a1, a0
-               	srliw	a2, s1, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x1fc>
-               	mv	a1, a0
-               	slliw	a2, s3, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x214>
-               	mv	a1, a0
-               	srliw	a2, s3, 0x1f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x22c>
-               	mv	s5, a0
-               	li	s6, 0x0
+               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x3f4>
+               	li	a1, 0x0
                	li	t0, 0x20
-               	bltu	s6, t0, 0x248 <corpus.cases.bits.shift_u32.checksum+0x248>
-               	j	0x290 <corpus.cases.bits.shift_u32.checksum+0x290>
-               	sllw	a1, s1, s6
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x250>
-               	srlw	a1, s1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x25c>
-               	addw	s7, s6, s2
-               	sllw	a1, s3, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x26c>
-               	srlw	a1, s4, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x278>
-               	addiw	s6, s6, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x40c <corpus.cases.bits.shift_u32.checksum+0x40c>
+               	j	0x568 <corpus.cases.bits.shift_u32.checksum+0x568>
+               	sllw	a2, s2, a1
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x42c <corpus.cases.bits.shift_u32.checksum+0x42c>
+               	j	0x460 <corpus.cases.bits.shift_u32.checksum+0x460>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x42c <corpus.cases.bits.shift_u32.checksum+0x42c>
+               	srlw	a3, s2, a1
+               	slli	a4, a3, 0x20
+               	srli	a4, a4, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.bits.shift_u32.checksum+0x47c>
+               	j	0x4b0 <corpus.cases.bits.shift_u32.checksum+0x4b0>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.bits.shift_u32.checksum+0x47c>
+               	addw	a3, a1, s1
+               	sllw	a4, s3, a3
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4d0 <corpus.cases.bits.shift_u32.checksum+0x4d0>
+               	j	0x504 <corpus.cases.bits.shift_u32.checksum+0x504>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x4d0 <corpus.cases.bits.shift_u32.checksum+0x4d0>
+               	addw	a3, a1, s1
+               	srlw	a4, s4, a3
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x524 <corpus.cases.bits.shift_u32.checksum+0x524>
+               	j	0x558 <corpus.cases.bits.shift_u32.checksum+0x558>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x524 <corpus.cases.bits.shift_u32.checksum+0x524>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a2
                	li	t0, 0x20
-               	bltu	s6, t0, 0x248 <corpus.cases.bits.shift_u32.checksum+0x248>
-               	li	s3, 0x1e
+               	bltu	a1, t0, 0x40c <corpus.cases.bits.shift_u32.checksum+0x40c>
+               	li	a1, 0x1e
                	li	t0, 0x28
-               	bltu	s3, t0, 0x2a0 <corpus.cases.bits.shift_u32.checksum+0x2a0>
-               	j	0x2d0 <corpus.cases.bits.shift_u32.checksum+0x2d0>
-               	addw	s4, s3, s2
-               	sllw	a1, s1, s4
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x2ac>
-               	srlw	a1, s1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u32.checksum+0x2b8>
-               	addiw	s3, s3, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x578 <corpus.cases.bits.shift_u32.checksum+0x578>
+               	j	0x634 <corpus.cases.bits.shift_u32.checksum+0x634>
+               	addw	a2, a1, s1
+               	sllw	a3, s2, a2
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x59c <corpus.cases.bits.shift_u32.checksum+0x59c>
+               	j	0x5d0 <corpus.cases.bits.shift_u32.checksum+0x5d0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x59c <corpus.cases.bits.shift_u32.checksum+0x59c>
+               	addw	a2, a1, s1
+               	srlw	a4, s2, a2
+               	slli	a2, a4, 0x20
+               	srli	a2, a2, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x5f0 <corpus.cases.bits.shift_u32.checksum+0x5f0>
+               	j	0x624 <corpus.cases.bits.shift_u32.checksum+0x624>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x5f0 <corpus.cases.bits.shift_u32.checksum+0x5f0>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x28
-               	bltu	s3, t0, 0x2a0 <corpus.cases.bits.shift_u32.checksum+0x2a0>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x578 <corpus.cases.bits.shift_u32.checksum+0x578>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	s4, 0x0(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/bits/shift_u64.dis
+++ b/test/golden/riscv64-linux/bits/shift_u64.dis
@@ -3,21 +3,15 @@ bits/shift_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.bits.shift_u64.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
+               	sd	s4, 0x0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x30>
-               	mv	a1, a0
                	li	t1, -0x1
                	xor	s2, t1, s1
                	lui	t1, 0xfaaab
@@ -38,171 +32,357 @@ Disassembly of section .text:
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x555
                	xor	s4, t1, s1
-               	mv	a0, a1
-               	mv	a1, s2
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa4 <corpus.cases.bits.shift_u64.checksum+0xa4>
+               	j	0xd8 <corpus.cases.bits.shift_u64.checksum+0xd8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s2, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa4 <corpus.cases.bits.shift_u64.checksum+0xa4>
+               	slli	a1, s2, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xec <corpus.cases.bits.shift_u64.checksum+0xec>
+               	j	0x120 <corpus.cases.bits.shift_u64.checksum+0x120>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xec <corpus.cases.bits.shift_u64.checksum+0xec>
+               	slli	a1, s2, 0x3f
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.bits.shift_u64.checksum+0x134>
+               	j	0x168 <corpus.cases.bits.shift_u64.checksum+0x168>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.bits.shift_u64.checksum+0x134>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.shift_u64.checksum+0x178>
+               	j	0x1ac <corpus.cases.bits.shift_u64.checksum+0x1ac>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s2, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x178 <corpus.cases.bits.shift_u64.checksum+0x178>
+               	srli	a1, s2, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c0 <corpus.cases.bits.shift_u64.checksum+0x1c0>
+               	j	0x1f4 <corpus.cases.bits.shift_u64.checksum+0x1f4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c0 <corpus.cases.bits.shift_u64.checksum+0x1c0>
+               	srli	a1, s2, 0x3f
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.bits.shift_u64.checksum+0x208>
+               	j	0x23c <corpus.cases.bits.shift_u64.checksum+0x23c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.bits.shift_u64.checksum+0x208>
+               	slli	a1, s3, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x250 <corpus.cases.bits.shift_u64.checksum+0x250>
+               	j	0x284 <corpus.cases.bits.shift_u64.checksum+0x284>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x250 <corpus.cases.bits.shift_u64.checksum+0x250>
+               	srli	a1, s3, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x298 <corpus.cases.bits.shift_u64.checksum+0x298>
+               	j	0x2cc <corpus.cases.bits.shift_u64.checksum+0x2cc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x298 <corpus.cases.bits.shift_u64.checksum+0x298>
+               	slli	a1, s4, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <corpus.cases.bits.shift_u64.checksum+0x2e0>
+               	j	0x314 <corpus.cases.bits.shift_u64.checksum+0x314>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <corpus.cases.bits.shift_u64.checksum+0x2e0>
+               	srli	a1, s4, 0x1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.bits.shift_u64.checksum+0x328>
+               	j	0x35c <corpus.cases.bits.shift_u64.checksum+0x35c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.bits.shift_u64.checksum+0x328>
+               	slli	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x94>
-               	mv	a1, a0
-               	slli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x360>
+               	srli	a1, s1, 0x5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0xac>
-               	mv	a1, a0
-               	slli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x36c>
+               	slli	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0xc4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x378>
+               	srli	a1, s2, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0xd8>
-               	mv	a1, a0
-               	srli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x384>
+               	slli	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0xf0>
-               	mv	a1, a0
-               	srli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x390>
+               	srli	a1, s2, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x108>
-               	mv	a1, a0
-               	slli	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x39c>
+               	slli	a1, s2, 0x3f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x120>
-               	mv	a1, a0
-               	srli	a2, s3, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x3a8>
+               	srli	a1, s2, 0x3f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x138>
-               	mv	a1, a0
-               	slli	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x3b4>
+               	slli	a1, s3, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x150>
-               	mv	a1, a0
-               	srli	a2, s4, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x3c0>
+               	srli	a1, s3, 0x3f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x168>
-               	mv	a1, a0
-               	slli	a2, s1, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x180>
-               	mv	a1, a0
-               	srli	a2, s1, 0x5
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x198>
-               	mv	a1, a0
-               	slli	a2, s2, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x1b0>
-               	mv	a1, a0
-               	srli	a2, s2, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x1c8>
-               	mv	a1, a0
-               	slli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x1e0>
-               	mv	a1, a0
-               	srli	a2, s2, 0x1
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x1f8>
-               	mv	a1, a0
-               	slli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x210>
-               	mv	a1, a0
-               	srli	a2, s2, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x228>
-               	mv	a1, a0
-               	slli	a2, s3, 0x0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x240>
-               	mv	a1, a0
-               	srli	a2, s3, 0x3f
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x258>
-               	mv	s5, a0
-               	li	s6, 0x0
+               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x3cc>
+               	li	a1, 0x0
                	li	t0, 0x40
-               	bltu	s6, t0, 0x274 <corpus.cases.bits.shift_u64.checksum+0x274>
-               	j	0x2bc <corpus.cases.bits.shift_u64.checksum+0x2bc>
-               	sll	a1, s2, s6
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x27c>
-               	srl	a1, s2, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x288>
-               	add	s7, s6, s1
-               	sll	a1, s3, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x298>
-               	srl	a1, s4, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x2a4>
-               	addi	s6, s6, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x3e4 <corpus.cases.bits.shift_u64.checksum+0x3e4>
+               	j	0x520 <corpus.cases.bits.shift_u64.checksum+0x520>
+               	sll	a2, s2, a1
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3fc <corpus.cases.bits.shift_u64.checksum+0x3fc>
+               	j	0x430 <corpus.cases.bits.shift_u64.checksum+0x430>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3fc <corpus.cases.bits.shift_u64.checksum+0x3fc>
+               	srl	a2, s2, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x444 <corpus.cases.bits.shift_u64.checksum+0x444>
+               	j	0x478 <corpus.cases.bits.shift_u64.checksum+0x478>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x444 <corpus.cases.bits.shift_u64.checksum+0x444>
+               	add	a2, a1, s1
+               	sll	a4, s3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.bits.shift_u64.checksum+0x490>
+               	j	0x4c4 <corpus.cases.bits.shift_u64.checksum+0x4c4>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.bits.shift_u64.checksum+0x490>
+               	add	a2, a1, s1
+               	srl	a4, s4, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4dc <corpus.cases.bits.shift_u64.checksum+0x4dc>
+               	j	0x510 <corpus.cases.bits.shift_u64.checksum+0x510>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4dc <corpus.cases.bits.shift_u64.checksum+0x4dc>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x40
-               	bltu	s6, t0, 0x274 <corpus.cases.bits.shift_u64.checksum+0x274>
-               	li	s3, 0x3c
+               	bltu	a1, t0, 0x3e4 <corpus.cases.bits.shift_u64.checksum+0x3e4>
+               	li	a1, 0x3c
                	li	t0, 0x48
-               	bltu	s3, t0, 0x2cc <corpus.cases.bits.shift_u64.checksum+0x2cc>
-               	j	0x2fc <corpus.cases.bits.shift_u64.checksum+0x2fc>
-               	add	s4, s3, s1
-               	sll	a1, s2, s4
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x2d8>
-               	srl	a1, s2, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.bits.shift_u64.checksum+0x2e4>
-               	addi	s3, s3, 0x1
-               	mv	s5, a0
+               	bltu	a1, t0, 0x530 <corpus.cases.bits.shift_u64.checksum+0x530>
+               	j	0x5dc <corpus.cases.bits.shift_u64.checksum+0x5dc>
+               	add	a2, a1, s1
+               	sll	a3, s2, a2
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x54c <corpus.cases.bits.shift_u64.checksum+0x54c>
+               	j	0x580 <corpus.cases.bits.shift_u64.checksum+0x580>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x54c <corpus.cases.bits.shift_u64.checksum+0x54c>
+               	add	a3, a1, s1
+               	srl	a4, s2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x598 <corpus.cases.bits.shift_u64.checksum+0x598>
+               	j	0x5cc <corpus.cases.bits.shift_u64.checksum+0x5cc>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x598 <corpus.cases.bits.shift_u64.checksum+0x598>
+               	addi	a1, a1, 0x1
+               	mv	a0, a2
                	li	t0, 0x48
-               	bltu	s3, t0, 0x2cc <corpus.cases.bits.shift_u64.checksum+0x2cc>
-               	mv	a0, s5
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	bltu	a1, t0, 0x530 <corpus.cases.bits.shift_u64.checksum+0x530>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	s4, 0x0(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/call/call_chain.dis
+++ b/test/golden/riscv64-linux/call/call_chain.dis
@@ -49,27 +49,15 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_chain.burn>:
-               	addi	sp, sp, -0xb0
-               	sd	ra, 0xa8(sp)
-               	sd	s0, 0xa0(sp)
-               	addi	s0, sp, 0xb0
-               	sd	s1, 0x98(sp)
-               	sd	s2, 0x90(sp)
-               	sd	s3, 0x88(sp)
-               	sd	s4, 0x80(sp)
-               	sd	s5, 0x78(sp)
-               	sd	s6, 0x70(sp)
-               	sd	s7, 0x68(sp)
-               	sd	s8, 0x60(sp)
-               	sd	s9, 0x58(sp)
-               	sd	s10, 0x50(sp)
-               	sd	s11, 0x48(sp)
-               	fsd	fs0, 0x40(sp)
-               	fsd	fs1, 0x38(sp)
-               	fsd	fs2, 0x30(sp)
-               	fsd	fs3, 0x28(sp)
-               	fsd	fs4, 0x20(sp)
-               	fsd	fs5, 0x18(sp)
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	sd	s2, 0x20(sp)
+               	sd	s3, 0x18(sp)
+               	sd	s4, 0x10(sp)
+               	sd	s5, 0x8(sp)
                	li	t0, 0x1
                	xor	a1, a0, t0
                	li	t0, 0x3
@@ -150,96 +138,134 @@ Disassembly of section .text:
                	lui	t0, 0x40800
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft0, ft10
-               	mv	s5, a1
-               	mv	s6, a3
-               	mv	s7, a4
-               	mv	s8, a6
-               	mv	s9, a5
-               	mv	s10, t5
-               	mv	s11, a7
-               	mv	t2, t6
-               	sd	t2, -0xa0(s0)
-               	fmv.d	fs0, ft1
-               	fmv.d	fs1, ft2
-               	fmv.d	fs2, ft3
-               	fmv.d	fs3, ft4
-               	fmv.d	fs4, ft5
-               	fmv.d	fs5, ft6
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0x260 <.Lpcrel_hi.3+0xac>
-               	j	0x2c4 <.Lpcrel_hi.3+0x110>
-               	add	s5, s5, s6
-               	xor	s6, s6, s7
-               	add	s7, s7, s8
-               	xor	s8, s8, s9
-               	add	s9, s9, s10
-               	xor	s10, s10, s11
-               	ld	t2, -0xa0(s0)
-               	add	s11, s11, t2
-               	ld	t2, -0xa0(s0)
-               	xor	a2, t2, s2
+               	bltu	a0, t0, 0x1f4 <.Lpcrel_hi.3+0x70>
+               	j	0x248 <.Lpcrel_hi.3+0xc4>
+               	add	a1, a1, a3
+               	xor	a3, a3, a4
+               	add	a4, a4, a6
+               	xor	a6, a6, a5
+               	add	a5, a5, t5
+               	xor	t5, t5, a7
+               	add	a7, a7, t6
+               	xor	t6, t6, s2
                	add	s2, s2, s1
                	xor	s1, s1, s4
                	add	s4, s4, s3
-               	xor	s3, s3, s5
-               	fadd.d	fs0, fs0, fs1
-               	fsub.d	fs1, fs1, fs2
-               	fadd.d	fs2, fs2, fs0
-               	fadd.s	fs3, fs3, fs4
-               	fsub.s	fs4, fs4, fs5
-               	fadd.s	fs5, fs5, fs3
+               	xor	s3, s3, a1
+               	fadd.d	ft1, ft1, ft2
+               	fsub.d	ft2, ft2, ft3
+               	fadd.d	ft3, ft3, ft1
+               	fadd.s	ft4, ft4, ft5
+               	fsub.s	ft5, ft5, ft6
+               	fadd.s	ft6, ft6, ft4
                	addi	a0, a0, 0x1
-               	mv	t2, a2
-               	sd	t2, -0xa0(s0)
                	li	t0, 0x6
-               	bltu	a0, t0, 0x260 <.Lpcrel_hi.3+0xac>
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x110>
-               	xor	a1, s5, s6
-               	xor	a3, a1, s7
-               	xor	a1, a3, s8
-               	xor	a3, a1, s9
-               	xor	a1, a3, s10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x12c>
-               	ld	t2, -0xa0(s0)
-               	xor	a1, s11, t2
-               	xor	a2, a1, s2
-               	xor	a1, a2, s1
-               	xor	a2, a1, s4
-               	xor	a1, a2, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x14c>
-               	fadd.d	ft0, fs0, fs1
-               	fadd.d	fa0, ft0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x15c>
-               	fadd.s	ft0, fs3, fs4
-               	fadd.s	ft1, ft0, fs5
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x170>
-               	ld	s1, 0x98(sp)
-               	ld	s2, 0x90(sp)
-               	ld	s3, 0x88(sp)
-               	ld	s4, 0x80(sp)
-               	ld	s5, 0x78(sp)
-               	ld	s6, 0x70(sp)
-               	ld	s7, 0x68(sp)
-               	ld	s8, 0x60(sp)
-               	ld	s9, 0x58(sp)
-               	ld	s10, 0x50(sp)
-               	ld	s11, 0x48(sp)
-               	fld	fs0, 0x40(sp)
-               	fld	fs1, 0x38(sp)
-               	fld	fs2, 0x30(sp)
-               	fld	fs3, 0x28(sp)
-               	fld	fs4, 0x20(sp)
-               	fld	fs5, 0x18(sp)
-               	ld	ra, 0xa8(sp)
-               	ld	s0, 0xa0(sp)
-               	addi	sp, sp, 0xb0
+               	bltu	a0, t0, 0x1f4 <.Lpcrel_hi.3+0x70>
+               	xor	a0, a1, a3
+               	xor	a1, a0, a4
+               	xor	a0, a1, a6
+               	xor	a1, a0, a5
+               	xor	a0, a1, t5
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x28c <.Lpcrel_hi.3+0x108>
+               	j	0x2c0 <.Lpcrel_hi.3+0x13c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x28c <.Lpcrel_hi.3+0x108>
+               	xor	a0, a7, t6
+               	xor	a2, a0, s2
+               	xor	a0, a2, s1
+               	xor	a2, a0, s4
+               	xor	a0, a2, s3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e4 <.Lpcrel_hi.3+0x160>
+               	j	0x318 <.Lpcrel_hi.3+0x194>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e4 <.Lpcrel_hi.3+0x160>
+               	fadd.d	ft0, ft1, ft2
+               	fadd.d	ft1, ft0, ft3
+               	fmv.x.d	a0, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <.Lpcrel_hi.3+0x1b0>
+               	j	0x368 <.Lpcrel_hi.3+0x1e4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <.Lpcrel_hi.3+0x1b0>
+               	fadd.s	ft0, ft4, ft5
+               	fadd.s	ft1, ft0, ft6
+               	fmv.x.w	a0, ft1
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x38c <.Lpcrel_hi.3+0x208>
+               	j	0x3c0 <.Lpcrel_hi.3+0x23c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x38c <.Lpcrel_hi.3+0x208>
+               	mv	a0, a1
+               	ld	s1, 0x28(sp)
+               	ld	s2, 0x20(sp)
+               	ld	s3, 0x18(sp)
+               	ld	s4, 0x10(sp)
+               	ld	s5, 0x8(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.call.call_chain.chain>:
@@ -352,17 +378,31 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fdiv.s	fs5, ft0, ft10
                	li	t1, 0x0
-               	bltu	t1, s1, 0x548 <.Lpcrel_hi.6+0x90>
+               	bltu	t1, s1, 0x5e8 <.Lpcrel_hi.6+0xc8>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.6+0x6c>
-               	mv	a1, a0
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x7c>
-               	mv	t2, a0
+               	mv	a1, s3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5a8 <.Lpcrel_hi.6+0x88>
+               	j	0x5dc <.Lpcrel_hi.6+0xbc>
+               	li	t0, 0x8
+               	mul	a7, a2, t0
+               	srl	t5, a0, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a1, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, t5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5a8 <.Lpcrel_hi.6+0x88>
+               	mv	t2, a1
                	sd	t2, -0xc0(s0)
-               	j	0x570 <.Lpcrel_hi.6+0xb8>
+               	j	0x610 <.Lpcrel_hi.6+0xf0>
                	addi	a0, s1, -0x1
                	li	t0, 0x3
                	mul	a1, s2, t0
@@ -370,84 +410,252 @@ Disassembly of section .text:
                	mv	a1, a2
                	mv	a2, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xa8>
+               	jalr	ra <.Lpcrel_hi.6+0xe0>
                	mv	t2, a0
                	sd	t2, -0xc0(s0)
                	ld	t2, -0xc0(s0)
-               	mv	a0, t2
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xc4>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xd0>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xdc>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xe8>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xf4>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x100>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x10c>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x118>
+               	mv	a7, t2
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x628 <.Lpcrel_hi.6+0x108>
+               	j	0x65c <.Lpcrel_hi.6+0x13c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s4, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x628 <.Lpcrel_hi.6+0x108>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x66c <.Lpcrel_hi.6+0x14c>
+               	j	0x6a0 <.Lpcrel_hi.6+0x180>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s5, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x66c <.Lpcrel_hi.6+0x14c>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6b0 <.Lpcrel_hi.6+0x190>
+               	j	0x6e4 <.Lpcrel_hi.6+0x1c4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s6, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6b0 <.Lpcrel_hi.6+0x190>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6f4 <.Lpcrel_hi.6+0x1d4>
+               	j	0x728 <.Lpcrel_hi.6+0x208>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s7, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6f4 <.Lpcrel_hi.6+0x1d4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x738 <.Lpcrel_hi.6+0x218>
+               	j	0x76c <.Lpcrel_hi.6+0x24c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s8, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x738 <.Lpcrel_hi.6+0x218>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x77c <.Lpcrel_hi.6+0x25c>
+               	j	0x7b0 <.Lpcrel_hi.6+0x290>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s9, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x77c <.Lpcrel_hi.6+0x25c>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x7c0 <.Lpcrel_hi.6+0x2a0>
+               	j	0x7f4 <.Lpcrel_hi.6+0x2d4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s10, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x7c0 <.Lpcrel_hi.6+0x2a0>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x804 <.Lpcrel_hi.6+0x2e4>
+               	j	0x838 <.Lpcrel_hi.6+0x318>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s11, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x804 <.Lpcrel_hi.6+0x2e4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x848 <.Lpcrel_hi.6+0x328>
+               	j	0x880 <.Lpcrel_hi.6+0x360>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
                	ld	t2, -0xa0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x128>
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x848 <.Lpcrel_hi.6+0x328>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x890 <.Lpcrel_hi.6+0x370>
+               	j	0x8c8 <.Lpcrel_hi.6+0x3a8>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
                	ld	t2, -0xa8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x138>
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x890 <.Lpcrel_hi.6+0x370>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8d8 <.Lpcrel_hi.6+0x3b8>
+               	j	0x910 <.Lpcrel_hi.6+0x3f0>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
                	ld	t2, -0xb0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x148>
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, a7, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8d8 <.Lpcrel_hi.6+0x3b8>
+               	mv	a0, a7
                	ld	t2, -0xb8(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x158>
-               	fmv.d	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.6+0x3fc>
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x164>
-               	fmv.d	fa0, fs1
+               	jalr	ra <.Lpcrel_hi.6+0x408>
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x170>
-               	fmv.d	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.6+0x414>
+               	fmv.x.d	a1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x17c>
-               	fmv.s	fa0, fs3
+               	jalr	ra <.Lpcrel_hi.6+0x420>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x188>
-               	fmv.s	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.6+0x438>
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x194>
-               	fmv.s	fa0, fs5
+               	jalr	ra <.Lpcrel_hi.6+0x450>
+               	fmv.x.w	a1, fs5
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1a0>
+               	jalr	ra <.Lpcrel_hi.6+0x468>
                	fadd.d	ft0, fs0, fs1
-               	fsub.d	fa0, ft0, fs2
+               	fsub.d	ft1, ft0, fs2
+               	fmv.x.d	a1, ft1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1b0>
+               	jalr	ra <.Lpcrel_hi.6+0x47c>
                	fadd.s	ft0, fs3, fs4
                	fsub.s	ft1, ft0, fs5
-               	fmv.s	fa0, ft1
+               	fmv.x.w	a1, ft1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1c4>
+               	jalr	ra <.Lpcrel_hi.6+0x49c>
                	xor	a1, s4, s9
                	ld	t2, -0xb8(s0)
                	xor	a2, a1, t2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1dc>
+               	jalr	ra <.Lpcrel_hi.6+0x4b4>
                	ld	s1, 0xb8(sp)
                	ld	s2, 0xb0(sp)
                	ld	s3, 0xa8(sp)
@@ -521,12 +729,15 @@ Disassembly of section .text:
                	mv	a1, s4
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0x6c>
-               	fmv.d	fa0, fs0
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0x78>
-               	fmv.s	fa0, fs1
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x84>
+               	jalr	ra <.Lpcrel_hi.7+0x90>
                	ld	s1, 0x28(sp)
                	ld	s2, 0x20(sp)
                	ld	s3, 0x18(sp)
@@ -639,39 +850,45 @@ Disassembly of section .text:
                	mv	a1, s9
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0x6c>
-               	fmv.d	fa0, fs3
+               	fmv.x.d	a1, fs3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0x78>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x84>
-               	mv	a1, s2
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0x90>
-               	mv	a1, s3
+               	mv	a1, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0x9c>
-               	mv	a1, s4
+               	mv	a1, s3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xa8>
-               	mv	a1, s5
+               	mv	a1, s4
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xb4>
-               	mv	a1, s6
+               	mv	a1, s5
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xc0>
-               	fmv.d	fa0, fs0
+               	mv	a1, s6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xcc>
-               	fmv.d	fa0, fs1
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xd8>
-               	fmv.s	fa0, fs2
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.10+0xe4>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.10+0xfc>
                	xor	a1, s2, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0xf0>
+               	jalr	ra <.Lpcrel_hi.10+0x108>
                	ld	s1, 0x68(sp)
                	ld	s2, 0x60(sp)
                	ld	s3, 0x58(sp)
@@ -864,83 +1081,95 @@ Disassembly of section .text:
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x74>
-               	fmv.d	fa0, fs8
+               	fmv.x.d	a1, fs8
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x80>
-               	fmv.s	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x8c>
-               	mv	a1, s9
+               	fmv.x.w	a1, fs9
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a1, a4
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x98>
-               	mv	a1, s10
+               	mv	a1, s9
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0xa4>
-               	mv	a1, s11
+               	mv	a1, s10
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0xb0>
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.16+0xbc>
                	ld	t2, -0xc0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0xc0>
+               	jalr	ra <.Lpcrel_hi.16+0xcc>
                	ld	t2, -0xc8(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0xd0>
-               	fmv.d	fa0, fs5
-               	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0xdc>
-               	fmv.d	fa0, fs6
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0xe8>
-               	fmv.s	fa0, fs7
+               	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0xf4>
+               	fmv.x.w	a1, fs7
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.16+0x10c>
                	ld	t2, -0xc8(s0)
                	xor	a1, s9, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x104>
+               	jalr	ra <.Lpcrel_hi.16+0x11c>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x110>
+               	jalr	ra <.Lpcrel_hi.16+0x128>
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x11c>
+               	jalr	ra <.Lpcrel_hi.16+0x134>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x128>
+               	jalr	ra <.Lpcrel_hi.16+0x140>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x134>
+               	jalr	ra <.Lpcrel_hi.16+0x14c>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x140>
+               	jalr	ra <.Lpcrel_hi.16+0x158>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x14c>
+               	jalr	ra <.Lpcrel_hi.16+0x164>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x158>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x164>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x170>
-               	fmv.d	fa0, fs2
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x17c>
-               	fmv.s	fa0, fs3
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x188>
-               	fmv.s	fa0, fs4
+               	fmv.x.d	a1, fs2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.16+0x194>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.16+0x1ac>
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.16+0x1c4>
                	add	a1, s2, s5
                	add	a2, a1, s8
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x1a8>
+               	jalr	ra <.Lpcrel_hi.16+0x1d8>
                	ld	s1, 0xd8(sp)
                	ld	s2, 0xd0(sp)
                	ld	s3, 0xc8(sp)
@@ -1226,139 +1455,157 @@ Disassembly of section .text:
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x84>
-               	fld	fa0, -0x158(s0)
+               	ld	a1, -0x158(s0)
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x90>
-               	flw	fa0, -0x168(s0)
+               	lw	a1, -0x168(s0)
+               	slli	s1, a1, 0x20
+               	srli	s1, s1, 0x20
+               	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x9c>
+               	jalr	ra <.Lpcrel_hi.24+0xa8>
                	ld	t2, -0x140(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0xac>
+               	jalr	ra <.Lpcrel_hi.24+0xb8>
                	ld	t2, -0x148(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0xbc>
+               	jalr	ra <.Lpcrel_hi.24+0xc8>
                	ld	t2, -0xd0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0xcc>
+               	jalr	ra <.Lpcrel_hi.24+0xd8>
                	ld	t2, -0xd8(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0xdc>
+               	jalr	ra <.Lpcrel_hi.24+0xe8>
                	ld	t2, -0xe0(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0xec>
-               	fmv.d	fa0, fs9
-               	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0xf8>
-               	fmv.d	fa0, fs10
+               	fmv.x.d	a1, fs9
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x104>
-               	fmv.s	fa0, fs11
+               	fmv.x.d	a1, fs10
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x110>
+               	fmv.x.w	a1, fs11
+               	slli	t6, a1, 0x20
+               	srli	t6, t6, 0x20
+               	mv	a1, t6
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x128>
                	ld	t2, -0x140(s0)
                	ld	t3, -0xe0(s0)
                	xor	a1, t2, t3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x124>
+               	jalr	ra <.Lpcrel_hi.24+0x13c>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x130>
+               	jalr	ra <.Lpcrel_hi.24+0x148>
                	ld	t2, -0x110(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x140>
+               	jalr	ra <.Lpcrel_hi.24+0x158>
                	ld	t2, -0x118(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x150>
+               	jalr	ra <.Lpcrel_hi.24+0x168>
                	ld	t2, -0x120(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x160>
+               	jalr	ra <.Lpcrel_hi.24+0x178>
                	ld	t2, -0x128(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x170>
+               	jalr	ra <.Lpcrel_hi.24+0x188>
                	ld	t2, -0x130(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x180>
+               	jalr	ra <.Lpcrel_hi.24+0x198>
                	ld	t2, -0x138(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x190>
-               	fmv.d	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x19c>
-               	fmv.d	fa0, fs5
-               	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x1a8>
-               	fmv.d	fa0, fs6
+               	fmv.x.d	a1, fs4
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x1b4>
-               	fmv.s	fa0, fs7
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x1c0>
-               	fmv.s	fa0, fs8
+               	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x1cc>
+               	fmv.x.w	a1, fs7
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x1e4>
+               	fmv.x.w	a1, fs8
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x1fc>
                	ld	t2, -0x120(s0)
                	add	a1, s11, t2
                	ld	t2, -0x138(s0)
                	add	a2, a1, t2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x1e8>
+               	jalr	ra <.Lpcrel_hi.24+0x218>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x1f4>
+               	jalr	ra <.Lpcrel_hi.24+0x224>
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x200>
+               	jalr	ra <.Lpcrel_hi.24+0x230>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x20c>
+               	jalr	ra <.Lpcrel_hi.24+0x23c>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x218>
+               	jalr	ra <.Lpcrel_hi.24+0x248>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x224>
+               	jalr	ra <.Lpcrel_hi.24+0x254>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x230>
+               	jalr	ra <.Lpcrel_hi.24+0x260>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x23c>
+               	jalr	ra <.Lpcrel_hi.24+0x26c>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x248>
+               	jalr	ra <.Lpcrel_hi.24+0x278>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x254>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x260>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x26c>
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x278>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x284>
+               	fmv.x.d	a1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x290>
+               	fmv.x.d	a1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x29c>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x2b4>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.24+0x2cc>
                	xor	a1, s2, s6
                	xor	a2, a1, s10
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x298>
+               	jalr	ra <.Lpcrel_hi.24+0x2e0>
                	ld	s1, 0x158(sp)
                	ld	s2, 0x150(sp)
                	ld	s3, 0x148(sp)
@@ -1388,61 +1635,58 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_chain.checksum>:
-               	addi	sp, sp, -0x1c0
-               	sd	ra, 0x1b8(sp)
-               	sd	s0, 0x1b0(sp)
-               	addi	s0, sp, 0x1c0
-               	sd	s1, 0x1a8(sp)
-               	sd	s2, 0x1a0(sp)
-               	sd	s3, 0x198(sp)
-               	sd	s4, 0x190(sp)
-               	sd	s5, 0x188(sp)
-               	sd	s6, 0x180(sp)
-               	sd	s7, 0x178(sp)
-               	sd	s8, 0x170(sp)
-               	sd	s9, 0x168(sp)
-               	sd	s10, 0x160(sp)
-               	sd	s11, 0x158(sp)
-               	fsd	fs0, 0x150(sp)
-               	fsd	fs1, 0x148(sp)
-               	fsd	fs2, 0x140(sp)
-               	fsd	fs3, 0x138(sp)
-               	fsd	fs4, 0x130(sp)
-               	fsd	fs5, 0x128(sp)
-               	fsd	fs6, 0x120(sp)
-               	fsd	fs7, 0x118(sp)
-               	fsd	fs8, 0x110(sp)
-               	fsd	fs9, 0x108(sp)
-               	fsd	fs10, 0x100(sp)
-               	fsd	fs11, 0xf8(sp)
+               	addi	sp, sp, -0x1d0
+               	sd	ra, 0x1c8(sp)
+               	sd	s0, 0x1c0(sp)
+               	addi	s0, sp, 0x1d0
+               	sd	s1, 0x1b8(sp)
+               	sd	s2, 0x1b0(sp)
+               	sd	s3, 0x1a8(sp)
+               	sd	s4, 0x1a0(sp)
+               	sd	s5, 0x198(sp)
+               	sd	s6, 0x190(sp)
+               	sd	s7, 0x188(sp)
+               	sd	s8, 0x180(sp)
+               	sd	s9, 0x178(sp)
+               	sd	s10, 0x170(sp)
+               	sd	s11, 0x168(sp)
+               	fsd	fs0, 0x160(sp)
+               	fsd	fs1, 0x158(sp)
+               	fsd	fs2, 0x150(sp)
+               	fsd	fs3, 0x148(sp)
+               	fsd	fs4, 0x140(sp)
+               	fsd	fs5, 0x138(sp)
+               	fsd	fs6, 0x130(sp)
+               	fsd	fs7, 0x128(sp)
+               	fsd	fs8, 0x120(sp)
+               	fsd	fs9, 0x118(sp)
+               	fsd	fs10, 0x110(sp)
+               	fsd	fs11, 0x108(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_chain.checksum+0x70>
-               	mv	a2, a0
                	addi	s2, s0, -0xf8
                	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1544 <corpus.cases.call.call_chain.checksum+0xb0>
+               	bnez	a1, 0x1914 <corpus.cases.call.call_chain.checksum+0xa4>
                	mv	a1, a0
-               	li	a3, 0x30
+               	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	a3, a3, -0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x152c <corpus.cases.call.call_chain.checksum+0x98>
-               	j	0x1560 <corpus.cases.call.call_chain.checksum+0xcc>
+               	bne	a2, t0, 0x18fc <corpus.cases.call.call_chain.checksum+0x8c>
+               	j	0x1930 <corpus.cases.call.call_chain.checksum+0xc0>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x154c <corpus.cases.call.call_chain.checksum+0xb8>
+               	bne	a0, t0, 0x191c <corpus.cases.call.call_chain.checksum+0xac>
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0x1570 <corpus.cases.call.call_chain.checksum+0xdc>
-               	j	0x15d4 <corpus.cases.call.call_chain.checksum+0x140>
+               	bltu	a0, t0, 0x1940 <corpus.cases.call.call_chain.checksum+0xd0>
+               	j	0x19a4 <corpus.cases.call.call_chain.checksum+0x134>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -1460,21 +1704,29 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a1, t0
-               	add	a1, a3, s1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
                	slli	t0, a0, 0x3
-               	add	a3, s2, t0
-               	sd	a1, 0x0(a3)
+               	add	a2, s2, t0
+               	sd	a1, 0x0(a2)
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0x1570 <corpus.cases.call.call_chain.checksum+0xdc>
+               	bltu	a0, t0, 0x1940 <corpus.cases.call.call_chain.checksum+0xd0>
                	li	t1, 0x10
                	add	a0, t1, s1
                	mv	a1, s2
-               	ld	a3, 0x0(a1)
-               	mv	a1, a3
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_chain.checksum+0x154>
+               	jalr	ra <corpus.cases.call.call_chain.checksum+0x168>
                	mv	a2, a0
                	li	t1, 0x1
                	add	a0, t1, s1
@@ -1482,12 +1734,12 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_chain.checksum+0x174>
+               	jalr	ra <corpus.cases.call.call_chain.checksum+0x188>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1624 <corpus.cases.call.call_chain.checksum+0x190>
-               	j	0x1c08 <.Lpcrel_hi.32+0x2c4>
+               	bltu	s4, t0, 0x1a14 <corpus.cases.call.call_chain.checksum+0x1a4>
+               	j	0x2050 <.Lpcrel_hi.32+0x31c>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -1510,11 +1762,11 @@ Disassembly of section .text:
                	li	t0, 0x35
                	mul	s11, a0, t0
                	addi	t2, a1, 0x3b
-               	sd	t2, -0x160(s0)
+               	sd	t2, -0x170(s0)
                	li	t0, 0x3d
                	mul	a1, a0, t0
                	addi	t2, a1, 0x4
-               	sd	t2, -0x168(s0)
+               	sd	t2, -0x178(s0)
                	srli	a1, a0, 0x8
                	li	t0, 0x3ff
                	and	a4, a1, t0
@@ -1555,29 +1807,29 @@ Disassembly of section .text:
                	li	t0, 0xd
                	mul	a1, t2, t0
                	addi	t2, a1, 0x3
-               	sd	t2, -0x170(s0)
+               	sd	t2, -0x180(s0)
                	ld	t3, -0x108(s0)
                	lui	t0, 0x55555
                	addiw	t0, t0, 0x555
                	xor	t2, t3, t0
-               	sd	t2, -0x178(s0)
+               	sd	t2, -0x188(s0)
                	ld	t2, -0x108(s0)
                	not	a1, t2
                	li	t0, 0x3
                	mul	t2, a1, t0
-               	sd	t2, -0x180(s0)
+               	sd	t2, -0x190(s0)
                	ld	t3, -0x108(s0)
                	addi	t2, t3, 0x11
-               	sd	t2, -0x188(s0)
+               	sd	t2, -0x198(s0)
                	ld	t3, -0x108(s0)
                	li	t0, 0x13
                	mul	t2, t3, t0
-               	sd	t2, -0x190(s0)
+               	sd	t2, -0x1a0(s0)
                	ld	t3, -0x108(s0)
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	xor	t2, t3, t0
-               	sd	t2, -0x198(s0)
+               	sd	t2, -0x1a8(s0)
                	ld	t3, -0x108(s0)
                	addi	t2, t3, 0x17
                	sd	t2, -0x100(s0)
@@ -1707,7 +1959,7 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft11, ft0, ft10
-               	fsd	ft11, -0x1a8(s0)
+               	fsd	ft11, -0x1b8(s0)
                	ld	t2, -0x158(s0)
                	srli	a0, t2, 0x7
                	li	t0, 0xff
@@ -1716,7 +1968,7 @@ Disassembly of section .text:
                	lui	t0, 0x40800
                	fmv.w.x	ft10, t0
                	fdiv.s	ft11, ft0, ft10
-               	fsw	ft11, -0x1b8(s0)
+               	fsw	ft11, -0x1c8(s0)
                	ld	t2, -0x158(s0)
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
@@ -1739,181 +1991,203 @@ Disassembly of section .text:
                	mv	a1, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.32+0x84>
-               	fld	fa0, -0x1a8(s0)
+               	ld	a1, -0x1b8(s0)
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.32+0x90>
-               	flw	fa0, -0x1b8(s0)
+               	lw	a1, -0x1c8(s0)
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	sd	t2, -0x160(s0)
+               	ld	t2, -0x160(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x9c>
+               	jalr	ra <.Lpcrel_hi.32+0xb0>
                	ld	t2, -0x110(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xac>
+               	jalr	ra <.Lpcrel_hi.32+0xc0>
                	ld	t2, -0x118(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xbc>
+               	jalr	ra <.Lpcrel_hi.32+0xd0>
                	ld	t2, -0x120(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xcc>
+               	jalr	ra <.Lpcrel_hi.32+0xe0>
                	ld	t2, -0x128(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xdc>
+               	jalr	ra <.Lpcrel_hi.32+0xf0>
                	ld	t2, -0x130(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xec>
-               	fmv.d	fa0, fs9
+               	jalr	ra <.Lpcrel_hi.32+0x100>
+               	fmv.x.d	a1, fs9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0xf8>
-               	fmv.d	fa0, fs10
+               	jalr	ra <.Lpcrel_hi.32+0x10c>
+               	fmv.x.d	a1, fs10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x104>
-               	fmv.s	fa0, fs11
+               	jalr	ra <.Lpcrel_hi.32+0x118>
+               	fmv.x.w	a1, fs11
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	sd	t2, -0x168(s0)
+               	ld	t2, -0x168(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x110>
+               	jalr	ra <.Lpcrel_hi.32+0x138>
                	ld	t2, -0x110(s0)
                	ld	t3, -0x130(s0)
                	xor	a1, t2, t3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x124>
-               	ld	t2, -0x170(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x134>
-               	ld	t2, -0x178(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x144>
+               	jalr	ra <.Lpcrel_hi.32+0x14c>
                	ld	t2, -0x180(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x154>
+               	jalr	ra <.Lpcrel_hi.32+0x15c>
                	ld	t2, -0x188(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x164>
+               	jalr	ra <.Lpcrel_hi.32+0x16c>
                	ld	t2, -0x190(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x174>
+               	jalr	ra <.Lpcrel_hi.32+0x17c>
                	ld	t2, -0x198(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x184>
+               	jalr	ra <.Lpcrel_hi.32+0x18c>
+               	ld	t2, -0x1a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x19c>
+               	ld	t2, -0x1a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x1ac>
                	ld	t2, -0x100(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x194>
-               	fmv.d	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.32+0x1bc>
+               	fmv.x.d	a1, fs4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1a0>
-               	fmv.d	fa0, fs5
+               	jalr	ra <.Lpcrel_hi.32+0x1c8>
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1ac>
-               	fmv.d	fa0, fs6
+               	jalr	ra <.Lpcrel_hi.32+0x1d4>
+               	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1b8>
-               	fmv.s	fa0, fs7
+               	jalr	ra <.Lpcrel_hi.32+0x1e0>
+               	fmv.x.w	a1, fs7
+               	slli	a5, a1, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a1, a5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1c4>
-               	fmv.s	fa0, fs8
+               	jalr	ra <.Lpcrel_hi.32+0x1f8>
+               	fmv.x.w	a1, fs8
+               	slli	a5, a1, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a1, a5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1d0>
-               	ld	t2, -0x170(s0)
-               	ld	t3, -0x188(s0)
+               	jalr	ra <.Lpcrel_hi.32+0x210>
+               	ld	t2, -0x180(s0)
+               	ld	t3, -0x198(s0)
                	add	a1, t2, t3
                	ld	t2, -0x100(s0)
                	add	a4, a1, t2
                	mv	a1, a4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1f0>
+               	jalr	ra <.Lpcrel_hi.32+0x230>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x1fc>
+               	jalr	ra <.Lpcrel_hi.32+0x23c>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x208>
+               	jalr	ra <.Lpcrel_hi.32+0x248>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x214>
+               	jalr	ra <.Lpcrel_hi.32+0x254>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x220>
+               	jalr	ra <.Lpcrel_hi.32+0x260>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x22c>
+               	jalr	ra <.Lpcrel_hi.32+0x26c>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x238>
+               	jalr	ra <.Lpcrel_hi.32+0x278>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x244>
-               	ld	t2, -0x160(s0)
+               	jalr	ra <.Lpcrel_hi.32+0x284>
+               	ld	t2, -0x170(s0)
                	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x254>
-               	ld	t2, -0x168(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x264>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x270>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x27c>
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x288>
-               	fmv.s	fa0, fs3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.32+0x294>
+               	ld	t2, -0x178(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x2a4>
+               	fmv.x.d	a1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x2b0>
+               	fmv.x.d	a1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x2bc>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x2d4>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.32+0x2ec>
                	xor	a1, s5, s9
-               	ld	t2, -0x168(s0)
+               	ld	t2, -0x178(s0)
                	xor	a2, a1, t2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x2ac>
+               	jalr	ra <.Lpcrel_hi.32+0x304>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1624 <corpus.cases.call.call_chain.checksum+0x190>
+               	bltu	s4, t0, 0x1a14 <corpus.cases.call.call_chain.checksum+0x1a4>
                	addi	a0, s2, 0x28
                	ld	a1, 0x0(a0)
                	add	a0, a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x2d0>
+               	jalr	ra <.Lpcrel_hi.32+0x328>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x2e0>
-               	ld	s1, 0x1a8(sp)
-               	ld	s2, 0x1a0(sp)
-               	ld	s3, 0x198(sp)
-               	ld	s4, 0x190(sp)
-               	ld	s5, 0x188(sp)
-               	ld	s6, 0x180(sp)
-               	ld	s7, 0x178(sp)
-               	ld	s8, 0x170(sp)
-               	ld	s9, 0x168(sp)
-               	ld	s10, 0x160(sp)
-               	ld	s11, 0x158(sp)
-               	fld	fs0, 0x150(sp)
-               	fld	fs1, 0x148(sp)
-               	fld	fs2, 0x140(sp)
-               	fld	fs3, 0x138(sp)
-               	fld	fs4, 0x130(sp)
-               	fld	fs5, 0x128(sp)
-               	fld	fs6, 0x120(sp)
-               	fld	fs7, 0x118(sp)
-               	fld	fs8, 0x110(sp)
-               	fld	fs9, 0x108(sp)
-               	fld	fs10, 0x100(sp)
-               	fld	fs11, 0xf8(sp)
-               	ld	ra, 0x1b8(sp)
-               	ld	s0, 0x1b0(sp)
-               	addi	sp, sp, 0x1c0
+               	jalr	ra <.Lpcrel_hi.32+0x338>
+               	ld	s1, 0x1b8(sp)
+               	ld	s2, 0x1b0(sp)
+               	ld	s3, 0x1a8(sp)
+               	ld	s4, 0x1a0(sp)
+               	ld	s5, 0x198(sp)
+               	ld	s6, 0x190(sp)
+               	ld	s7, 0x188(sp)
+               	ld	s8, 0x180(sp)
+               	ld	s9, 0x178(sp)
+               	ld	s10, 0x170(sp)
+               	ld	s11, 0x168(sp)
+               	fld	fs0, 0x160(sp)
+               	fld	fs1, 0x158(sp)
+               	fld	fs2, 0x150(sp)
+               	fld	fs3, 0x148(sp)
+               	fld	fs4, 0x140(sp)
+               	fld	fs5, 0x138(sp)
+               	fld	fs6, 0x130(sp)
+               	fld	fs7, 0x128(sp)
+               	fld	fs8, 0x120(sp)
+               	fld	fs9, 0x118(sp)
+               	fld	fs10, 0x110(sp)
+               	fld	fs11, 0x108(sp)
+               	ld	ra, 0x1c8(sp)
+               	ld	s0, 0x1c0(sp)
+               	addi	sp, sp, 0x1d0
                	ret

--- a/test/golden/riscv64-linux/call/call_float_regs.dis
+++ b/test/golden/riscv64-linux/call/call_float_regs.dis
@@ -57,169 +57,391 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_float_regs.takef16>:
-               	addi	sp, sp, -0xb0
-               	sd	ra, 0xa8(sp)
-               	sd	s0, 0xa0(sp)
-               	addi	s0, sp, 0xb0
-               	fsd	fs0, 0x98(sp)
-               	fsd	fs1, 0x90(sp)
-               	fsd	fs2, 0x88(sp)
-               	fsd	fs3, 0x80(sp)
-               	fsd	fs4, 0x78(sp)
-               	fsd	fs5, 0x70(sp)
-               	fsd	fs6, 0x68(sp)
-               	fsd	fs7, 0x60(sp)
-               	fsd	fs8, 0x58(sp)
-               	fsd	fs9, 0x50(sp)
-               	fsd	fs10, 0x48(sp)
-               	fsd	fs11, 0x40(sp)
-               	fmv.s	fs0, fa0
-               	fmv.d	fs1, fa1
-               	fmv.s	fs2, fa2
-               	fmv.d	fs3, fa3
-               	fmv.s	fs4, fa4
-               	fmv.d	fs5, fa5
-               	fmv.s	fs6, fa6
-               	fmv.d	fs7, fa7
-               	fmv.w.x	fs8, a0
-               	fmv.d.x	fs9, a1
-               	fmv.w.x	fs10, a2
-               	fmv.d.x	fs11, a3
-               	sw	a4, -0x80(s0)
-               	sd	a5, -0x90(s0)
-               	sw	a6, -0xa0(s0)
-               	sd	a7, -0xb0(s0)
+               	addi	sp, sp, -0x70
+               	sd	ra, 0x68(sp)
+               	sd	s0, 0x60(sp)
+               	addi	s0, sp, 0x70
+               	fsd	fs0, 0x58(sp)
+               	fsd	fs1, 0x50(sp)
+               	fsd	fs2, 0x48(sp)
+               	fsd	fs3, 0x40(sp)
+               	fsd	fs4, 0x38(sp)
+               	fsd	fs5, 0x30(sp)
+               	fsd	fs6, 0x28(sp)
+               	fsd	fs7, 0x20(sp)
+               	fsd	fs8, 0x18(sp)
+               	fsd	fs9, 0x10(sp)
+               	fsd	fs10, 0x8(sp)
+               	fsd	fs11, 0x0(sp)
+               	fmv.d	fs0, fa1
+               	fmv.d	fs1, fa3
+               	fmv.d	fs2, fa5
+               	fmv.d	fs3, fa7
+               	fmv.w.x	fs4, a0
+               	fmv.d.x	fs5, a1
+               	fmv.w.x	fs6, a2
+               	fmv.d.x	fs7, a3
+               	fmv.w.x	fs8, a4
+               	fmv.d.x	fs9, a5
+               	fmv.w.x	fs10, a6
+               	fmv.d.x	fs11, a7
+               	fmv.x.w	a0, fa0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x15c <corpus.cases.call.call_float_regs.takef16+0xac>
+               	j	0x190 <corpus.cases.call.call_float_regs.takef16+0xe0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x15c <corpus.cases.call.call_float_regs.takef16+0xac>
+               	fmv.x.d	a1, fs0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1a4 <corpus.cases.call.call_float_regs.takef16+0xf4>
+               	j	0x1d8 <corpus.cases.call.call_float_regs.takef16+0x128>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1a4 <corpus.cases.call.call_float_regs.takef16+0xf4>
+               	fmv.x.w	a1, fa2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1f4 <corpus.cases.call.call_float_regs.takef16+0x144>
+               	j	0x228 <corpus.cases.call.call_float_regs.takef16+0x178>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1f4 <corpus.cases.call.call_float_regs.takef16+0x144>
+               	fmv.x.d	a1, fs1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23c <corpus.cases.call.call_float_regs.takef16+0x18c>
+               	j	0x270 <corpus.cases.call.call_float_regs.takef16+0x1c0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23c <corpus.cases.call.call_float_regs.takef16+0x18c>
+               	fmv.x.w	a1, fa4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x28c <corpus.cases.call.call_float_regs.takef16+0x1dc>
+               	j	0x2c0 <corpus.cases.call.call_float_regs.takef16+0x210>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x28c <corpus.cases.call.call_float_regs.takef16+0x1dc>
+               	fmv.x.d	a1, fs2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2d4 <corpus.cases.call.call_float_regs.takef16+0x224>
+               	j	0x308 <corpus.cases.call.call_float_regs.takef16+0x258>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2d4 <corpus.cases.call.call_float_regs.takef16+0x224>
+               	fmv.x.w	a1, fa6
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x324 <corpus.cases.call.call_float_regs.takef16+0x274>
+               	j	0x358 <corpus.cases.call.call_float_regs.takef16+0x2a8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x324 <corpus.cases.call.call_float_regs.takef16+0x274>
+               	fmv.x.d	a1, fs3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x36c <corpus.cases.call.call_float_regs.takef16+0x2bc>
+               	j	0x3a0 <corpus.cases.call.call_float_regs.takef16+0x2f0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x36c <corpus.cases.call.call_float_regs.takef16+0x2bc>
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.call.call_float_regs.takef16+0x30c>
+               	j	0x3f0 <corpus.cases.call.call_float_regs.takef16+0x340>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.call.call_float_regs.takef16+0x30c>
+               	fmv.x.d	a1, fs5
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x404 <corpus.cases.call.call_float_regs.takef16+0x354>
+               	j	0x438 <corpus.cases.call.call_float_regs.takef16+0x388>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x404 <corpus.cases.call.call_float_regs.takef16+0x354>
+               	fmv.x.w	a1, fs6
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x454 <corpus.cases.call.call_float_regs.takef16+0x3a4>
+               	j	0x488 <corpus.cases.call.call_float_regs.takef16+0x3d8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x454 <corpus.cases.call.call_float_regs.takef16+0x3a4>
+               	fmv.x.d	a1, fs7
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.call.call_float_regs.takef16+0x3ec>
+               	j	0x4d0 <corpus.cases.call.call_float_regs.takef16+0x420>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.call.call_float_regs.takef16+0x3ec>
+               	fmv.x.w	a1, fs8
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ec <corpus.cases.call.call_float_regs.takef16+0x43c>
+               	j	0x520 <corpus.cases.call.call_float_regs.takef16+0x470>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ec <corpus.cases.call.call_float_regs.takef16+0x43c>
+               	fmv.x.d	a1, fs9
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x534 <corpus.cases.call.call_float_regs.takef16+0x484>
+               	j	0x568 <corpus.cases.call.call_float_regs.takef16+0x4b8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x534 <corpus.cases.call.call_float_regs.takef16+0x484>
+               	fmv.x.w	a1, fs10
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x584 <corpus.cases.call.call_float_regs.takef16+0x4d4>
+               	j	0x5b8 <corpus.cases.call.call_float_regs.takef16+0x508>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x584 <corpus.cases.call.call_float_regs.takef16+0x4d4>
+               	fmv.x.d	a1, fs11
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5cc <corpus.cases.call.call_float_regs.takef16+0x51c>
+               	j	0x600 <corpus.cases.call.call_float_regs.takef16+0x550>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5cc <corpus.cases.call.call_float_regs.takef16+0x51c>
+               	fmul.s	ft0, fa2, fa4
+               	fadd.s	ft1, fa0, ft0
+               	fsub.s	ft0, ft1, fa6
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x56c>
+               	fmul.d	ft0, fs1, fs2
+               	fadd.d	ft1, fs0, ft0
+               	fsub.d	ft0, ft1, fs3
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x584>
+               	fsub.s	ft0, fs4, fs6
+               	fmul.s	ft1, fs8, fs10
+               	fadd.s	ft2, ft0, ft1
+               	fmv.x.w	a1, ft2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x5a8>
+               	fsub.d	ft0, fs5, fs7
+               	fmul.d	ft1, fs9, fs11
+               	fadd.d	ft2, ft0, ft1
+               	fmv.x.d	a1, ft2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0xd0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0xe4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0xf8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x10c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x120>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x134>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x148>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x15c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x170>
-               	mv	a1, a0
-               	mv	a0, a1
-               	flw	fa0, -0x80(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x184>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fld	fa0, -0x90(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x198>
-               	mv	a1, a0
-               	mv	a0, a1
-               	flw	fa0, -0xa0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x1ac>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fld	fa0, -0xb0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x1c0>
-               	mv	a1, a0
-               	fmul.s	ft4, fs2, fs4
-               	fadd.s	ft5, fs0, ft4
-               	fsub.s	ft4, ft5, fs6
-               	mv	a0, a1
-               	fmv.s	fa0, ft4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x1e0>
-               	mv	a1, a0
-               	fmul.d	ft4, fs3, fs5
-               	fadd.d	ft5, fs1, ft4
-               	fsub.d	fa0, ft5, fs7
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x1fc>
-               	mv	a1, a0
-               	fsub.s	ft4, fs8, fs10
-               	flw	ft11, -0x80(s0)
-               	flw	ft10, -0xa0(s0)
-               	fmul.s	ft5, ft11, ft10
-               	fadd.s	ft0, ft4, ft5
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x224>
-               	mv	a1, a0
-               	fsub.d	ft0, fs9, fs11
-               	fld	ft11, -0x90(s0)
-               	fld	ft10, -0xb0(s0)
-               	fmul.d	ft2, ft11, ft10
-               	fadd.d	fa0, ft0, ft2
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x248>
-               	fld	fs0, 0x98(sp)
-               	fld	fs1, 0x90(sp)
-               	fld	fs2, 0x88(sp)
-               	fld	fs3, 0x80(sp)
-               	fld	fs4, 0x78(sp)
-               	fld	fs5, 0x70(sp)
-               	fld	fs6, 0x68(sp)
-               	fld	fs7, 0x60(sp)
-               	fld	fs8, 0x58(sp)
-               	fld	fs9, 0x50(sp)
-               	fld	fs10, 0x48(sp)
-               	fld	fs11, 0x40(sp)
-               	ld	ra, 0xa8(sp)
-               	ld	s0, 0xa0(sp)
-               	addi	sp, sp, 0xb0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16+0x5c0>
+               	fld	fs0, 0x58(sp)
+               	fld	fs1, 0x50(sp)
+               	fld	fs2, 0x48(sp)
+               	fld	fs3, 0x40(sp)
+               	fld	fs4, 0x38(sp)
+               	fld	fs5, 0x30(sp)
+               	fld	fs6, 0x28(sp)
+               	fld	fs7, 0x20(sp)
+               	fld	fs8, 0x18(sp)
+               	fld	fs9, 0x10(sp)
+               	fld	fs10, 0x8(sp)
+               	fld	fs11, 0x0(sp)
+               	ld	ra, 0x68(sp)
+               	ld	s0, 0x60(sp)
+               	addi	sp, sp, 0x70
                	ret
 
 <corpus.cases.call.call_float_regs.takef16s>:
@@ -255,109 +477,94 @@ Disassembly of section .text:
                	sw	a5, -0x90(s0)
                	sw	a6, -0xa0(s0)
                	sw	a7, -0xb0(s0)
+               	fmv.x.w	a0, fs0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xac>
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xc4>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xdc>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xd0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xe4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xf8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs6
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0xf4>
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x10c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	fmv.x.w	a1, fs5
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x124>
+               	fmv.s	fa0, fs6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x130>
                	fmv.s	fa0, fs7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x120>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x13c>
                	fmv.s	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x134>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x148>
                	fmv.s	fa0, fs9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x148>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x154>
                	fmv.s	fa0, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x15c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x160>
                	fmv.s	fa0, fs11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x170>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x16c>
                	flw	fa0, -0x80(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x184>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x178>
                	flw	fa0, -0x90(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x198>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x184>
                	flw	fa0, -0xa0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1ac>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x190>
                	flw	fa0, -0xb0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1c0>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x19c>
                	flw	ft10, -0xb0(s0)
                	fadd.s	ft1, fs0, ft10
-               	mv	a0, a1
                	fmv.s	fa0, ft1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1dc>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1b0>
                	flw	ft10, -0x80(s0)
                	fsub.s	ft1, fs7, ft10
-               	mv	a0, a1
                	fmv.s	fa0, ft1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1f8>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1c4>
                	flw	ft10, -0xa0(s0)
                	fmul.s	ft0, fs3, ft10
-               	mv	a0, a1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x214>
+               	jalr	ra <corpus.cases.call.call_float_regs.takef16s+0x1d8>
                	fld	fs0, 0x98(sp)
                	fld	fs1, 0x90(sp)
                	fld	fs2, 0x88(sp)
@@ -376,60 +583,52 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_float_regs.checksum>:
-               	addi	sp, sp, -0x310
-               	sd	ra, 0x308(sp)
-               	sd	s0, 0x300(sp)
-               	addi	s0, sp, 0x310
-               	sd	s1, 0x2f8(sp)
-               	sd	s2, 0x2f0(sp)
-               	sd	s3, 0x2e8(sp)
-               	sd	s4, 0x2e0(sp)
-               	sd	s5, 0x2d8(sp)
-               	sd	s6, 0x2d0(sp)
-               	sd	s7, 0x2c8(sp)
-               	sd	s8, 0x2c0(sp)
-               	sd	s9, 0x2b8(sp)
-               	sd	s10, 0x2b0(sp)
-               	sd	s11, 0x2a8(sp)
-               	fsd	fs0, 0x2a0(sp)
-               	fsd	fs1, 0x298(sp)
-               	fsd	fs2, 0x290(sp)
-               	fsd	fs3, 0x288(sp)
-               	fsd	fs4, 0x280(sp)
-               	fsd	fs5, 0x278(sp)
-               	fsd	fs6, 0x270(sp)
-               	fsd	fs7, 0x268(sp)
-               	fsd	fs8, 0x260(sp)
-               	fsd	fs9, 0x258(sp)
-               	fsd	fs10, 0x250(sp)
-               	fsd	fs11, 0x248(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_float_regs.checksum+0x70>
-               	addi	a1, s0, -0x168
+               	addi	sp, sp, -0x250
+               	sd	ra, 0x248(sp)
+               	sd	s0, 0x240(sp)
+               	addi	s0, sp, 0x250
+               	sd	s1, 0x238(sp)
+               	sd	s2, 0x230(sp)
+               	sd	s3, 0x228(sp)
+               	sd	s4, 0x220(sp)
+               	sd	s5, 0x218(sp)
+               	sd	s6, 0x210(sp)
+               	sd	s7, 0x208(sp)
+               	sd	s8, 0x200(sp)
+               	sd	s9, 0x1f8(sp)
+               	sd	s10, 0x1f0(sp)
+               	sd	s11, 0x1e8(sp)
+               	fsd	fs0, 0x1e0(sp)
+               	fsd	fs1, 0x1d8(sp)
+               	fsd	fs2, 0x1d0(sp)
+               	fsd	fs3, 0x1c8(sp)
+               	fsd	fs4, 0x1c0(sp)
+               	fsd	fs5, 0x1b8(sp)
+               	fsd	fs6, 0x1b0(sp)
+               	addi	a1, s0, -0x230
                	mv	a2, a1
                	li	t0, 0x7
                	and	a3, a2, t0
-               	bnez	a3, 0x648 <corpus.cases.call.call_float_regs.checksum+0xac>
+               	bnez	a3, 0x964 <corpus.cases.call.call_float_regs.checksum+0x8c>
                	mv	a3, a2
                	li	a4, 0xa0
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x630 <corpus.cases.call.call_float_regs.checksum+0x94>
-               	j	0x664 <corpus.cases.call.call_float_regs.checksum+0xc8>
+               	bne	a4, t0, 0x94c <corpus.cases.call.call_float_regs.checksum+0x74>
+               	j	0x980 <corpus.cases.call.call_float_regs.checksum+0xa8>
                	mv	a3, a2
                	li	a2, 0xa0
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x650 <corpus.cases.call.call_float_regs.checksum+0xb4>
+               	bne	a2, t0, 0x96c <corpus.cases.call.call_float_regs.checksum+0x94>
                	li	a2, 0x0
                	li	t0, 0x14
-               	bltu	a2, t0, 0x674 <corpus.cases.call.call_float_regs.checksum+0xd8>
-               	j	0x6d8 <corpus.cases.call.call_float_regs.checksum+0x13c>
+               	bltu	a2, t0, 0x990 <corpus.cases.call.call_float_regs.checksum+0xb8>
+               	j	0x9f4 <corpus.cases.call.call_float_regs.checksum+0x11c>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -448,80 +647,80 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
                	add	a4, a3, t0
-               	add	a3, a4, s1
+               	add	a3, a4, a0
                	slli	t0, a2, 0x3
                	add	a4, a1, t0
                	sd	a3, 0x0(a4)
                	addi	a2, a2, 0x1
                	li	t0, 0x14
-               	bltu	a2, t0, 0x674 <corpus.cases.call.call_float_regs.checksum+0xd8>
-               	addi	s1, s0, -0x1b8
-               	mv	a2, s1
+               	bltu	a2, t0, 0x990 <corpus.cases.call.call_float_regs.checksum+0xb8>
+               	addi	s1, s0, -0xf0
+               	mv	a0, s1
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x70c <corpus.cases.call.call_float_regs.checksum+0x170>
-               	mv	a3, a2
-               	li	a4, 0x50
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a2, a0, t0
+               	bnez	a2, 0xa28 <corpus.cases.call.call_float_regs.checksum+0x150>
+               	mv	a2, a0
+               	li	a3, 0x50
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x6f4 <corpus.cases.call.call_float_regs.checksum+0x158>
-               	j	0x728 <corpus.cases.call.call_float_regs.checksum+0x18c>
-               	mv	a3, a2
-               	li	a2, 0x50
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a3, t0, 0xa10 <corpus.cases.call.call_float_regs.checksum+0x138>
+               	j	0xa44 <corpus.cases.call.call_float_regs.checksum+0x16c>
+               	mv	a2, a0
+               	li	a0, 0x50
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x714 <corpus.cases.call.call_float_regs.checksum+0x178>
-               	addi	s2, s0, -0x258
-               	mv	a2, s2
+               	bne	a0, t0, 0xa30 <corpus.cases.call.call_float_regs.checksum+0x158>
+               	addi	s2, s0, -0x190
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x75c <corpus.cases.call.call_float_regs.checksum+0x1c0>
-               	mv	a3, a2
-               	li	a4, 0xa0
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a2, a0, t0
+               	bnez	a2, 0xa78 <corpus.cases.call.call_float_regs.checksum+0x1a0>
+               	mv	a2, a0
+               	li	a3, 0xa0
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x744 <corpus.cases.call.call_float_regs.checksum+0x1a8>
-               	j	0x778 <corpus.cases.call.call_float_regs.checksum+0x1dc>
-               	mv	a3, a2
-               	li	a2, 0xa0
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a3, t0, 0xa60 <corpus.cases.call.call_float_regs.checksum+0x188>
+               	j	0xa94 <corpus.cases.call.call_float_regs.checksum+0x1bc>
+               	mv	a2, a0
+               	li	a0, 0xa0
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x764 <corpus.cases.call.call_float_regs.checksum+0x1c8>
-               	li	a2, 0x0
+               	bne	a0, t0, 0xa80 <corpus.cases.call.call_float_regs.checksum+0x1a8>
+               	li	a0, 0x0
                	li	t0, 0x14
-               	bltu	a2, t0, 0x788 <corpus.cases.call.call_float_regs.checksum+0x1ec>
-               	j	0x814 <.Lpcrel_hi.3+0x24>
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	ld	a4, 0x0(a3)
+               	bltu	a0, t0, 0xaa4 <corpus.cases.call.call_float_regs.checksum+0x1cc>
+               	j	0xb30 <.Lpcrel_hi.3+0x24>
+               	slli	t0, a0, 0x3
+               	add	a2, a1, t0
+               	ld	a3, 0x0(a2)
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a3, a4, t0
-               	fcvt.s.lu	ft0, a3
+               	and	a2, a3, t0
+               	fcvt.s.lu	ft0, a2
                	lui	t0, 0x45000
                	fmv.w.x	ft10, t0
                	fsub.s	ft1, ft0, ft10
                	lui	t0, 0x41000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, ft1, ft10
-               	slli	t0, a2, 0x2
-               	add	a3, s1, t0
-               	fsw	ft0, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	ld	a4, 0x0(a3)
+               	slli	t0, a0, 0x2
+               	add	a2, s1, t0
+               	fsw	ft0, 0x0(a2)
+               	slli	t0, a0, 0x3
+               	add	a2, a1, t0
+               	ld	a3, 0x0(a2)
                	lui	t0, 0x100
                	addiw	t0, t0, -0x1
-               	and	a3, a4, t0
-               	fcvt.d.lu	ft0, a3
+               	and	a2, a3, t0
+               	fcvt.d.lu	ft0, a2
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
@@ -532,18 +731,26 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft0, ft1, ft10
-               	slli	t0, a2, 0x3
-               	add	a3, s2, t0
-               	fsd	ft0, 0x0(a3)
-               	addi	a2, a2, 0x1
+               	slli	t0, a0, 0x3
+               	add	a2, s2, t0
+               	fsd	ft0, 0x0(a2)
+               	addi	a0, a0, 0x1
                	li	t0, 0x14
-               	bltu	a2, t0, 0x788 <corpus.cases.call.call_float_regs.checksum+0x1ec>
-               	mv	s3, a0
-               	li	s4, 0x0
+               	bltu	a0, t0, 0xaa4 <corpus.cases.call.call_float_regs.checksum+0x1cc>
+               	lui	s3, 0xfcbf3
+               	addiw	s3, s3, -0x632
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x484
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x222
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x325
+               	li	t2, 0x0
+               	sd	t2, -0x238(s0)
                	li	s5, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x82c <.Lpcrel_hi.3+0x3c>
-               	j	0xadc <.Lpcrel_hi.3+0x2ec>
+               	bltu	s5, t0, 0xb68 <.Lpcrel_hi.3+0x5c>
+               	j	0xd40 <.Lpcrel_hi.3+0x234>
                	li	t0, 0x3
                	and	a0, s5, t0
                	fcvt.s.lu	ft0, a0
@@ -576,14 +783,14 @@ Disassembly of section .text:
                	addi	a0, s2, 0x58
                	fld	ft7, 0x0(a0)
                	addi	t2, s1, 0x30
-               	sd	t2, -0x260(s0)
-               	ld	t2, -0x260(s0)
+               	sd	t2, -0x240(s0)
+               	ld	t2, -0x240(s0)
                	flw	ft8, 0x0(t2)
                	addi	a0, s2, 0x68
                	fld	ft9, 0x0(a0)
                	addi	t2, s1, 0x38
-               	sd	t2, -0x268(s0)
-               	ld	t2, -0x268(s0)
+               	sd	t2, -0x248(s0)
+               	ld	t2, -0x248(s0)
                	flw	fs1, 0x0(t2)
                	addi	a0, s2, 0x78
                	fld	fs2, 0x0(a0)
@@ -600,223 +807,118 @@ Disassembly of section .text:
                	fmv.x.w	a6, fs1
                	fmv.x.d	a7, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x118>
+               	jalr	ra <.Lpcrel_hi.3+0x138>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x128>
-               	mv	t2, a0
-               	sd	t2, -0x270(s0)
-               	ld	t2, -0x270(s0)
-               	flw	fs1, 0x0(s6)
+               	jalr	ra <.Lpcrel_hi.3+0x148>
+               	mv	s4, a0
+               	flw	ft0, 0x0(s6)
                	addi	a0, s1, 0x4
-               	flw	fs2, 0x0(a0)
-               	flw	fs3, 0x0(s7)
+               	flw	ft1, 0x0(a0)
+               	flw	ft2, 0x0(s7)
                	addi	a0, s1, 0xc
-               	flw	fs4, 0x0(a0)
-               	flw	fs5, 0x0(s8)
+               	flw	ft3, 0x0(a0)
+               	flw	ft4, 0x0(s8)
                	addi	a0, s1, 0x14
-               	flw	fs6, 0x0(a0)
-               	flw	fs7, 0x0(s9)
+               	flw	ft5, 0x0(a0)
+               	flw	ft6, 0x0(s9)
                	addi	a0, s1, 0x1c
-               	flw	fs8, 0x0(a0)
-               	flw	fs9, 0x0(s10)
+               	flw	ft7, 0x0(a0)
+               	flw	ft8, 0x0(s10)
                	addi	a0, s1, 0x24
-               	flw	fs10, 0x0(a0)
-               	flw	fs11, 0x0(s11)
+               	flw	ft9, 0x0(a0)
+               	flw	fs1, 0x0(s11)
                	addi	a0, s1, 0x2c
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x280(s0)
-               	ld	t2, -0x260(s0)
-               	flw	ft11, 0x0(t2)
-               	fsw	ft11, -0x290(s0)
+               	flw	fs2, 0x0(a0)
+               	ld	t2, -0x240(s0)
+               	flw	fs3, 0x0(t2)
                	addi	a0, s1, 0x34
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x2a0(s0)
-               	ld	t2, -0x268(s0)
-               	flw	ft11, 0x0(t2)
-               	fsw	ft11, -0x2b0(s0)
+               	flw	fs4, 0x0(a0)
+               	ld	t2, -0x248(s0)
+               	flw	fs5, 0x0(t2)
                	addi	a0, s1, 0x3c
-               	flw	ft4, 0x0(a0)
-               	fadd.s	ft11, ft4, fs0
-               	fsw	ft11, -0x2c0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1bc>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1c8>
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1d4>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1e0>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1ec>
-               	fmv.s	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1f8>
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x204>
-               	fmv.s	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x210>
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x21c>
-               	fmv.s	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x228>
-               	fmv.s	fa0, fs10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x234>
-               	fmv.s	fa0, fs11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x240>
-               	flw	fa0, -0x280(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x24c>
-               	flw	fa0, -0x290(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x258>
-               	flw	fa0, -0x2a0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x264>
-               	flw	fa0, -0x2b0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x270>
-               	flw	fa0, -0x2c0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x27c>
-               	flw	ft10, -0x2c0(s0)
-               	fadd.s	ft0, fs1, ft10
+               	flw	fa0, 0x0(a0)
+               	fadd.s	fs6, fa0, fs0
                	fmv.s	fa0, ft0
+               	fmv.s	fa1, ft1
+               	fmv.s	fa2, ft2
+               	fmv.s	fa3, ft3
+               	fmv.s	fa4, ft4
+               	fmv.s	fa5, ft5
+               	fmv.s	fa6, ft6
+               	fmv.s	fa7, ft7
+               	fmv.x.w	a0, ft8
+               	fmv.x.w	a1, ft9
+               	fmv.x.w	a2, fs1
+               	fmv.x.w	a3, fs2
+               	fmv.x.w	a4, fs3
+               	fmv.x.w	a5, fs4
+               	fmv.x.w	a6, fs5
+               	fmv.x.w	a7, fs6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x290>
-               	flw	ft10, -0x290(s0)
-               	fsub.s	ft0, fs8, ft10
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2a4>
-               	flw	ft10, -0x2b0(s0)
-               	fmul.s	ft0, fs4, ft10
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2b8>
+               	jalr	ra <.Lpcrel_hi.3+0x200>
                	mv	s6, a0
-               	ld	t2, -0x270(s0)
-               	mv	a0, t2
+               	mv	a0, s4
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2d0>
+               	jalr	ra <.Lpcrel_hi.3+0x214>
                	addi	s5, s5, 0x1
                	mv	s3, a0
-               	mv	s4, s6
+               	mv	t2, s6
+               	sd	t2, -0x238(s0)
                	li	t0, 0x3
-               	bltu	s5, t0, 0x82c <.Lpcrel_hi.3+0x3c>
+               	bltu	s5, t0, 0xb68 <.Lpcrel_hi.3+0x5c>
                	addi	a0, s1, 0x4c
-               	flw	fs0, 0x0(a0)
+               	flw	ft0, 0x0(a0)
                	addi	a0, s1, 0x48
-               	flw	fs1, 0x0(a0)
+               	flw	ft1, 0x0(a0)
                	addi	a0, s1, 0x44
-               	flw	fs2, 0x0(a0)
+               	flw	ft2, 0x0(a0)
                	addi	a0, s1, 0x40
-               	flw	fs3, 0x0(a0)
+               	flw	ft3, 0x0(a0)
                	addi	a0, s1, 0x3c
-               	flw	fs4, 0x0(a0)
+               	flw	ft4, 0x0(a0)
                	addi	a0, s1, 0x38
-               	flw	fs5, 0x0(a0)
+               	flw	ft5, 0x0(a0)
                	addi	a0, s1, 0x34
-               	flw	fs6, 0x0(a0)
+               	flw	ft6, 0x0(a0)
                	addi	a0, s1, 0x30
-               	flw	fs7, 0x0(a0)
+               	flw	ft7, 0x0(a0)
                	addi	a0, s1, 0x2c
-               	flw	fs8, 0x0(a0)
+               	flw	ft8, 0x0(a0)
                	addi	a0, s1, 0x28
-               	flw	fs9, 0x0(a0)
+               	flw	ft9, 0x0(a0)
                	addi	a0, s1, 0x24
-               	flw	fs10, 0x0(a0)
+               	flw	fs0, 0x0(a0)
                	addi	a0, s1, 0x20
-               	flw	fs11, 0x0(a0)
+               	flw	fs1, 0x0(a0)
                	addi	a0, s1, 0x1c
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x2d0(s0)
+               	flw	fs2, 0x0(a0)
                	addi	a0, s1, 0x18
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x2e0(s0)
+               	flw	fs3, 0x0(a0)
                	addi	a0, s1, 0x14
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x2f0(s0)
+               	flw	fs4, 0x0(a0)
                	addi	a0, s1, 0x10
-               	flw	ft11, 0x0(a0)
-               	fsw	ft11, -0x300(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x37c>
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x388>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x394>
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3a0>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3ac>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3b8>
-               	fmv.s	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3c4>
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3d0>
-               	fmv.s	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3dc>
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3e8>
-               	fmv.s	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3f4>
-               	fmv.s	fa0, fs10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x400>
-               	fmv.s	fa0, fs11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x40c>
-               	flw	fa0, -0x2d0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x418>
-               	flw	fa0, -0x2e0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x424>
-               	flw	fa0, -0x2f0(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x430>
-               	flw	fa0, -0x300(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x43c>
-               	flw	ft10, -0x300(s0)
-               	fadd.s	ft1, fs0, ft10
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x450>
-               	flw	ft10, -0x2d0(s0)
-               	fsub.s	ft1, fs7, ft10
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x464>
-               	flw	ft10, -0x2f0(s0)
-               	fmul.s	ft0, fs3, ft10
+               	flw	fs5, 0x0(a0)
                	fmv.s	fa0, ft0
+               	fmv.s	fa1, ft1
+               	fmv.s	fa2, ft2
+               	fmv.s	fa3, ft3
+               	fmv.s	fa4, ft4
+               	fmv.s	fa5, ft5
+               	fmv.s	fa6, ft6
+               	fmv.s	fa7, ft7
+               	fmv.x.w	a0, ft8
+               	fmv.x.w	a1, ft9
+               	fmv.x.w	a2, fs0
+               	fmv.x.w	a3, fs1
+               	fmv.x.w	a4, fs2
+               	fmv.x.w	a5, fs3
+               	fmv.x.w	a6, fs4
+               	fmv.x.w	a7, fs5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x478>
+               	jalr	ra <.Lpcrel_hi.3+0x2f4>
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a1, a0, t0
@@ -841,9 +943,10 @@ Disassembly of section .text:
                	flw	ft3, 0x0(a0)
                	addi	a0, s2, 0x30
                	fld	fa7, 0x0(a0)
+               	ld	t2, -0x238(s0)
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a0, s4, t0
+               	and	a0, t2, t0
                	fcvt.s.lu	ft4, a0
                	lui	t0, 0x45000
                	fmv.w.x	ft10, t0
@@ -878,35 +981,30 @@ Disassembly of section .text:
                	fmv.x.w	a6, fs0
                	fmv.x.d	a7, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x570>
+               	jalr	ra <.Lpcrel_hi.3+0x3f0>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x580>
-               	ld	s1, 0x2f8(sp)
-               	ld	s2, 0x2f0(sp)
-               	ld	s3, 0x2e8(sp)
-               	ld	s4, 0x2e0(sp)
-               	ld	s5, 0x2d8(sp)
-               	ld	s6, 0x2d0(sp)
-               	ld	s7, 0x2c8(sp)
-               	ld	s8, 0x2c0(sp)
-               	ld	s9, 0x2b8(sp)
-               	ld	s10, 0x2b0(sp)
-               	ld	s11, 0x2a8(sp)
-               	fld	fs0, 0x2a0(sp)
-               	fld	fs1, 0x298(sp)
-               	fld	fs2, 0x290(sp)
-               	fld	fs3, 0x288(sp)
-               	fld	fs4, 0x280(sp)
-               	fld	fs5, 0x278(sp)
-               	fld	fs6, 0x270(sp)
-               	fld	fs7, 0x268(sp)
-               	fld	fs8, 0x260(sp)
-               	fld	fs9, 0x258(sp)
-               	fld	fs10, 0x250(sp)
-               	fld	fs11, 0x248(sp)
-               	ld	ra, 0x308(sp)
-               	ld	s0, 0x300(sp)
-               	addi	sp, sp, 0x310
+               	jalr	ra <.Lpcrel_hi.3+0x400>
+               	ld	s1, 0x238(sp)
+               	ld	s2, 0x230(sp)
+               	ld	s3, 0x228(sp)
+               	ld	s4, 0x220(sp)
+               	ld	s5, 0x218(sp)
+               	ld	s6, 0x210(sp)
+               	ld	s7, 0x208(sp)
+               	ld	s8, 0x200(sp)
+               	ld	s9, 0x1f8(sp)
+               	ld	s10, 0x1f0(sp)
+               	ld	s11, 0x1e8(sp)
+               	fld	fs0, 0x1e0(sp)
+               	fld	fs1, 0x1d8(sp)
+               	fld	fs2, 0x1d0(sp)
+               	fld	fs3, 0x1c8(sp)
+               	fld	fs4, 0x1c0(sp)
+               	fld	fs5, 0x1b8(sp)
+               	fld	fs6, 0x1b0(sp)
+               	ld	ra, 0x248(sp)
+               	ld	s0, 0x240(sp)
+               	addi	sp, sp, 0x250
                	ret

--- a/test/golden/riscv64-linux/call/call_indirect.dis
+++ b/test/golden/riscv64-linux/call/call_indirect.dis
@@ -72,38 +72,63 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_indirect.fold24>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	sd	s2, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	ld	s1, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s2, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.fold24+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.fold24+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.fold24+0x64>
-               	ld	s1, 0x8(sp)
-               	ld	s2, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	a4, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.call.call_indirect.fold24+0x28>
+               	j	0x138 <corpus.cases.call.call_indirect.fold24+0x5c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.call.call_indirect.fold24+0x28>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x148 <corpus.cases.call.call_indirect.fold24+0x6c>
+               	j	0x17c <corpus.cases.call.call_indirect.fold24+0xa0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a4, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x148 <corpus.cases.call.call_indirect.fold24+0x6c>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x18c <corpus.cases.call.call_indirect.fold24+0xb0>
+               	j	0x1c0 <corpus.cases.call.call_indirect.fold24+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x18c <corpus.cases.call.call_indirect.fold24+0xb0>
                	ret
 
 <corpus.cases.call.call_indirect.sum24>:
@@ -152,8 +177,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x264 <corpus.cases.call.call_indirect.mk_lin+0xa8>
-               	bnez	a2, 0x238 <corpus.cases.call.call_indirect.mk_lin+0x7c>
+               	bltu	a1, a3, 0x2c8 <corpus.cases.call.call_indirect.mk_lin+0xa8>
+               	bnez	a2, 0x29c <corpus.cases.call.call_indirect.mk_lin+0x7c>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -163,8 +188,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x218 <corpus.cases.call.call_indirect.mk_lin+0x5c>
-               	j	0x2bc <corpus.cases.call.call_indirect.mk_lin+0x100>
+               	bne	a6, t0, 0x27c <corpus.cases.call.call_indirect.mk_lin+0x5c>
+               	j	0x320 <corpus.cases.call.call_indirect.mk_lin+0x100>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -174,9 +199,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x244 <corpus.cases.call.call_indirect.mk_lin+0x88>
-               	j	0x2bc <corpus.cases.call.call_indirect.mk_lin+0x100>
-               	bnez	a2, 0x294 <corpus.cases.call.call_indirect.mk_lin+0xd8>
+               	bne	a6, t0, 0x2a8 <corpus.cases.call.call_indirect.mk_lin+0x88>
+               	j	0x320 <corpus.cases.call.call_indirect.mk_lin+0x100>
+               	bnez	a2, 0x2f8 <corpus.cases.call.call_indirect.mk_lin+0xd8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -186,8 +211,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x274 <corpus.cases.call.call_indirect.mk_lin+0xb8>
-               	j	0x2bc <corpus.cases.call.call_indirect.mk_lin+0x100>
+               	bne	a5, t0, 0x2d8 <corpus.cases.call.call_indirect.mk_lin+0xb8>
+               	j	0x320 <corpus.cases.call.call_indirect.mk_lin+0x100>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -197,7 +222,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2a0 <corpus.cases.call.call_indirect.mk_lin+0xe4>
+               	bne	a3, t0, 0x304 <corpus.cases.call.call_indirect.mk_lin+0xe4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -222,8 +247,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x374 <corpus.cases.call.call_indirect.mk_pow+0xa8>
-               	bnez	a2, 0x348 <corpus.cases.call.call_indirect.mk_pow+0x7c>
+               	bltu	a1, a3, 0x3d8 <corpus.cases.call.call_indirect.mk_pow+0xa8>
+               	bnez	a2, 0x3ac <corpus.cases.call.call_indirect.mk_pow+0x7c>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -233,8 +258,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x328 <corpus.cases.call.call_indirect.mk_pow+0x5c>
-               	j	0x3cc <corpus.cases.call.call_indirect.mk_pow+0x100>
+               	bne	a6, t0, 0x38c <corpus.cases.call.call_indirect.mk_pow+0x5c>
+               	j	0x430 <corpus.cases.call.call_indirect.mk_pow+0x100>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -244,9 +269,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x354 <corpus.cases.call.call_indirect.mk_pow+0x88>
-               	j	0x3cc <corpus.cases.call.call_indirect.mk_pow+0x100>
-               	bnez	a2, 0x3a4 <corpus.cases.call.call_indirect.mk_pow+0xd8>
+               	bne	a6, t0, 0x3b8 <corpus.cases.call.call_indirect.mk_pow+0x88>
+               	j	0x430 <corpus.cases.call.call_indirect.mk_pow+0x100>
+               	bnez	a2, 0x408 <corpus.cases.call.call_indirect.mk_pow+0xd8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -256,8 +281,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x384 <corpus.cases.call.call_indirect.mk_pow+0xb8>
-               	j	0x3cc <corpus.cases.call.call_indirect.mk_pow+0x100>
+               	bne	a5, t0, 0x3e8 <corpus.cases.call.call_indirect.mk_pow+0xb8>
+               	j	0x430 <corpus.cases.call.call_indirect.mk_pow+0x100>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -267,118 +292,251 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x3b0 <corpus.cases.call.call_indirect.mk_pow+0xe4>
+               	bne	a3, t0, 0x414 <corpus.cases.call.call_indirect.mk_pow+0xe4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.call.call_indirect.wide>:
-               	addi	sp, sp, -0x70
-               	sd	ra, 0x68(sp)
-               	sd	s0, 0x60(sp)
-               	addi	s0, sp, 0x70
-               	sd	s1, 0x58(sp)
-               	sd	s2, 0x50(sp)
-               	sd	s3, 0x48(sp)
-               	sd	s4, 0x40(sp)
-               	sd	s5, 0x38(sp)
-               	sd	s6, 0x30(sp)
-               	sd	s7, 0x28(sp)
-               	sd	s8, 0x20(sp)
-               	fsd	fs0, 0x18(sp)
-               	fsd	fs1, 0x10(sp)
-               	fsd	fs2, 0x8(sp)
-               	fsd	fs3, 0x0(sp)
-               	mv	s1, a0
-               	mv	s2, a1
-               	fmv.d	fs0, fa0
-               	mv	s3, a2
-               	fmv.s	fs1, fa1
-               	mv	s4, a3
-               	mv	s5, a4
-               	fmv.d	fs2, fa2
-               	mv	s6, a5
-               	mv	s7, a6
-               	fmv.s	fs3, fa3
-               	mv	s8, a7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x70>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x84>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x98>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0xac>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0xc0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0xd4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0xe8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0xfc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x110>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x124>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x138>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x14c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.wide+0x160>
-               	ld	s1, 0x58(sp)
-               	ld	s2, 0x50(sp)
-               	ld	s3, 0x48(sp)
-               	ld	s4, 0x40(sp)
-               	ld	s5, 0x38(sp)
-               	ld	s6, 0x30(sp)
-               	ld	s7, 0x28(sp)
-               	ld	s8, 0x20(sp)
-               	fld	fs0, 0x18(sp)
-               	fld	fs1, 0x10(sp)
-               	fld	fs2, 0x8(sp)
-               	fld	fs3, 0x0(sp)
-               	ld	ra, 0x68(sp)
-               	ld	s0, 0x60(sp)
-               	addi	sp, sp, 0x70
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	lui	t5, 0xfcbf3
+               	addiw	t5, t5, -0x632
+               	slli	t5, t5, 0xc
+               	addi	t5, t5, 0x484
+               	slli	t5, t5, 0xc
+               	addi	t5, t5, 0x222
+               	slli	t5, t5, 0xc
+               	addi	t5, t5, 0x325
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x488 <corpus.cases.call.call_indirect.wide+0x48>
+               	j	0x4bc <corpus.cases.call.call_indirect.wide+0x7c>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a0, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x488 <corpus.cases.call.call_indirect.wide+0x48>
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d4 <corpus.cases.call.call_indirect.wide+0x94>
+               	j	0x508 <corpus.cases.call.call_indirect.wide+0xc8>
+               	li	t0, 0x8
+               	mul	t6, a1, t0
+               	srl	s1, a0, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, t5, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s1, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d4 <corpus.cases.call.call_indirect.wide+0x94>
+               	fmv.x.d	a0, fa0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.call.call_indirect.wide+0xdc>
+               	j	0x550 <corpus.cases.call.call_indirect.wide+0x110>
+               	li	t0, 0x8
+               	mul	t6, a1, t0
+               	srl	s1, a0, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, t5, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s1, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.call.call_indirect.wide+0xdc>
+               	zext.b	a0, a2
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x564 <corpus.cases.call.call_indirect.wide+0x124>
+               	j	0x598 <corpus.cases.call.call_indirect.wide+0x158>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	t6, a0, a2
+               	li	t0, 0xff
+               	and	a2, t6, t0
+               	xor	t6, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, t6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x564 <corpus.cases.call.call_indirect.wide+0x124>
+               	fmv.x.w	a0, fa1
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5b4 <corpus.cases.call.call_indirect.wide+0x174>
+               	j	0x5e8 <corpus.cases.call.call_indirect.wide+0x1a8>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	t6, a1, a2
+               	li	t0, 0xff
+               	and	a2, t6, t0
+               	xor	t6, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, t6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5b4 <corpus.cases.call.call_indirect.wide+0x174>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5f8 <corpus.cases.call.call_indirect.wide+0x1b8>
+               	j	0x62c <corpus.cases.call.call_indirect.wide+0x1ec>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, a3, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, t5, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5f8 <corpus.cases.call.call_indirect.wide+0x1b8>
+               	sext.w	a0, a4
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x640 <corpus.cases.call.call_indirect.wide+0x200>
+               	j	0x674 <corpus.cases.call.call_indirect.wide+0x234>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x640 <corpus.cases.call.call_indirect.wide+0x200>
+               	fmv.x.d	a0, fa2
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x688 <corpus.cases.call.call_indirect.wide+0x248>
+               	j	0x6bc <corpus.cases.call.call_indirect.wide+0x27c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x688 <corpus.cases.call.call_indirect.wide+0x248>
+               	slli	a0, a5, 0x30
+               	srli	a0, a0, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6d4 <corpus.cases.call.call_indirect.wide+0x294>
+               	j	0x708 <corpus.cases.call.call_indirect.wide+0x2c8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6d4 <corpus.cases.call.call_indirect.wide+0x294>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x718 <corpus.cases.call.call_indirect.wide+0x2d8>
+               	j	0x74c <corpus.cases.call.call_indirect.wide+0x30c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, a6, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, t5, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x718 <corpus.cases.call.call_indirect.wide+0x2d8>
+               	fmv.x.w	a0, fa3
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x768 <corpus.cases.call.call_indirect.wide+0x328>
+               	j	0x79c <corpus.cases.call.call_indirect.wide+0x35c>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, t5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x768 <corpus.cases.call.call_indirect.wide+0x328>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x7ac <corpus.cases.call.call_indirect.wide+0x36c>
+               	j	0x7e0 <corpus.cases.call.call_indirect.wide+0x3a0>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, a7, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, t5, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x7ac <corpus.cases.call.call_indirect.wide+0x36c>
+               	mv	a0, t5
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_indirect.apply>:
@@ -422,15 +580,15 @@ Disassembly of section .text:
 
 <corpus.cases.call.call_indirect.pick>:
                	li	t0, 0x0
-               	beq	a0, t0, 0x674 <.Lpcrel_hi.5>
+               	beq	a0, t0, 0x8ec <.Lpcrel_hi.5>
                	li	t0, 0x1
-               	beq	a0, t0, 0x668 <.Lpcrel_hi.4>
+               	beq	a0, t0, 0x8e0 <.Lpcrel_hi.4>
                	li	t0, 0x2
-               	beq	a0, t0, 0x65c <.Lpcrel_hi.3>
+               	beq	a0, t0, 0x8d4 <.Lpcrel_hi.3>
                	li	t0, 0x3
-               	beq	a0, t0, 0x650 <.Lpcrel_hi.2>
+               	beq	a0, t0, 0x8c8 <.Lpcrel_hi.2>
                	li	t0, 0x4
-               	beq	a0, t0, 0x644 <.Lpcrel_hi.1>
+               	beq	a0, t0, 0x8bc <.Lpcrel_hi.1>
 
 <.Lpcrel_hi.0>:
                	auipc	a0, 0x0
@@ -463,52 +621,50 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_indirect.checksum>:
-               	addi	sp, sp, -0x210
-               	sd	ra, 0x208(sp)
-               	sd	s0, 0x200(sp)
-               	addi	s0, sp, 0x210
-               	sd	s1, 0x1f8(sp)
-               	sd	s2, 0x1f0(sp)
-               	sd	s3, 0x1e8(sp)
-               	sd	s4, 0x1e0(sp)
-               	sd	s5, 0x1d8(sp)
-               	sd	s6, 0x1d0(sp)
-               	sd	s7, 0x1c8(sp)
-               	sd	s8, 0x1c0(sp)
-               	sd	s9, 0x1b8(sp)
-               	sd	s10, 0x1b0(sp)
-               	sd	s11, 0x1a8(sp)
-               	fsd	fs0, 0x1a0(sp)
-               	fsd	fs1, 0x198(sp)
-               	fsd	fs2, 0x190(sp)
-               	fsd	fs3, 0x188(sp)
+               	addi	sp, sp, -0x200
+               	sd	ra, 0x1f8(sp)
+               	sd	s0, 0x1f0(sp)
+               	addi	s0, sp, 0x200
+               	sd	s1, 0x1e8(sp)
+               	sd	s2, 0x1e0(sp)
+               	sd	s3, 0x1d8(sp)
+               	sd	s4, 0x1d0(sp)
+               	sd	s5, 0x1c8(sp)
+               	sd	s6, 0x1c0(sp)
+               	sd	s7, 0x1b8(sp)
+               	sd	s8, 0x1b0(sp)
+               	sd	s9, 0x1a8(sp)
+               	sd	s10, 0x1a0(sp)
+               	sd	s11, 0x198(sp)
+               	fsd	fs0, 0x190(sp)
+               	fsd	fs1, 0x188(sp)
+               	fsd	fs2, 0x180(sp)
+               	fsd	fs3, 0x178(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_indirect.checksum+0x50>
-               	addi	s2, s0, -0xe8
-               	mv	a1, s2
+               	addi	s2, s0, -0x168
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x70c <corpus.cases.call.call_indirect.checksum+0x8c>
-               	mv	a2, a1
-               	li	a3, 0x60
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x97c <corpus.cases.call.call_indirect.checksum+0x84>
+               	mv	a1, a0
+               	li	a2, 0x60
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x6f4 <corpus.cases.call.call_indirect.checksum+0x74>
-               	j	0x728 <corpus.cases.call.call_indirect.checksum+0xa8>
-               	mv	a2, a1
-               	li	a1, 0x60
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x964 <corpus.cases.call.call_indirect.checksum+0x6c>
+               	j	0x998 <corpus.cases.call.call_indirect.checksum+0xa0>
+               	mv	a1, a0
+               	li	a0, 0x60
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x714 <corpus.cases.call.call_indirect.checksum+0x94>
-               	li	a1, 0x0
+               	bne	a0, t0, 0x984 <corpus.cases.call.call_indirect.checksum+0x8c>
+               	li	a0, 0x0
                	li	t0, 0xc
-               	bltu	a1, t0, 0x738 <corpus.cases.call.call_indirect.checksum+0xb8>
-               	j	0x79c <corpus.cases.call.call_indirect.checksum+0x11c>
+               	bltu	a0, t0, 0x9a8 <corpus.cases.call.call_indirect.checksum+0xb0>
+               	j	0xa0c <corpus.cases.call.call_indirect.checksum+0x114>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -517,7 +673,7 @@ Disassembly of section .text:
                	addi	t0, t0, -0x6a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd3
-               	mul	a2, a1, t0
+               	mul	a1, a0, t0
                	lui	t0, 0x1405
                	addiw	t0, t0, 0x7b8
                	slli	t0, t0, 0xc
@@ -526,267 +682,284 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a2, t0
-               	add	a2, a3, s1
-               	slli	t0, a1, 0x3
-               	add	a3, s2, t0
-               	sd	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
+               	slli	t0, a0, 0x3
+               	add	a2, s2, t0
+               	sd	a1, 0x0(a2)
+               	addi	a0, a0, 0x1
                	li	t0, 0xc
-               	bltu	a1, t0, 0x738 <corpus.cases.call.call_indirect.checksum+0xb8>
-               	addi	s3, s0, -0x118
-               	mv	a1, s3
+               	bltu	a0, t0, 0x9a8 <corpus.cases.call.call_indirect.checksum+0xb0>
+               	addi	s3, s0, -0xb8
+               	mv	a0, s3
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x7d0 <corpus.cases.call.call_indirect.checksum+0x150>
-               	mv	a2, a1
-               	li	a3, 0x30
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0xa40 <corpus.cases.call.call_indirect.checksum+0x148>
+               	mv	a1, a0
+               	li	a2, 0x30
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x7b8 <corpus.cases.call.call_indirect.checksum+0x138>
-               	j	0x7ec <corpus.cases.call.call_indirect.checksum+0x16c>
-               	mv	a2, a1
-               	li	a1, 0x30
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xa28 <corpus.cases.call.call_indirect.checksum+0x130>
+               	j	0xa5c <corpus.cases.call.call_indirect.checksum+0x164>
+               	mv	a1, a0
+               	li	a0, 0x30
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x7d8 <corpus.cases.call.call_indirect.checksum+0x158>
-               	mv	a1, s3
+               	bne	a0, t0, 0xa48 <corpus.cases.call.call_indirect.checksum+0x150>
+               	mv	a0, s3
 
 <.Lpcrel_hi.6>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x8
 
 <.Lpcrel_hi.7>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x10
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x10
 
 <.Lpcrel_hi.8>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x18
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x18
 
 <.Lpcrel_hi.9>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x20
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x20
 
 <.Lpcrel_hi.10>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x28
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x28
 
 <.Lpcrel_hi.11>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	s4, s0, -0x128
-               	mv	a1, s4
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	s4, s0, -0xc8
+               	mv	a0, s4
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x880 <.Lpcrel_hi.11+0x40>
-               	mv	a2, a1
-               	li	a3, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0xaf0 <.Lpcrel_hi.11+0x40>
+               	mv	a1, a0
+               	li	a2, 0x10
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x868 <.Lpcrel_hi.11+0x28>
-               	j	0x89c <.Lpcrel_hi.11+0x5c>
-               	mv	a2, a1
-               	li	a1, 0x10
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xad8 <.Lpcrel_hi.11+0x28>
+               	j	0xb0c <.Lpcrel_hi.11+0x5c>
+               	mv	a1, a0
+               	li	a0, 0x10
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x888 <.Lpcrel_hi.11+0x48>
-               	mv	a1, s4
+               	bne	a0, t0, 0xaf8 <.Lpcrel_hi.11+0x48>
+               	mv	a0, s4
 
 <.Lpcrel_hi.12>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
 
 <.Lpcrel_hi.13>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	s5, s0, -0x138
-               	mv	a1, s5
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	s5, s0, -0xd8
+               	mv	a0, s5
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x8f0 <.Lpcrel_hi.13+0x40>
-               	mv	a2, a1
-               	li	a3, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0xb60 <.Lpcrel_hi.13+0x40>
+               	mv	a1, a0
+               	li	a2, 0x10
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x8d8 <.Lpcrel_hi.13+0x28>
-               	j	0x90c <.Lpcrel_hi.13+0x5c>
-               	mv	a2, a1
-               	li	a1, 0x10
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xb48 <.Lpcrel_hi.13+0x28>
+               	j	0xb7c <.Lpcrel_hi.13+0x5c>
+               	mv	a1, a0
+               	li	a0, 0x10
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x8f8 <.Lpcrel_hi.13+0x48>
-               	mv	a1, s5
+               	bne	a0, t0, 0xb68 <.Lpcrel_hi.13+0x48>
+               	mv	a0, s5
 
 <.Lpcrel_hi.14>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s5, 0x8
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s5, 0x8
 
 <.Lpcrel_hi.15>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a2, 0x0(a1)
-               	addi	a1, s1, 0x1
-               	mv	s6, a0
-               	mv	s7, a1
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a1, 0x0(a0)
+               	addi	a0, s1, 0x1
+               	lui	s6, 0xfcbf3
+               	addiw	s6, s6, -0x632
+               	slli	s6, s6, 0xc
+               	addi	s6, s6, 0x484
+               	slli	s6, s6, 0xc
+               	addi	s6, s6, 0x222
+               	slli	s6, s6, 0xc
+               	addi	s6, s6, 0x325
+               	mv	s7, a0
                	li	s8, 0x0
                	li	t0, 0xc
-               	bltu	s8, t0, 0x948 <.Lpcrel_hi.15+0x28>
-               	j	0xafc <.Lpcrel_hi.21+0x48>
-               	slli	t0, s8, 0x3
-               	add	s9, s2, t0
-               	ld	a0, 0x0(s9)
-               	add	a1, a0, s1
-               	li	a0, 0x6
-               	bnez	a0, 0x964 <.Lpcrel_hi.15+0x44>
-               	ebreak
-               	remu	s10, a1, a0
-               	slli	t0, s10, 0x3
-               	add	s11, s3, t0
-               	ld	a2, 0x0(s11)
-               	ld	a1, 0x0(s9)
-               	mv	a0, s7
-               	jalr	a2
-               	mv	t2, a0
-               	sd	t2, -0x1d0(s0)
-               	ld	t2, -0x1d0(s0)
-               	mv	a0, s6
-               	ld	t2, -0x1d0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x78>
-               	mv	t2, a0
-               	sd	t2, -0x1d8(s0)
-               	ld	t2, -0x1d8(s0)
-               	ld	a4, 0x0(s11)
-               	ld	a1, 0x0(s9)
-               	ld	t2, -0x1d0(s0)
-               	mv	a0, t2
-               	jalr	a4
-               	mv	a1, a0
-               	ld	t2, -0x1d8(s0)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0xac>
-               	mv	s9, a0
-               	addi	a0, s10, 0x1
-               	li	a1, 0x6
-               	bnez	a1, 0x9e8 <.Lpcrel_hi.15+0xc8>
-               	ebreak
-               	remu	a3, a0, a1
-               	slli	t0, a3, 0x3
-               	add	a0, s3, t0
-               	ld	s10, 0x0(a0)
+               	bltu	s8, t0, 0xbd4 <.Lpcrel_hi.15+0x44>
+               	j	0xdb0 <.Lpcrel_hi.21+0x40>
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
-               	ld	s11, 0x0(a0)
-               	ld	t2, -0x1d0(s0)
-               	mv	a0, t2
-               	mv	a1, s11
+               	ld	a1, 0x0(a0)
+               	add	a2, a1, s1
+               	li	a1, 0x6
+               	bnez	a1, 0xbf0 <.Lpcrel_hi.15+0x60>
+               	ebreak
+               	remu	s9, a2, a1
+               	slli	t0, s9, 0x3
+               	add	a1, s3, t0
+               	ld	s10, 0x0(a1)
+               	ld	a1, 0x0(a0)
+               	mv	a0, s7
                	jalr	s10
-               	mv	a1, s11
-               	jalr	s10
+               	mv	s10, a0
+               	mv	s11, s6
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc24 <.Lpcrel_hi.15+0x94>
+               	j	0xc58 <.Lpcrel_hi.15+0xc8>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s10, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s11, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s11, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc24 <.Lpcrel_hi.15+0x94>
+               	slli	t0, s9, 0x3
+               	add	a0, s3, t0
+               	ld	a2, 0x0(a0)
+               	slli	t0, s8, 0x3
+               	add	a0, s2, t0
+               	ld	a1, 0x0(a0)
+               	mv	a0, s10
+               	jalr	a2
                	mv	a1, a0
-               	mv	a0, s9
+               	mv	a0, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x104>
+               	jalr	ra <.Lpcrel_hi.15+0xf0>
+               	mv	s11, a0
+               	addi	a0, s9, 0x1
+               	li	a1, 0x6
+               	bnez	a1, 0xc9c <.Lpcrel_hi.15+0x10c>
+               	ebreak
+               	remu	a2, a0, a1
+               	slli	t0, a2, 0x3
+               	add	a0, s3, t0
+               	ld	s9, 0x0(a0)
+               	slli	t0, s8, 0x3
+               	add	a0, s2, t0
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x1d0(s0)
+               	mv	a0, s10
+               	ld	t2, -0x1d0(s0)
+               	mv	a1, t2
+               	jalr	s9
+               	ld	t2, -0x1d0(s0)
+               	mv	a1, t2
+               	jalr	s9
+               	mv	a1, a0
+               	mv	a0, s11
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.15+0x150>
                	mv	s9, a0
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a0, a1, s1
                	li	a1, 0x6
-               	bnez	a1, 0xa4c <.Lpcrel_hi.15+0x12c>
+               	bnez	a1, 0xd08 <.Lpcrel_hi.15+0x178>
                	ebreak
-               	remu	a3, a0, a1
+               	remu	a2, a0, a1
                	li	t0, 0x0
-               	beq	a3, t0, 0xab4 <.Lpcrel_hi.21>
+               	beq	a2, t0, 0xd70 <.Lpcrel_hi.21>
                	li	t0, 0x1
-               	beq	a3, t0, 0xaa8 <.Lpcrel_hi.20>
+               	beq	a2, t0, 0xd64 <.Lpcrel_hi.20>
                	li	t0, 0x2
-               	beq	a3, t0, 0xa9c <.Lpcrel_hi.19>
+               	beq	a2, t0, 0xd58 <.Lpcrel_hi.19>
                	li	t0, 0x3
-               	beq	a3, t0, 0xa90 <.Lpcrel_hi.18>
+               	beq	a2, t0, 0xd4c <.Lpcrel_hi.18>
                	li	t0, 0x4
-               	beq	a3, t0, 0xa84 <.Lpcrel_hi.17>
+               	beq	a2, t0, 0xd40 <.Lpcrel_hi.17>
 
 <.Lpcrel_hi.16>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
-               	j	0xabc <.Lpcrel_hi.21+0x8>
+               	auipc	s11, 0x0
+               	mv	s11, s11
+               	j	0xd78 <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.17>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
-               	j	0xabc <.Lpcrel_hi.21+0x8>
+               	auipc	s11, 0x0
+               	mv	s11, s11
+               	j	0xd78 <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.18>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
-               	j	0xabc <.Lpcrel_hi.21+0x8>
+               	auipc	s11, 0x0
+               	mv	s11, s11
+               	j	0xd78 <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.19>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
-               	j	0xabc <.Lpcrel_hi.21+0x8>
+               	auipc	s11, 0x0
+               	mv	s11, s11
+               	j	0xd78 <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.20>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
-               	j	0xabc <.Lpcrel_hi.21+0x8>
+               	auipc	s11, 0x0
+               	mv	s11, s11
+               	j	0xd78 <.Lpcrel_hi.21+0x8>
 
 <.Lpcrel_hi.21>:
-               	auipc	s10, 0x0
-               	mv	s10, s10
+               	auipc	s11, 0x0
+               	mv	s11, s11
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
-               	ld	t2, -0x1d0(s0)
-               	mv	a0, t2
-               	jalr	s10
+               	mv	a0, s10
+               	jalr	s11
                	mv	a1, a0
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x28>
+               	jalr	ra <.Lpcrel_hi.21+0x24>
                	addi	s8, s8, 0x1
                	mv	s6, a0
-               	ld	t2, -0x1d0(s0)
-               	mv	s7, t2
+               	mv	s7, s10
                	li	t0, 0xc
-               	bltu	s8, t0, 0x948 <.Lpcrel_hi.15+0x28>
+               	bltu	s8, t0, 0xbd4 <.Lpcrel_hi.15+0x44>
                	mv	a0, s2
                	ld	a1, 0x0(a0)
                	add	a0, a1, s1
                	li	a1, 0x6
-               	bnez	a1, 0xb14 <.Lpcrel_hi.21+0x60>
+               	bnez	a1, 0xdc8 <.Lpcrel_hi.21+0x58>
                	ebreak
                	remu	a2, a0, a1
                	slli	t0, a2, 0x3
@@ -795,15 +968,15 @@ Disassembly of section .text:
                	li	s8, 0x0
                	mv	s9, a1
                	li	t0, 0x8
-               	bltu	s8, t0, 0xb38 <.Lpcrel_hi.21+0x84>
-               	j	0xba8 <.Lpcrel_hi.21+0xf4>
+               	bltu	s8, t0, 0xdec <.Lpcrel_hi.21+0x7c>
+               	j	0xe5c <.Lpcrel_hi.21+0xec>
                	slli	t0, s8, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	add	a1, a2, s8
                	li	a2, 0x6
-               	bnez	a2, 0xb58 <.Lpcrel_hi.21+0xa4>
+               	bnez	a2, 0xe0c <.Lpcrel_hi.21+0x9c>
                	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
@@ -819,52 +992,52 @@ Disassembly of section .text:
                	mv	a0, s6
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0xd8>
+               	jalr	ra <.Lpcrel_hi.21+0xd0>
                	addi	s8, s8, 0x1
                	mv	s6, a0
                	mv	s9, s10
                	li	t0, 0x8
-               	bltu	s8, t0, 0xb38 <.Lpcrel_hi.21+0x84>
+               	bltu	s8, t0, 0xdec <.Lpcrel_hi.21+0x7c>
                	li	s3, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0xbb8 <.Lpcrel_hi.21+0x104>
-               	j	0x102c <.Lpcrel_hi.21+0x578>
+               	bltu	s3, t0, 0xe6c <.Lpcrel_hi.21+0xfc>
+               	j	0x1384 <.Lpcrel_hi.21+0x614>
                	slli	t0, s3, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	li	a1, 0x2
-               	bnez	a1, 0xbd4 <.Lpcrel_hi.21+0x120>
+               	bnez	a1, 0xe88 <.Lpcrel_hi.21+0x118>
                	ebreak
                	remu	s8, a2, a1
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
                	addi	a1, a2, 0x1
                	li	a2, 0x2
-               	bnez	a2, 0xbf0 <.Lpcrel_hi.21+0x13c>
+               	bnez	a2, 0xea4 <.Lpcrel_hi.21+0x134>
                	ebreak
                	remu	s9, a1, a2
-               	addi	s10, s0, -0x150
+               	addi	s10, s0, -0xf0
                	slli	t0, s8, 0x3
                	add	a1, s5, t0
                	ld	s11, 0x0(a1)
                	ld	a1, 0x0(a0)
                	add	a2, a1, s7
-               	addi	t2, s0, -0x168
-               	sd	t2, -0x1e0(s0)
-               	ld	t2, -0x1e0(s0)
+               	addi	t2, s0, -0x108
+               	sd	t2, -0x1d8(s0)
+               	ld	t2, -0x1d8(s0)
                	mv	a0, t2
                	mv	a1, a2
                	jalr	s11
-               	ld	t2, -0x1e0(s0)
+               	ld	t2, -0x1d8(s0)
                	mv	a0, s10
-               	ld	t2, -0x1e0(s0)
+               	ld	t2, -0x1d8(s0)
                	mv	a1, t2
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0xca0 <.Lpcrel_hi.21+0x1ec>
-               	bnez	a2, 0xc74 <.Lpcrel_hi.21+0x1c0>
+               	bltu	a0, a1, 0xf54 <.Lpcrel_hi.21+0x1e4>
+               	bnez	a2, 0xf28 <.Lpcrel_hi.21+0x1b8>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -874,8 +1047,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xc54 <.Lpcrel_hi.21+0x1a0>
-               	j	0xcf8 <.Lpcrel_hi.21+0x244>
+               	bne	a5, t0, 0xf08 <.Lpcrel_hi.21+0x198>
+               	j	0xfac <.Lpcrel_hi.21+0x23c>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -885,9 +1058,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0xc80 <.Lpcrel_hi.21+0x1cc>
-               	j	0xcf8 <.Lpcrel_hi.21+0x244>
-               	bnez	a2, 0xcd0 <.Lpcrel_hi.21+0x21c>
+               	bne	a5, t0, 0xf34 <.Lpcrel_hi.21+0x1c4>
+               	j	0xfac <.Lpcrel_hi.21+0x23c>
+               	bnez	a2, 0xf84 <.Lpcrel_hi.21+0x214>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x18
@@ -897,8 +1070,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xcb0 <.Lpcrel_hi.21+0x1fc>
-               	j	0xcf8 <.Lpcrel_hi.21+0x244>
+               	bne	a4, t0, 0xf64 <.Lpcrel_hi.21+0x1f4>
+               	j	0xfac <.Lpcrel_hi.21+0x23c>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x18
@@ -908,29 +1081,70 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xcdc <.Lpcrel_hi.21+0x228>
+               	bne	a1, t0, 0xf90 <.Lpcrel_hi.21+0x220>
                	mv	a0, s10
                	ld	a1, 0x0(a0)
                	addi	a0, s10, 0x8
-               	ld	s11, 0x0(a0)
+               	ld	a2, 0x0(a0)
                	addi	a0, s10, 0x10
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x1e8(s0)
+               	ld	a3, 0x0(a0)
                	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x264>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x270>
-               	ld	t2, -0x1e8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x280>
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xfd8 <.Lpcrel_hi.21+0x268>
+               	j	0x100c <.Lpcrel_hi.21+0x29c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xfd8 <.Lpcrel_hi.21+0x268>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x101c <.Lpcrel_hi.21+0x2ac>
+               	j	0x1050 <.Lpcrel_hi.21+0x2e0>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x101c <.Lpcrel_hi.21+0x2ac>
                	mv	s11, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1064 <.Lpcrel_hi.21+0x2f4>
+               	j	0x1098 <.Lpcrel_hi.21+0x328>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, a3, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s11, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s11, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1064 <.Lpcrel_hi.21+0x2f4>
                	slli	t0, s9, 0x3
                	add	t2, s4, t0
-               	sd	t2, -0x1f0(s0)
-               	ld	t2, -0x1f0(s0)
+               	sd	t2, -0x1e0(s0)
+               	ld	t2, -0x1e0(s0)
                	ld	s9, 0x0(t2)
                	addi	a0, s0, -0x180
                	mv	a1, a0
@@ -938,8 +1152,8 @@ Disassembly of section .text:
                	or	a4, a1, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a1, a3, 0xdcc <.Lpcrel_hi.21+0x318>
-               	bnez	a4, 0xda0 <.Lpcrel_hi.21+0x2ec>
+               	bltu	a1, a3, 0x1124 <.Lpcrel_hi.21+0x3b4>
+               	bnez	a4, 0x10f8 <.Lpcrel_hi.21+0x388>
                	addi	a5, a1, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -949,8 +1163,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xd80 <.Lpcrel_hi.21+0x2cc>
-               	j	0xe24 <.Lpcrel_hi.21+0x370>
+               	bne	a7, t0, 0x10d8 <.Lpcrel_hi.21+0x368>
+               	j	0x117c <.Lpcrel_hi.21+0x40c>
                	addi	a5, a1, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -960,9 +1174,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0xdac <.Lpcrel_hi.21+0x2f8>
-               	j	0xe24 <.Lpcrel_hi.21+0x370>
-               	bnez	a4, 0xdfc <.Lpcrel_hi.21+0x348>
+               	bne	a7, t0, 0x1104 <.Lpcrel_hi.21+0x394>
+               	j	0x117c <.Lpcrel_hi.21+0x40c>
+               	bnez	a4, 0x1154 <.Lpcrel_hi.21+0x3e4>
                	mv	a4, a1
                	mv	a5, a3
                	li	a6, 0x18
@@ -972,8 +1186,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xddc <.Lpcrel_hi.21+0x328>
-               	j	0xe24 <.Lpcrel_hi.21+0x370>
+               	bne	a6, t0, 0x1134 <.Lpcrel_hi.21+0x3c4>
+               	j	0x117c <.Lpcrel_hi.21+0x40c>
                	mv	a4, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -983,14 +1197,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xe08 <.Lpcrel_hi.21+0x354>
+               	bne	a3, t0, 0x1160 <.Lpcrel_hi.21+0x3f0>
                	addi	a1, s0, -0x198
                	mv	a3, a0
                	or	a0, a1, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a3, 0xe98 <.Lpcrel_hi.21+0x3e4>
-               	bnez	a0, 0xe6c <.Lpcrel_hi.21+0x3b8>
+               	bltu	a1, a3, 0x11f0 <.Lpcrel_hi.21+0x480>
+               	bnez	a0, 0x11c4 <.Lpcrel_hi.21+0x454>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1000,8 +1214,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xe4c <.Lpcrel_hi.21+0x398>
-               	j	0xef0 <.Lpcrel_hi.21+0x43c>
+               	bne	a6, t0, 0x11a4 <.Lpcrel_hi.21+0x434>
+               	j	0x1248 <.Lpcrel_hi.21+0x4d8>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1011,9 +1225,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xe78 <.Lpcrel_hi.21+0x3c4>
-               	j	0xef0 <.Lpcrel_hi.21+0x43c>
-               	bnez	a0, 0xec8 <.Lpcrel_hi.21+0x414>
+               	bne	a6, t0, 0x11d0 <.Lpcrel_hi.21+0x460>
+               	j	0x1248 <.Lpcrel_hi.21+0x4d8>
+               	bnez	a0, 0x1220 <.Lpcrel_hi.21+0x4b0>
                	mv	a0, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -1023,8 +1237,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xea8 <.Lpcrel_hi.21+0x3f4>
-               	j	0xef0 <.Lpcrel_hi.21+0x43c>
+               	bne	a5, t0, 0x1200 <.Lpcrel_hi.21+0x490>
+               	j	0x1248 <.Lpcrel_hi.21+0x4d8>
                	mv	a0, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -1034,15 +1248,15 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xed4 <.Lpcrel_hi.21+0x420>
+               	bne	a3, t0, 0x122c <.Lpcrel_hi.21+0x4bc>
                	addi	a0, s0, -0x198
                	jalr	s9
                	mv	a1, a0
                	mv	a0, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x44c>
+               	jalr	ra <.Lpcrel_hi.21+0x4e8>
                	mv	s9, a0
-               	ld	t2, -0x1f0(s0)
+               	ld	t2, -0x1e0(s0)
                	ld	s10, 0x0(t2)
                	slli	t0, s8, 0x3
                	add	a0, s5, t0
@@ -1058,8 +1272,8 @@ Disassembly of section .text:
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0xfac <.Lpcrel_hi.21+0x4f8>
-               	bnez	a2, 0xf80 <.Lpcrel_hi.21+0x4cc>
+               	bltu	a0, a1, 0x1304 <.Lpcrel_hi.21+0x594>
+               	bnez	a2, 0x12d8 <.Lpcrel_hi.21+0x568>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -1069,8 +1283,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xf60 <.Lpcrel_hi.21+0x4ac>
-               	j	0x1004 <.Lpcrel_hi.21+0x550>
+               	bne	a5, t0, 0x12b8 <.Lpcrel_hi.21+0x548>
+               	j	0x135c <.Lpcrel_hi.21+0x5ec>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -1080,9 +1294,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0xf8c <.Lpcrel_hi.21+0x4d8>
-               	j	0x1004 <.Lpcrel_hi.21+0x550>
-               	bnez	a2, 0xfdc <.Lpcrel_hi.21+0x528>
+               	bne	a5, t0, 0x12e4 <.Lpcrel_hi.21+0x574>
+               	j	0x135c <.Lpcrel_hi.21+0x5ec>
+               	bnez	a2, 0x1334 <.Lpcrel_hi.21+0x5c4>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x18
@@ -1092,8 +1306,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xfbc <.Lpcrel_hi.21+0x508>
-               	j	0x1004 <.Lpcrel_hi.21+0x550>
+               	bne	a4, t0, 0x1314 <.Lpcrel_hi.21+0x5a4>
+               	j	0x135c <.Lpcrel_hi.21+0x5ec>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x18
@@ -1103,21 +1317,21 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xfe8 <.Lpcrel_hi.21+0x534>
+               	bne	a1, t0, 0x1340 <.Lpcrel_hi.21+0x5d0>
                	addi	a0, s0, -0x1c8
                	jalr	s10
                	mv	a1, a0
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x560>
+               	jalr	ra <.Lpcrel_hi.21+0x5fc>
                	addi	s3, s3, 0x1
                	mv	s6, a0
                	li	t0, 0x8
-               	bltu	s3, t0, 0xbb8 <.Lpcrel_hi.21+0x104>
+               	bltu	s3, t0, 0xe6c <.Lpcrel_hi.21+0xfc>
                	li	s3, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x103c <.Lpcrel_hi.21+0x588>
-               	j	0x12b8 <.Lpcrel_hi.25+0xf8>
+               	bltu	s3, t0, 0x1394 <.Lpcrel_hi.21+0x624>
+               	j	0x14e0 <.Lpcrel_hi.25+0x64>
                	slli	t0, s3, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -1126,12 +1340,12 @@ Disassembly of section .text:
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a0, s4, t0
-               	fcvt.d.lu	ft0, a0
+               	fcvt.d.lu	fs0, a0
 
 <.Lpcrel_hi.22>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
+               	fdiv.d	fa0, fs0, ft10
                	sext.w	s8, s4
                	li	t0, 0xff
                	and	a0, s4, t0
@@ -1141,12 +1355,12 @@ Disassembly of section .text:
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
                	and	a0, s4, t0
-               	fcvt.d.lu	ft0, a0
+               	fcvt.d.lu	fs2, a0
 
 <.Lpcrel_hi.23>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs2, ft0, ft10
+               	fdiv.d	fa2, fs2, ft10
                	sext.w	s10, s4
                	not	s11, s4
                	li	t0, 0x3ff
@@ -1156,152 +1370,76 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fsub.s	fs3, ft0, ft10
                	xor	t2, s4, s7
-               	sd	t2, -0x1f8(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x34>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x40>
+               	sd	t2, -0x1e8(s0)
+               	mv	a0, s4
                	mv	a1, s5
+               	mv	a2, s8
+               	fmv.s	fa1, fs1
+               	mv	a3, s9
+               	mv	a4, s5
+               	mv	a5, s10
+               	mv	a6, s11
+               	fmv.s	fa3, fs3
+               	ld	t2, -0x1e8(s0)
+               	mv	a7, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x4c>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x58>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x64>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x70>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x7c>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x88>
-               	fmv.d	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0x94>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0xa0>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0xac>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0xb8>
-               	ld	t2, -0x1f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0xc8>
+               	jalr	ra <.Lpcrel_hi.23+0x60>
                	mv	a1, a0
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.23+0xd8>
-               	mv	s5, a0
-               	sext.w	s8, s4
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	and	a0, s4, t0
-               	fcvt.d.lu	ft0, a0
+               	jalr	ra <.Lpcrel_hi.23+0x70>
+               	mv	t2, a0
+               	sd	t2, -0x1f0(s0)
+               	ld	t2, -0x1f0(s0)
 
 <.Lpcrel_hi.24>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
-               	sext.w	s9, s4
-               	li	t0, 0xff
-               	and	a0, s4, t0
-               	fcvt.s.lu	fs1, a0
-               	li	t0, 0x3
-               	mul	s10, s4, t0
-               	lui	t0, 0x10
-               	addiw	t0, t0, -0x1
-               	and	a0, s4, t0
-               	fcvt.d.lu	ft0, a0
+               	fdiv.d	fa0, fs0, ft10
 
 <.Lpcrel_hi.25>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs2, ft0, ft10
-               	sext.w	s11, s4
-               	not	t2, s4
-               	sd	t2, -0x200(s0)
-               	li	t0, 0x3ff
-               	and	a0, s4, t0
-               	fcvt.s.lu	ft0, a0
-               	lui	t0, 0x44000
-               	fmv.w.x	ft10, t0
-               	fsub.s	fs3, ft0, ft10
-               	xor	t2, s4, s7
-               	sd	t2, -0x208(s0)
+               	fdiv.d	fa2, fs2, ft10
+               	mv	a0, s4
+               	mv	a1, s5
+               	mv	a2, s8
+               	fmv.s	fa1, fs1
+               	mv	a3, s9
+               	mv	a4, s5
+               	mv	a5, s10
+               	mv	a6, s11
+               	fmv.s	fa3, fs3
+               	ld	t2, -0x1e8(s0)
+               	mv	a7, t2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.25+0x38>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x44>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x50>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x5c>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x68>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x74>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x80>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x8c>
-               	fmv.d	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0x98>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0xa4>
-               	ld	t2, -0x200(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0xb4>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0xc0>
-               	ld	t2, -0x208(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0xd0>
                	mv	a1, a0
-               	mv	a0, s5
+               	ld	t2, -0x1f0(s0)
+               	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.25+0xe0>
+               	jalr	ra <.Lpcrel_hi.25+0x4c>
                	addi	s3, s3, 0x1
                	mv	s6, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x103c <.Lpcrel_hi.21+0x588>
+               	bltu	s3, t0, 0x1394 <.Lpcrel_hi.21+0x624>
                	mv	a0, s6
-               	ld	s1, 0x1f8(sp)
-               	ld	s2, 0x1f0(sp)
-               	ld	s3, 0x1e8(sp)
-               	ld	s4, 0x1e0(sp)
-               	ld	s5, 0x1d8(sp)
-               	ld	s6, 0x1d0(sp)
-               	ld	s7, 0x1c8(sp)
-               	ld	s8, 0x1c0(sp)
-               	ld	s9, 0x1b8(sp)
-               	ld	s10, 0x1b0(sp)
-               	ld	s11, 0x1a8(sp)
-               	fld	fs0, 0x1a0(sp)
-               	fld	fs1, 0x198(sp)
-               	fld	fs2, 0x190(sp)
-               	fld	fs3, 0x188(sp)
-               	ld	ra, 0x208(sp)
-               	ld	s0, 0x200(sp)
-               	addi	sp, sp, 0x210
+               	ld	s1, 0x1e8(sp)
+               	ld	s2, 0x1e0(sp)
+               	ld	s3, 0x1d8(sp)
+               	ld	s4, 0x1d0(sp)
+               	ld	s5, 0x1c8(sp)
+               	ld	s6, 0x1c0(sp)
+               	ld	s7, 0x1b8(sp)
+               	ld	s8, 0x1b0(sp)
+               	ld	s9, 0x1a8(sp)
+               	ld	s10, 0x1a0(sp)
+               	ld	s11, 0x198(sp)
+               	fld	fs0, 0x190(sp)
+               	fld	fs1, 0x188(sp)
+               	fld	fs2, 0x180(sp)
+               	fld	fs3, 0x178(sp)
+               	ld	ra, 0x1f8(sp)
+               	ld	s0, 0x1f0(sp)
+               	addi	sp, sp, 0x200
                	ret

--- a/test/golden/riscv64-linux/call/call_int_regs.dis
+++ b/test/golden/riscv64-linux/call/call_int_regs.dis
@@ -26,328 +26,507 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_int_regs.take16>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	sd	s2, 0x80(sp)
-               	sd	s3, 0x78(sp)
-               	sd	s4, 0x70(sp)
-               	sd	s5, 0x68(sp)
-               	sd	s6, 0x60(sp)
-               	sd	s7, 0x58(sp)
-               	sd	s8, 0x50(sp)
-               	sd	s9, 0x48(sp)
-               	sd	s10, 0x40(sp)
-               	sd	s11, 0x38(sp)
-               	mv	s1, a0
-               	mv	s2, a1
-               	mv	s3, a2
-               	mv	s4, a3
-               	mv	s5, a4
-               	mv	s6, a5
-               	mv	s7, a6
-               	mv	s8, a7
-               	ld	s9, 0x0(s0)
-               	ld	s10, 0x8(s0)
-               	ld	s11, 0x10(s0)
-               	ld	t2, 0x18(s0)
-               	sd	t2, -0x70(s0)
-               	ld	t2, 0x20(s0)
-               	sd	t2, -0x78(s0)
-               	ld	t2, 0x28(s0)
-               	sd	t2, -0x80(s0)
-               	ld	t2, 0x30(s0)
-               	sd	t2, -0x88(s0)
-               	ld	t2, 0x38(s0)
-               	sd	t2, -0x90(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x90>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0xa4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0xb8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0xcc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0xe0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0xf4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x108>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x11c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x130>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x144>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x158>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x16c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x70(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x184>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x78(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x19c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x80(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x1b4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x88(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x1cc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x90(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16+0x1e4>
-               	ld	s1, 0x88(sp)
-               	ld	s2, 0x80(sp)
-               	ld	s3, 0x78(sp)
-               	ld	s4, 0x70(sp)
-               	ld	s5, 0x68(sp)
-               	ld	s6, 0x60(sp)
-               	ld	s7, 0x58(sp)
-               	ld	s8, 0x50(sp)
-               	ld	s9, 0x48(sp)
-               	ld	s10, 0x40(sp)
-               	ld	s11, 0x38(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	addi	sp, sp, -0x60
+               	sd	ra, 0x58(sp)
+               	sd	s0, 0x50(sp)
+               	addi	s0, sp, 0x60
+               	sd	s1, 0x48(sp)
+               	sd	s2, 0x40(sp)
+               	sd	s3, 0x38(sp)
+               	sd	s4, 0x30(sp)
+               	sd	s5, 0x28(sp)
+               	sd	s6, 0x20(sp)
+               	sd	s7, 0x18(sp)
+               	sd	s8, 0x10(sp)
+               	sd	s9, 0x8(sp)
+               	sd	s10, 0x0(sp)
+               	ld	t5, 0x0(s0)
+               	ld	t6, 0x8(s0)
+               	ld	s1, 0x10(s0)
+               	ld	s2, 0x18(s0)
+               	ld	s3, 0x20(s0)
+               	ld	s4, 0x28(s0)
+               	ld	s5, 0x30(s0)
+               	ld	s6, 0x38(s0)
+               	zext.b	s7, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	s8, 0x0
+               	li	t0, 0x8
+               	bltu	s8, t0, 0xe0 <corpus.cases.call.call_int_regs.take16+0x8c>
+               	j	0x114 <corpus.cases.call.call_int_regs.take16+0xc0>
+               	li	t0, 0x8
+               	mul	s9, s8, t0
+               	srl	s10, s7, s9
+               	li	t0, 0xff
+               	and	s9, s10, t0
+               	xor	s10, a0, s9
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s10, t0
+               	addi	s8, s8, 0x1
+               	li	t0, 0x8
+               	bltu	s8, t0, 0xe0 <corpus.cases.call.call_int_regs.take16+0x8c>
+               	slli	s7, a1, 0x38
+               	srai	s7, s7, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12c <corpus.cases.call.call_int_regs.take16+0xd8>
+               	j	0x160 <corpus.cases.call.call_int_regs.take16+0x10c>
+               	li	t0, 0x8
+               	mul	s8, a1, t0
+               	srl	s9, s7, s8
+               	li	t0, 0xff
+               	and	s8, s9, t0
+               	xor	s9, a0, s8
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s9, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12c <corpus.cases.call.call_int_regs.take16+0xd8>
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x178 <corpus.cases.call.call_int_regs.take16+0x124>
+               	j	0x1ac <corpus.cases.call.call_int_regs.take16+0x158>
+               	li	t0, 0x8
+               	mul	s7, a2, t0
+               	srl	s8, a1, s7
+               	li	t0, 0xff
+               	and	s7, s8, t0
+               	xor	s8, a0, s7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s8, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x178 <corpus.cases.call.call_int_regs.take16+0x124>
+               	slli	a1, a3, 0x30
+               	srai	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c4 <corpus.cases.call.call_int_regs.take16+0x170>
+               	j	0x1f8 <corpus.cases.call.call_int_regs.take16+0x1a4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	s7, a1, a3
+               	li	t0, 0xff
+               	and	a3, s7, t0
+               	xor	s7, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c4 <corpus.cases.call.call_int_regs.take16+0x170>
+               	slli	a1, a4, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x210 <corpus.cases.call.call_int_regs.take16+0x1bc>
+               	j	0x244 <corpus.cases.call.call_int_regs.take16+0x1f0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x210 <corpus.cases.call.call_int_regs.take16+0x1bc>
+               	sext.w	a1, a5
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x258 <corpus.cases.call.call_int_regs.take16+0x204>
+               	j	0x28c <corpus.cases.call.call_int_regs.take16+0x238>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x258 <corpus.cases.call.call_int_regs.take16+0x204>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.call.call_int_regs.take16+0x248>
+               	j	0x2d0 <corpus.cases.call.call_int_regs.take16+0x27c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a6, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.call.call_int_regs.take16+0x248>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <corpus.cases.call.call_int_regs.take16+0x28c>
+               	j	0x314 <corpus.cases.call.call_int_regs.take16+0x2c0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a7, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <corpus.cases.call.call_int_regs.take16+0x28c>
+               	zext.b	a1, t5
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.call.call_int_regs.take16+0x2d4>
+               	j	0x35c <corpus.cases.call.call_int_regs.take16+0x308>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x328 <corpus.cases.call.call_int_regs.take16+0x2d4>
+               	slli	a1, t6, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x374 <corpus.cases.call.call_int_regs.take16+0x320>
+               	j	0x3a8 <corpus.cases.call.call_int_regs.take16+0x354>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x374 <corpus.cases.call.call_int_regs.take16+0x320>
+               	slli	a1, s1, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c0 <corpus.cases.call.call_int_regs.take16+0x36c>
+               	j	0x3f4 <corpus.cases.call.call_int_regs.take16+0x3a0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c0 <corpus.cases.call.call_int_regs.take16+0x36c>
+               	slli	a1, s2, 0x30
+               	srai	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40c <corpus.cases.call.call_int_regs.take16+0x3b8>
+               	j	0x440 <corpus.cases.call.call_int_regs.take16+0x3ec>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40c <corpus.cases.call.call_int_regs.take16+0x3b8>
+               	slli	a1, s3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x458 <corpus.cases.call.call_int_regs.take16+0x404>
+               	j	0x48c <corpus.cases.call.call_int_regs.take16+0x438>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x458 <corpus.cases.call.call_int_regs.take16+0x404>
+               	sext.w	a1, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a0 <corpus.cases.call.call_int_regs.take16+0x44c>
+               	j	0x4d4 <corpus.cases.call.call_int_regs.take16+0x480>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a0 <corpus.cases.call.call_int_regs.take16+0x44c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4e4 <corpus.cases.call.call_int_regs.take16+0x490>
+               	j	0x518 <corpus.cases.call.call_int_regs.take16+0x4c4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s5, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4e4 <corpus.cases.call.call_int_regs.take16+0x490>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x528 <corpus.cases.call.call_int_regs.take16+0x4d4>
+               	j	0x55c <corpus.cases.call.call_int_regs.take16+0x508>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s6, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x528 <corpus.cases.call.call_int_regs.take16+0x4d4>
+               	ld	s1, 0x48(sp)
+               	ld	s2, 0x40(sp)
+               	ld	s3, 0x38(sp)
+               	ld	s4, 0x30(sp)
+               	ld	s5, 0x28(sp)
+               	ld	s6, 0x20(sp)
+               	ld	s7, 0x18(sp)
+               	ld	s8, 0x10(sp)
+               	ld	s9, 0x8(sp)
+               	ld	s10, 0x0(sp)
+               	ld	ra, 0x58(sp)
+               	ld	s0, 0x50(sp)
+               	addi	sp, sp, 0x60
                	ret
 
 <corpus.cases.call.call_int_regs.take16n>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	sd	s2, 0x80(sp)
-               	sd	s3, 0x78(sp)
-               	sd	s4, 0x70(sp)
-               	sd	s5, 0x68(sp)
-               	sd	s6, 0x60(sp)
-               	sd	s7, 0x58(sp)
-               	sd	s8, 0x50(sp)
-               	sd	s9, 0x48(sp)
-               	sd	s10, 0x40(sp)
-               	sd	s11, 0x38(sp)
-               	mv	s1, a0
-               	mv	s2, a1
-               	mv	s3, a2
-               	mv	s4, a3
-               	mv	s5, a4
-               	mv	s6, a5
-               	mv	s7, a6
-               	mv	s8, a7
-               	ld	s9, 0x0(s0)
-               	ld	s10, 0x8(s0)
-               	ld	s11, 0x10(s0)
-               	ld	t2, 0x18(s0)
-               	sd	t2, -0x70(s0)
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	sd	s1, 0x78(sp)
+               	sd	s2, 0x70(sp)
+               	sd	s3, 0x68(sp)
+               	sd	s4, 0x60(sp)
+               	sd	s5, 0x58(sp)
+               	sd	s6, 0x50(sp)
+               	sd	s7, 0x48(sp)
+               	sd	s8, 0x40(sp)
+               	sd	s9, 0x38(sp)
+               	sd	s10, 0x30(sp)
+               	sd	s11, 0x28(sp)
+               	mv	s1, a1
+               	mv	s2, a2
+               	mv	s3, a3
+               	mv	s4, a4
+               	mv	s5, a5
+               	mv	s6, a6
+               	mv	s7, a7
+               	ld	s8, 0x0(s0)
+               	ld	s9, 0x8(s0)
+               	ld	s10, 0x10(s0)
+               	ld	s11, 0x18(s0)
                	ld	t2, 0x20(s0)
-               	sd	t2, -0x78(s0)
+               	sd	t2, -0x70(s0)
                	ld	t2, 0x28(s0)
-               	sd	t2, -0x80(s0)
+               	sd	t2, -0x78(s0)
                	ld	t2, 0x30(s0)
-               	sd	t2, -0x88(s0)
+               	sd	t2, -0x80(s0)
                	ld	t2, 0x38(s0)
-               	sd	t2, -0x90(s0)
+               	sd	t2, -0x88(s0)
+               	zext.b	a1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x90>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xa4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xac>
+               	zext.b	a1, s1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xb8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
+               	slli	a1, s2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xcc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xc8>
+               	slli	a1, s3, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xe0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xd8>
+               	slli	a1, s4, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xf4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xe8>
+               	slli	a1, s5, 0x30
+               	srli	a1, a1, 0x30
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0xf8>
+               	slli	a1, s6, 0x30
+               	srai	a1, a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x108>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s7
+               	slli	a1, s7, 0x30
+               	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x11c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s8
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x118>
+               	zext.b	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x130>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s9
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x124>
+               	slli	a1, s9, 0x38
+               	srai	a1, a1, 0x38
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x134>
+               	slli	a1, s10, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x144>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s10
+               	slli	a1, s11, 0x30
+               	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x158>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x16c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x154>
                	ld	t2, -0x70(s0)
-               	mv	a1, t2
+               	zext.b	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x184>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x164>
                	ld	t2, -0x78(s0)
-               	mv	a1, t2
+               	slli	a1, t2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x19c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x178>
                	ld	t2, -0x80(s0)
-               	mv	a1, t2
+               	slli	a1, t2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x1b4>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x18c>
                	ld	t2, -0x88(s0)
-               	mv	a1, t2
+               	slli	a1, t2, 0x30
+               	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x1cc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x90(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x1e4>
-               	ld	s1, 0x88(sp)
-               	ld	s2, 0x80(sp)
-               	ld	s3, 0x78(sp)
-               	ld	s4, 0x70(sp)
-               	ld	s5, 0x68(sp)
-               	ld	s6, 0x60(sp)
-               	ld	s7, 0x58(sp)
-               	ld	s8, 0x50(sp)
-               	ld	s9, 0x48(sp)
-               	ld	s10, 0x40(sp)
-               	ld	s11, 0x38(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	jalr	ra <corpus.cases.call.call_int_regs.take16n+0x1a0>
+               	ld	s1, 0x78(sp)
+               	ld	s2, 0x70(sp)
+               	ld	s3, 0x68(sp)
+               	ld	s4, 0x60(sp)
+               	ld	s5, 0x58(sp)
+               	ld	s6, 0x50(sp)
+               	ld	s7, 0x48(sp)
+               	ld	s8, 0x40(sp)
+               	ld	s9, 0x38(sp)
+               	ld	s10, 0x30(sp)
+               	ld	s11, 0x28(sp)
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret
 
 <corpus.cases.call.call_int_regs.checksum>:
-               	addi	sp, sp, -0x2b0
-               	sd	ra, 0x2a8(sp)
-               	sd	s0, 0x2a0(sp)
-               	addi	s0, sp, 0x2b0
-               	sd	s1, 0x298(sp)
-               	sd	s2, 0x290(sp)
-               	sd	s3, 0x288(sp)
-               	sd	s4, 0x280(sp)
-               	sd	s5, 0x278(sp)
-               	sd	s6, 0x270(sp)
-               	sd	s7, 0x268(sp)
-               	sd	s8, 0x260(sp)
-               	sd	s9, 0x258(sp)
-               	sd	s10, 0x250(sp)
-               	sd	s11, 0x248(sp)
+               	addi	sp, sp, -0x2a0
+               	sd	ra, 0x298(sp)
+               	sd	s0, 0x290(sp)
+               	addi	s0, sp, 0x2a0
+               	sd	s1, 0x288(sp)
+               	sd	s2, 0x280(sp)
+               	sd	s3, 0x278(sp)
+               	sd	s4, 0x270(sp)
+               	sd	s5, 0x268(sp)
+               	sd	s6, 0x260(sp)
+               	sd	s7, 0x258(sp)
+               	sd	s8, 0x250(sp)
+               	sd	s9, 0x248(sp)
+               	sd	s10, 0x240(sp)
+               	sd	s11, 0x238(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x40>
                	addi	s2, s0, -0x108
-               	mv	a1, s2
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x520 <corpus.cases.call.call_int_regs.checksum+0x7c>
-               	mv	a2, a1
-               	li	a3, 0xa0
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x7ec <corpus.cases.call.call_int_regs.checksum+0x74>
+               	mv	a1, a0
+               	li	a2, 0xa0
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x508 <corpus.cases.call.call_int_regs.checksum+0x64>
-               	j	0x53c <corpus.cases.call.call_int_regs.checksum+0x98>
-               	mv	a2, a1
-               	li	a1, 0xa0
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x7d4 <corpus.cases.call.call_int_regs.checksum+0x5c>
+               	j	0x808 <corpus.cases.call.call_int_regs.checksum+0x90>
+               	mv	a1, a0
+               	li	a0, 0xa0
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x528 <corpus.cases.call.call_int_regs.checksum+0x84>
-               	li	a1, 0x0
+               	bne	a0, t0, 0x7f4 <corpus.cases.call.call_int_regs.checksum+0x7c>
+               	li	a0, 0x0
                	li	t0, 0x14
-               	bltu	a1, t0, 0x54c <corpus.cases.call.call_int_regs.checksum+0xa8>
-               	j	0x5b0 <corpus.cases.call.call_int_regs.checksum+0x10c>
+               	bltu	a0, t0, 0x818 <corpus.cases.call.call_int_regs.checksum+0xa0>
+               	j	0x87c <corpus.cases.call.call_int_regs.checksum+0x104>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -356,7 +535,7 @@ Disassembly of section .text:
                	addi	t0, t0, -0x6a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd3
-               	mul	a2, a1, t0
+               	mul	a1, a0, t0
                	lui	t0, 0x1405
                	addiw	t0, t0, 0x7b8
                	slli	t0, t0, 0xc
@@ -365,629 +544,441 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a2, t0
-               	add	a2, a3, s1
-               	slli	t0, a1, 0x3
-               	add	a3, s2, t0
-               	sd	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
+               	slli	t0, a0, 0x3
+               	add	a2, s2, t0
+               	sd	a1, 0x0(a2)
+               	addi	a0, a0, 0x1
                	li	t0, 0x14
-               	bltu	a1, t0, 0x54c <corpus.cases.call.call_int_regs.checksum+0xa8>
-               	mv	s3, a0
+               	bltu	a0, t0, 0x818 <corpus.cases.call.call_int_regs.checksum+0xa0>
+               	lui	t2, 0xfcbf3
+               	addiw	t2, t2, -0x632
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x484
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x222
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x325
+               	sd	t2, -0x198(s0)
                	li	s4, 0x0
                	li	s5, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x5c8 <corpus.cases.call.call_int_regs.checksum+0x124>
-               	j	0x9d0 <corpus.cases.call.call_int_regs.checksum+0x52c>
+               	bltu	s5, t0, 0x8b4 <corpus.cases.call.call_int_regs.checksum+0x13c>
+               	j	0xba4 <corpus.cases.call.call_int_regs.checksum+0x42c>
                	li	t0, 0x7
                	mul	a0, s5, t0
                	add	s6, a0, s1
-               	mv	a0, s2
-               	ld	a1, 0x0(a0)
-               	sext.w	s7, a1
-               	addi	a0, s2, 0x8
-               	ld	a1, 0x0(a0)
-               	sext.w	s8, a1
-               	addi	a0, s2, 0x10
-               	ld	a1, 0x0(a0)
-               	sext.w	s9, a1
-               	addi	a0, s2, 0x18
-               	ld	a1, 0x0(a0)
-               	sext.w	s10, a1
-               	addi	a0, s2, 0x20
-               	ld	a1, 0x0(a0)
-               	sext.w	s11, a1
-               	addi	a0, s2, 0x28
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	mv	s7, s2
+               	ld	a0, 0x0(s7)
+               	sext.w	t2, a0
+               	sd	t2, -0x128(s0)
+               	addi	s8, s2, 0x8
+               	ld	a0, 0x0(s8)
+               	sext.w	t2, a0
+               	sd	t2, -0x138(s0)
+               	addi	s9, s2, 0x10
+               	ld	a0, 0x0(s9)
+               	sext.w	t2, a0
+               	sd	t2, -0x148(s0)
+               	addi	s10, s2, 0x18
+               	ld	a0, 0x0(s10)
+               	sext.w	t2, a0
+               	sd	t2, -0x158(s0)
+               	addi	s11, s2, 0x20
+               	ld	a0, 0x0(s11)
+               	sext.w	t2, a0
+               	sd	t2, -0x168(s0)
+               	addi	t2, s2, 0x28
+               	sd	t2, -0x238(s0)
+               	ld	t2, -0x238(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	t2, a0
                	sd	t2, -0x178(s0)
-               	addi	a0, s2, 0x30
-               	ld	a1, 0x0(a0)
-               	add	t2, a1, s6
-               	sd	t2, -0x180(s0)
-               	addi	a0, s2, 0x38
-               	ld	t2, 0x0(a0)
+               	addi	t2, s2, 0x30
+               	sd	t2, -0x240(s0)
+               	ld	t2, -0x240(s0)
+               	ld	a0, 0x0(t2)
+               	add	t2, a0, s6
                	sd	t2, -0x188(s0)
-               	addi	a0, s2, 0x40
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	addi	t2, s2, 0x38
+               	sd	t2, -0x110(s0)
+               	ld	t3, -0x110(s0)
+               	ld	t2, 0x0(t3)
+               	sd	t2, -0x118(s0)
+               	addi	t2, s2, 0x40
+               	sd	t2, -0x120(s0)
+               	ld	t2, -0x120(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a1, a0
+               	addi	t2, s2, 0x48
+               	sd	t2, -0x130(s0)
+               	ld	t2, -0x130(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a2, a0
+               	addi	t2, s2, 0x50
+               	sd	t2, -0x140(s0)
+               	ld	t2, -0x140(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a3, a0
+               	addi	t2, s2, 0x58
+               	sd	t2, -0x150(s0)
+               	ld	t2, -0x150(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a4, a0
+               	addi	t2, s2, 0x60
+               	sd	t2, -0x160(s0)
+               	ld	t2, -0x160(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a5, a0
+               	addi	t2, s2, 0x68
+               	sd	t2, -0x170(s0)
+               	ld	t2, -0x170(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a6, a0
+               	addi	t2, s2, 0x70
+               	sd	t2, -0x180(s0)
+               	ld	t2, -0x180(s0)
+               	ld	a0, 0x0(t2)
+               	add	a7, a0, s6
+               	addi	t2, s2, 0x78
                	sd	t2, -0x190(s0)
-               	addi	a0, s2, 0x48
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x198(s0)
-               	addi	a0, s2, 0x50
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	ld	t2, -0x190(s0)
+               	ld	a0, 0x0(t2)
+               	sd	a1, 0x0(sp)
+               	sd	a2, 0x8(sp)
+               	sd	a3, 0x10(sp)
+               	sd	a4, 0x18(sp)
+               	sd	a5, 0x20(sp)
+               	sd	a6, 0x28(sp)
+               	sd	a7, 0x30(sp)
+               	sd	a0, 0x38(sp)
+               	ld	t2, -0x128(s0)
+               	mv	a0, t2
+               	ld	t2, -0x138(s0)
+               	mv	a1, t2
+               	ld	t2, -0x148(s0)
+               	mv	a2, t2
+               	ld	t2, -0x158(s0)
+               	mv	a3, t2
+               	ld	t2, -0x168(s0)
+               	mv	a4, t2
+               	ld	t2, -0x178(s0)
+               	mv	a5, t2
+               	ld	t2, -0x188(s0)
+               	mv	a6, t2
+               	ld	t2, -0x118(s0)
+               	mv	a7, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2d8>
+               	mv	a1, a0
+               	ld	t2, -0x198(s0)
+               	mv	a0, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2ec>
+               	mv	s3, a0
+               	ld	a0, 0x0(s7)
+               	sext.w	t2, a0
                	sd	t2, -0x1a0(s0)
-               	addi	a0, s2, 0x58
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	ld	a0, 0x0(s8)
+               	sext.w	t2, a0
                	sd	t2, -0x1a8(s0)
-               	addi	a0, s2, 0x60
+               	ld	a0, 0x0(s9)
+               	sext.w	a3, a0
+               	ld	a0, 0x0(s10)
+               	sext.w	a4, a0
+               	ld	a0, 0x0(s11)
+               	sext.w	a5, a0
+               	ld	t2, -0x238(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a6, a0
+               	ld	t2, -0x240(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a7, a0
+               	ld	t2, -0x110(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	t5, a0
+               	ld	t2, -0x120(s0)
+               	ld	a0, 0x0(t2)
+               	add	t6, a0, s6
+               	sext.w	a0, t6
+               	ld	t2, -0x130(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	s7, t6
+               	ld	t2, -0x140(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	s8, t6
+               	ld	t2, -0x150(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	s9, t6
+               	ld	t2, -0x160(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	s10, t6
+               	ld	t2, -0x170(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	s11, t6
+               	ld	t2, -0x180(s0)
+               	ld	t6, 0x0(t2)
+               	sext.w	a1, t6
+               	ld	t2, -0x190(s0)
+               	ld	t6, 0x0(t2)
+               	add	a2, t6, s6
+               	sext.w	t6, a2
+               	sd	a0, 0x0(sp)
+               	sd	s7, 0x8(sp)
+               	sd	s8, 0x10(sp)
+               	sd	s9, 0x18(sp)
+               	sd	s10, 0x20(sp)
+               	sd	s11, 0x28(sp)
+               	sd	a1, 0x30(sp)
+               	sd	t6, 0x38(sp)
+               	ld	t2, -0x1a0(s0)
+               	mv	a0, t2
+               	ld	t2, -0x1a8(s0)
+               	mv	a1, t2
+               	mv	a2, a3
+               	mv	a3, a4
+               	mv	a4, a5
+               	mv	a5, a6
+               	mv	a6, a7
+               	mv	a7, t5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x3fc>
+               	mv	s4, a0
+               	mv	a0, s3
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x410>
+               	addi	s5, s5, 0x1
+               	mv	t2, a0
+               	sd	t2, -0x198(s0)
+               	li	t0, 0x3
+               	bltu	s5, t0, 0x8b4 <corpus.cases.call.call_int_regs.checksum+0x13c>
+               	mv	a0, s2
                	ld	a1, 0x0(a0)
                	sext.w	t2, a1
                	sd	t2, -0x1b0(s0)
-               	addi	a0, s2, 0x68
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x110(s0)
-               	addi	a0, s2, 0x70
-               	ld	a1, 0x0(a0)
-               	add	t2, a1, s6
-               	sd	t2, -0x118(s0)
-               	addi	a0, s2, 0x78
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x120(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x214>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x220>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x22c>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x238>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x244>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x250>
-               	ld	t2, -0x178(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x260>
-               	ld	t2, -0x180(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x270>
-               	ld	t2, -0x188(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x280>
-               	ld	t2, -0x190(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x290>
-               	ld	t2, -0x198(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2a0>
-               	ld	t2, -0x1a0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2b0>
-               	ld	t2, -0x1a8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2c0>
-               	ld	t2, -0x1b0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2d0>
-               	ld	t2, -0x110(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2e0>
-               	ld	t2, -0x118(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x2f0>
-               	ld	t2, -0x120(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x300>
-               	mv	a1, a0
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x310>
-               	mv	s7, a0
-               	mv	a0, s2
-               	ld	a1, 0x0(a0)
-               	sext.w	s8, a1
-               	addi	a0, s2, 0x8
-               	ld	a1, 0x0(a0)
-               	sext.w	s9, a1
-               	addi	a0, s2, 0x10
-               	ld	a1, 0x0(a0)
-               	sext.w	s10, a1
-               	addi	a0, s2, 0x18
-               	ld	a1, 0x0(a0)
-               	sext.w	s11, a1
-               	addi	a0, s2, 0x20
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x1b8(s0)
-               	addi	a0, s2, 0x28
-               	ld	a1, 0x0(a0)
+               	addi	s1, s2, 0x8
+               	ld	a1, 0x0(s1)
                	sext.w	t2, a1
                	sd	t2, -0x1c0(s0)
-               	addi	a0, s2, 0x30
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x1c8(s0)
-               	addi	a0, s2, 0x38
-               	ld	a1, 0x0(a0)
+               	addi	s3, s2, 0x10
+               	ld	a1, 0x0(s3)
                	sext.w	t2, a1
                	sd	t2, -0x1d0(s0)
-               	addi	a0, s2, 0x40
-               	ld	a1, 0x0(a0)
-               	add	a0, a1, s6
-               	sext.w	t2, a0
-               	sd	t2, -0x1d8(s0)
-               	addi	a0, s2, 0x48
-               	ld	a1, 0x0(a0)
+               	addi	s5, s2, 0x18
+               	ld	a1, 0x0(s5)
                	sext.w	t2, a1
                	sd	t2, -0x1e0(s0)
-               	addi	a0, s2, 0x50
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x1e8(s0)
-               	addi	a0, s2, 0x58
-               	ld	a1, 0x0(a0)
+               	addi	s6, s2, 0x20
+               	ld	a1, 0x0(s6)
                	sext.w	t2, a1
                	sd	t2, -0x1f0(s0)
-               	addi	a0, s2, 0x60
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x128(s0)
-               	addi	a0, s2, 0x68
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x130(s0)
-               	addi	a0, s2, 0x70
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x138(s0)
-               	addi	a0, s2, 0x78
-               	ld	a1, 0x0(a0)
-               	add	a0, a1, s6
-               	sext.w	s6, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x410>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x41c>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x428>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x434>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x440>
-               	ld	t2, -0x1b8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x450>
-               	ld	t2, -0x1c0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x460>
-               	ld	t2, -0x1c8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x470>
-               	ld	t2, -0x1d0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x480>
-               	ld	t2, -0x1d8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x490>
-               	ld	t2, -0x1e0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4a0>
-               	ld	t2, -0x1e8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4b0>
-               	ld	t2, -0x1f0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4c0>
-               	ld	t2, -0x128(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4d0>
-               	ld	t2, -0x130(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4e0>
-               	ld	t2, -0x138(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4f0>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x4fc>
-               	mv	s6, a0
-               	mv	a0, s7
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x510>
-               	addi	s5, s5, 0x1
-               	mv	s3, a0
-               	mv	s4, s6
-               	li	t0, 0x3
-               	bltu	s5, t0, 0x5c8 <corpus.cases.call.call_int_regs.checksum+0x124>
-               	mv	a0, s2
-               	ld	a1, 0x0(a0)
-               	sext.w	s1, a1
-               	addi	a0, s2, 0x8
-               	ld	a1, 0x0(a0)
-               	sext.w	s5, a1
-               	addi	a0, s2, 0x10
-               	ld	a1, 0x0(a0)
-               	sext.w	s6, a1
-               	addi	a0, s2, 0x18
-               	ld	a1, 0x0(a0)
-               	sext.w	s7, a1
-               	addi	a0, s2, 0x20
-               	ld	a1, 0x0(a0)
-               	sext.w	s8, a1
-               	addi	a0, s2, 0x28
-               	ld	a1, 0x0(a0)
-               	sext.w	s9, a1
-               	addi	a0, s2, 0x30
-               	ld	s10, 0x0(a0)
-               	addi	a0, s2, 0x38
-               	ld	s11, 0x0(a0)
-               	addi	a0, s2, 0x40
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x1f8(s0)
-               	addi	a0, s2, 0x48
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x200(s0)
-               	addi	a0, s2, 0x50
-               	ld	a1, 0x0(a0)
+               	addi	s7, s2, 0x28
+               	ld	a1, 0x0(s7)
                	sext.w	t2, a1
                	sd	t2, -0x208(s0)
-               	addi	a0, s2, 0x58
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	addi	s8, s2, 0x30
+               	ld	a7, 0x0(s8)
+               	addi	s9, s2, 0x38
+               	ld	t5, 0x0(s9)
+               	addi	s10, s2, 0x40
+               	ld	a1, 0x0(s10)
+               	sext.w	t6, a1
+               	addi	s11, s2, 0x48
+               	ld	a1, 0x0(s11)
+               	sext.w	a0, a1
+               	addi	t2, s2, 0x50
+               	sd	t2, -0x1b8(s0)
+               	ld	t2, -0x1b8(s0)
+               	ld	a1, 0x0(t2)
+               	sext.w	a2, a1
+               	addi	t2, s2, 0x58
+               	sd	t2, -0x1c8(s0)
+               	ld	t2, -0x1c8(s0)
+               	ld	a1, 0x0(t2)
+               	sext.w	a3, a1
+               	addi	t2, s2, 0x60
+               	sd	t2, -0x1d8(s0)
+               	ld	t2, -0x1d8(s0)
+               	ld	a1, 0x0(t2)
+               	sext.w	a4, a1
+               	addi	t2, s2, 0x68
+               	sd	t2, -0x1e8(s0)
+               	ld	t2, -0x1e8(s0)
+               	ld	a1, 0x0(t2)
+               	sext.w	a5, a1
+               	addi	t2, s2, 0x70
+               	sd	t2, -0x1f8(s0)
+               	ld	t2, -0x1f8(s0)
+               	ld	a1, 0x0(t2)
+               	addi	t2, s2, 0x78
+               	sd	t2, -0x200(s0)
+               	ld	t2, -0x200(s0)
+               	ld	a6, 0x0(t2)
+               	sd	t6, 0x0(sp)
+               	sd	a0, 0x8(sp)
+               	sd	a2, 0x10(sp)
+               	sd	a3, 0x18(sp)
+               	sd	a4, 0x20(sp)
+               	sd	a5, 0x28(sp)
+               	sd	a1, 0x30(sp)
+               	sd	a6, 0x38(sp)
+               	ld	t2, -0x1b0(s0)
+               	mv	a0, t2
+               	ld	t2, -0x1c0(s0)
+               	mv	a1, t2
+               	ld	t2, -0x1d0(s0)
+               	mv	a2, t2
+               	ld	t2, -0x1e0(s0)
+               	mv	a3, t2
+               	ld	t2, -0x1f0(s0)
+               	mv	a4, t2
+               	ld	t2, -0x208(s0)
+               	mv	a5, t2
+               	mv	a6, a7
+               	mv	a7, t5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x57c>
+               	sext.w	t2, a0
+               	sd	t2, -0x248(s0)
+               	ld	a0, 0x0(s1)
+               	sext.w	s1, a0
+               	ld	a0, 0x0(s3)
+               	sext.w	s3, a0
+               	ld	a0, 0x0(s5)
+               	sext.w	s5, a0
+               	sext.w	t2, s4
+               	sd	t2, -0x250(s0)
+               	ld	a0, 0x0(s7)
+               	sext.w	s4, a0
+               	ld	t2, 0x0(s8)
                	sd	t2, -0x210(s0)
-               	addi	a0, s2, 0x60
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
+               	ld	t2, 0x0(s9)
                	sd	t2, -0x218(s0)
-               	addi	a0, s2, 0x68
+               	addi	a0, s2, 0x80
                	ld	a1, 0x0(a0)
                	sext.w	t2, a1
                	sd	t2, -0x220(s0)
-               	addi	a0, s2, 0x70
-               	ld	t2, 0x0(a0)
+               	addi	a1, s2, 0x88
+               	ld	a2, 0x0(a1)
+               	sext.w	t2, a2
                	sd	t2, -0x228(s0)
-               	addi	a0, s2, 0x78
-               	ld	t2, 0x0(a0)
+               	addi	a2, s2, 0x90
+               	ld	a3, 0x0(a2)
+               	sext.w	t2, a3
                	sd	t2, -0x230(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x5fc>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x608>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x614>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x620>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x62c>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x638>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x644>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x650>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x65c>
+               	addi	a3, s2, 0x98
+               	ld	a4, 0x0(a3)
+               	sext.w	a3, a4
+               	ld	a4, 0x0(s6)
+               	sext.w	a5, a4
+               	ld	a4, 0x0(s7)
+               	sext.w	a6, a4
+               	ld	a4, 0x0(s8)
+               	sext.w	a7, a4
+               	ld	a4, 0x0(s9)
+               	sext.w	s2, a4
+               	ld	a4, 0x0(s10)
+               	sext.w	s6, a4
+               	ld	a4, 0x0(s11)
+               	sext.w	s7, a4
+               	ld	t2, -0x1b8(s0)
+               	ld	a4, 0x0(t2)
+               	sext.w	s8, a4
+               	ld	t2, -0x1c8(s0)
+               	ld	a4, 0x0(t2)
+               	sext.w	s9, a4
+               	ld	t2, -0x1d8(s0)
+               	ld	a4, 0x0(t2)
+               	sext.w	s10, a4
+               	ld	t2, -0x1e8(s0)
+               	ld	a4, 0x0(t2)
+               	sext.w	a0, a4
                	ld	t2, -0x1f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x66c>
+               	ld	a4, 0x0(t2)
+               	sext.w	a1, a4
                	ld	t2, -0x200(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x67c>
-               	ld	t2, -0x208(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x68c>
-               	ld	t2, -0x210(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x69c>
-               	ld	t2, -0x218(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x6ac>
+               	ld	a4, 0x0(t2)
+               	sext.w	a2, a4
+               	sd	s6, 0x0(sp)
+               	sd	s7, 0x8(sp)
+               	sd	s8, 0x10(sp)
+               	sd	s9, 0x18(sp)
+               	sd	s10, 0x20(sp)
+               	sd	a0, 0x28(sp)
+               	sd	a1, 0x30(sp)
+               	sd	a2, 0x38(sp)
                	ld	t2, -0x220(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x6bc>
+               	mv	a0, t2
                	ld	t2, -0x228(s0)
                	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x6cc>
                	ld	t2, -0x230(s0)
-               	mv	a1, t2
+               	mv	a2, t2
+               	mv	a4, a5
+               	mv	a5, a6
+               	mv	a6, a7
+               	mv	a7, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x6dc>
-               	sext.w	s1, a0
-               	addi	a0, s2, 0x8
-               	ld	a1, 0x0(a0)
-               	sext.w	s5, a1
-               	addi	a0, s2, 0x10
-               	ld	a1, 0x0(a0)
-               	sext.w	s6, a1
-               	addi	a0, s2, 0x18
-               	ld	a1, 0x0(a0)
-               	sext.w	s7, a1
-               	sext.w	s8, s4
-               	addi	a0, s2, 0x28
-               	ld	a1, 0x0(a0)
-               	sext.w	s4, a1
-               	addi	a1, s2, 0x30
-               	ld	s9, 0x0(a1)
-               	addi	a2, s2, 0x38
-               	ld	s10, 0x0(a2)
-               	addi	a3, s2, 0x80
-               	ld	a4, 0x0(a3)
-               	sext.w	s11, a4
-               	addi	a3, s2, 0x88
-               	ld	a4, 0x0(a3)
-               	sext.w	t2, a4
-               	sd	t2, -0x238(s0)
-               	addi	a4, s2, 0x90
-               	ld	a5, 0x0(a4)
-               	sext.w	t2, a5
-               	sd	t2, -0x240(s0)
-               	addi	a5, s2, 0x98
-               	ld	a6, 0x0(a5)
-               	sext.w	t2, a6
-               	sd	t2, -0x248(s0)
-               	addi	a6, s2, 0x20
-               	ld	a7, 0x0(a6)
-               	sext.w	t2, a7
-               	sd	t2, -0x250(s0)
-               	ld	a7, 0x0(a0)
-               	sext.w	t2, a7
-               	sd	t2, -0x258(s0)
-               	ld	a0, 0x0(a1)
-               	sext.w	t2, a0
-               	sd	t2, -0x260(s0)
-               	ld	a0, 0x0(a2)
-               	sext.w	t2, a0
-               	sd	t2, -0x268(s0)
-               	addi	a0, s2, 0x40
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x270(s0)
-               	addi	a0, s2, 0x48
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x140(s0)
-               	addi	a0, s2, 0x50
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x148(s0)
-               	addi	a0, s2, 0x58
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x150(s0)
-               	addi	a0, s2, 0x60
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x158(s0)
-               	addi	a0, s2, 0x68
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x160(s0)
-               	addi	a0, s2, 0x70
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x168(s0)
-               	addi	a0, s2, 0x78
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x170(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x81c>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x828>
-               	ld	t2, -0x238(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x838>
-               	ld	t2, -0x240(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x848>
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x6c0>
+               	sext.w	a1, a0
+               	ld	a0, 0x0(s11)
+               	sext.w	a2, a0
+               	ld	t2, -0x1b8(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a3, a0
+               	ld	t2, -0x1c8(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a4, a0
+               	ld	t2, -0x1d8(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a5, a0
+               	ld	t2, -0x1e8(s0)
+               	ld	a0, 0x0(t2)
+               	sext.w	a6, a0
+               	ld	t2, -0x1f8(s0)
+               	ld	a0, 0x0(t2)
+               	ld	t2, -0x200(s0)
+               	ld	a7, 0x0(t2)
+               	sd	a1, 0x0(sp)
+               	sd	a2, 0x8(sp)
+               	sd	a3, 0x10(sp)
+               	sd	a4, 0x18(sp)
+               	sd	a5, 0x20(sp)
+               	sd	a6, 0x28(sp)
+               	sd	a0, 0x30(sp)
+               	sd	a7, 0x38(sp)
                	ld	t2, -0x248(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x858>
-               	ld	t2, -0x250(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x868>
-               	ld	t2, -0x258(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x878>
-               	ld	t2, -0x260(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x888>
-               	ld	t2, -0x268(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x898>
-               	ld	t2, -0x270(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8a8>
-               	ld	t2, -0x140(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8b8>
-               	ld	t2, -0x148(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8c8>
-               	ld	t2, -0x150(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8d8>
-               	ld	t2, -0x158(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8e8>
-               	ld	t2, -0x160(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x8f8>
-               	ld	t2, -0x168(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x908>
-               	ld	t2, -0x170(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x918>
-               	sext.w	s11, a0
-               	addi	a0, s2, 0x48
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x278(s0)
-               	addi	a0, s2, 0x50
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x280(s0)
-               	addi	a0, s2, 0x58
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x288(s0)
-               	addi	a0, s2, 0x60
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x290(s0)
-               	addi	a0, s2, 0x68
-               	ld	a1, 0x0(a0)
-               	sext.w	t2, a1
-               	sd	t2, -0x298(s0)
-               	addi	a0, s2, 0x70
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x2a0(s0)
-               	addi	a0, s2, 0x78
-               	ld	s2, 0x0(a0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x988>
+               	mv	a0, t2
                	mv	a1, s1
+               	mv	a2, s3
+               	mv	a3, s5
+               	ld	t2, -0x250(s0)
+               	mv	a4, t2
+               	mv	a5, s4
+               	ld	t2, -0x210(s0)
+               	mv	a6, t2
+               	ld	t2, -0x218(s0)
+               	mv	a7, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x994>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9a0>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9ac>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9b8>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9c4>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9d0>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9dc>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9e8>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x9f4>
-               	ld	t2, -0x278(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa04>
-               	ld	t2, -0x280(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa14>
-               	ld	t2, -0x288(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa24>
-               	ld	t2, -0x290(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa34>
-               	ld	t2, -0x298(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa44>
-               	ld	t2, -0x2a0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa54>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa60>
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x764>
                	mv	a1, a0
-               	mv	a0, s3
+               	ld	t2, -0x198(s0)
+               	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0xa70>
-               	ld	s1, 0x298(sp)
-               	ld	s2, 0x290(sp)
-               	ld	s3, 0x288(sp)
-               	ld	s4, 0x280(sp)
-               	ld	s5, 0x278(sp)
-               	ld	s6, 0x270(sp)
-               	ld	s7, 0x268(sp)
-               	ld	s8, 0x260(sp)
-               	ld	s9, 0x258(sp)
-               	ld	s10, 0x250(sp)
-               	ld	s11, 0x248(sp)
-               	ld	ra, 0x2a8(sp)
-               	ld	s0, 0x2a0(sp)
-               	addi	sp, sp, 0x2b0
+               	jalr	ra <corpus.cases.call.call_int_regs.checksum+0x778>
+               	ld	s1, 0x288(sp)
+               	ld	s2, 0x280(sp)
+               	ld	s3, 0x278(sp)
+               	ld	s4, 0x270(sp)
+               	ld	s5, 0x268(sp)
+               	ld	s6, 0x260(sp)
+               	ld	s7, 0x258(sp)
+               	ld	s8, 0x250(sp)
+               	ld	s9, 0x248(sp)
+               	ld	s10, 0x240(sp)
+               	ld	s11, 0x238(sp)
+               	ld	ra, 0x298(sp)
+               	ld	s0, 0x290(sp)
+               	addi	sp, sp, 0x2a0
                	ret

--- a/test/golden/riscv64-linux/call/call_mixed.dis
+++ b/test/golden/riscv64-linux/call/call_mixed.dis
@@ -57,346 +57,546 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_mixed.mixed>:
-               	addi	sp, sp, -0x1d0
-               	sd	ra, 0x1c8(sp)
-               	sd	s0, 0x1c0(sp)
-               	addi	s0, sp, 0x1d0
-               	sd	s1, 0x1b8(sp)
-               	sd	s2, 0x1b0(sp)
-               	sd	s3, 0x1a8(sp)
-               	sd	s4, 0x1a0(sp)
-               	sd	s5, 0x198(sp)
-               	sd	s6, 0x190(sp)
-               	sd	s7, 0x188(sp)
-               	sd	s8, 0x180(sp)
-               	sd	s9, 0x178(sp)
-               	sd	s10, 0x170(sp)
-               	sd	s11, 0x168(sp)
-               	fsd	fs0, 0x160(sp)
-               	fsd	fs1, 0x158(sp)
-               	fsd	fs2, 0x150(sp)
-               	fsd	fs3, 0x148(sp)
-               	fsd	fs4, 0x140(sp)
-               	fsd	fs5, 0x138(sp)
-               	fsd	fs6, 0x130(sp)
-               	fsd	fs7, 0x128(sp)
-               	fsd	fs8, 0x120(sp)
-               	fsd	fs9, 0x118(sp)
-               	fsd	fs10, 0x110(sp)
+               	addi	sp, sp, -0x1a0
+               	sd	ra, 0x198(sp)
+               	sd	s0, 0x190(sp)
+               	addi	s0, sp, 0x1a0
+               	sd	s1, 0x188(sp)
+               	sd	s2, 0x180(sp)
+               	sd	s3, 0x178(sp)
+               	sd	s4, 0x170(sp)
+               	sd	s5, 0x168(sp)
+               	sd	s6, 0x160(sp)
+               	sd	s7, 0x158(sp)
+               	sd	s8, 0x150(sp)
+               	sd	s9, 0x148(sp)
+               	sd	s10, 0x140(sp)
+               	sd	s11, 0x138(sp)
+               	fsd	fs0, 0x130(sp)
+               	fsd	fs1, 0x128(sp)
+               	fsd	fs2, 0x120(sp)
+               	fsd	fs3, 0x118(sp)
+               	fsd	fs4, 0x110(sp)
+               	fsd	fs5, 0x108(sp)
+               	fsd	fs6, 0x100(sp)
+               	fsd	fs7, 0xf8(sp)
                	mv	s1, a0
                	fmv.s	fs0, fa0
-               	mv	s2, a1
                	fmv.d	fs1, fa1
-               	mv	s3, a2
-               	mv	s4, a3
+               	mv	s2, a2
                	fmv.s	fs2, fa2
-               	mv	s5, a4
-               	mv	s6, a5
+               	mv	s3, a5
                	fmv.d	fs3, fa3
-               	mv	s7, a6
+               	mv	s4, a6
                	fmv.s	fs4, fa4
-               	mv	s8, a7
+               	mv	s5, a7
                	fmv.d	fs5, fa5
-               	ld	s9, 0x0(s0)
-               	ld	s10, 0x8(s0)
+               	ld	s6, 0x0(s0)
+               	ld	s7, 0x8(s0)
                	fmv.s	fs6, fa6
-               	ld	s11, 0x10(s0)
+               	ld	s8, 0x10(s0)
                	fmv.d	fs7, fa7
-               	ld	t2, 0x18(s0)
-               	sd	t2, -0x1b8(s0)
-               	addi	a1, s0, -0xcc
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe4
-               	addi	a1, s0, -0xf4
-               	addi	a1, s0, -0x104
-               	addi	a1, s0, -0x114
-               	addi	a1, s0, -0x124
-               	addi	a1, s0, -0x12c
-               	addi	a1, s0, -0x134
-               	addi	a1, s0, -0x140
-               	addi	a1, s0, -0x150
-               	addi	a1, s0, -0x160
-               	addi	a1, s0, -0x168
-               	addi	t2, s0, -0x174
-               	sd	t2, -0x1c0(s0)
-               	addi	t2, s0, -0x180
-               	sd	t2, -0x1c8(s0)
-               	addi	a1, s0, -0x18c
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x10c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x120>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x134>
-               	mv	a1, a0
-               	mv	a0, a1
+               	ld	s9, 0x18(s0)
+               	addi	a0, s0, -0xb4
+               	addi	a0, s0, -0xc0
+               	addi	a0, s0, -0xcc
+               	addi	a0, s0, -0xdc
+               	addi	a0, s0, -0xec
+               	addi	a0, s0, -0xfc
+               	addi	a0, s0, -0x10c
+               	addi	a0, s0, -0x114
+               	addi	a0, s0, -0x11c
+               	addi	a0, s0, -0x128
+               	addi	a0, s0, -0x138
+               	addi	a0, s0, -0x148
+               	addi	a0, s0, -0x150
+               	addi	s10, s0, -0x15c
+               	addi	s11, s0, -0x168
+               	addi	a0, s0, -0x174
+               	addi	a0, s0, -0x180
+               	addi	a0, s0, -0x18c
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c8 <corpus.cases.call.call_mixed.mixed+0x118>
+               	j	0x1fc <corpus.cases.call.call_mixed.mixed+0x14c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, s1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c8 <corpus.cases.call.call_mixed.mixed+0x118>
+               	fmv.x.w	a2, fs0
+               	slli	a5, a2, 0x20
+               	srli	a5, a5, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x218 <corpus.cases.call.call_mixed.mixed+0x168>
+               	j	0x24c <corpus.cases.call.call_mixed.mixed+0x19c>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a0, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x218 <corpus.cases.call.call_mixed.mixed+0x168>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.call.call_mixed.mixed+0x1b4>
+               	j	0x298 <corpus.cases.call.call_mixed.mixed+0x1e8>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.call.call_mixed.mixed+0x1b4>
+               	fmv.x.d	a1, fs1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2ac <corpus.cases.call.call_mixed.mixed+0x1fc>
+               	j	0x2e0 <corpus.cases.call.call_mixed.mixed+0x230>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2ac <corpus.cases.call.call_mixed.mixed+0x1fc>
                	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x304 <corpus.cases.call.call_mixed.mixed+0x254>
+               	j	0x338 <corpus.cases.call.call_mixed.mixed+0x288>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x304 <corpus.cases.call.call_mixed.mixed+0x254>
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x35c <corpus.cases.call.call_mixed.mixed+0x2ac>
+               	j	0x390 <corpus.cases.call.call_mixed.mixed+0x2e0>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x35c <corpus.cases.call.call_mixed.mixed+0x2ac>
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b4 <corpus.cases.call.call_mixed.mixed+0x304>
+               	j	0x3e8 <corpus.cases.call.call_mixed.mixed+0x338>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b4 <corpus.cases.call.call_mixed.mixed+0x304>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3f8 <corpus.cases.call.call_mixed.mixed+0x348>
+               	j	0x42c <corpus.cases.call.call_mixed.mixed+0x37c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a5, a3, a2
+               	li	t0, 0xff
+               	and	a2, a5, t0
+               	xor	a5, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3f8 <corpus.cases.call.call_mixed.mixed+0x348>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x448 <corpus.cases.call.call_mixed.mixed+0x398>
+               	j	0x47c <corpus.cases.call.call_mixed.mixed+0x3cc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a5, a2, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x448 <corpus.cases.call.call_mixed.mixed+0x398>
+               	slli	a1, a4, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x494 <corpus.cases.call.call_mixed.mixed+0x3e4>
+               	j	0x4c8 <corpus.cases.call.call_mixed.mixed+0x418>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x494 <corpus.cases.call.call_mixed.mixed+0x3e4>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ec <corpus.cases.call.call_mixed.mixed+0x43c>
+               	j	0x520 <corpus.cases.call.call_mixed.mixed+0x470>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ec <corpus.cases.call.call_mixed.mixed+0x43c>
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x544 <corpus.cases.call.call_mixed.mixed+0x494>
+               	j	0x578 <corpus.cases.call.call_mixed.mixed+0x4c8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x544 <corpus.cases.call.call_mixed.mixed+0x494>
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x59c <corpus.cases.call.call_mixed.mixed+0x4ec>
+               	j	0x5d0 <corpus.cases.call.call_mixed.mixed+0x520>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x59c <corpus.cases.call.call_mixed.mixed+0x4ec>
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5f4 <corpus.cases.call.call_mixed.mixed+0x544>
+               	j	0x628 <corpus.cases.call.call_mixed.mixed+0x578>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5f4 <corpus.cases.call.call_mixed.mixed+0x544>
+               	fmv.x.d	a1, fs3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x63c <corpus.cases.call.call_mixed.mixed+0x58c>
+               	j	0x670 <corpus.cases.call.call_mixed.mixed+0x5c0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x63c <corpus.cases.call.call_mixed.mixed+0x58c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x680 <corpus.cases.call.call_mixed.mixed+0x5d0>
+               	j	0x6b4 <corpus.cases.call.call_mixed.mixed+0x604>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x680 <corpus.cases.call.call_mixed.mixed+0x5d0>
+               	fmv.x.w	a1, fs4
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x148>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x614>
+               	zext.b	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x15c>
-               	mv	a1, a0
-               	mv	a5, s3
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x620>
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x178>
-               	mv	a1, a0
-               	addi	a5, s3, 0x4
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x62c>
+               	mv	a1, s6
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x194>
-               	mv	a1, a0
-               	addi	a5, s3, 0x8
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x64c>
+               	addi	a1, s6, 0x4
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x1b0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x1c4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x1d8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x1ec>
-               	mv	a1, a0
-               	mv	a5, s6
-               	flw	fs8, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x208>
-               	mv	a1, a0
-               	addi	a5, s6, 0x4
-               	flw	fs9, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x224>
-               	mv	a1, a0
-               	addi	a5, s6, 0x8
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x240>
-               	mv	a1, a0
-               	addi	a5, s6, 0xc
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x25c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x270>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x66c>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x284>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs4
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x678>
+               	fmv.x.w	a1, fs6
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x298>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s8
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x690>
+               	sext.w	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x2ac>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs5
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x69c>
+               	fmv.x.d	a1, fs7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x2c0>
-               	mv	a1, a0
-               	mv	a5, s9
-               	flw	fs10, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, fs10
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x6a8>
+               	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x2dc>
-               	mv	a1, a0
-               	addi	a5, s9, 0x4
-               	flw	ft0, 0x0(a5)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x6b4>
+               	mul	a1, s4, s7
+               	add	a2, s1, a1
+               	sub	a1, a2, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x2f8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x30c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x320>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x334>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x348>
-               	mv	a1, a0
-               	mv	a0, a1
-               	ld	t2, -0x1b8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x360>
-               	mv	a1, a0
-               	mul	a5, s7, s10
-               	add	a6, s1, a5
-               	ld	t2, -0x1b8(s0)
-               	sub	a5, a6, t2
-               	mv	a0, a1
-               	mv	a1, a5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x384>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x6c8>
                	fmul.s	ft0, fs2, fs4
                	fadd.s	ft1, fs0, ft0
                	fsub.s	ft0, ft1, fs6
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x3a4>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x6ec>
                	fmul.d	ft0, fs3, fs5
                	fadd.d	ft1, fs1, ft0
-               	fsub.d	fa0, ft1, fs7
-               	mv	a0, a1
+               	fsub.d	ft0, ft1, fs7
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x3c0>
-               	mv	a1, a0
-               	addi	a2, s0, -0x1b0
-               	mv	a5, a2
-               	fsw	fs8, 0x0(a5)
-               	addi	a5, a2, 0x4
-               	fsw	fs9, 0x0(a5)
-               	addi	a5, a2, 0x8
-               	fsw	fs10, 0x0(a5)
-               	mv	a5, a2
-               	flw	ft0, 0x0(a5)
-               	ld	t2, -0x1c0(s0)
-               	mv	a5, t2
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, a2, 0x4
-               	flw	ft0, 0x0(a5)
-               	ld	t2, -0x1c0(s0)
-               	addi	a5, t2, 0x4
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, a2, 0x8
-               	flw	ft0, 0x0(a5)
-               	ld	t2, -0x1c0(s0)
-               	addi	a2, t2, 0x8
-               	fsw	ft0, 0x0(a2)
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x704>
+               	addi	a1, s0, -0x198
                	mv	a2, s3
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x1c0(s0)
-               	mv	a2, t2
-               	flw	ft1, 0x0(a2)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x1c8(s0)
-               	mv	a2, t2
-               	fsw	ft2, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
                	addi	a2, s3, 0x4
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x1c0(s0)
-               	addi	a2, t2, 0x4
-               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	mv	a2, s6
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	flw	ft0, 0x0(a2)
+               	mv	a2, s10
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, s10, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a1, s10, 0x8
+               	fsw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s10
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x1c8(s0)
-               	addi	a2, t2, 0x4
-               	fsw	ft2, 0x0(a2)
-               	addi	a2, s3, 0x8
-               	flw	ft0, 0x0(a2)
-               	ld	t2, -0x1c0(s0)
-               	addi	a2, t2, 0x8
-               	flw	ft1, 0x0(a2)
+               	mv	a1, s11
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x1c8(s0)
-               	addi	a2, t2, 0x8
-               	fsw	ft2, 0x0(a2)
-               	ld	t2, -0x1c8(s0)
-               	mv	a2, t2
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
+               	addi	a1, s11, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s10, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s11
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x7dc>
+               	addi	a1, s11, 0x4
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x7fc>
+               	addi	a1, s11, 0x8
+               	flw	ft0, 0x0(a1)
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x4a4>
-               	mv	a1, a0
-               	ld	t2, -0x1c8(s0)
-               	addi	a2, t2, 0x4
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x4c4>
-               	mv	a1, a0
-               	ld	t2, -0x1c8(s0)
-               	addi	a2, t2, 0x8
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x4e4>
-               	ld	s1, 0x1b8(sp)
-               	ld	s2, 0x1b0(sp)
-               	ld	s3, 0x1a8(sp)
-               	ld	s4, 0x1a0(sp)
-               	ld	s5, 0x198(sp)
-               	ld	s6, 0x190(sp)
-               	ld	s7, 0x188(sp)
-               	ld	s8, 0x180(sp)
-               	ld	s9, 0x178(sp)
-               	ld	s10, 0x170(sp)
-               	ld	s11, 0x168(sp)
-               	fld	fs0, 0x160(sp)
-               	fld	fs1, 0x158(sp)
-               	fld	fs2, 0x150(sp)
-               	fld	fs3, 0x148(sp)
-               	fld	fs4, 0x140(sp)
-               	fld	fs5, 0x138(sp)
-               	fld	fs6, 0x130(sp)
-               	fld	fs7, 0x128(sp)
-               	fld	fs8, 0x120(sp)
-               	fld	fs9, 0x118(sp)
-               	fld	fs10, 0x110(sp)
-               	ld	ra, 0x1c8(sp)
-               	ld	s0, 0x1c0(sp)
-               	addi	sp, sp, 0x1d0
+               	jalr	ra <corpus.cases.call.call_mixed.mixed+0x810>
+               	ld	s1, 0x188(sp)
+               	ld	s2, 0x180(sp)
+               	ld	s3, 0x178(sp)
+               	ld	s4, 0x170(sp)
+               	ld	s5, 0x168(sp)
+               	ld	s6, 0x160(sp)
+               	ld	s7, 0x158(sp)
+               	ld	s8, 0x150(sp)
+               	ld	s9, 0x148(sp)
+               	ld	s10, 0x140(sp)
+               	ld	s11, 0x138(sp)
+               	fld	fs0, 0x130(sp)
+               	fld	fs1, 0x128(sp)
+               	fld	fs2, 0x120(sp)
+               	fld	fs3, 0x118(sp)
+               	fld	fs4, 0x110(sp)
+               	fld	fs5, 0x108(sp)
+               	fld	fs6, 0x100(sp)
+               	fld	fs7, 0xf8(sp)
+               	ld	ra, 0x198(sp)
+               	ld	s0, 0x190(sp)
+               	addi	sp, sp, 0x1a0
                	ret
 
 <corpus.cases.call.call_mixed.checksum>:
@@ -425,44 +625,42 @@ Disassembly of section .text:
                	addi	s2, s0, -0xa4
                	addi	s3, s0, -0xb4
                	addi	s4, s0, -0xbc
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe0
+               	addi	a0, s0, -0xc8
+               	addi	a0, s0, -0xd8
+               	addi	a0, s0, -0xe0
                	addi	s5, s0, -0xec
                	addi	s6, s0, -0xfc
                	addi	s7, s0, -0x104
-               	addi	a1, s0, -0x110
-               	addi	a1, s0, -0x120
-               	addi	a1, s0, -0x128
-               	addi	a1, s0, -0x134
-               	addi	a1, s0, -0x144
-               	addi	a1, s0, -0x14c
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x94>
-               	addi	s8, s0, -0x210
-               	mv	a1, s8
+               	addi	a0, s0, -0x110
+               	addi	a0, s0, -0x120
+               	addi	a0, s0, -0x128
+               	addi	a0, s0, -0x134
+               	addi	a0, s0, -0x144
+               	addi	a0, s0, -0x14c
+               	addi	s8, s0, -0x228
+               	mv	a0, s8
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x6d4 <corpus.cases.call.call_mixed.checksum+0xd0>
-               	mv	a2, a1
-               	li	a3, 0xc0
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x9ec <corpus.cases.call.call_mixed.checksum+0xc8>
+               	mv	a1, a0
+               	li	a2, 0xc0
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x6bc <corpus.cases.call.call_mixed.checksum+0xb8>
-               	j	0x6f0 <corpus.cases.call.call_mixed.checksum+0xec>
-               	mv	a2, a1
-               	li	a1, 0xc0
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x9d4 <corpus.cases.call.call_mixed.checksum+0xb0>
+               	j	0xa08 <corpus.cases.call.call_mixed.checksum+0xe4>
+               	mv	a1, a0
+               	li	a0, 0xc0
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x6dc <corpus.cases.call.call_mixed.checksum+0xd8>
-               	li	a1, 0x0
+               	bne	a0, t0, 0x9f4 <corpus.cases.call.call_mixed.checksum+0xd0>
+               	li	a0, 0x0
                	li	t0, 0x18
-               	bltu	a1, t0, 0x700 <corpus.cases.call.call_mixed.checksum+0xfc>
-               	j	0x764 <corpus.cases.call.call_mixed.checksum+0x160>
+               	bltu	a0, t0, 0xa18 <corpus.cases.call.call_mixed.checksum+0xf4>
+               	j	0xa7c <corpus.cases.call.call_mixed.checksum+0x158>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -471,7 +669,7 @@ Disassembly of section .text:
                	addi	t0, t0, -0x6a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd3
-               	mul	a2, a1, t0
+               	mul	a1, a0, t0
                	lui	t0, 0x1405
                	addiw	t0, t0, 0x7b8
                	slli	t0, t0, 0xc
@@ -480,25 +678,32 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a2, t0
-               	add	a2, a3, s1
-               	slli	t0, a1, 0x3
-               	add	a3, s8, t0
-               	sd	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
+               	slli	t0, a0, 0x3
+               	add	a2, s8, t0
+               	sd	a1, 0x0(a2)
+               	addi	a0, a0, 0x1
                	li	t0, 0x18
-               	bltu	a1, t0, 0x700 <corpus.cases.call.call_mixed.checksum+0xfc>
-               	mv	s9, a0
+               	bltu	a0, t0, 0xa18 <corpus.cases.call.call_mixed.checksum+0xf4>
+               	lui	s9, 0xfcbf3
+               	addiw	s9, s9, -0x632
+               	slli	s9, s9, 0xc
+               	addi	s9, s9, 0x484
+               	slli	s9, s9, 0xc
+               	addi	s9, s9, 0x222
+               	slli	s9, s9, 0xc
+               	addi	s9, s9, 0x325
                	li	s10, 0x0
                	li	s11, 0x0
                	li	t0, 0x3
-               	bltu	s11, t0, 0x77c <corpus.cases.call.call_mixed.checksum+0x178>
-               	j	0xc68 <.Lpcrel_hi.9+0xb4>
+               	bltu	s11, t0, 0xab0 <corpus.cases.call.call_mixed.checksum+0x18c>
+               	j	0xf9c <.Lpcrel_hi.9+0xb4>
                	li	t0, 0xb
                	mul	a0, s11, t0
                	add	t2, a0, s1
                	sd	t2, -0x268(s0)
-               	addi	a0, s0, -0x21c
+               	addi	a0, s0, -0x158
                	addi	a2, s8, 0x80
                	ld	a3, 0x0(a2)
                	lui	t0, 0x1
@@ -651,7 +856,7 @@ Disassembly of section .text:
                	add	a4, a0, t2
                	mv	a0, a4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x3e8>
+               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x3fc>
                	ld	t2, -0x270(s0)
                	addi	a0, t2, 0x4
                	fsw	fa0, 0x0(a0)
@@ -674,7 +879,7 @@ Disassembly of section .text:
                	ld	a3, 0x0(a0)
                	mv	a0, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x444>
+               	jalr	ra <corpus.cases.call.call_mixed.checksum+0x458>
                	fmv.s	fs0, fa0
                	addi	a0, s8, 0x10
                	ld	a3, 0x0(a0)
@@ -824,8 +1029,8 @@ Disassembly of section .text:
                	addi	s11, s11, 0x1
                	mv	s9, a0
                	li	t0, 0x3
-               	bltu	s11, t0, 0x77c <corpus.cases.call.call_mixed.checksum+0x178>
-               	addi	a0, s0, -0x228
+               	bltu	s11, t0, 0xab0 <corpus.cases.call.call_mixed.checksum+0x18c>
+               	addi	a0, s0, -0x164
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a1, s10, t0

--- a/test/golden/riscv64-linux/call/call_rec_edge.dis
+++ b/test/golden/riscv64-linux/call/call_rec_edge.dis
@@ -26,1343 +26,329 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_edge.fold_e9>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	mv	a3, a0
-               	sd	a1, -0x38(s0)
-               	sd	a2, -0x30(s0)
-               	addi	s1, s0, -0x40
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	sd	s2, 0x20(sp)
+               	sd	a1, -0x30(s0)
+               	sd	a2, -0x28(s0)
                	addi	a1, s0, -0x38
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s0, -0x37
-               	lbu	a4, 0x0(a1)
-               	lbu	a5, 0x1(a1)
-               	lbu	a6, 0x2(a1)
-               	lbu	a7, 0x3(a1)
-               	lbu	t5, 0x4(a1)
-               	lbu	t6, 0x5(a1)
-               	lbu	s2, 0x6(a1)
-               	lbu	s3, 0x7(a1)
-               	sb	a4, 0x0(s1)
-               	sb	a5, 0x1(s1)
-               	sb	a6, 0x2(s1)
-               	sb	a7, 0x3(s1)
-               	sb	t5, 0x4(s1)
-               	sb	t6, 0x5(s1)
-               	sb	s2, 0x6(s1)
-               	sb	s3, 0x7(s1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e9+0x80>
-               	mv	s2, a0
-               	li	s3, 0x0
+               	addi	a2, s0, -0x30
+               	lbu	a3, 0x0(a2)
+               	addi	a2, s0, -0x2f
+               	lbu	a4, 0x0(a2)
+               	lbu	a5, 0x1(a2)
+               	lbu	a6, 0x2(a2)
+               	lbu	a7, 0x3(a2)
+               	lbu	t5, 0x4(a2)
+               	lbu	t6, 0x5(a2)
+               	lbu	s1, 0x6(a2)
+               	lbu	s2, 0x7(a2)
+               	sb	a4, 0x0(a1)
+               	sb	a5, 0x1(a1)
+               	sb	a6, 0x2(a1)
+               	sb	a7, 0x3(a1)
+               	sb	t5, 0x4(a1)
+               	sb	t6, 0x5(a1)
+               	sb	s1, 0x6(a1)
+               	sb	s2, 0x7(a1)
+               	zext.b	a2, a3
+               	li	a3, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0xf0 <corpus.cases.call.call_rec_edge.fold_e9+0x9c>
-               	j	0x114 <corpus.cases.call.call_rec_edge.fold_e9+0xc0>
-               	add	a0, s1, s3
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e9+0xa8>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	bltu	a3, t0, 0xd8 <corpus.cases.call.call_rec_edge.fold_e9+0x84>
+               	j	0x10c <corpus.cases.call.call_rec_edge.fold_e9+0xb8>
                	li	t0, 0x8
-               	bltu	s3, t0, 0xf0 <corpus.cases.call.call_rec_edge.fold_e9+0x9c>
-               	mv	a0, s2
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xd8 <corpus.cases.call.call_rec_edge.fold_e9+0x84>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x11c <corpus.cases.call.call_rec_edge.fold_e9+0xc8>
+               	j	0x180 <corpus.cases.call.call_rec_edge.fold_e9+0x12c>
+               	add	a3, a1, a2
+               	lbu	a4, 0x0(a3)
+               	zext.b	a3, a4
+               	mv	a4, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x13c <corpus.cases.call.call_rec_edge.fold_e9+0xe8>
+               	j	0x170 <corpus.cases.call.call_rec_edge.fold_e9+0x11c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x13c <corpus.cases.call.call_rec_edge.fold_e9+0xe8>
+               	addi	a2, a2, 0x1
+               	mv	a0, a4
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x11c <corpus.cases.call.call_rec_edge.fold_e9+0xc8>
+               	ld	s1, 0x28(sp)
+               	ld	s2, 0x20(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.call.call_rec_edge.fold_e12>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lw	a2, 0x0(a1)
-               	addi	a1, s0, -0x2c
-               	lw	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	lw	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e12+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e12+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e12+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1c
+               	lw	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	lw	a4, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1e0 <corpus.cases.call.call_rec_edge.fold_e12+0x48>
+               	j	0x214 <corpus.cases.call.call_rec_edge.fold_e12+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1e0 <corpus.cases.call.call_rec_edge.fold_e12+0x48>
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x22c <corpus.cases.call.call_rec_edge.fold_e12+0x94>
+               	j	0x260 <corpus.cases.call.call_rec_edge.fold_e12+0xc8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x22c <corpus.cases.call.call_rec_edge.fold_e12+0x94>
+               	slli	a1, a4, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x278 <corpus.cases.call.call_rec_edge.fold_e12+0xe0>
+               	j	0x2ac <corpus.cases.call.call_rec_edge.fold_e12+0x114>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x278 <corpus.cases.call.call_rec_edge.fold_e12+0xe0>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_edge.fold_e16>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a3, a0
-               	sd	a1, -0x28(s0)
-               	sd	a2, -0x20(s0)
-               	addi	a1, s0, -0x28
-               	ld	a2, 0x0(a1)
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
                	addi	a1, s0, -0x20
-               	ld	s1, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16+0x4c>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	ld	a2, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a3, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2f4 <corpus.cases.call.call_rec_edge.fold_e16+0x38>
+               	j	0x328 <corpus.cases.call.call_rec_edge.fold_e16+0x6c>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2f4 <corpus.cases.call.call_rec_edge.fold_e16+0x38>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x338 <corpus.cases.call.call_rec_edge.fold_e16+0x7c>
+               	j	0x36c <corpus.cases.call.call_rec_edge.fold_e16+0xb0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a4, a3, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x338 <corpus.cases.call.call_rec_edge.fold_e16+0x7c>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_edge.fold_e16f>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	fsd	fs0, 0x18(sp)
-               	mv	a1, a0
-               	fsd	fa0, -0x28(s0)
-               	fsd	fa1, -0x20(s0)
-               	addi	a2, s0, -0x28
-               	fld	fa0, 0x0(a2)
-               	addi	a2, s0, -0x20
-               	fld	fs0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16f+0x34>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16f+0x48>
-               	fld	fs0, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	fsd	fa0, -0x20(s0)
+               	fsd	fa1, -0x18(s0)
+               	addi	a1, s0, -0x20
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	fld	ft1, 0x0(a1)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3b8 <corpus.cases.call.call_rec_edge.fold_e16f+0x3c>
+               	j	0x3ec <corpus.cases.call.call_rec_edge.fold_e16f+0x70>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3b8 <corpus.cases.call.call_rec_edge.fold_e16f+0x3c>
+               	fmv.x.d	a1, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x400 <corpus.cases.call.call_rec_edge.fold_e16f+0x84>
+               	j	0x434 <corpus.cases.call.call_rec_edge.fold_e16f+0xb8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x400 <corpus.cases.call.call_rec_edge.fold_e16f+0x84>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_edge.fold_e16m>:
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	fsd	fa0, -0x18(s0)
+               	addi	a1, s0, -0x20
+               	ld	a2, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	fld	ft0, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x47c <corpus.cases.call.call_rec_edge.fold_e16m+0x38>
+               	j	0x4b0 <corpus.cases.call.call_rec_edge.fold_e16m+0x6c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x47c <corpus.cases.call.call_rec_edge.fold_e16m+0x38>
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4c4 <corpus.cases.call.call_rec_edge.fold_e16m+0x80>
+               	j	0x4f8 <corpus.cases.call.call_rec_edge.fold_e16m+0xb4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4c4 <corpus.cases.call.call_rec_edge.fold_e16m+0x80>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
+               	ret
+
+<corpus.cases.call.call_rec_edge.fold_e17>:
                	addi	sp, sp, -0x30
                	sd	ra, 0x28(sp)
                	sd	s0, 0x20(sp)
                	addi	s0, sp, 0x30
-               	fsd	fs0, 0x18(sp)
-               	mv	a2, a0
-               	sd	a1, -0x28(s0)
-               	fsd	fa0, -0x20(s0)
-               	addi	a1, s0, -0x28
-               	ld	a3, 0x0(a1)
-               	addi	a1, s0, -0x20
-               	fld	fs0, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16m+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e16m+0x4c>
-               	fld	fs0, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
-               	ret
-
-<corpus.cases.call.call_rec_edge.fold_e17>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	addi	s1, s0, -0x39
-               	mv	a2, s1
-               	mv	a3, a1
-               	or	a1, a2, a3
-               	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x390 <corpus.cases.call.call_rec_edge.fold_e17+0x9c>
-               	bnez	a1, 0x364 <corpus.cases.call.call_rec_edge.fold_e17+0x70>
-               	addi	a4, a2, 0x10
-               	addi	a5, a3, 0x10
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a4)
-               	li	a6, 0x10
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0x344 <corpus.cases.call.call_rec_edge.fold_e17+0x50>
-               	j	0x3f0 <corpus.cases.call.call_rec_edge.fold_e17+0xfc>
-               	addi	a4, a2, 0x11
-               	addi	a5, a3, 0x11
-               	li	a6, 0x11
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x370 <corpus.cases.call.call_rec_edge.fold_e17+0x7c>
-               	j	0x3f0 <corpus.cases.call.call_rec_edge.fold_e17+0xfc>
-               	bnez	a1, 0x3c8 <corpus.cases.call.call_rec_edge.fold_e17+0xd4>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x10
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x3a0 <corpus.cases.call.call_rec_edge.fold_e17+0xac>
-               	lbu	a5, 0x0(a4)
-               	sb	a5, 0x0(a1)
-               	j	0x3f0 <corpus.cases.call.call_rec_edge.fold_e17+0xfc>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x11
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x3d4 <corpus.cases.call.call_rec_edge.fold_e17+0xe0>
-               	mv	a1, s1
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e17+0x108>
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x418 <corpus.cases.call.call_rec_edge.fold_e17+0x124>
-               	j	0x444 <corpus.cases.call.call_rec_edge.fold_e17+0x150>
-               	addi	a0, s1, 0x1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.fold_e17+0x138>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x418 <corpus.cases.call.call_rec_edge.fold_e17+0x124>
-               	mv	a0, s2
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
-               	ret
-
-<corpus.cases.call.call_rec_edge.layout>:
-               	addi	sp, sp, -0x10
-               	sd	ra, 0x8(sp)
-               	sd	s0, 0x0(sp)
-               	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0xc
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x30>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x6c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xd0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xe4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xf8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x10c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x120>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x134>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x148>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x15c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x170>
-               	ld	ra, 0x8(sp)
-               	ld	s0, 0x0(sp)
-               	addi	sp, sp, 0x10
-               	ret
-
-<corpus.cases.call.call_rec_edge.take_edge>:
-               	addi	sp, sp, -0x380
-               	sd	ra, 0x378(sp)
-               	sd	s0, 0x370(sp)
-               	addi	s0, sp, 0x380
-               	sd	s1, 0x368(sp)
-               	sd	s2, 0x360(sp)
-               	sd	s3, 0x358(sp)
-               	sd	s4, 0x350(sp)
-               	sd	s5, 0x348(sp)
-               	sd	s6, 0x340(sp)
-               	sd	s7, 0x338(sp)
-               	sd	s8, 0x330(sp)
-               	sd	s9, 0x328(sp)
-               	sd	s10, 0x320(sp)
-               	sd	s11, 0x318(sp)
-               	fsd	fs0, 0x310(sp)
-               	fsd	fs1, 0x308(sp)
-               	fsd	fs2, 0x300(sp)
-               	fsd	fs3, 0x2f8(sp)
-               	fsd	fs4, 0x2f0(sp)
-               	mv	s1, a0
-               	sd	a1, -0xa0(s0)
-               	sd	a2, -0x98(s0)
-               	mv	s2, a3
-               	sd	a4, -0xb0(s0)
-               	sd	a5, -0xa8(s0)
-               	fmv.d	fs0, fa0
-               	sd	a6, -0xc0(s0)
-               	sd	a7, -0xb8(s0)
-               	fsd	fa1, -0xd0(s0)
-               	fsd	fa2, -0xc8(s0)
-               	mv	a0, s0
-               	ld	s3, 0x10(s0)
-               	ld	t2, 0x18(s0)
-               	sd	t2, -0x1f8(s0)
-               	addi	t2, s0, 0x20
-               	sd	t2, -0x1e8(s0)
-               	addi	t2, s0, 0x30
-               	sd	t2, -0x1f0(s0)
-               	addi	t2, s0, 0x40
-               	sd	t2, -0x1e0(s0)
-               	ld	t2, 0x50(s0)
-               	sd	t2, -0x1d8(s0)
-               	fmv.s	fs1, fa3
-               	ld	t2, 0x58(s0)
-               	sd	t2, -0x298(s0)
-               	addi	s5, s0, -0xd8
-               	addi	s6, s0, -0xe0
-               	addi	s7, s0, -0xe8
-               	addi	s8, s0, -0xf0
-               	addi	s9, s0, -0xf8
-               	addi	s10, s0, -0x100
-               	addi	a6, s0, -0xa0
-               	lbu	s11, 0x0(a6)
-               	addi	a6, s0, -0x9f
-               	lbu	a7, 0x0(a6)
-               	lbu	t5, 0x1(a6)
-               	lbu	t6, 0x2(a6)
-               	lbu	a5, 0x3(a6)
-               	lbu	a4, 0x4(a6)
-               	lbu	a2, 0x5(a6)
-               	lbu	a3, 0x6(a6)
-               	lbu	a1, 0x7(a6)
-               	sb	a7, 0x0(s5)
-               	sb	t5, 0x1(s5)
-               	sb	t6, 0x2(s5)
-               	sb	a5, 0x3(s5)
-               	sb	a4, 0x4(s5)
-               	sb	a2, 0x5(s5)
-               	sb	a3, 0x6(s5)
-               	sb	a1, 0x7(s5)
-               	addi	a1, s0, -0xb0
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0x350(s0)
-               	addi	a1, s0, -0xac
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0x358(s0)
-               	addi	a1, s0, -0xa8
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0x360(s0)
-               	addi	a1, s0, -0xc0
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x368(s0)
-               	addi	a1, s0, -0xb8
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x370(s0)
-               	addi	a1, s0, -0xd0
-               	fld	fs2, 0x0(a1)
-               	addi	a1, s0, -0xc8
-               	fld	fs3, 0x0(a1)
-               	mv	a1, a0
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x378(s0)
-               	addi	a1, a0, 0x8
-               	fld	fs4, 0x0(a1)
-               	addi	t2, s0, -0x111
-               	sd	t2, -0x348(s0)
-               	ld	t3, -0x348(s0)
-               	mv	t2, t3
-               	sd	t2, -0x200(s0)
-               	ld	t3, -0x1f8(s0)
-               	mv	t2, t3
-               	sd	t2, -0x208(s0)
-               	ld	t3, -0x200(s0)
-               	ld	t4, -0x208(s0)
-               	or	t2, t3, t4
-               	sd	t2, -0x210(s0)
-               	ld	t2, -0x210(s0)
-               	li	t0, 0x7
-               	and	t2, t2, t0
-               	sd	t2, -0x210(s0)
-               	ld	t2, -0x200(s0)
-               	ld	t3, -0x208(s0)
-               	bltu	t2, t3, 0x850 <corpus.cases.call.call_rec_edge.take_edge+0x264>
-               	ld	t2, -0x210(s0)
-               	bnez	t2, 0x80c <corpus.cases.call.call_rec_edge.take_edge+0x220>
-               	ld	t3, -0x200(s0)
-               	addi	t2, t3, 0x10
-               	sd	t2, -0x218(s0)
-               	ld	t2, -0x208(s0)
-               	addi	a1, t2, 0x10
-               	lbu	t6, 0x0(a1)
-               	ld	t2, -0x218(s0)
-               	sb	t6, 0x0(t2)
-               	li	t6, 0x10
-               	ld	t2, -0x218(s0)
-               	addi	t2, t2, -0x8
-               	sd	t2, -0x218(s0)
-               	addi	a1, a1, -0x8
-               	ld	a0, 0x0(a1)
-               	ld	t2, -0x218(s0)
-               	sd	a0, 0x0(t2)
-               	addi	t6, t6, -0x8
-               	li	t0, 0x0
-               	bne	t6, t0, 0x7e0 <corpus.cases.call.call_rec_edge.take_edge+0x1f4>
-               	j	0x8e8 <corpus.cases.call.call_rec_edge.take_edge+0x2fc>
-               	ld	t3, -0x200(s0)
-               	addi	t2, t3, 0x11
-               	sd	t2, -0x220(s0)
-               	ld	t2, -0x208(s0)
-               	addi	a1, t2, 0x11
-               	li	t6, 0x11
-               	ld	t2, -0x220(s0)
-               	addi	t2, t2, -0x1
-               	sd	t2, -0x220(s0)
-               	addi	a1, a1, -0x1
-               	lbu	a0, 0x0(a1)
-               	ld	t2, -0x220(s0)
-               	sb	a0, 0x0(t2)
-               	addi	t6, t6, -0x1
-               	li	t0, 0x0
-               	bne	t6, t0, 0x824 <corpus.cases.call.call_rec_edge.take_edge+0x238>
-               	j	0x8e8 <corpus.cases.call.call_rec_edge.take_edge+0x2fc>
-               	ld	t2, -0x210(s0)
-               	bnez	t2, 0x8a8 <corpus.cases.call.call_rec_edge.take_edge+0x2bc>
-               	ld	t3, -0x200(s0)
-               	mv	t2, t3
-               	sd	t2, -0x228(s0)
-               	ld	t2, -0x208(s0)
-               	mv	a1, t2
-               	li	t6, 0x10
-               	ld	a0, 0x0(a1)
-               	ld	t2, -0x228(s0)
-               	sd	a0, 0x0(t2)
-               	ld	t2, -0x228(s0)
-               	addi	t2, t2, 0x8
-               	sd	t2, -0x228(s0)
-               	addi	a1, a1, 0x8
-               	addi	t6, t6, -0x8
-               	li	t0, 0x0
-               	bne	t6, t0, 0x870 <corpus.cases.call.call_rec_edge.take_edge+0x284>
-               	lbu	a0, 0x0(a1)
-               	ld	t2, -0x228(s0)
-               	sb	a0, 0x0(t2)
-               	j	0x8e8 <corpus.cases.call.call_rec_edge.take_edge+0x2fc>
-               	ld	t3, -0x200(s0)
-               	mv	t2, t3
-               	sd	t2, -0x230(s0)
-               	ld	t2, -0x208(s0)
-               	mv	a1, t2
-               	li	t6, 0x11
-               	lbu	a0, 0x0(a1)
-               	ld	t2, -0x230(s0)
-               	sb	a0, 0x0(t2)
-               	ld	t2, -0x230(s0)
-               	addi	t2, t2, 0x1
-               	sd	t2, -0x230(s0)
-               	addi	a1, a1, 0x1
-               	addi	t6, t6, -0x1
-               	li	t0, 0x0
-               	bne	t6, t0, 0x8c0 <corpus.cases.call.call_rec_edge.take_edge+0x2d4>
-               	ld	t2, -0x1e8(s0)
-               	mv	a0, t2
-               	lbu	t2, 0x0(a0)
-               	sd	t2, -0x380(s0)
-               	ld	t2, -0x1e8(s0)
-               	addi	a0, t2, 0x1
-               	lbu	a1, 0x0(a0)
-               	lbu	t2, 0x1(a0)
-               	sd	t2, -0x238(s0)
-               	lbu	t2, 0x2(a0)
-               	sd	t2, -0x240(s0)
-               	lbu	t2, 0x3(a0)
-               	sd	t2, -0x248(s0)
-               	lbu	t2, 0x4(a0)
-               	sd	t2, -0x250(s0)
-               	lbu	t2, 0x5(a0)
-               	sd	t2, -0x258(s0)
-               	lbu	t2, 0x6(a0)
-               	sd	t2, -0x260(s0)
-               	lbu	t2, 0x7(a0)
-               	sd	t2, -0x268(s0)
-               	sb	a1, 0x0(s6)
-               	ld	t2, -0x238(s0)
-               	sb	t2, 0x1(s6)
-               	ld	t2, -0x240(s0)
-               	sb	t2, 0x2(s6)
-               	ld	t2, -0x248(s0)
-               	sb	t2, 0x3(s6)
-               	ld	t2, -0x250(s0)
-               	sb	t2, 0x4(s6)
-               	ld	t2, -0x258(s0)
-               	sb	t2, 0x5(s6)
-               	ld	t2, -0x260(s0)
-               	sb	t2, 0x6(s6)
-               	ld	t2, -0x268(s0)
-               	sb	t2, 0x7(s6)
-               	ld	t2, -0x1f0(s0)
-               	mv	a0, t2
-               	lw	t2, 0x0(a0)
-               	sd	t2, -0x270(s0)
-               	ld	t2, -0x1f0(s0)
-               	addi	a0, t2, 0x4
-               	lw	t2, 0x0(a0)
-               	sd	t2, -0x278(s0)
-               	ld	t2, -0x1f0(s0)
-               	addi	a0, t2, 0x8
-               	lw	t2, 0x0(a0)
-               	sd	t2, -0x280(s0)
-               	ld	t2, -0x1e0(s0)
-               	mv	a0, t2
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x288(s0)
-               	ld	t2, -0x1e0(s0)
-               	addi	a0, t2, 0x8
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x290(s0)
-               	addi	s4, s0, -0x122
-               	mv	t2, s4
-               	sd	t2, -0x2a0(s0)
-               	ld	t3, -0x1d8(s0)
-               	mv	t2, t3
-               	sd	t2, -0x2a8(s0)
-               	ld	t3, -0x2a0(s0)
-               	ld	t4, -0x2a8(s0)
-               	or	t2, t3, t4
-               	sd	t2, -0x2b0(s0)
-               	ld	t2, -0x2b0(s0)
-               	li	t0, 0x7
-               	and	t2, t2, t0
-               	sd	t2, -0x2b0(s0)
-               	ld	t2, -0x2a0(s0)
-               	ld	t3, -0x2a8(s0)
-               	bltu	t2, t3, 0xacc <corpus.cases.call.call_rec_edge.take_edge+0x4e0>
-               	ld	t2, -0x2b0(s0)
-               	bnez	t2, 0xa78 <corpus.cases.call.call_rec_edge.take_edge+0x48c>
-               	ld	t3, -0x2a0(s0)
-               	addi	t2, t3, 0x10
-               	sd	t2, -0x2b8(s0)
-               	ld	t3, -0x2a8(s0)
-               	addi	t2, t3, 0x10
-               	sd	t2, -0x2c0(s0)
-               	ld	t2, -0x2c0(s0)
-               	lbu	a1, 0x0(t2)
-               	ld	t2, -0x2b8(s0)
-               	sb	a1, 0x0(t2)
-               	li	a1, 0x10
-               	ld	t2, -0x2b8(s0)
-               	addi	t2, t2, -0x8
-               	sd	t2, -0x2b8(s0)
-               	ld	t2, -0x2c0(s0)
-               	addi	t2, t2, -0x8
-               	sd	t2, -0x2c0(s0)
-               	ld	t2, -0x2c0(s0)
-               	ld	a0, 0x0(t2)
-               	ld	t2, -0x2b8(s0)
-               	sd	a0, 0x0(t2)
-               	addi	a1, a1, -0x8
-               	li	t0, 0x0
-               	bne	a1, t0, 0xa40 <corpus.cases.call.call_rec_edge.take_edge+0x454>
-               	j	0xb88 <corpus.cases.call.call_rec_edge.take_edge+0x59c>
-               	ld	t3, -0x2a0(s0)
-               	addi	t2, t3, 0x11
-               	sd	t2, -0x2c8(s0)
-               	ld	t3, -0x2a8(s0)
-               	addi	t2, t3, 0x11
-               	sd	t2, -0x2d0(s0)
-               	li	a0, 0x11
-               	ld	t2, -0x2c8(s0)
-               	addi	t2, t2, -0x1
-               	sd	t2, -0x2c8(s0)
-               	ld	t2, -0x2d0(s0)
-               	addi	t2, t2, -0x1
-               	sd	t2, -0x2d0(s0)
-               	ld	t2, -0x2d0(s0)
-               	lbu	a1, 0x0(t2)
-               	ld	t2, -0x2c8(s0)
-               	sb	a1, 0x0(t2)
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0xa94 <corpus.cases.call.call_rec_edge.take_edge+0x4a8>
-               	j	0xb88 <corpus.cases.call.call_rec_edge.take_edge+0x59c>
-               	ld	t2, -0x2b0(s0)
-               	bnez	t2, 0xb38 <corpus.cases.call.call_rec_edge.take_edge+0x54c>
-               	ld	t3, -0x2a0(s0)
-               	mv	t2, t3
-               	sd	t2, -0x2d8(s0)
-               	ld	t3, -0x2a8(s0)
-               	mv	t2, t3
-               	sd	t2, -0x2e0(s0)
-               	li	a0, 0x10
-               	ld	t2, -0x2e0(s0)
-               	ld	a1, 0x0(t2)
-               	ld	t2, -0x2d8(s0)
-               	sd	a1, 0x0(t2)
-               	ld	t2, -0x2d8(s0)
-               	addi	t2, t2, 0x8
-               	sd	t2, -0x2d8(s0)
-               	ld	t2, -0x2e0(s0)
-               	addi	t2, t2, 0x8
-               	sd	t2, -0x2e0(s0)
-               	addi	a0, a0, -0x8
-               	li	t0, 0x0
-               	bne	a0, t0, 0xaf0 <corpus.cases.call.call_rec_edge.take_edge+0x504>
-               	ld	t2, -0x2e0(s0)
-               	lbu	a0, 0x0(t2)
-               	ld	t2, -0x2d8(s0)
-               	sb	a0, 0x0(t2)
-               	j	0xb88 <corpus.cases.call.call_rec_edge.take_edge+0x59c>
-               	ld	t3, -0x2a0(s0)
-               	mv	t2, t3
-               	sd	t2, -0x2e8(s0)
-               	ld	t3, -0x2a8(s0)
-               	mv	t2, t3
-               	sd	t2, -0x2f0(s0)
-               	li	a0, 0x11
-               	ld	t2, -0x2f0(s0)
-               	lbu	a1, 0x0(t2)
-               	ld	t2, -0x2e8(s0)
-               	sb	a1, 0x0(t2)
-               	ld	t2, -0x2e8(s0)
-               	addi	t2, t2, 0x1
-               	sd	t2, -0x2e8(s0)
-               	ld	t2, -0x2f0(s0)
-               	addi	t2, t2, 0x1
-               	sd	t2, -0x2f0(s0)
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0xb54 <corpus.cases.call.call_rec_edge.take_edge+0x568>
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x59c>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x5a8>
-               	mv	t2, a0
-               	sd	t2, -0x2f8(s0)
-               	ld	t2, -0x2f8(s0)
-               	lbu	a1, 0x0(s5)
-               	lbu	s1, 0x1(s5)
-               	lbu	a0, 0x2(s5)
-               	lbu	t2, 0x3(s5)
-               	sd	t2, -0x300(s0)
-               	lbu	t2, 0x4(s5)
-               	sd	t2, -0x308(s0)
-               	lbu	t2, 0x5(s5)
-               	sd	t2, -0x310(s0)
-               	lbu	t2, 0x6(s5)
-               	sd	t2, -0x318(s0)
-               	lbu	t2, 0x7(s5)
-               	sd	t2, -0x320(s0)
-               	sb	a1, 0x0(s7)
-               	sb	s1, 0x1(s7)
-               	sb	a0, 0x2(s7)
-               	ld	t2, -0x300(s0)
-               	sb	t2, 0x3(s7)
-               	ld	t2, -0x308(s0)
-               	sb	t2, 0x4(s7)
-               	ld	t2, -0x310(s0)
-               	sb	t2, 0x5(s7)
-               	ld	t2, -0x318(s0)
-               	sb	t2, 0x6(s7)
-               	ld	t2, -0x320(s0)
-               	sb	t2, 0x7(s7)
-               	lbu	a0, 0x0(s7)
-               	lbu	a1, 0x1(s7)
-               	lbu	s1, 0x2(s7)
-               	lbu	s5, 0x3(s7)
-               	lbu	t2, 0x4(s7)
-               	sd	t2, -0x328(s0)
-               	lbu	t2, 0x5(s7)
-               	sd	t2, -0x330(s0)
-               	lbu	t2, 0x6(s7)
-               	sd	t2, -0x338(s0)
-               	lbu	t2, 0x7(s7)
-               	sd	t2, -0x340(s0)
-               	sb	a0, 0x0(s9)
-               	sb	a1, 0x1(s9)
-               	sb	s1, 0x2(s9)
-               	sb	s5, 0x3(s9)
-               	ld	t2, -0x328(s0)
-               	sb	t2, 0x4(s9)
-               	ld	t2, -0x330(s0)
-               	sb	t2, 0x5(s9)
-               	ld	t2, -0x338(s0)
-               	sb	t2, 0x6(s9)
-               	ld	t2, -0x340(s0)
-               	sb	t2, 0x7(s9)
-               	ld	t2, -0x2f8(s0)
-               	mv	a0, t2
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x690>
-               	mv	s1, a0
-               	li	s5, 0x0
-               	li	t0, 0x8
-               	bltu	s5, t0, 0xc98 <corpus.cases.call.call_rec_edge.take_edge+0x6ac>
-               	j	0xcbc <corpus.cases.call.call_rec_edge.take_edge+0x6d0>
-               	add	a0, s9, s5
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x6b8>
-               	addi	s5, s5, 0x1
-               	mv	s1, a0
-               	li	t0, 0x8
-               	bltu	s5, t0, 0xc98 <corpus.cases.call.call_rec_edge.take_edge+0x6ac>
-               	mv	a0, s1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x6d8>
-               	ld	t2, -0x350(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x6e8>
-               	ld	t2, -0x358(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x6f8>
-               	ld	t2, -0x360(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x708>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x714>
-               	ld	t2, -0x368(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x724>
-               	ld	t2, -0x370(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x734>
-               	fmv.d	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x740>
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x74c>
-               	ld	t2, -0x378(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x75c>
-               	fmv.d	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x768>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x774>
-               	addi	a1, s0, -0x177
-               	mv	a2, a1
-               	ld	t2, -0x348(s0)
-               	mv	a3, t2
-               	or	a4, a2, a3
-               	li	t0, 0x7
-               	and	a4, a4, t0
-               	bltu	a2, a3, 0xdec <corpus.cases.call.call_rec_edge.take_edge+0x800>
-               	bnez	a4, 0xdc0 <corpus.cases.call.call_rec_edge.take_edge+0x7d4>
-               	addi	a5, a2, 0x10
-               	addi	a6, a3, 0x10
-               	lbu	a7, 0x0(a6)
-               	sb	a7, 0x0(a5)
-               	li	a7, 0x10
-               	addi	a5, a5, -0x8
-               	addi	a6, a6, -0x8
-               	ld	s1, 0x0(a6)
-               	sd	s1, 0x0(a5)
-               	addi	a7, a7, -0x8
-               	li	t0, 0x0
-               	bne	a7, t0, 0xda0 <corpus.cases.call.call_rec_edge.take_edge+0x7b4>
-               	j	0xe4c <corpus.cases.call.call_rec_edge.take_edge+0x860>
-               	addi	a5, a2, 0x11
-               	addi	a6, a3, 0x11
-               	li	a7, 0x11
-               	addi	a5, a5, -0x1
-               	addi	a6, a6, -0x1
-               	lbu	s1, 0x0(a6)
-               	sb	s1, 0x0(a5)
-               	addi	a7, a7, -0x1
-               	li	t0, 0x0
-               	bne	a7, t0, 0xdcc <corpus.cases.call.call_rec_edge.take_edge+0x7e0>
-               	j	0xe4c <corpus.cases.call.call_rec_edge.take_edge+0x860>
-               	bnez	a4, 0xe24 <corpus.cases.call.call_rec_edge.take_edge+0x838>
-               	mv	a4, a2
-               	mv	a5, a3
-               	li	a6, 0x10
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, 0x8
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0xdfc <corpus.cases.call.call_rec_edge.take_edge+0x810>
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a4)
-               	j	0xe4c <corpus.cases.call.call_rec_edge.take_edge+0x860>
-               	mv	a4, a2
-               	mv	a2, a3
-               	li	a3, 0x11
-               	lbu	a5, 0x0(a2)
-               	sb	a5, 0x0(a4)
-               	addi	a4, a4, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0xe30 <corpus.cases.call.call_rec_edge.take_edge+0x844>
-               	addi	s1, s0, -0x188
-               	mv	a2, s1
-               	mv	a3, a1
-               	or	a1, a2, a3
-               	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0xecc <corpus.cases.call.call_rec_edge.take_edge+0x8e0>
-               	bnez	a1, 0xea0 <corpus.cases.call.call_rec_edge.take_edge+0x8b4>
-               	addi	a4, a2, 0x10
-               	addi	a5, a3, 0x10
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a4)
-               	li	a6, 0x10
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0xe80 <corpus.cases.call.call_rec_edge.take_edge+0x894>
-               	j	0xf2c <corpus.cases.call.call_rec_edge.take_edge+0x940>
-               	addi	a4, a2, 0x11
-               	addi	a5, a3, 0x11
-               	li	a6, 0x11
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0xeac <corpus.cases.call.call_rec_edge.take_edge+0x8c0>
-               	j	0xf2c <corpus.cases.call.call_rec_edge.take_edge+0x940>
-               	bnez	a1, 0xf04 <corpus.cases.call.call_rec_edge.take_edge+0x918>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x10
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0xedc <corpus.cases.call.call_rec_edge.take_edge+0x8f0>
-               	lbu	a5, 0x0(a4)
-               	sb	a5, 0x0(a1)
-               	j	0xf2c <corpus.cases.call.call_rec_edge.take_edge+0x940>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x11
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0xf10 <corpus.cases.call.call_rec_edge.take_edge+0x924>
-               	mv	a1, s1
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x94c>
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0xf54 <corpus.cases.call.call_rec_edge.take_edge+0x968>
-               	j	0xf80 <corpus.cases.call.call_rec_edge.take_edge+0x994>
-               	addi	a0, s1, 0x1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x97c>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0xf54 <corpus.cases.call.call_rec_edge.take_edge+0x968>
-               	lbu	a0, 0x0(s6)
-               	lbu	a1, 0x1(s6)
-               	lbu	a2, 0x2(s6)
-               	lbu	a3, 0x3(s6)
-               	lbu	a4, 0x4(s6)
-               	lbu	a5, 0x5(s6)
-               	lbu	a6, 0x6(s6)
-               	lbu	a7, 0x7(s6)
-               	sb	a0, 0x0(s8)
-               	sb	a1, 0x1(s8)
-               	sb	a2, 0x2(s8)
-               	sb	a3, 0x3(s8)
-               	sb	a4, 0x4(s8)
-               	sb	a5, 0x5(s8)
-               	sb	a6, 0x6(s8)
-               	sb	a7, 0x7(s8)
-               	lbu	a0, 0x0(s8)
-               	lbu	a1, 0x1(s8)
-               	lbu	a2, 0x2(s8)
-               	lbu	a3, 0x3(s8)
-               	lbu	a4, 0x4(s8)
-               	lbu	a5, 0x5(s8)
-               	lbu	a6, 0x6(s8)
-               	lbu	a7, 0x7(s8)
-               	sb	a0, 0x0(s10)
-               	sb	a1, 0x1(s10)
-               	sb	a2, 0x2(s10)
-               	sb	a3, 0x3(s10)
-               	sb	a4, 0x4(s10)
-               	sb	a5, 0x5(s10)
-               	sb	a6, 0x6(s10)
-               	sb	a7, 0x7(s10)
-               	mv	a0, s2
-               	ld	t2, -0x380(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa20>
-               	mv	s1, a0
-               	li	s2, 0x0
-               	li	t0, 0x8
-               	bltu	s2, t0, 0x1028 <corpus.cases.call.call_rec_edge.take_edge+0xa3c>
-               	j	0x104c <corpus.cases.call.call_rec_edge.take_edge+0xa60>
-               	add	a0, s10, s2
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa48>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
-               	li	t0, 0x8
-               	bltu	s2, t0, 0x1028 <corpus.cases.call.call_rec_edge.take_edge+0xa3c>
-               	mv	a0, s1
-               	ld	t2, -0x270(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa6c>
-               	ld	t2, -0x278(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa7c>
-               	ld	t2, -0x280(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa8c>
-               	ld	t2, -0x288(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa9c>
-               	ld	t2, -0x290(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xaac>
-               	addi	a1, s0, -0x199
-               	mv	a2, a1
-               	mv	a3, s4
-               	or	a4, a2, a3
-               	li	t0, 0x7
-               	and	a4, a4, t0
-               	bltu	a2, a3, 0x1120 <corpus.cases.call.call_rec_edge.take_edge+0xb34>
-               	bnez	a4, 0x10f4 <corpus.cases.call.call_rec_edge.take_edge+0xb08>
-               	addi	a5, a2, 0x10
-               	addi	a6, a3, 0x10
-               	lbu	a7, 0x0(a6)
-               	sb	a7, 0x0(a5)
-               	li	a7, 0x10
-               	addi	a5, a5, -0x8
-               	addi	a6, a6, -0x8
-               	ld	t6, 0x0(a6)
-               	sd	t6, 0x0(a5)
-               	addi	a7, a7, -0x8
-               	li	t0, 0x0
-               	bne	a7, t0, 0x10d4 <corpus.cases.call.call_rec_edge.take_edge+0xae8>
-               	j	0x1180 <corpus.cases.call.call_rec_edge.take_edge+0xb94>
-               	addi	a5, a2, 0x11
-               	addi	a6, a3, 0x11
-               	li	a7, 0x11
-               	addi	a5, a5, -0x1
-               	addi	a6, a6, -0x1
-               	lbu	t6, 0x0(a6)
-               	sb	t6, 0x0(a5)
-               	addi	a7, a7, -0x1
-               	li	t0, 0x0
-               	bne	a7, t0, 0x1100 <corpus.cases.call.call_rec_edge.take_edge+0xb14>
-               	j	0x1180 <corpus.cases.call.call_rec_edge.take_edge+0xb94>
-               	bnez	a4, 0x1158 <corpus.cases.call.call_rec_edge.take_edge+0xb6c>
-               	mv	a4, a2
-               	mv	a5, a3
-               	li	a6, 0x10
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, 0x8
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0x1130 <corpus.cases.call.call_rec_edge.take_edge+0xb44>
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a4)
-               	j	0x1180 <corpus.cases.call.call_rec_edge.take_edge+0xb94>
-               	mv	a4, a2
-               	mv	a2, a3
-               	li	a3, 0x11
-               	lbu	a5, 0x0(a2)
-               	sb	a5, 0x0(a4)
-               	addi	a4, a4, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x1164 <corpus.cases.call.call_rec_edge.take_edge+0xb78>
-               	addi	s1, s0, -0x1aa
-               	mv	a2, s1
-               	mv	a3, a1
-               	or	a1, a2, a3
-               	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x1200 <corpus.cases.call.call_rec_edge.take_edge+0xc14>
-               	bnez	a1, 0x11d4 <corpus.cases.call.call_rec_edge.take_edge+0xbe8>
-               	addi	a4, a2, 0x10
-               	addi	a5, a3, 0x10
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a4)
-               	li	a6, 0x10
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0x11b4 <corpus.cases.call.call_rec_edge.take_edge+0xbc8>
-               	j	0x1260 <corpus.cases.call.call_rec_edge.take_edge+0xc74>
-               	addi	a4, a2, 0x11
-               	addi	a5, a3, 0x11
-               	li	a6, 0x11
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x11e0 <corpus.cases.call.call_rec_edge.take_edge+0xbf4>
-               	j	0x1260 <corpus.cases.call.call_rec_edge.take_edge+0xc74>
-               	bnez	a1, 0x1238 <corpus.cases.call.call_rec_edge.take_edge+0xc4c>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x10
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x1210 <corpus.cases.call.call_rec_edge.take_edge+0xc24>
-               	lbu	a5, 0x0(a4)
-               	sb	a5, 0x0(a1)
-               	j	0x1260 <corpus.cases.call.call_rec_edge.take_edge+0xc74>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x11
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x1244 <corpus.cases.call.call_rec_edge.take_edge+0xc58>
-               	mv	a1, s1
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xc80>
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x1288 <corpus.cases.call.call_rec_edge.take_edge+0xc9c>
-               	j	0x12b4 <corpus.cases.call.call_rec_edge.take_edge+0xcc8>
-               	addi	a0, s1, 0x1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xcb0>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x1288 <corpus.cases.call.call_rec_edge.take_edge+0xc9c>
-               	mv	a0, s2
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xcd0>
-               	ld	t2, -0x298(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xce0>
-               	addi	a1, s0, -0x1bb
-               	addi	a2, s0, -0x1cc
-               	mv	a3, a2
-               	ld	t2, -0x348(s0)
-               	mv	a4, t2
-               	or	a5, a3, a4
-               	li	t0, 0x7
-               	and	a5, a5, t0
-               	bltu	a3, a4, 0x135c <corpus.cases.call.call_rec_edge.take_edge+0xd70>
-               	bnez	a5, 0x1330 <corpus.cases.call.call_rec_edge.take_edge+0xd44>
-               	addi	a6, a3, 0x10
-               	addi	a7, a4, 0x10
-               	lbu	t6, 0x0(a7)
-               	sb	t6, 0x0(a6)
-               	li	t6, 0x10
-               	addi	a6, a6, -0x8
-               	addi	a7, a7, -0x8
-               	ld	s1, 0x0(a7)
-               	sd	s1, 0x0(a6)
-               	addi	t6, t6, -0x8
-               	li	t0, 0x0
-               	bne	t6, t0, 0x1310 <corpus.cases.call.call_rec_edge.take_edge+0xd24>
-               	j	0x13bc <corpus.cases.call.call_rec_edge.take_edge+0xdd0>
-               	addi	a6, a3, 0x11
-               	addi	a7, a4, 0x11
-               	li	t6, 0x11
-               	addi	a6, a6, -0x1
-               	addi	a7, a7, -0x1
-               	lbu	s1, 0x0(a7)
-               	sb	s1, 0x0(a6)
-               	addi	t6, t6, -0x1
-               	li	t0, 0x0
-               	bne	t6, t0, 0x133c <corpus.cases.call.call_rec_edge.take_edge+0xd50>
-               	j	0x13bc <corpus.cases.call.call_rec_edge.take_edge+0xdd0>
-               	bnez	a5, 0x1394 <corpus.cases.call.call_rec_edge.take_edge+0xda8>
-               	mv	a5, a3
-               	mv	a6, a4
-               	li	a7, 0x10
-               	ld	t6, 0x0(a6)
-               	sd	t6, 0x0(a5)
-               	addi	a5, a5, 0x8
-               	addi	a6, a6, 0x8
-               	addi	a7, a7, -0x8
-               	li	t0, 0x0
-               	bne	a7, t0, 0x136c <corpus.cases.call.call_rec_edge.take_edge+0xd80>
-               	lbu	a7, 0x0(a6)
-               	sb	a7, 0x0(a5)
-               	j	0x13bc <corpus.cases.call.call_rec_edge.take_edge+0xdd0>
-               	mv	a5, a3
-               	mv	a3, a4
-               	li	a4, 0x11
-               	lbu	a6, 0x0(a3)
-               	sb	a6, 0x0(a5)
-               	addi	a5, a5, 0x1
-               	addi	a3, a3, 0x1
-               	addi	a4, a4, -0x1
-               	li	t0, 0x0
-               	bne	a4, t0, 0x13a0 <corpus.cases.call.call_rec_edge.take_edge+0xdb4>
-               	mv	a3, a1
-               	mv	a4, a2
-               	or	a2, a3, a4
-               	li	t0, 0x7
-               	and	a2, a2, t0
-               	bltu	a3, a4, 0x1438 <corpus.cases.call.call_rec_edge.take_edge+0xe4c>
-               	bnez	a2, 0x140c <corpus.cases.call.call_rec_edge.take_edge+0xe20>
-               	addi	a5, a3, 0x10
-               	addi	a6, a4, 0x10
-               	lbu	a7, 0x0(a6)
-               	sb	a7, 0x0(a5)
-               	li	a7, 0x10
-               	addi	a5, a5, -0x8
-               	addi	a6, a6, -0x8
-               	ld	t6, 0x0(a6)
-               	sd	t6, 0x0(a5)
-               	addi	a7, a7, -0x8
-               	li	t0, 0x0
-               	bne	a7, t0, 0x13ec <corpus.cases.call.call_rec_edge.take_edge+0xe00>
-               	j	0x1498 <corpus.cases.call.call_rec_edge.take_edge+0xeac>
-               	addi	a5, a3, 0x11
-               	addi	a6, a4, 0x11
-               	li	a7, 0x11
-               	addi	a5, a5, -0x1
-               	addi	a6, a6, -0x1
-               	lbu	t6, 0x0(a6)
-               	sb	t6, 0x0(a5)
-               	addi	a7, a7, -0x1
-               	li	t0, 0x0
-               	bne	a7, t0, 0x1418 <corpus.cases.call.call_rec_edge.take_edge+0xe2c>
-               	j	0x1498 <corpus.cases.call.call_rec_edge.take_edge+0xeac>
-               	bnez	a2, 0x1470 <corpus.cases.call.call_rec_edge.take_edge+0xe84>
-               	mv	a2, a3
-               	mv	a5, a4
-               	li	a6, 0x10
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a5, a5, 0x8
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0x1448 <corpus.cases.call.call_rec_edge.take_edge+0xe5c>
-               	lbu	a6, 0x0(a5)
-               	sb	a6, 0x0(a2)
-               	j	0x1498 <corpus.cases.call.call_rec_edge.take_edge+0xeac>
-               	mv	a2, a3
-               	mv	a3, a4
-               	li	a4, 0x11
-               	lbu	a5, 0x0(a3)
-               	sb	a5, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, 0x1
-               	addi	a4, a4, -0x1
-               	li	t0, 0x0
-               	bne	a4, t0, 0x147c <corpus.cases.call.call_rec_edge.take_edge+0xe90>
-               	mv	a2, a1
-               	lbu	a3, 0x0(a2)
-               	addiw	a4, a3, 0x1
-               	sb	a4, 0x0(a2)
-               	li	a2, 0x0
-               	li	t0, 0x10
-               	bltu	a2, t0, 0x14b8 <corpus.cases.call.call_rec_edge.take_edge+0xecc>
-               	j	0x14e0 <corpus.cases.call.call_rec_edge.take_edge+0xef4>
-               	addi	a3, a1, 0x1
-               	add	a4, a3, a2
-               	lbu	a3, 0x0(a4)
-               	sext.w	a5, a2
-               	addw	a6, a3, a5
-               	addiw	a3, a6, 0x1
-               	sb	a3, 0x0(a4)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x10
-               	bltu	a2, t0, 0x14b8 <corpus.cases.call.call_rec_edge.take_edge+0xecc>
-               	addi	a2, s0, -0x133
+               	addi	a2, s0, -0x21
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x1560 <corpus.cases.call.call_rec_edge.take_edge+0xf74>
-               	bnez	a1, 0x1534 <corpus.cases.call.call_rec_edge.take_edge+0xf48>
+               	bltu	a3, a4, 0x598 <corpus.cases.call.call_rec_edge.fold_e17+0x90>
+               	bnez	a1, 0x56c <corpus.cases.call.call_rec_edge.fold_e17+0x64>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lbu	a7, 0x0(a6)
@@ -1370,24 +356,24 @@ Disassembly of section .text:
                	li	a7, 0x10
                	addi	a5, a5, -0x8
                	addi	a6, a6, -0x8
-               	ld	t6, 0x0(a6)
-               	sd	t6, 0x0(a5)
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1514 <corpus.cases.call.call_rec_edge.take_edge+0xf28>
-               	j	0x15c0 <corpus.cases.call.call_rec_edge.take_edge+0xfd4>
+               	bne	a7, t0, 0x54c <corpus.cases.call.call_rec_edge.fold_e17+0x44>
+               	j	0x5f8 <corpus.cases.call.call_rec_edge.fold_e17+0xf0>
                	addi	a5, a3, 0x11
                	addi	a6, a4, 0x11
                	li	a7, 0x11
                	addi	a5, a5, -0x1
                	addi	a6, a6, -0x1
-               	lbu	t6, 0x0(a6)
-               	sb	t6, 0x0(a5)
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1540 <corpus.cases.call.call_rec_edge.take_edge+0xf54>
-               	j	0x15c0 <corpus.cases.call.call_rec_edge.take_edge+0xfd4>
-               	bnez	a1, 0x1598 <corpus.cases.call.call_rec_edge.take_edge+0xfac>
+               	bne	a7, t0, 0x578 <corpus.cases.call.call_rec_edge.fold_e17+0x70>
+               	j	0x5f8 <corpus.cases.call.call_rec_edge.fold_e17+0xf0>
+               	bnez	a1, 0x5d0 <corpus.cases.call.call_rec_edge.fold_e17+0xc8>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -1397,10 +383,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1570 <corpus.cases.call.call_rec_edge.take_edge+0xf84>
+               	bne	a6, t0, 0x5a8 <corpus.cases.call.call_rec_edge.fold_e17+0xa0>
                	lbu	a6, 0x0(a5)
                	sb	a6, 0x0(a1)
-               	j	0x15c0 <corpus.cases.call.call_rec_edge.take_edge+0xfd4>
+               	j	0x5f8 <corpus.cases.call.call_rec_edge.fold_e17+0xf0>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x11
@@ -1410,15 +396,1637 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x15a4 <corpus.cases.call.call_rec_edge.take_edge+0xfb8>
-               	addi	s1, s0, -0x144
-               	mv	a1, s1
+               	bne	a4, t0, 0x5dc <corpus.cases.call.call_rec_edge.fold_e17+0xd4>
+               	mv	a1, a2
+               	lbu	a3, 0x0(a1)
+               	zext.b	a1, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x614 <corpus.cases.call.call_rec_edge.fold_e17+0x10c>
+               	j	0x648 <corpus.cases.call.call_rec_edge.fold_e17+0x140>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x614 <corpus.cases.call.call_rec_edge.fold_e17+0x10c>
+               	li	a1, 0x0
+               	li	t0, 0x10
+               	bltu	a1, t0, 0x658 <corpus.cases.call.call_rec_edge.fold_e17+0x150>
+               	j	0x6c0 <corpus.cases.call.call_rec_edge.fold_e17+0x1b8>
+               	addi	a3, a2, 0x1
+               	add	a4, a3, a1
+               	lbu	a3, 0x0(a4)
+               	zext.b	a4, a3
+               	mv	a3, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x67c <corpus.cases.call.call_rec_edge.fold_e17+0x174>
+               	j	0x6b0 <corpus.cases.call.call_rec_edge.fold_e17+0x1a8>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a3, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x67c <corpus.cases.call.call_rec_edge.fold_e17+0x174>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
+               	li	t0, 0x10
+               	bltu	a1, t0, 0x658 <corpus.cases.call.call_rec_edge.fold_e17+0x150>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
+               	ret
+
+<corpus.cases.call.call_rec_edge.layout>:
+               	addi	sp, sp, -0x10
+               	sd	ra, 0x8(sp)
+               	sd	s0, 0x0(sp)
+               	addi	s0, sp, 0x10
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6f0 <corpus.cases.call.call_rec_edge.layout+0x20>
+               	j	0x728 <corpus.cases.call.call_rec_edge.layout+0x58>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x9
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6f0 <corpus.cases.call.call_rec_edge.layout+0x20>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x738 <corpus.cases.call.call_rec_edge.layout+0x68>
+               	j	0x770 <corpus.cases.call.call_rec_edge.layout+0xa0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0xc
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x738 <corpus.cases.call.call_rec_edge.layout+0x68>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x780 <corpus.cases.call.call_rec_edge.layout+0xb0>
+               	j	0x7b8 <corpus.cases.call.call_rec_edge.layout+0xe8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x10
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x780 <corpus.cases.call.call_rec_edge.layout+0xb0>
+               	li	a1, 0x10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xec>
+               	li	a1, 0x10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0xf8>
+               	li	a1, 0x11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x104>
+               	li	a1, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x110>
+               	li	a1, 0x4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x11c>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x128>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x134>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x140>
+               	li	a1, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x14c>
+               	li	a1, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x158>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x164>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x170>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x17c>
+               	li	a1, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x188>
+               	li	a1, 0x1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.layout+0x194>
+               	ld	ra, 0x8(sp)
+               	ld	s0, 0x0(sp)
+               	addi	sp, sp, 0x10
+               	ret
+
+<corpus.cases.call.call_rec_edge.take_edge>:
+               	addi	sp, sp, -0x2b0
+               	sd	ra, 0x2a8(sp)
+               	sd	s0, 0x2a0(sp)
+               	addi	s0, sp, 0x2b0
+               	sd	s1, 0x298(sp)
+               	sd	s2, 0x290(sp)
+               	sd	s3, 0x288(sp)
+               	sd	s4, 0x280(sp)
+               	sd	s5, 0x278(sp)
+               	sd	s6, 0x270(sp)
+               	sd	s7, 0x268(sp)
+               	sd	s8, 0x260(sp)
+               	sd	s9, 0x258(sp)
+               	sd	s10, 0x250(sp)
+               	sd	s11, 0x248(sp)
+               	fsd	fs0, 0x240(sp)
+               	fsd	fs1, 0x238(sp)
+               	fsd	fs2, 0x230(sp)
+               	fsd	fs3, 0x228(sp)
+               	fsd	fs4, 0x220(sp)
+               	mv	t5, a0
+               	sd	a1, -0xa0(s0)
+               	sd	a2, -0x98(s0)
+               	mv	s1, a3
+               	sd	a4, -0xb0(s0)
+               	sd	a5, -0xa8(s0)
+               	fmv.d	fs0, fa0
+               	sd	a6, -0xc0(s0)
+               	sd	a7, -0xb8(s0)
+               	fsd	fa1, -0xd0(s0)
+               	fsd	fa2, -0xc8(s0)
+               	mv	a0, s0
+               	ld	s2, 0x10(s0)
+               	ld	a1, 0x18(s0)
+               	addi	a2, s0, 0x20
+               	addi	a3, s0, 0x30
+               	addi	a4, s0, 0x40
+               	ld	a5, 0x50(s0)
+               	fmv.s	fs1, fa3
+               	ld	s3, 0x58(s0)
+               	addi	s4, s0, -0xd9
+               	mv	a6, s4
+               	addi	a7, s0, -0xa0
+               	or	t6, a6, a7
+               	li	t0, 0x7
+               	and	t6, t6, t0
+               	bltu	a6, a7, 0x99c <corpus.cases.call.call_rec_edge.take_edge+0x120>
+               	bnez	t6, 0x970 <corpus.cases.call.call_rec_edge.take_edge+0xf4>
+               	addi	s5, a6, 0x8
+               	addi	s6, a7, 0x8
+               	lbu	s7, 0x0(s6)
+               	sb	s7, 0x0(s5)
+               	li	s7, 0x8
+               	addi	s5, s5, -0x8
+               	addi	s6, s6, -0x8
+               	ld	s8, 0x0(s6)
+               	sd	s8, 0x0(s5)
+               	addi	s7, s7, -0x8
+               	li	t0, 0x0
+               	bne	s7, t0, 0x950 <corpus.cases.call.call_rec_edge.take_edge+0xd4>
+               	j	0x9fc <corpus.cases.call.call_rec_edge.take_edge+0x180>
+               	addi	s5, a6, 0x9
+               	addi	s6, a7, 0x9
+               	li	s7, 0x9
+               	addi	s5, s5, -0x1
+               	addi	s6, s6, -0x1
+               	lbu	s8, 0x0(s6)
+               	sb	s8, 0x0(s5)
+               	addi	s7, s7, -0x1
+               	li	t0, 0x0
+               	bne	s7, t0, 0x97c <corpus.cases.call.call_rec_edge.take_edge+0x100>
+               	j	0x9fc <corpus.cases.call.call_rec_edge.take_edge+0x180>
+               	bnez	t6, 0x9d4 <corpus.cases.call.call_rec_edge.take_edge+0x158>
+               	mv	t6, a6
+               	mv	s5, a7
+               	li	s6, 0x8
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(t6)
+               	addi	t6, t6, 0x8
+               	addi	s5, s5, 0x8
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x9ac <corpus.cases.call.call_rec_edge.take_edge+0x130>
+               	lbu	s6, 0x0(s5)
+               	sb	s6, 0x0(t6)
+               	j	0x9fc <corpus.cases.call.call_rec_edge.take_edge+0x180>
+               	mv	t6, a6
+               	mv	a6, a7
+               	li	a7, 0x9
+               	lbu	s5, 0x0(a6)
+               	sb	s5, 0x0(t6)
+               	addi	t6, t6, 0x1
+               	addi	a6, a6, 0x1
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x9e0 <corpus.cases.call.call_rec_edge.take_edge+0x164>
+               	addi	s5, s0, -0xe8
+               	mv	a6, s5
+               	addi	a7, s0, -0xb0
+               	or	t6, a6, a7
+               	li	t0, 0x7
+               	and	t6, t6, t0
+               	bltu	a6, a7, 0xa7c <corpus.cases.call.call_rec_edge.take_edge+0x200>
+               	bnez	t6, 0xa50 <corpus.cases.call.call_rec_edge.take_edge+0x1d4>
+               	addi	s6, a6, 0x8
+               	addi	s7, a7, 0x8
+               	lw	s8, 0x0(s7)
+               	sw	s8, 0x0(s6)
+               	li	s8, 0x8
+               	addi	s6, s6, -0x8
+               	addi	s7, s7, -0x8
+               	ld	s9, 0x0(s7)
+               	sd	s9, 0x0(s6)
+               	addi	s8, s8, -0x8
+               	li	t0, 0x0
+               	bne	s8, t0, 0xa30 <corpus.cases.call.call_rec_edge.take_edge+0x1b4>
+               	j	0xadc <corpus.cases.call.call_rec_edge.take_edge+0x260>
+               	addi	s6, a6, 0xc
+               	addi	s7, a7, 0xc
+               	li	s8, 0xc
+               	addi	s6, s6, -0x1
+               	addi	s7, s7, -0x1
+               	lbu	s9, 0x0(s7)
+               	sb	s9, 0x0(s6)
+               	addi	s8, s8, -0x1
+               	li	t0, 0x0
+               	bne	s8, t0, 0xa5c <corpus.cases.call.call_rec_edge.take_edge+0x1e0>
+               	j	0xadc <corpus.cases.call.call_rec_edge.take_edge+0x260>
+               	bnez	t6, 0xab4 <corpus.cases.call.call_rec_edge.take_edge+0x238>
+               	mv	t6, a6
+               	mv	s6, a7
+               	li	s7, 0x8
+               	ld	s8, 0x0(s6)
+               	sd	s8, 0x0(t6)
+               	addi	t6, t6, 0x8
+               	addi	s6, s6, 0x8
+               	addi	s7, s7, -0x8
+               	li	t0, 0x0
+               	bne	s7, t0, 0xa8c <corpus.cases.call.call_rec_edge.take_edge+0x210>
+               	lw	s7, 0x0(s6)
+               	sw	s7, 0x0(t6)
+               	j	0xadc <corpus.cases.call.call_rec_edge.take_edge+0x260>
+               	mv	t6, a6
+               	mv	a6, a7
+               	li	a7, 0xc
+               	lbu	s6, 0x0(a6)
+               	sb	s6, 0x0(t6)
+               	addi	t6, t6, 0x1
+               	addi	a6, a6, 0x1
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xac0 <corpus.cases.call.call_rec_edge.take_edge+0x244>
+               	addi	s6, s0, -0xf8
+               	mv	a6, s6
+               	addi	a7, s0, -0xc0
+               	or	t6, a6, a7
+               	li	t0, 0x7
+               	and	t6, t6, t0
+               	bltu	a6, a7, 0xb54 <corpus.cases.call.call_rec_edge.take_edge+0x2d8>
+               	bnez	t6, 0xb28 <corpus.cases.call.call_rec_edge.take_edge+0x2ac>
+               	addi	s7, a6, 0x10
+               	addi	s8, a7, 0x10
+               	li	s9, 0x10
+               	addi	s7, s7, -0x8
+               	addi	s8, s8, -0x8
+               	ld	s10, 0x0(s8)
+               	sd	s10, 0x0(s7)
+               	addi	s9, s9, -0x8
+               	li	t0, 0x0
+               	bne	s9, t0, 0xb08 <corpus.cases.call.call_rec_edge.take_edge+0x28c>
+               	j	0xbac <corpus.cases.call.call_rec_edge.take_edge+0x330>
+               	addi	s7, a6, 0x10
+               	addi	s8, a7, 0x10
+               	li	s9, 0x10
+               	addi	s7, s7, -0x1
+               	addi	s8, s8, -0x1
+               	lbu	s10, 0x0(s8)
+               	sb	s10, 0x0(s7)
+               	addi	s9, s9, -0x1
+               	li	t0, 0x0
+               	bne	s9, t0, 0xb34 <corpus.cases.call.call_rec_edge.take_edge+0x2b8>
+               	j	0xbac <corpus.cases.call.call_rec_edge.take_edge+0x330>
+               	bnez	t6, 0xb84 <corpus.cases.call.call_rec_edge.take_edge+0x308>
+               	mv	t6, a6
+               	mv	s7, a7
+               	li	s8, 0x10
+               	ld	s9, 0x0(s7)
+               	sd	s9, 0x0(t6)
+               	addi	t6, t6, 0x8
+               	addi	s7, s7, 0x8
+               	addi	s8, s8, -0x8
+               	li	t0, 0x0
+               	bne	s8, t0, 0xb64 <corpus.cases.call.call_rec_edge.take_edge+0x2e8>
+               	j	0xbac <corpus.cases.call.call_rec_edge.take_edge+0x330>
+               	mv	t6, a6
+               	mv	a6, a7
+               	li	a7, 0x10
+               	lbu	s7, 0x0(a6)
+               	sb	s7, 0x0(t6)
+               	addi	t6, t6, 0x1
+               	addi	a6, a6, 0x1
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xb90 <corpus.cases.call.call_rec_edge.take_edge+0x314>
+               	addi	a6, s0, -0xd0
+               	fld	fs2, 0x0(a6)
+               	addi	a6, s0, -0xc8
+               	fld	fs3, 0x0(a6)
+               	mv	a6, a0
+               	ld	s7, 0x0(a6)
+               	addi	a6, a0, 0x8
+               	fld	fs4, 0x0(a6)
+               	addi	s8, s0, -0x109
+               	mv	a0, s8
+               	mv	a6, a1
+               	or	a1, a0, a6
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a0, a6, 0xc4c <corpus.cases.call.call_rec_edge.take_edge+0x3d0>
+               	bnez	a1, 0xc20 <corpus.cases.call.call_rec_edge.take_edge+0x3a4>
+               	addi	a7, a0, 0x10
+               	addi	t6, a6, 0x10
+               	lbu	s9, 0x0(t6)
+               	sb	s9, 0x0(a7)
+               	li	s9, 0x10
+               	addi	a7, a7, -0x8
+               	addi	t6, t6, -0x8
+               	ld	s10, 0x0(t6)
+               	sd	s10, 0x0(a7)
+               	addi	s9, s9, -0x8
+               	li	t0, 0x0
+               	bne	s9, t0, 0xc00 <corpus.cases.call.call_rec_edge.take_edge+0x384>
+               	j	0xcac <corpus.cases.call.call_rec_edge.take_edge+0x430>
+               	addi	a7, a0, 0x11
+               	addi	t6, a6, 0x11
+               	li	s9, 0x11
+               	addi	a7, a7, -0x1
+               	addi	t6, t6, -0x1
+               	lbu	s10, 0x0(t6)
+               	sb	s10, 0x0(a7)
+               	addi	s9, s9, -0x1
+               	li	t0, 0x0
+               	bne	s9, t0, 0xc2c <corpus.cases.call.call_rec_edge.take_edge+0x3b0>
+               	j	0xcac <corpus.cases.call.call_rec_edge.take_edge+0x430>
+               	bnez	a1, 0xc84 <corpus.cases.call.call_rec_edge.take_edge+0x408>
+               	mv	a1, a0
+               	mv	a7, a6
+               	li	t6, 0x10
+               	ld	s9, 0x0(a7)
+               	sd	s9, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a7, a7, 0x8
+               	addi	t6, t6, -0x8
+               	li	t0, 0x0
+               	bne	t6, t0, 0xc5c <corpus.cases.call.call_rec_edge.take_edge+0x3e0>
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a1)
+               	j	0xcac <corpus.cases.call.call_rec_edge.take_edge+0x430>
+               	mv	a1, a0
+               	mv	a0, a6
+               	li	a6, 0x11
+               	lbu	a7, 0x0(a0)
+               	sb	a7, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xc90 <corpus.cases.call.call_rec_edge.take_edge+0x414>
+               	addi	s9, s0, -0x112
+               	mv	a0, s9
+               	mv	a1, a2
+               	or	a2, a0, a1
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a0, a1, 0xd2c <corpus.cases.call.call_rec_edge.take_edge+0x4b0>
+               	bnez	a2, 0xd00 <corpus.cases.call.call_rec_edge.take_edge+0x484>
+               	addi	a6, a0, 0x8
+               	addi	a7, a1, 0x8
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	li	t6, 0x8
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	s10, 0x0(a7)
+               	sd	s10, 0x0(a6)
+               	addi	t6, t6, -0x8
+               	li	t0, 0x0
+               	bne	t6, t0, 0xce0 <corpus.cases.call.call_rec_edge.take_edge+0x464>
+               	j	0xd8c <corpus.cases.call.call_rec_edge.take_edge+0x510>
+               	addi	a6, a0, 0x9
+               	addi	a7, a1, 0x9
+               	li	t6, 0x9
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	s10, 0x0(a7)
+               	sb	s10, 0x0(a6)
+               	addi	t6, t6, -0x1
+               	li	t0, 0x0
+               	bne	t6, t0, 0xd0c <corpus.cases.call.call_rec_edge.take_edge+0x490>
+               	j	0xd8c <corpus.cases.call.call_rec_edge.take_edge+0x510>
+               	bnez	a2, 0xd64 <corpus.cases.call.call_rec_edge.take_edge+0x4e8>
+               	mv	a2, a0
+               	mv	a6, a1
+               	li	a7, 0x8
+               	ld	t6, 0x0(a6)
+               	sd	t6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xd3c <corpus.cases.call.call_rec_edge.take_edge+0x4c0>
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a2)
+               	j	0xd8c <corpus.cases.call.call_rec_edge.take_edge+0x510>
+               	mv	a2, a0
+               	mv	a0, a1
+               	li	a1, 0x9
+               	lbu	a6, 0x0(a0)
+               	sb	a6, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xd70 <corpus.cases.call.call_rec_edge.take_edge+0x4f4>
+               	addi	s10, s0, -0x120
+               	mv	a0, s10
+               	mv	a1, a3
+               	or	a2, a0, a1
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a0, a1, 0xe0c <corpus.cases.call.call_rec_edge.take_edge+0x590>
+               	bnez	a2, 0xde0 <corpus.cases.call.call_rec_edge.take_edge+0x564>
+               	addi	a3, a0, 0x8
+               	addi	a6, a1, 0x8
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a3)
+               	li	a7, 0x8
+               	addi	a3, a3, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t6, 0x0(a6)
+               	sd	t6, 0x0(a3)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xdc0 <corpus.cases.call.call_rec_edge.take_edge+0x544>
+               	j	0xe6c <corpus.cases.call.call_rec_edge.take_edge+0x5f0>
+               	addi	a3, a0, 0xc
+               	addi	a6, a1, 0xc
+               	li	a7, 0xc
+               	addi	a3, a3, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t6, 0x0(a6)
+               	sb	t6, 0x0(a3)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xdec <corpus.cases.call.call_rec_edge.take_edge+0x570>
+               	j	0xe6c <corpus.cases.call.call_rec_edge.take_edge+0x5f0>
+               	bnez	a2, 0xe44 <corpus.cases.call.call_rec_edge.take_edge+0x5c8>
+               	mv	a2, a0
+               	mv	a3, a1
+               	li	a6, 0x8
+               	ld	a7, 0x0(a3)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xe1c <corpus.cases.call.call_rec_edge.take_edge+0x5a0>
+               	lw	a6, 0x0(a3)
+               	sw	a6, 0x0(a2)
+               	j	0xe6c <corpus.cases.call.call_rec_edge.take_edge+0x5f0>
+               	mv	a2, a0
+               	mv	a0, a1
+               	li	a1, 0xc
+               	lbu	a3, 0x0(a0)
+               	sb	a3, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xe50 <corpus.cases.call.call_rec_edge.take_edge+0x5d4>
+               	addi	s11, s0, -0x130
+               	mv	a0, s11
+               	mv	a1, a4
+               	or	a2, a0, a1
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a0, a1, 0xee4 <corpus.cases.call.call_rec_edge.take_edge+0x668>
+               	bnez	a2, 0xeb8 <corpus.cases.call.call_rec_edge.take_edge+0x63c>
+               	addi	a3, a0, 0x10
+               	addi	a4, a1, 0x10
+               	li	a6, 0x10
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a7, 0x0(a4)
+               	sd	a7, 0x0(a3)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xe98 <corpus.cases.call.call_rec_edge.take_edge+0x61c>
+               	j	0xf3c <corpus.cases.call.call_rec_edge.take_edge+0x6c0>
+               	addi	a3, a0, 0x10
+               	addi	a4, a1, 0x10
+               	li	a6, 0x10
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a7, 0x0(a4)
+               	sb	a7, 0x0(a3)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xec4 <corpus.cases.call.call_rec_edge.take_edge+0x648>
+               	j	0xf3c <corpus.cases.call.call_rec_edge.take_edge+0x6c0>
+               	bnez	a2, 0xf14 <corpus.cases.call.call_rec_edge.take_edge+0x698>
+               	mv	a2, a0
+               	mv	a3, a1
+               	li	a4, 0x10
+               	ld	a6, 0x0(a3)
+               	sd	a6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0xef4 <corpus.cases.call.call_rec_edge.take_edge+0x678>
+               	j	0xf3c <corpus.cases.call.call_rec_edge.take_edge+0x6c0>
+               	mv	a2, a0
+               	mv	a0, a1
+               	li	a1, 0x10
+               	lbu	a3, 0x0(a0)
+               	sb	a3, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xf20 <corpus.cases.call.call_rec_edge.take_edge+0x6a4>
+               	addi	t2, s0, -0x141
+               	sd	t2, -0x2b0(s0)
+               	ld	t2, -0x2b0(s0)
+               	mv	a0, t2
+               	mv	a1, a5
+               	or	a2, a0, a1
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a0, a1, 0xfc4 <corpus.cases.call.call_rec_edge.take_edge+0x748>
+               	bnez	a2, 0xf98 <corpus.cases.call.call_rec_edge.take_edge+0x71c>
+               	addi	a4, a0, 0x10
+               	addi	a5, a1, 0x10
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a4)
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xf78 <corpus.cases.call.call_rec_edge.take_edge+0x6fc>
+               	j	0x1024 <corpus.cases.call.call_rec_edge.take_edge+0x7a8>
+               	addi	a4, a0, 0x11
+               	addi	a5, a1, 0x11
+               	li	a6, 0x11
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xfa4 <corpus.cases.call.call_rec_edge.take_edge+0x728>
+               	j	0x1024 <corpus.cases.call.call_rec_edge.take_edge+0x7a8>
+               	bnez	a2, 0xffc <corpus.cases.call.call_rec_edge.take_edge+0x780>
+               	mv	a2, a0
+               	mv	a4, a1
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xfd4 <corpus.cases.call.call_rec_edge.take_edge+0x758>
+               	lbu	a5, 0x0(a4)
+               	sb	a5, 0x0(a2)
+               	j	0x1024 <corpus.cases.call.call_rec_edge.take_edge+0x7a8>
+               	mv	a2, a0
+               	mv	a0, a1
+               	li	a1, 0x11
+               	lbu	a4, 0x0(a0)
+               	sb	a4, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x1008 <corpus.cases.call.call_rec_edge.take_edge+0x78c>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, t5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x7cc>
+               	addi	a1, s0, -0x19c
+               	mv	a2, a1
+               	mv	a4, s4
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x10d0 <corpus.cases.call.call_rec_edge.take_edge+0x854>
+               	bnez	a5, 0x10a4 <corpus.cases.call.call_rec_edge.take_edge+0x828>
+               	addi	a6, a2, 0x8
+               	addi	a7, a4, 0x8
+               	lbu	t5, 0x0(a7)
+               	sb	t5, 0x0(a6)
+               	li	t5, 0x8
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1084 <corpus.cases.call.call_rec_edge.take_edge+0x808>
+               	j	0x1130 <corpus.cases.call.call_rec_edge.take_edge+0x8b4>
+               	addi	a6, a2, 0x9
+               	addi	a7, a4, 0x9
+               	li	t5, 0x9
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x10b0 <corpus.cases.call.call_rec_edge.take_edge+0x834>
+               	j	0x1130 <corpus.cases.call.call_rec_edge.take_edge+0x8b4>
+               	bnez	a5, 0x1108 <corpus.cases.call.call_rec_edge.take_edge+0x88c>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x10e0 <corpus.cases.call.call_rec_edge.take_edge+0x864>
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	j	0x1130 <corpus.cases.call.call_rec_edge.take_edge+0x8b4>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0x9
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1114 <corpus.cases.call.call_rec_edge.take_edge+0x898>
+               	lbu	a2, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s4, 0x7(a1)
+               	sb	a2, -0x1a8(s0)
+               	sb	a4, -0x1a7(s0)
+               	sb	a5, -0x1a6(s0)
+               	sb	a6, -0x1a5(s0)
+               	sb	a7, -0x1a4(s0)
+               	sb	t5, -0x1a3(s0)
+               	sb	t6, -0x1a2(s0)
+               	sb	s4, -0x1a1(s0)
+               	ld	a2, -0x1a8(s0)
+               	sd	zero, -0x1b0(s0)
+               	lbu	a4, 0x8(a1)
+               	sb	a4, -0x1b0(s0)
+               	ld	a4, -0x1b0(s0)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x910>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x920>
+               	addi	a1, s0, -0x1bc
+               	mv	a2, a1
+               	mv	a4, s5
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x1224 <corpus.cases.call.call_rec_edge.take_edge+0x9a8>
+               	bnez	a5, 0x11f8 <corpus.cases.call.call_rec_edge.take_edge+0x97c>
+               	addi	a6, a2, 0x8
+               	addi	a7, a4, 0x8
+               	lw	t5, 0x0(a7)
+               	sw	t5, 0x0(a6)
+               	li	t5, 0x8
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x11d8 <corpus.cases.call.call_rec_edge.take_edge+0x95c>
+               	j	0x1284 <corpus.cases.call.call_rec_edge.take_edge+0xa08>
+               	addi	a6, a2, 0xc
+               	addi	a7, a4, 0xc
+               	li	t5, 0xc
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1204 <corpus.cases.call.call_rec_edge.take_edge+0x988>
+               	j	0x1284 <corpus.cases.call.call_rec_edge.take_edge+0xa08>
+               	bnez	a5, 0x125c <corpus.cases.call.call_rec_edge.take_edge+0x9e0>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1234 <corpus.cases.call.call_rec_edge.take_edge+0x9b8>
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	j	0x1284 <corpus.cases.call.call_rec_edge.take_edge+0xa08>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0xc
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1268 <corpus.cases.call.call_rec_edge.take_edge+0x9ec>
+               	lbu	a2, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s1, 0x7(a1)
+               	sb	a2, -0x1c8(s0)
+               	sb	a4, -0x1c7(s0)
+               	sb	a5, -0x1c6(s0)
+               	sb	a6, -0x1c5(s0)
+               	sb	a7, -0x1c4(s0)
+               	sb	t5, -0x1c3(s0)
+               	sb	t6, -0x1c2(s0)
+               	sb	s1, -0x1c1(s0)
+               	ld	a2, -0x1c8(s0)
+               	sd	zero, -0x1d0(s0)
+               	lbu	a4, 0x8(a1)
+               	lbu	a5, 0x9(a1)
+               	lbu	a6, 0xa(a1)
+               	lbu	a7, 0xb(a1)
+               	sb	a4, -0x1d0(s0)
+               	sb	a5, -0x1cf(s0)
+               	sb	a6, -0x1ce(s0)
+               	sb	a7, -0x1cd(s0)
+               	ld	a4, -0x1d0(s0)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa7c>
+               	fmv.x.d	a1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xa88>
+               	addi	a1, s0, -0x1e0
+               	mv	a2, a1
+               	mv	a4, s6
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x1384 <corpus.cases.call.call_rec_edge.take_edge+0xb08>
+               	bnez	a5, 0x1358 <corpus.cases.call.call_rec_edge.take_edge+0xadc>
+               	addi	a6, a2, 0x10
+               	addi	a7, a4, 0x10
+               	li	t5, 0x10
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1338 <corpus.cases.call.call_rec_edge.take_edge+0xabc>
+               	j	0x13dc <corpus.cases.call.call_rec_edge.take_edge+0xb60>
+               	addi	a6, a2, 0x10
+               	addi	a7, a4, 0x10
+               	li	t5, 0x10
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1364 <corpus.cases.call.call_rec_edge.take_edge+0xae8>
+               	j	0x13dc <corpus.cases.call.call_rec_edge.take_edge+0xb60>
+               	bnez	a5, 0x13b4 <corpus.cases.call.call_rec_edge.take_edge+0xb38>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x10
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1394 <corpus.cases.call.call_rec_edge.take_edge+0xb18>
+               	j	0x13dc <corpus.cases.call.call_rec_edge.take_edge+0xb60>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0x10
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x13c0 <corpus.cases.call.call_rec_edge.take_edge+0xb44>
+               	ld	a2, 0x0(a1)
+               	ld	a4, 0x8(a1)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xb70>
+               	fmv.x.d	a1, fs2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1408 <corpus.cases.call.call_rec_edge.take_edge+0xb8c>
+               	j	0x143c <corpus.cases.call.call_rec_edge.take_edge+0xbc0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1408 <corpus.cases.call.call_rec_edge.take_edge+0xb8c>
+               	fmv.x.d	a1, fs3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1450 <corpus.cases.call.call_rec_edge.take_edge+0xbd4>
+               	j	0x1484 <corpus.cases.call.call_rec_edge.take_edge+0xc08>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1450 <corpus.cases.call.call_rec_edge.take_edge+0xbd4>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1494 <corpus.cases.call.call_rec_edge.take_edge+0xc18>
+               	j	0x14c8 <corpus.cases.call.call_rec_edge.take_edge+0xc4c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a4, s7, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1494 <corpus.cases.call.call_rec_edge.take_edge+0xc18>
+               	fmv.x.d	a1, fs4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x14dc <corpus.cases.call.call_rec_edge.take_edge+0xc60>
+               	j	0x1510 <corpus.cases.call.call_rec_edge.take_edge+0xc94>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x14dc <corpus.cases.call.call_rec_edge.take_edge+0xc60>
+               	mv	a1, s2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xc98>
+               	addi	a1, s0, -0x1f1
+               	mv	a2, a1
+               	mv	a4, s8
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x159c <corpus.cases.call.call_rec_edge.take_edge+0xd20>
+               	bnez	a5, 0x1570 <corpus.cases.call.call_rec_edge.take_edge+0xcf4>
+               	addi	a6, a2, 0x10
+               	addi	a7, a4, 0x10
+               	lbu	t5, 0x0(a7)
+               	sb	t5, 0x0(a6)
+               	li	t5, 0x10
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1550 <corpus.cases.call.call_rec_edge.take_edge+0xcd4>
+               	j	0x15fc <corpus.cases.call.call_rec_edge.take_edge+0xd80>
+               	addi	a6, a2, 0x11
+               	addi	a7, a4, 0x11
+               	li	t5, 0x11
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x157c <corpus.cases.call.call_rec_edge.take_edge+0xd00>
+               	j	0x15fc <corpus.cases.call.call_rec_edge.take_edge+0xd80>
+               	bnez	a5, 0x15d4 <corpus.cases.call.call_rec_edge.take_edge+0xd58>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x10
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x15ac <corpus.cases.call.call_rec_edge.take_edge+0xd30>
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	j	0x15fc <corpus.cases.call.call_rec_edge.take_edge+0xd80>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0x11
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x15e0 <corpus.cases.call.call_rec_edge.take_edge+0xd64>
+               	addi	a2, s0, -0x209
+               	mv	a4, a1
+               	or	a1, a2, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a4, 0x1678 <corpus.cases.call.call_rec_edge.take_edge+0xdfc>
+               	bnez	a1, 0x164c <corpus.cases.call.call_rec_edge.take_edge+0xdd0>
+               	addi	a5, a2, 0x10
+               	addi	a6, a4, 0x10
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x162c <corpus.cases.call.call_rec_edge.take_edge+0xdb0>
+               	j	0x16d8 <corpus.cases.call.call_rec_edge.take_edge+0xe5c>
+               	addi	a5, a2, 0x11
+               	addi	a6, a4, 0x11
+               	li	a7, 0x11
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1658 <corpus.cases.call.call_rec_edge.take_edge+0xddc>
+               	j	0x16d8 <corpus.cases.call.call_rec_edge.take_edge+0xe5c>
+               	bnez	a1, 0x16b0 <corpus.cases.call.call_rec_edge.take_edge+0xe34>
+               	mv	a1, a2
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1688 <corpus.cases.call.call_rec_edge.take_edge+0xe0c>
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a1)
+               	j	0x16d8 <corpus.cases.call.call_rec_edge.take_edge+0xe5c>
+               	mv	a1, a2
+               	mv	a2, a4
+               	li	a4, 0x11
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x16bc <corpus.cases.call.call_rec_edge.take_edge+0xe40>
+               	addi	a1, s0, -0x209
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xe60>
+               	addi	a1, s0, -0x212
+               	mv	a2, a1
+               	mv	a4, s9
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x1764 <corpus.cases.call.call_rec_edge.take_edge+0xee8>
+               	bnez	a5, 0x1738 <corpus.cases.call.call_rec_edge.take_edge+0xebc>
+               	addi	a6, a2, 0x8
+               	addi	a7, a4, 0x8
+               	lbu	t5, 0x0(a7)
+               	sb	t5, 0x0(a6)
+               	li	t5, 0x8
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1718 <corpus.cases.call.call_rec_edge.take_edge+0xe9c>
+               	j	0x17c4 <corpus.cases.call.call_rec_edge.take_edge+0xf48>
+               	addi	a6, a2, 0x9
+               	addi	a7, a4, 0x9
+               	li	t5, 0x9
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1744 <corpus.cases.call.call_rec_edge.take_edge+0xec8>
+               	j	0x17c4 <corpus.cases.call.call_rec_edge.take_edge+0xf48>
+               	bnez	a5, 0x179c <corpus.cases.call.call_rec_edge.take_edge+0xf20>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1774 <corpus.cases.call.call_rec_edge.take_edge+0xef8>
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	j	0x17c4 <corpus.cases.call.call_rec_edge.take_edge+0xf48>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0x9
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x17a8 <corpus.cases.call.call_rec_edge.take_edge+0xf2c>
+               	lbu	a2, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s1, 0x7(a1)
+               	sb	a2, -0x220(s0)
+               	sb	a4, -0x21f(s0)
+               	sb	a5, -0x21e(s0)
+               	sb	a6, -0x21d(s0)
+               	sb	a7, -0x21c(s0)
+               	sb	t5, -0x21b(s0)
+               	sb	t6, -0x21a(s0)
+               	sb	s1, -0x219(s0)
+               	ld	a2, -0x220(s0)
+               	sd	zero, -0x228(s0)
+               	lbu	a4, 0x8(a1)
+               	sb	a4, -0x228(s0)
+               	ld	a4, -0x228(s0)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0xfa4>
+               	addi	a1, s0, -0x234
+               	mv	a2, a1
+               	mv	a4, s10
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x18a8 <corpus.cases.call.call_rec_edge.take_edge+0x102c>
+               	bnez	a5, 0x187c <corpus.cases.call.call_rec_edge.take_edge+0x1000>
+               	addi	a6, a2, 0x8
+               	addi	a7, a4, 0x8
+               	lw	t5, 0x0(a7)
+               	sw	t5, 0x0(a6)
+               	li	t5, 0x8
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x185c <corpus.cases.call.call_rec_edge.take_edge+0xfe0>
+               	j	0x1908 <corpus.cases.call.call_rec_edge.take_edge+0x108c>
+               	addi	a6, a2, 0xc
+               	addi	a7, a4, 0xc
+               	li	t5, 0xc
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1888 <corpus.cases.call.call_rec_edge.take_edge+0x100c>
+               	j	0x1908 <corpus.cases.call.call_rec_edge.take_edge+0x108c>
+               	bnez	a5, 0x18e0 <corpus.cases.call.call_rec_edge.take_edge+0x1064>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x18b8 <corpus.cases.call.call_rec_edge.take_edge+0x103c>
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	j	0x1908 <corpus.cases.call.call_rec_edge.take_edge+0x108c>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0xc
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x18ec <corpus.cases.call.call_rec_edge.take_edge+0x1070>
+               	lbu	a2, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s1, 0x7(a1)
+               	sb	a2, -0x240(s0)
+               	sb	a4, -0x23f(s0)
+               	sb	a5, -0x23e(s0)
+               	sb	a6, -0x23d(s0)
+               	sb	a7, -0x23c(s0)
+               	sb	t5, -0x23b(s0)
+               	sb	t6, -0x23a(s0)
+               	sb	s1, -0x239(s0)
+               	ld	a2, -0x240(s0)
+               	sd	zero, -0x248(s0)
+               	lbu	a4, 0x8(a1)
+               	lbu	a5, 0x9(a1)
+               	lbu	a6, 0xa(a1)
+               	lbu	a7, 0xb(a1)
+               	sb	a4, -0x248(s0)
+               	sb	a5, -0x247(s0)
+               	sb	a6, -0x246(s0)
+               	sb	a7, -0x245(s0)
+               	ld	a4, -0x248(s0)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x1100>
+               	addi	a1, s0, -0x258
+               	mv	a2, a1
+               	mv	a4, s11
+               	or	a5, a2, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a2, a4, 0x19fc <corpus.cases.call.call_rec_edge.take_edge+0x1180>
+               	bnez	a5, 0x19d0 <corpus.cases.call.call_rec_edge.take_edge+0x1154>
+               	addi	a6, a2, 0x10
+               	addi	a7, a4, 0x10
+               	li	t5, 0x10
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x19b0 <corpus.cases.call.call_rec_edge.take_edge+0x1134>
+               	j	0x1a54 <corpus.cases.call.call_rec_edge.take_edge+0x11d8>
+               	addi	a6, a2, 0x10
+               	addi	a7, a4, 0x10
+               	li	t5, 0x10
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x19dc <corpus.cases.call.call_rec_edge.take_edge+0x1160>
+               	j	0x1a54 <corpus.cases.call.call_rec_edge.take_edge+0x11d8>
+               	bnez	a5, 0x1a2c <corpus.cases.call.call_rec_edge.take_edge+0x11b0>
+               	mv	a5, a2
+               	mv	a6, a4
+               	li	a7, 0x10
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1a0c <corpus.cases.call.call_rec_edge.take_edge+0x1190>
+               	j	0x1a54 <corpus.cases.call.call_rec_edge.take_edge+0x11d8>
+               	mv	a5, a2
+               	mv	a2, a4
+               	li	a4, 0x10
+               	lbu	a6, 0x0(a2)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1a38 <corpus.cases.call.call_rec_edge.take_edge+0x11bc>
+               	ld	a2, 0x0(a1)
+               	ld	a4, 0x8(a1)
+               	mv	a1, a2
+               	mv	a2, a4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x11e8>
+               	addi	a1, s0, -0x269
+               	mv	a2, a1
+               	ld	t2, -0x2b0(s0)
+               	mv	a4, t2
+               	or	a3, a2, a4
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a2, a4, 0x1af0 <corpus.cases.call.call_rec_edge.take_edge+0x1274>
+               	bnez	a3, 0x1ac4 <corpus.cases.call.call_rec_edge.take_edge+0x1248>
+               	addi	a5, a2, 0x10
+               	addi	a6, a4, 0x10
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1aa4 <corpus.cases.call.call_rec_edge.take_edge+0x1228>
+               	j	0x1b50 <corpus.cases.call.call_rec_edge.take_edge+0x12d4>
+               	addi	a5, a2, 0x11
+               	addi	a6, a4, 0x11
+               	li	a7, 0x11
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1ad0 <corpus.cases.call.call_rec_edge.take_edge+0x1254>
+               	j	0x1b50 <corpus.cases.call.call_rec_edge.take_edge+0x12d4>
+               	bnez	a3, 0x1b28 <corpus.cases.call.call_rec_edge.take_edge+0x12ac>
+               	mv	a3, a2
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1b00 <corpus.cases.call.call_rec_edge.take_edge+0x1284>
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a3)
+               	j	0x1b50 <corpus.cases.call.call_rec_edge.take_edge+0x12d4>
+               	mv	a3, a2
+               	mv	a2, a4
+               	li	a4, 0x11
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1b34 <corpus.cases.call.call_rec_edge.take_edge+0x12b8>
+               	addi	a2, s0, -0x281
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x1bcc <corpus.cases.call.call_rec_edge.take_edge+0x1350>
+               	bnez	a1, 0x1ba0 <corpus.cases.call.call_rec_edge.take_edge+0x1324>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a4)
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1b80 <corpus.cases.call.call_rec_edge.take_edge+0x1304>
+               	j	0x1c2c <corpus.cases.call.call_rec_edge.take_edge+0x13b0>
+               	addi	a4, a2, 0x11
+               	addi	a5, a3, 0x11
+               	li	a6, 0x11
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1bac <corpus.cases.call.call_rec_edge.take_edge+0x1330>
+               	j	0x1c2c <corpus.cases.call.call_rec_edge.take_edge+0x13b0>
+               	bnez	a1, 0x1c04 <corpus.cases.call.call_rec_edge.take_edge+0x1388>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x1bdc <corpus.cases.call.call_rec_edge.take_edge+0x1360>
+               	lbu	a5, 0x0(a4)
+               	sb	a5, 0x0(a1)
+               	j	0x1c2c <corpus.cases.call.call_rec_edge.take_edge+0x13b0>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x11
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1c10 <corpus.cases.call.call_rec_edge.take_edge+0x1394>
+               	addi	a1, s0, -0x281
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x13b4>
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x13cc>
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x13d8>
+               	addi	a1, s0, -0x292
+               	addi	a2, s0, -0x2a3
+               	mv	a3, a2
+               	mv	a4, s8
+               	or	a5, a3, a4
+               	li	t0, 0x7
+               	and	a5, a5, t0
+               	bltu	a3, a4, 0x1ce0 <corpus.cases.call.call_rec_edge.take_edge+0x1464>
+               	bnez	a5, 0x1cb4 <corpus.cases.call.call_rec_edge.take_edge+0x1438>
+               	addi	a6, a3, 0x10
+               	addi	a7, a4, 0x10
+               	lbu	t5, 0x0(a7)
+               	sb	t5, 0x0(a6)
+               	li	t5, 0x10
+               	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1c94 <corpus.cases.call.call_rec_edge.take_edge+0x1418>
+               	j	0x1d40 <corpus.cases.call.call_rec_edge.take_edge+0x14c4>
+               	addi	a6, a3, 0x11
+               	addi	a7, a4, 0x11
+               	li	t5, 0x11
+               	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x1cc0 <corpus.cases.call.call_rec_edge.take_edge+0x1444>
+               	j	0x1d40 <corpus.cases.call.call_rec_edge.take_edge+0x14c4>
+               	bnez	a5, 0x1d18 <corpus.cases.call.call_rec_edge.take_edge+0x149c>
+               	mv	a5, a3
+               	mv	a6, a4
+               	li	a7, 0x10
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1cf0 <corpus.cases.call.call_rec_edge.take_edge+0x1474>
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	j	0x1d40 <corpus.cases.call.call_rec_edge.take_edge+0x14c4>
+               	mv	a5, a3
+               	mv	a3, a4
+               	li	a4, 0x11
+               	lbu	a6, 0x0(a3)
+               	sb	a6, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1d24 <corpus.cases.call.call_rec_edge.take_edge+0x14a8>
+               	mv	a3, a1
+               	mv	a4, a2
+               	or	a2, a3, a4
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x1dbc <corpus.cases.call.call_rec_edge.take_edge+0x1540>
+               	bnez	a2, 0x1d90 <corpus.cases.call.call_rec_edge.take_edge+0x1514>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1d70 <corpus.cases.call.call_rec_edge.take_edge+0x14f4>
+               	j	0x1e1c <corpus.cases.call.call_rec_edge.take_edge+0x15a0>
+               	addi	a5, a3, 0x11
+               	addi	a6, a4, 0x11
+               	li	a7, 0x11
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1d9c <corpus.cases.call.call_rec_edge.take_edge+0x1520>
+               	j	0x1e1c <corpus.cases.call.call_rec_edge.take_edge+0x15a0>
+               	bnez	a2, 0x1df4 <corpus.cases.call.call_rec_edge.take_edge+0x1578>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1dcc <corpus.cases.call.call_rec_edge.take_edge+0x1550>
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a2)
+               	j	0x1e1c <corpus.cases.call.call_rec_edge.take_edge+0x15a0>
+               	mv	a2, a3
+               	mv	a3, a4
+               	li	a4, 0x11
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1e00 <corpus.cases.call.call_rec_edge.take_edge+0x1584>
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	addiw	a4, a3, 0x1
+               	sb	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x10
+               	bltu	a2, t0, 0x1e3c <corpus.cases.call.call_rec_edge.take_edge+0x15c0>
+               	j	0x1e64 <corpus.cases.call.call_rec_edge.take_edge+0x15e8>
+               	addi	a3, a1, 0x1
+               	add	a4, a3, a2
+               	lbu	a3, 0x0(a4)
+               	sext.w	a5, a2
+               	addw	a6, a3, a5
+               	addiw	a3, a6, 0x1
+               	sb	a3, 0x0(a4)
+               	addi	a2, a2, 0x1
+               	li	t0, 0x10
+               	bltu	a2, t0, 0x1e3c <corpus.cases.call.call_rec_edge.take_edge+0x15c0>
+               	addi	a2, s0, -0x152
+               	mv	a3, a2
+               	mv	a4, a1
+               	or	a1, a3, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, a4, 0x1ee4 <corpus.cases.call.call_rec_edge.take_edge+0x1668>
+               	bnez	a1, 0x1eb8 <corpus.cases.call.call_rec_edge.take_edge+0x163c>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1e98 <corpus.cases.call.call_rec_edge.take_edge+0x161c>
+               	j	0x1f44 <corpus.cases.call.call_rec_edge.take_edge+0x16c8>
+               	addi	a5, a3, 0x11
+               	addi	a6, a4, 0x11
+               	li	a7, 0x11
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1ec4 <corpus.cases.call.call_rec_edge.take_edge+0x1648>
+               	j	0x1f44 <corpus.cases.call.call_rec_edge.take_edge+0x16c8>
+               	bnez	a1, 0x1f1c <corpus.cases.call.call_rec_edge.take_edge+0x16a0>
+               	mv	a1, a3
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1ef4 <corpus.cases.call.call_rec_edge.take_edge+0x1678>
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a1)
+               	j	0x1f44 <corpus.cases.call.call_rec_edge.take_edge+0x16c8>
+               	mv	a1, a3
+               	mv	a3, a4
+               	li	a4, 0x11
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1f28 <corpus.cases.call.call_rec_edge.take_edge+0x16ac>
+               	addi	a1, s0, -0x16a
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x1640 <corpus.cases.call.call_rec_edge.take_edge+0x1054>
-               	bnez	a2, 0x1614 <corpus.cases.call.call_rec_edge.take_edge+0x1028>
+               	bltu	a1, a3, 0x1fc0 <corpus.cases.call.call_rec_edge.take_edge+0x1744>
+               	bnez	a2, 0x1f94 <corpus.cases.call.call_rec_edge.take_edge+0x1718>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lbu	a6, 0x0(a5)
@@ -1430,8 +2038,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x15f4 <corpus.cases.call.call_rec_edge.take_edge+0x1008>
-               	j	0x16a0 <corpus.cases.call.call_rec_edge.take_edge+0x10b4>
+               	bne	a6, t0, 0x1f74 <corpus.cases.call.call_rec_edge.take_edge+0x16f8>
+               	j	0x2020 <corpus.cases.call.call_rec_edge.take_edge+0x17a4>
                	addi	a4, a1, 0x11
                	addi	a5, a3, 0x11
                	li	a6, 0x11
@@ -1441,9 +2049,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1620 <corpus.cases.call.call_rec_edge.take_edge+0x1034>
-               	j	0x16a0 <corpus.cases.call.call_rec_edge.take_edge+0x10b4>
-               	bnez	a2, 0x1678 <corpus.cases.call.call_rec_edge.take_edge+0x108c>
+               	bne	a6, t0, 0x1fa0 <corpus.cases.call.call_rec_edge.take_edge+0x1724>
+               	j	0x2020 <corpus.cases.call.call_rec_edge.take_edge+0x17a4>
+               	bnez	a2, 0x1ff8 <corpus.cases.call.call_rec_edge.take_edge+0x177c>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -1453,10 +2061,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1650 <corpus.cases.call.call_rec_edge.take_edge+0x1064>
+               	bne	a5, t0, 0x1fd0 <corpus.cases.call.call_rec_edge.take_edge+0x1754>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a2)
-               	j	0x16a0 <corpus.cases.call.call_rec_edge.take_edge+0x10b4>
+               	j	0x2020 <corpus.cases.call.call_rec_edge.take_edge+0x17a4>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x11
@@ -1466,39 +2074,75 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1684 <corpus.cases.call.call_rec_edge.take_edge+0x1098>
-               	mv	a1, s1
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
+               	bne	a3, t0, 0x2004 <corpus.cases.call.call_rec_edge.take_edge+0x1788>
+               	addi	a1, s0, -0x16a
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x10c0>
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x16c8 <corpus.cases.call.call_rec_edge.take_edge+0x10dc>
-               	j	0x16f4 <corpus.cases.call.call_rec_edge.take_edge+0x1108>
-               	addi	a0, s1, 0x1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x10f0>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x16c8 <corpus.cases.call.call_rec_edge.take_edge+0x10dc>
-               	addi	a0, s0, -0x155
-               	mv	a1, a0
-               	ld	t2, -0x348(s0)
-               	mv	a2, t2
-               	or	a3, a1, a2
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x17a8>
+               	addi	a1, s0, -0x17b
+               	mv	a2, a1
+               	mv	a3, s8
+               	or	a4, a2, a3
                	li	t0, 0x7
-               	and	a3, a3, t0
-               	bltu	a1, a2, 0x1778 <corpus.cases.call.call_rec_edge.take_edge+0x118c>
-               	bnez	a3, 0x174c <corpus.cases.call.call_rec_edge.take_edge+0x1160>
-               	addi	a4, a1, 0x10
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x20ac <corpus.cases.call.call_rec_edge.take_edge+0x1830>
+               	bnez	a4, 0x2080 <corpus.cases.call.call_rec_edge.take_edge+0x1804>
                	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	lbu	a7, 0x0(a6)
+               	sb	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x2060 <corpus.cases.call.call_rec_edge.take_edge+0x17e4>
+               	j	0x210c <corpus.cases.call.call_rec_edge.take_edge+0x1890>
+               	addi	a5, a2, 0x11
+               	addi	a6, a3, 0x11
+               	li	a7, 0x11
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x208c <corpus.cases.call.call_rec_edge.take_edge+0x1810>
+               	j	0x210c <corpus.cases.call.call_rec_edge.take_edge+0x1890>
+               	bnez	a4, 0x20e4 <corpus.cases.call.call_rec_edge.take_edge+0x1868>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x20bc <corpus.cases.call.call_rec_edge.take_edge+0x1840>
+               	lbu	a6, 0x0(a5)
+               	sb	a6, 0x0(a4)
+               	j	0x210c <corpus.cases.call.call_rec_edge.take_edge+0x1890>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x11
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x20f0 <corpus.cases.call.call_rec_edge.take_edge+0x1874>
+               	addi	a2, s0, -0x193
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x2188 <corpus.cases.call.call_rec_edge.take_edge+0x190c>
+               	bnez	a1, 0x215c <corpus.cases.call.call_rec_edge.take_edge+0x18e0>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
                	lbu	a6, 0x0(a5)
                	sb	a6, 0x0(a4)
                	li	a6, 0x10
@@ -1508,10 +2152,10 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x172c <corpus.cases.call.call_rec_edge.take_edge+0x1140>
-               	j	0x17d8 <corpus.cases.call.call_rec_edge.take_edge+0x11ec>
-               	addi	a4, a1, 0x11
-               	addi	a5, a2, 0x11
+               	bne	a6, t0, 0x213c <corpus.cases.call.call_rec_edge.take_edge+0x18c0>
+               	j	0x21e8 <corpus.cases.call.call_rec_edge.take_edge+0x196c>
+               	addi	a4, a2, 0x11
+               	addi	a5, a3, 0x11
                	li	a6, 0x11
                	addi	a4, a4, -0x1
                	addi	a5, a5, -0x1
@@ -1519,129 +2163,54 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1758 <corpus.cases.call.call_rec_edge.take_edge+0x116c>
-               	j	0x17d8 <corpus.cases.call.call_rec_edge.take_edge+0x11ec>
-               	bnez	a3, 0x17b0 <corpus.cases.call.call_rec_edge.take_edge+0x11c4>
-               	mv	a3, a1
-               	mv	a4, a2
+               	bne	a6, t0, 0x2168 <corpus.cases.call.call_rec_edge.take_edge+0x18ec>
+               	j	0x21e8 <corpus.cases.call.call_rec_edge.take_edge+0x196c>
+               	bnez	a1, 0x21c0 <corpus.cases.call.call_rec_edge.take_edge+0x1944>
+               	mv	a1, a2
+               	mv	a4, a3
                	li	a5, 0x10
                	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a3)
-               	addi	a3, a3, 0x8
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1788 <corpus.cases.call.call_rec_edge.take_edge+0x119c>
+               	bne	a5, t0, 0x2198 <corpus.cases.call.call_rec_edge.take_edge+0x191c>
                	lbu	a5, 0x0(a4)
-               	sb	a5, 0x0(a3)
-               	j	0x17d8 <corpus.cases.call.call_rec_edge.take_edge+0x11ec>
-               	mv	a3, a1
+               	sb	a5, 0x0(a1)
+               	j	0x21e8 <corpus.cases.call.call_rec_edge.take_edge+0x196c>
                	mv	a1, a2
-               	li	a2, 0x11
-               	lbu	a4, 0x0(a1)
-               	sb	a4, 0x0(a3)
-               	addi	a3, a3, 0x1
+               	mv	a2, a3
+               	li	a3, 0x11
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
                	addi	a1, a1, 0x1
-               	addi	a2, a2, -0x1
-               	li	t0, 0x0
-               	bne	a2, t0, 0x17bc <corpus.cases.call.call_rec_edge.take_edge+0x11d0>
-               	addi	s1, s0, -0x166
-               	mv	a1, s1
-               	mv	a2, a0
-               	or	a0, a1, a2
-               	li	t0, 0x7
-               	and	a0, a0, t0
-               	bltu	a1, a2, 0x1858 <corpus.cases.call.call_rec_edge.take_edge+0x126c>
-               	bnez	a0, 0x182c <corpus.cases.call.call_rec_edge.take_edge+0x1240>
-               	addi	a3, a1, 0x10
-               	addi	a4, a2, 0x10
-               	lbu	a5, 0x0(a4)
-               	sb	a5, 0x0(a3)
-               	li	a5, 0x10
-               	addi	a3, a3, -0x8
-               	addi	a4, a4, -0x8
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a3)
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x180c <corpus.cases.call.call_rec_edge.take_edge+0x1220>
-               	j	0x18b8 <corpus.cases.call.call_rec_edge.take_edge+0x12cc>
-               	addi	a3, a1, 0x11
-               	addi	a4, a2, 0x11
-               	li	a5, 0x11
+               	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
-               	addi	a4, a4, -0x1
-               	lbu	a6, 0x0(a4)
-               	sb	a6, 0x0(a3)
-               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x1838 <corpus.cases.call.call_rec_edge.take_edge+0x124c>
-               	j	0x18b8 <corpus.cases.call.call_rec_edge.take_edge+0x12cc>
-               	bnez	a0, 0x1890 <corpus.cases.call.call_rec_edge.take_edge+0x12a4>
-               	mv	a0, a1
-               	mv	a3, a2
-               	li	a4, 0x10
-               	ld	a5, 0x0(a3)
-               	sd	a5, 0x0(a0)
-               	addi	a0, a0, 0x8
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
-               	li	t0, 0x0
-               	bne	a4, t0, 0x1868 <corpus.cases.call.call_rec_edge.take_edge+0x127c>
-               	lbu	a4, 0x0(a3)
-               	sb	a4, 0x0(a0)
-               	j	0x18b8 <corpus.cases.call.call_rec_edge.take_edge+0x12cc>
-               	mv	a0, a1
-               	mv	a1, a2
-               	li	a2, 0x11
-               	lbu	a3, 0x0(a1)
-               	sb	a3, 0x0(a0)
-               	addi	a0, a0, 0x1
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, -0x1
-               	li	t0, 0x0
-               	bne	a2, t0, 0x189c <corpus.cases.call.call_rec_edge.take_edge+0x12b0>
-               	mv	a0, s1
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s2
+               	bne	a3, t0, 0x21cc <corpus.cases.call.call_rec_edge.take_edge+0x1950>
+               	addi	a1, s0, -0x193
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x12d8>
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x18e0 <corpus.cases.call.call_rec_edge.take_edge+0x12f4>
-               	j	0x190c <corpus.cases.call.call_rec_edge.take_edge+0x1320>
-               	addi	a0, s1, 0x1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x1308>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	bltu	s3, t0, 0x18e0 <corpus.cases.call.call_rec_edge.take_edge+0x12f4>
-               	mv	a0, s2
-               	ld	s1, 0x368(sp)
-               	ld	s2, 0x360(sp)
-               	ld	s3, 0x358(sp)
-               	ld	s4, 0x350(sp)
-               	ld	s5, 0x348(sp)
-               	ld	s6, 0x340(sp)
-               	ld	s7, 0x338(sp)
-               	ld	s8, 0x330(sp)
-               	ld	s9, 0x328(sp)
-               	ld	s10, 0x320(sp)
-               	ld	s11, 0x318(sp)
-               	fld	fs0, 0x310(sp)
-               	fld	fs1, 0x308(sp)
-               	fld	fs2, 0x300(sp)
-               	fld	fs3, 0x2f8(sp)
-               	fld	fs4, 0x2f0(sp)
-               	ld	ra, 0x378(sp)
-               	ld	s0, 0x370(sp)
-               	addi	sp, sp, 0x380
+               	jalr	ra <corpus.cases.call.call_rec_edge.take_edge+0x1970>
+               	ld	s1, 0x298(sp)
+               	ld	s2, 0x290(sp)
+               	ld	s3, 0x288(sp)
+               	ld	s4, 0x280(sp)
+               	ld	s5, 0x278(sp)
+               	ld	s6, 0x270(sp)
+               	ld	s7, 0x268(sp)
+               	ld	s8, 0x260(sp)
+               	ld	s9, 0x258(sp)
+               	ld	s10, 0x250(sp)
+               	ld	s11, 0x248(sp)
+               	fld	fs0, 0x240(sp)
+               	fld	fs1, 0x238(sp)
+               	fld	fs2, 0x230(sp)
+               	fld	fs3, 0x228(sp)
+               	fld	fs4, 0x220(sp)
+               	ld	ra, 0x2a8(sp)
+               	ld	s0, 0x2a0(sp)
+               	addi	sp, sp, 0x2b0
                	ret
 
 <corpus.cases.call.call_rec_edge.mk9>:
@@ -1653,30 +2222,30 @@ Disassembly of section .text:
                	mv	a2, a1
                	li	t0, 0x7
                	and	a3, a2, t0
-               	bnez	a3, 0x19a8 <corpus.cases.call.call_rec_edge.mk9+0x48>
+               	bnez	a3, 0x228c <corpus.cases.call.call_rec_edge.mk9+0x48>
                	mv	a3, a2
                	li	a4, 0x8
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x198c <corpus.cases.call.call_rec_edge.mk9+0x2c>
+               	bne	a4, t0, 0x2270 <corpus.cases.call.call_rec_edge.mk9+0x2c>
                	sb	zero, 0x0(a3)
-               	j	0x19c4 <corpus.cases.call.call_rec_edge.mk9+0x64>
+               	j	0x22a8 <corpus.cases.call.call_rec_edge.mk9+0x64>
                	mv	a3, a2
                	li	a2, 0x9
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x19b0 <corpus.cases.call.call_rec_edge.mk9+0x50>
+               	bne	a2, t0, 0x2294 <corpus.cases.call.call_rec_edge.mk9+0x50>
                	sext.w	a2, a0
                	mv	a3, a1
                	sb	a2, 0x0(a3)
                	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	a2, t0, 0x19e0 <corpus.cases.call.call_rec_edge.mk9+0x80>
-               	j	0x1a10 <corpus.cases.call.call_rec_edge.mk9+0xb0>
+               	bltu	a2, t0, 0x22c4 <corpus.cases.call.call_rec_edge.mk9+0x80>
+               	j	0x22f4 <corpus.cases.call.call_rec_edge.mk9+0xb0>
                	li	t0, 0x8
                	mul	a3, a2, t0
                	srl	a4, a0, a3
@@ -1688,15 +2257,15 @@ Disassembly of section .text:
                	sb	a5, 0x0(a4)
                	addi	a2, a2, 0x1
                	li	t0, 0x8
-               	bltu	a2, t0, 0x19e0 <corpus.cases.call.call_rec_edge.mk9+0x80>
+               	bltu	a2, t0, 0x22c4 <corpus.cases.call.call_rec_edge.mk9+0x80>
                	addi	a0, s0, -0x22
                	mv	a2, a0
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1a90 <corpus.cases.call.call_rec_edge.mk9+0x130>
-               	bnez	a1, 0x1a64 <corpus.cases.call.call_rec_edge.mk9+0x104>
+               	bltu	a2, a3, 0x2374 <corpus.cases.call.call_rec_edge.mk9+0x130>
+               	bnez	a1, 0x2348 <corpus.cases.call.call_rec_edge.mk9+0x104>
                	addi	a4, a2, 0x8
                	addi	a5, a3, 0x8
                	lbu	a6, 0x0(a5)
@@ -1708,8 +2277,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1a44 <corpus.cases.call.call_rec_edge.mk9+0xe4>
-               	j	0x1af0 <corpus.cases.call.call_rec_edge.mk9+0x190>
+               	bne	a6, t0, 0x2328 <corpus.cases.call.call_rec_edge.mk9+0xe4>
+               	j	0x23d4 <corpus.cases.call.call_rec_edge.mk9+0x190>
                	addi	a4, a2, 0x9
                	addi	a5, a3, 0x9
                	li	a6, 0x9
@@ -1719,9 +2288,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1a70 <corpus.cases.call.call_rec_edge.mk9+0x110>
-               	j	0x1af0 <corpus.cases.call.call_rec_edge.mk9+0x190>
-               	bnez	a1, 0x1ac8 <corpus.cases.call.call_rec_edge.mk9+0x168>
+               	bne	a6, t0, 0x2354 <corpus.cases.call.call_rec_edge.mk9+0x110>
+               	j	0x23d4 <corpus.cases.call.call_rec_edge.mk9+0x190>
+               	bnez	a1, 0x23ac <corpus.cases.call.call_rec_edge.mk9+0x168>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x8
@@ -1731,10 +2300,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1aa0 <corpus.cases.call.call_rec_edge.mk9+0x140>
+               	bne	a5, t0, 0x2384 <corpus.cases.call.call_rec_edge.mk9+0x140>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a1)
-               	j	0x1af0 <corpus.cases.call.call_rec_edge.mk9+0x190>
+               	j	0x23d4 <corpus.cases.call.call_rec_edge.mk9+0x190>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x9
@@ -1744,7 +2313,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1ad4 <corpus.cases.call.call_rec_edge.mk9+0x174>
+               	bne	a3, t0, 0x23b8 <corpus.cases.call.call_rec_edge.mk9+0x174>
                	lbu	a1, 0x0(a0)
                	lbu	a2, 0x1(a0)
                	lbu	a3, 0x2(a0)
@@ -1916,31 +2485,31 @@ Disassembly of section .text:
                	mv	a3, a2
                	li	t0, 0x7
                	and	a4, a3, t0
-               	bnez	a4, 0x1d84 <corpus.cases.call.call_rec_edge.mk17+0x48>
+               	bnez	a4, 0x2668 <corpus.cases.call.call_rec_edge.mk17+0x48>
                	mv	a4, a3
                	li	a5, 0x10
                	sd	zero, 0x0(a4)
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1d68 <corpus.cases.call.call_rec_edge.mk17+0x2c>
+               	bne	a5, t0, 0x264c <corpus.cases.call.call_rec_edge.mk17+0x2c>
                	sb	zero, 0x0(a4)
-               	j	0x1da0 <corpus.cases.call.call_rec_edge.mk17+0x64>
+               	j	0x2684 <corpus.cases.call.call_rec_edge.mk17+0x64>
                	mv	a4, a3
                	li	a3, 0x11
                	sb	zero, 0x0(a4)
                	addi	a4, a4, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1d8c <corpus.cases.call.call_rec_edge.mk17+0x50>
+               	bne	a3, t0, 0x2670 <corpus.cases.call.call_rec_edge.mk17+0x50>
                	srli	a3, a1, 0x7
                	sext.w	a4, a3
                	mv	a3, a2
                	sb	a4, 0x0(a3)
                	li	a3, 0x0
                	li	t0, 0x10
-               	bltu	a3, t0, 0x1dc0 <corpus.cases.call.call_rec_edge.mk17+0x84>
-               	j	0x1df0 <corpus.cases.call.call_rec_edge.mk17+0xb4>
+               	bltu	a3, t0, 0x26a4 <corpus.cases.call.call_rec_edge.mk17+0x84>
+               	j	0x26d4 <corpus.cases.call.call_rec_edge.mk17+0xb4>
                	li	t0, 0x4
                	mul	a4, a3, t0
                	srl	a5, a1, a4
@@ -1952,15 +2521,15 @@ Disassembly of section .text:
                	sb	a6, 0x0(a5)
                	addi	a3, a3, 0x1
                	li	t0, 0x10
-               	bltu	a3, t0, 0x1dc0 <corpus.cases.call.call_rec_edge.mk17+0x84>
+               	bltu	a3, t0, 0x26a4 <corpus.cases.call.call_rec_edge.mk17+0x84>
                	addi	a1, s0, -0x32
                	mv	a3, a1
                	mv	a4, a2
                	or	a2, a3, a4
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a3, a4, 0x1e70 <corpus.cases.call.call_rec_edge.mk17+0x134>
-               	bnez	a2, 0x1e44 <corpus.cases.call.call_rec_edge.mk17+0x108>
+               	bltu	a3, a4, 0x2754 <corpus.cases.call.call_rec_edge.mk17+0x134>
+               	bnez	a2, 0x2728 <corpus.cases.call.call_rec_edge.mk17+0x108>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lbu	a7, 0x0(a6)
@@ -1972,8 +2541,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1e24 <corpus.cases.call.call_rec_edge.mk17+0xe8>
-               	j	0x1ed0 <corpus.cases.call.call_rec_edge.mk17+0x194>
+               	bne	a7, t0, 0x2708 <corpus.cases.call.call_rec_edge.mk17+0xe8>
+               	j	0x27b4 <corpus.cases.call.call_rec_edge.mk17+0x194>
                	addi	a5, a3, 0x11
                	addi	a6, a4, 0x11
                	li	a7, 0x11
@@ -1983,9 +2552,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1e50 <corpus.cases.call.call_rec_edge.mk17+0x114>
-               	j	0x1ed0 <corpus.cases.call.call_rec_edge.mk17+0x194>
-               	bnez	a2, 0x1ea8 <corpus.cases.call.call_rec_edge.mk17+0x16c>
+               	bne	a7, t0, 0x2734 <corpus.cases.call.call_rec_edge.mk17+0x114>
+               	j	0x27b4 <corpus.cases.call.call_rec_edge.mk17+0x194>
+               	bnez	a2, 0x278c <corpus.cases.call.call_rec_edge.mk17+0x16c>
                	mv	a2, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -1995,10 +2564,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1e80 <corpus.cases.call.call_rec_edge.mk17+0x144>
+               	bne	a6, t0, 0x2764 <corpus.cases.call.call_rec_edge.mk17+0x144>
                	lbu	a6, 0x0(a5)
                	sb	a6, 0x0(a2)
-               	j	0x1ed0 <corpus.cases.call.call_rec_edge.mk17+0x194>
+               	j	0x27b4 <corpus.cases.call.call_rec_edge.mk17+0x194>
                	mv	a2, a3
                	mv	a3, a4
                	li	a4, 0x11
@@ -2008,14 +2577,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x1eb4 <corpus.cases.call.call_rec_edge.mk17+0x178>
+               	bne	a4, t0, 0x2798 <corpus.cases.call.call_rec_edge.mk17+0x178>
                	mv	a2, a0
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1f4c <corpus.cases.call.call_rec_edge.mk17+0x210>
-               	bnez	a1, 0x1f20 <corpus.cases.call.call_rec_edge.mk17+0x1e4>
+               	bltu	a2, a3, 0x2830 <corpus.cases.call.call_rec_edge.mk17+0x210>
+               	bnez	a1, 0x2804 <corpus.cases.call.call_rec_edge.mk17+0x1e4>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	lbu	a6, 0x0(a5)
@@ -2027,8 +2596,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1f00 <corpus.cases.call.call_rec_edge.mk17+0x1c4>
-               	j	0x1fac <corpus.cases.call.call_rec_edge.mk17+0x270>
+               	bne	a6, t0, 0x27e4 <corpus.cases.call.call_rec_edge.mk17+0x1c4>
+               	j	0x2890 <corpus.cases.call.call_rec_edge.mk17+0x270>
                	addi	a4, a2, 0x11
                	addi	a5, a3, 0x11
                	li	a6, 0x11
@@ -2038,9 +2607,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1f2c <corpus.cases.call.call_rec_edge.mk17+0x1f0>
-               	j	0x1fac <corpus.cases.call.call_rec_edge.mk17+0x270>
-               	bnez	a1, 0x1f84 <corpus.cases.call.call_rec_edge.mk17+0x248>
+               	bne	a6, t0, 0x2810 <corpus.cases.call.call_rec_edge.mk17+0x1f0>
+               	j	0x2890 <corpus.cases.call.call_rec_edge.mk17+0x270>
+               	bnez	a1, 0x2868 <corpus.cases.call.call_rec_edge.mk17+0x248>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -2050,10 +2619,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1f5c <corpus.cases.call.call_rec_edge.mk17+0x220>
+               	bne	a5, t0, 0x2840 <corpus.cases.call.call_rec_edge.mk17+0x220>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a1)
-               	j	0x1fac <corpus.cases.call.call_rec_edge.mk17+0x270>
+               	j	0x2890 <corpus.cases.call.call_rec_edge.mk17+0x270>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x11
@@ -2063,7 +2632,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1f90 <corpus.cases.call.call_rec_edge.mk17+0x254>
+               	bne	a3, t0, 0x2874 <corpus.cases.call.call_rec_edge.mk17+0x254>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -2086,86 +2655,137 @@ Disassembly of section .text:
                	sd	s10, 0x350(sp)
                	sd	s11, 0x348(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x40>
-               	li	a1, 0x9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x4c>
-               	li	a1, 0xc
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x58>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2910 <corpus.cases.call.call_rec_edge.checksum+0x70>
+               	j	0x2948 <corpus.cases.call.call_rec_edge.checksum+0xa8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x9
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2910 <corpus.cases.call.call_rec_edge.checksum+0x70>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2958 <corpus.cases.call.call_rec_edge.checksum+0xb8>
+               	j	0x2990 <corpus.cases.call.call_rec_edge.checksum+0xf0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0xc
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2958 <corpus.cases.call.call_rec_edge.checksum+0xb8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29a0 <corpus.cases.call.call_rec_edge.checksum+0x100>
+               	j	0x29d8 <corpus.cases.call.call_rec_edge.checksum+0x138>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x10
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29a0 <corpus.cases.call.call_rec_edge.checksum+0x100>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x64>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x13c>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x70>
-               	li	a1, 0x10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x7c>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x148>
                	li	a1, 0x11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x88>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x154>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x94>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x160>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xa0>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x16c>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xac>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x178>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xb8>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x184>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xc4>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x190>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xd0>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x19c>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xdc>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1a8>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xe8>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1b4>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0xf4>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1c0>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x100>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1cc>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x10c>
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1d8>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x118>
-               	addi	s2, s0, -0xc8
+               	jalr	ra <corpus.cases.call.call_rec_edge.checksum+0x1e4>
+               	addi	s2, s0, -0xf0
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x2110 <corpus.cases.call.call_rec_edge.checksum+0x154>
+               	bnez	a2, 0x2ac0 <corpus.cases.call.call_rec_edge.checksum+0x220>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x20f8 <corpus.cases.call.call_rec_edge.checksum+0x13c>
-               	j	0x212c <corpus.cases.call.call_rec_edge.checksum+0x170>
+               	bne	a3, t0, 0x2aa8 <corpus.cases.call.call_rec_edge.checksum+0x208>
+               	j	0x2adc <corpus.cases.call.call_rec_edge.checksum+0x23c>
                	mv	a2, a1
                	li	a1, 0x60
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2118 <corpus.cases.call.call_rec_edge.checksum+0x15c>
+               	bne	a1, t0, 0x2ac8 <corpus.cases.call.call_rec_edge.checksum+0x228>
                	li	a1, 0x0
                	li	t0, 0xc
-               	bltu	a1, t0, 0x213c <corpus.cases.call.call_rec_edge.checksum+0x180>
-               	j	0x21a0 <corpus.cases.call.call_rec_edge.checksum+0x1e4>
+               	bltu	a1, t0, 0x2aec <corpus.cases.call.call_rec_edge.checksum+0x24c>
+               	j	0x2b50 <corpus.cases.call.call_rec_edge.checksum+0x2b0>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -2190,13 +2810,13 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0xc
-               	bltu	a1, t0, 0x213c <corpus.cases.call.call_rec_edge.checksum+0x180>
+               	bltu	a1, t0, 0x2aec <corpus.cases.call.call_rec_edge.checksum+0x24c>
                	mv	s3, a0
                	li	s4, 0x0
                	li	s5, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x21b8 <corpus.cases.call.call_rec_edge.checksum+0x1fc>
-               	j	0x3018 <.Lpcrel_hi.5+0xbb0>
+               	bltu	s5, t0, 0x2b68 <corpus.cases.call.call_rec_edge.checksum+0x2c8>
+               	j	0x39c8 <.Lpcrel_hi.5+0xbb0>
                	li	t0, 0x11
                	mul	a0, s5, t0
                	add	a1, a0, s1
@@ -2206,34 +2826,34 @@ Disassembly of section .text:
                	sd	t2, -0x300(s0)
                	addi	a2, s2, 0x8
                	ld	a3, 0x0(a2)
-               	addi	a2, s0, -0xd1
+               	addi	a2, s0, -0x71
                	mv	a4, a2
                	li	t0, 0x7
                	and	a5, a4, t0
-               	bnez	a5, 0x2214 <corpus.cases.call.call_rec_edge.checksum+0x258>
+               	bnez	a5, 0x2bc4 <corpus.cases.call.call_rec_edge.checksum+0x324>
                	mv	a5, a4
                	li	a6, 0x8
                	sd	zero, 0x0(a5)
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x21f8 <corpus.cases.call.call_rec_edge.checksum+0x23c>
+               	bne	a6, t0, 0x2ba8 <corpus.cases.call.call_rec_edge.checksum+0x308>
                	sb	zero, 0x0(a5)
-               	j	0x2230 <corpus.cases.call.call_rec_edge.checksum+0x274>
+               	j	0x2be0 <corpus.cases.call.call_rec_edge.checksum+0x340>
                	mv	a5, a4
                	li	a4, 0x9
                	sb	zero, 0x0(a5)
                	addi	a5, a5, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x221c <corpus.cases.call.call_rec_edge.checksum+0x260>
+               	bne	a4, t0, 0x2bcc <corpus.cases.call.call_rec_edge.checksum+0x32c>
                	sext.w	a4, a3
                	mv	a5, a2
                	sb	a4, 0x0(a5)
                	li	a4, 0x0
                	li	t0, 0x8
-               	bltu	a4, t0, 0x224c <corpus.cases.call.call_rec_edge.checksum+0x290>
-               	j	0x227c <corpus.cases.call.call_rec_edge.checksum+0x2c0>
+               	bltu	a4, t0, 0x2bfc <corpus.cases.call.call_rec_edge.checksum+0x35c>
+               	j	0x2c2c <corpus.cases.call.call_rec_edge.checksum+0x38c>
                	li	t0, 0x8
                	mul	a5, a4, t0
                	srl	a6, a3, a5
@@ -2245,15 +2865,15 @@ Disassembly of section .text:
                	sb	a7, 0x0(a6)
                	addi	a4, a4, 0x1
                	li	t0, 0x8
-               	bltu	a4, t0, 0x224c <corpus.cases.call.call_rec_edge.checksum+0x290>
-               	addi	a3, s0, -0xda
+               	bltu	a4, t0, 0x2bfc <corpus.cases.call.call_rec_edge.checksum+0x35c>
+               	addi	a3, s0, -0x7a
                	mv	a4, a3
                	mv	a5, a2
                	or	a2, a4, a5
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a4, a5, 0x22fc <corpus.cases.call.call_rec_edge.checksum+0x340>
-               	bnez	a2, 0x22d0 <corpus.cases.call.call_rec_edge.checksum+0x314>
+               	bltu	a4, a5, 0x2cac <corpus.cases.call.call_rec_edge.checksum+0x40c>
+               	bnez	a2, 0x2c80 <corpus.cases.call.call_rec_edge.checksum+0x3e0>
                	addi	a6, a4, 0x8
                	addi	a7, a5, 0x8
                	lbu	t5, 0x0(a7)
@@ -2265,8 +2885,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a6)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x22b0 <corpus.cases.call.call_rec_edge.checksum+0x2f4>
-               	j	0x235c <corpus.cases.call.call_rec_edge.checksum+0x3a0>
+               	bne	t5, t0, 0x2c60 <corpus.cases.call.call_rec_edge.checksum+0x3c0>
+               	j	0x2d0c <corpus.cases.call.call_rec_edge.checksum+0x46c>
                	addi	a6, a4, 0x9
                	addi	a7, a5, 0x9
                	li	t5, 0x9
@@ -2276,9 +2896,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a6)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x22dc <corpus.cases.call.call_rec_edge.checksum+0x320>
-               	j	0x235c <corpus.cases.call.call_rec_edge.checksum+0x3a0>
-               	bnez	a2, 0x2334 <corpus.cases.call.call_rec_edge.checksum+0x378>
+               	bne	t5, t0, 0x2c8c <corpus.cases.call.call_rec_edge.checksum+0x3ec>
+               	j	0x2d0c <corpus.cases.call.call_rec_edge.checksum+0x46c>
+               	bnez	a2, 0x2ce4 <corpus.cases.call.call_rec_edge.checksum+0x444>
                	mv	a2, a4
                	mv	a6, a5
                	li	a7, 0x8
@@ -2288,10 +2908,10 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x230c <corpus.cases.call.call_rec_edge.checksum+0x350>
+               	bne	a7, t0, 0x2cbc <corpus.cases.call.call_rec_edge.checksum+0x41c>
                	lbu	a7, 0x0(a6)
                	sb	a7, 0x0(a2)
-               	j	0x235c <corpus.cases.call.call_rec_edge.checksum+0x3a0>
+               	j	0x2d0c <corpus.cases.call.call_rec_edge.checksum+0x46c>
                	mv	a2, a4
                	mv	a4, a5
                	li	a5, 0x9
@@ -2301,14 +2921,14 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2340 <corpus.cases.call.call_rec_edge.checksum+0x384>
+               	bne	a5, t0, 0x2cf0 <corpus.cases.call.call_rec_edge.checksum+0x450>
                	addi	a2, s2, 0x10
                	ld	a4, 0x0(a2)
                	sext.w	t2, a4
                	sd	t2, -0x308(s0)
                	addi	a2, s2, 0x18
                	ld	a4, 0x0(a2)
-               	addi	a2, s0, -0xf8
+               	addi	a2, s0, -0xfc
                	sext.w	a6, a4
                	mv	a7, a2
                	sw	a6, 0x0(a7)
@@ -2389,31 +3009,31 @@ Disassembly of section .text:
                	mv	s6, a7
                	li	t0, 0x7
                	and	s7, s6, t0
-               	bnez	s7, 0x24c8 <.Lpcrel_hi.5+0x60>
+               	bnez	s7, 0x2e78 <.Lpcrel_hi.5+0x60>
                	mv	s7, s6
                	li	s8, 0x10
                	sd	zero, 0x0(s7)
                	addi	s7, s7, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x24ac <.Lpcrel_hi.5+0x44>
+               	bne	s8, t0, 0x2e5c <.Lpcrel_hi.5+0x44>
                	sb	zero, 0x0(s7)
-               	j	0x24e4 <.Lpcrel_hi.5+0x7c>
+               	j	0x2e94 <.Lpcrel_hi.5+0x7c>
                	mv	s7, s6
                	li	s6, 0x11
                	sb	zero, 0x0(s7)
                	addi	s7, s7, 0x1
                	addi	s6, s6, -0x1
                	li	t0, 0x0
-               	bne	s6, t0, 0x24d0 <.Lpcrel_hi.5+0x68>
+               	bne	s6, t0, 0x2e80 <.Lpcrel_hi.5+0x68>
                	srli	s6, t6, 0x7
                	sext.w	s7, s6
                	mv	s6, a7
                	sb	s7, 0x0(s6)
                	li	s6, 0x0
                	li	t0, 0x10
-               	bltu	s6, t0, 0x2504 <.Lpcrel_hi.5+0x9c>
-               	j	0x2534 <.Lpcrel_hi.5+0xcc>
+               	bltu	s6, t0, 0x2eb4 <.Lpcrel_hi.5+0x9c>
+               	j	0x2ee4 <.Lpcrel_hi.5+0xcc>
                	li	t0, 0x4
                	mul	s7, s6, t0
                	srl	s8, t6, s7
@@ -2425,7 +3045,7 @@ Disassembly of section .text:
                	sb	s9, 0x0(s8)
                	addi	s6, s6, 0x1
                	li	t0, 0x10
-               	bltu	s6, t0, 0x2504 <.Lpcrel_hi.5+0x9c>
+               	bltu	s6, t0, 0x2eb4 <.Lpcrel_hi.5+0x9c>
                	addi	t2, s0, -0x18a
                	sd	t2, -0x318(s0)
                	ld	t2, -0x318(s0)
@@ -2434,8 +3054,8 @@ Disassembly of section .text:
                	or	a7, s6, s7
                	li	t0, 0x7
                	and	a7, a7, t0
-               	bltu	s6, s7, 0x25bc <.Lpcrel_hi.5+0x154>
-               	bnez	a7, 0x2590 <.Lpcrel_hi.5+0x128>
+               	bltu	s6, s7, 0x2f6c <.Lpcrel_hi.5+0x154>
+               	bnez	a7, 0x2f40 <.Lpcrel_hi.5+0x128>
                	addi	s8, s6, 0x10
                	addi	s9, s7, 0x10
                	lbu	s10, 0x0(s9)
@@ -2447,8 +3067,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(s8)
                	addi	s10, s10, -0x8
                	li	t0, 0x0
-               	bne	s10, t0, 0x2570 <.Lpcrel_hi.5+0x108>
-               	j	0x261c <.Lpcrel_hi.5+0x1b4>
+               	bne	s10, t0, 0x2f20 <.Lpcrel_hi.5+0x108>
+               	j	0x2fcc <.Lpcrel_hi.5+0x1b4>
                	addi	s8, s6, 0x11
                	addi	s9, s7, 0x11
                	li	s10, 0x11
@@ -2458,9 +3078,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(s8)
                	addi	s10, s10, -0x1
                	li	t0, 0x0
-               	bne	s10, t0, 0x259c <.Lpcrel_hi.5+0x134>
-               	j	0x261c <.Lpcrel_hi.5+0x1b4>
-               	bnez	a7, 0x25f4 <.Lpcrel_hi.5+0x18c>
+               	bne	s10, t0, 0x2f4c <.Lpcrel_hi.5+0x134>
+               	j	0x2fcc <.Lpcrel_hi.5+0x1b4>
+               	bnez	a7, 0x2fa4 <.Lpcrel_hi.5+0x18c>
                	mv	a7, s6
                	mv	s8, s7
                	li	s9, 0x10
@@ -2470,10 +3090,10 @@ Disassembly of section .text:
                	addi	s8, s8, 0x8
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x25cc <.Lpcrel_hi.5+0x164>
+               	bne	s9, t0, 0x2f7c <.Lpcrel_hi.5+0x164>
                	lbu	s9, 0x0(s8)
                	sb	s9, 0x0(a7)
-               	j	0x261c <.Lpcrel_hi.5+0x1b4>
+               	j	0x2fcc <.Lpcrel_hi.5+0x1b4>
                	mv	a7, s6
                	mv	s6, s7
                	li	s7, 0x11
@@ -2483,37 +3103,37 @@ Disassembly of section .text:
                	addi	s6, s6, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x2600 <.Lpcrel_hi.5+0x198>
+               	bne	s7, t0, 0x2fb0 <.Lpcrel_hi.5+0x198>
                	addi	a7, s2, 0x50
                	ld	s6, 0x0(a7)
                	addi	a7, s0, -0x1b5
                	mv	s7, a7
                	li	t0, 0x7
                	and	s8, s7, t0
-               	bnez	s8, 0x265c <.Lpcrel_hi.5+0x1f4>
+               	bnez	s8, 0x300c <.Lpcrel_hi.5+0x1f4>
                	mv	s8, s7
                	li	s9, 0x8
                	sd	zero, 0x0(s8)
                	addi	s8, s8, 0x8
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2640 <.Lpcrel_hi.5+0x1d8>
+               	bne	s9, t0, 0x2ff0 <.Lpcrel_hi.5+0x1d8>
                	sb	zero, 0x0(s8)
-               	j	0x2678 <.Lpcrel_hi.5+0x210>
+               	j	0x3028 <.Lpcrel_hi.5+0x210>
                	mv	s8, s7
                	li	s7, 0x9
                	sb	zero, 0x0(s8)
                	addi	s8, s8, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x2664 <.Lpcrel_hi.5+0x1fc>
+               	bne	s7, t0, 0x3014 <.Lpcrel_hi.5+0x1fc>
                	sext.w	s7, s6
                	mv	s8, a7
                	sb	s7, 0x0(s8)
                	li	s7, 0x0
                	li	t0, 0x8
-               	bltu	s7, t0, 0x2694 <.Lpcrel_hi.5+0x22c>
-               	j	0x26c4 <.Lpcrel_hi.5+0x25c>
+               	bltu	s7, t0, 0x3044 <.Lpcrel_hi.5+0x22c>
+               	j	0x3074 <.Lpcrel_hi.5+0x25c>
                	li	t0, 0x8
                	mul	s8, s7, t0
                	srl	s9, s6, s8
@@ -2525,15 +3145,15 @@ Disassembly of section .text:
                	sb	s10, 0x0(s9)
                	addi	s7, s7, 0x1
                	li	t0, 0x8
-               	bltu	s7, t0, 0x2694 <.Lpcrel_hi.5+0x22c>
+               	bltu	s7, t0, 0x3044 <.Lpcrel_hi.5+0x22c>
                	addi	s6, s0, -0x1be
                	mv	s7, s6
                	mv	s8, a7
                	or	a7, s7, s8
                	li	t0, 0x7
                	and	a7, a7, t0
-               	bltu	s7, s8, 0x2744 <.Lpcrel_hi.5+0x2dc>
-               	bnez	a7, 0x2718 <.Lpcrel_hi.5+0x2b0>
+               	bltu	s7, s8, 0x30f4 <.Lpcrel_hi.5+0x2dc>
+               	bnez	a7, 0x30c8 <.Lpcrel_hi.5+0x2b0>
                	addi	s9, s7, 0x8
                	addi	s10, s8, 0x8
                	lbu	s11, 0x0(s10)
@@ -2545,8 +3165,8 @@ Disassembly of section .text:
                	sd	a0, 0x0(s9)
                	addi	s11, s11, -0x8
                	li	t0, 0x0
-               	bne	s11, t0, 0x26f8 <.Lpcrel_hi.5+0x290>
-               	j	0x27a4 <.Lpcrel_hi.5+0x33c>
+               	bne	s11, t0, 0x30a8 <.Lpcrel_hi.5+0x290>
+               	j	0x3154 <.Lpcrel_hi.5+0x33c>
                	addi	a0, s7, 0x9
                	addi	s9, s8, 0x9
                	li	s10, 0x9
@@ -2556,9 +3176,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(a0)
                	addi	s10, s10, -0x1
                	li	t0, 0x0
-               	bne	s10, t0, 0x2724 <.Lpcrel_hi.5+0x2bc>
-               	j	0x27a4 <.Lpcrel_hi.5+0x33c>
-               	bnez	a7, 0x277c <.Lpcrel_hi.5+0x314>
+               	bne	s10, t0, 0x30d4 <.Lpcrel_hi.5+0x2bc>
+               	j	0x3154 <.Lpcrel_hi.5+0x33c>
+               	bnez	a7, 0x312c <.Lpcrel_hi.5+0x314>
                	mv	a0, s7
                	mv	a7, s8
                	li	s9, 0x8
@@ -2568,10 +3188,10 @@ Disassembly of section .text:
                	addi	a7, a7, 0x8
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2754 <.Lpcrel_hi.5+0x2ec>
+               	bne	s9, t0, 0x3104 <.Lpcrel_hi.5+0x2ec>
                	lbu	s9, 0x0(a7)
                	sb	s9, 0x0(a0)
-               	j	0x27a4 <.Lpcrel_hi.5+0x33c>
+               	j	0x3154 <.Lpcrel_hi.5+0x33c>
                	mv	a0, s7
                	mv	a7, s8
                	li	s7, 0x9
@@ -2581,7 +3201,7 @@ Disassembly of section .text:
                	addi	a7, a7, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x2788 <.Lpcrel_hi.5+0x320>
+               	bne	s7, t0, 0x3138 <.Lpcrel_hi.5+0x320>
                	addi	a0, s2, 0x58
                	ld	a7, 0x0(a0)
                	addi	a0, s0, -0x1dc
@@ -2612,31 +3232,31 @@ Disassembly of section .text:
                	mv	s9, s7
                	li	t0, 0x7
                	and	s10, s9, t0
-               	bnez	s10, 0x2844 <.Lpcrel_hi.5+0x3dc>
+               	bnez	s10, 0x31f4 <.Lpcrel_hi.5+0x3dc>
                	mv	s10, s9
                	li	s11, 0x10
                	sd	zero, 0x0(s10)
                	addi	s10, s10, 0x8
                	addi	s11, s11, -0x8
                	li	t0, 0x0
-               	bne	s11, t0, 0x2828 <.Lpcrel_hi.5+0x3c0>
+               	bne	s11, t0, 0x31d8 <.Lpcrel_hi.5+0x3c0>
                	sb	zero, 0x0(s10)
-               	j	0x2860 <.Lpcrel_hi.5+0x3f8>
+               	j	0x3210 <.Lpcrel_hi.5+0x3f8>
                	mv	s10, s9
                	li	s9, 0x11
                	sb	zero, 0x0(s10)
                	addi	s10, s10, 0x1
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x284c <.Lpcrel_hi.5+0x3e4>
+               	bne	s9, t0, 0x31fc <.Lpcrel_hi.5+0x3e4>
                	srli	s9, s8, 0x7
                	sext.w	s10, s9
                	mv	s9, s7
                	sb	s10, 0x0(s9)
                	li	s9, 0x0
                	li	t0, 0x10
-               	bltu	s9, t0, 0x2880 <.Lpcrel_hi.5+0x418>
-               	j	0x28b0 <.Lpcrel_hi.5+0x448>
+               	bltu	s9, t0, 0x3230 <.Lpcrel_hi.5+0x418>
+               	j	0x3260 <.Lpcrel_hi.5+0x448>
                	li	t0, 0x4
                	mul	s10, s9, t0
                	srl	s11, s8, s10
@@ -2648,7 +3268,7 @@ Disassembly of section .text:
                	sb	a5, 0x0(s11)
                	addi	s9, s9, 0x1
                	li	t0, 0x10
-               	bltu	s9, t0, 0x2880 <.Lpcrel_hi.5+0x418>
+               	bltu	s9, t0, 0x3230 <.Lpcrel_hi.5+0x418>
                	addi	t2, s0, -0x22a
                	sd	t2, -0x328(s0)
                	ld	t2, -0x328(s0)
@@ -2657,8 +3277,8 @@ Disassembly of section .text:
                	or	s7, s8, s9
                	li	t0, 0x7
                	and	s7, s7, t0
-               	bltu	s8, s9, 0x2938 <.Lpcrel_hi.5+0x4d0>
-               	bnez	s7, 0x290c <.Lpcrel_hi.5+0x4a4>
+               	bltu	s8, s9, 0x32e8 <.Lpcrel_hi.5+0x4d0>
+               	bnez	s7, 0x32bc <.Lpcrel_hi.5+0x4a4>
                	addi	s10, s8, 0x10
                	addi	s11, s9, 0x10
                	lbu	t5, 0x0(s11)
@@ -2670,8 +3290,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(s10)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x28ec <.Lpcrel_hi.5+0x484>
-               	j	0x2998 <.Lpcrel_hi.5+0x530>
+               	bne	t5, t0, 0x329c <.Lpcrel_hi.5+0x484>
+               	j	0x3348 <.Lpcrel_hi.5+0x530>
                	addi	t5, s8, 0x11
                	addi	t6, s9, 0x11
                	li	s10, 0x11
@@ -2681,9 +3301,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(t5)
                	addi	s10, s10, -0x1
                	li	t0, 0x0
-               	bne	s10, t0, 0x2918 <.Lpcrel_hi.5+0x4b0>
-               	j	0x2998 <.Lpcrel_hi.5+0x530>
-               	bnez	s7, 0x2970 <.Lpcrel_hi.5+0x508>
+               	bne	s10, t0, 0x32c8 <.Lpcrel_hi.5+0x4b0>
+               	j	0x3348 <.Lpcrel_hi.5+0x530>
+               	bnez	s7, 0x3320 <.Lpcrel_hi.5+0x508>
                	mv	t5, s8
                	mv	t6, s9
                	li	s7, 0x10
@@ -2693,10 +3313,10 @@ Disassembly of section .text:
                	addi	t6, t6, 0x8
                	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x2948 <.Lpcrel_hi.5+0x4e0>
+               	bne	s7, t0, 0x32f8 <.Lpcrel_hi.5+0x4e0>
                	lbu	s7, 0x0(t6)
                	sb	s7, 0x0(t5)
-               	j	0x2998 <.Lpcrel_hi.5+0x530>
+               	j	0x3348 <.Lpcrel_hi.5+0x530>
                	mv	t5, s8
                	mv	t6, s9
                	li	s7, 0x11
@@ -2706,7 +3326,7 @@ Disassembly of section .text:
                	addi	t6, t6, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x297c <.Lpcrel_hi.5+0x514>
+               	bne	s7, t0, 0x332c <.Lpcrel_hi.5+0x514>
                	addi	t5, s2, 0x10
                	ld	t6, 0x0(t5)
                	li	t0, 0xff
@@ -2773,8 +3393,8 @@ Disassembly of section .text:
                	or	a4, a1, a2
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a1, a2, 0x2b00 <.Lpcrel_hi.5+0x698>
-               	bnez	a4, 0x2ad4 <.Lpcrel_hi.5+0x66c>
+               	bltu	a1, a2, 0x34b0 <.Lpcrel_hi.5+0x698>
+               	bnez	a4, 0x3484 <.Lpcrel_hi.5+0x66c>
                	addi	a6, a1, 0x10
                	addi	s8, a2, 0x10
                	li	s9, 0x10
@@ -2784,8 +3404,8 @@ Disassembly of section .text:
                	sd	s10, 0x0(a6)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2ab4 <.Lpcrel_hi.5+0x64c>
-               	j	0x2b58 <.Lpcrel_hi.5+0x6f0>
+               	bne	s9, t0, 0x3464 <.Lpcrel_hi.5+0x64c>
+               	j	0x3508 <.Lpcrel_hi.5+0x6f0>
                	addi	a6, a1, 0x10
                	addi	s8, a2, 0x10
                	li	s9, 0x10
@@ -2795,9 +3415,9 @@ Disassembly of section .text:
                	sb	s10, 0x0(a6)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x2ae0 <.Lpcrel_hi.5+0x678>
-               	j	0x2b58 <.Lpcrel_hi.5+0x6f0>
-               	bnez	a4, 0x2b30 <.Lpcrel_hi.5+0x6c8>
+               	bne	s9, t0, 0x3490 <.Lpcrel_hi.5+0x678>
+               	j	0x3508 <.Lpcrel_hi.5+0x6f0>
+               	bnez	a4, 0x34e0 <.Lpcrel_hi.5+0x6c8>
                	mv	a4, a1
                	mv	a6, a2
                	li	s8, 0x10
@@ -2807,8 +3427,8 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x2b10 <.Lpcrel_hi.5+0x6a8>
-               	j	0x2b58 <.Lpcrel_hi.5+0x6f0>
+               	bne	s8, t0, 0x34c0 <.Lpcrel_hi.5+0x6a8>
+               	j	0x3508 <.Lpcrel_hi.5+0x6f0>
                	mv	a4, a1
                	mv	a1, a2
                	li	a2, 0x10
@@ -2818,7 +3438,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2b3c <.Lpcrel_hi.5+0x6d4>
+               	bne	a2, t0, 0x34ec <.Lpcrel_hi.5+0x6d4>
                	ld	t2, -0x310(s0)
                	sd	t2, 0x10(sp)
                	addi	a1, s0, -0x268
@@ -2827,8 +3447,8 @@ Disassembly of section .text:
                	or	a4, a1, a2
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a1, a2, 0x2be0 <.Lpcrel_hi.5+0x778>
-               	bnez	a4, 0x2bb4 <.Lpcrel_hi.5+0x74c>
+               	bltu	a1, a2, 0x3590 <.Lpcrel_hi.5+0x778>
+               	bnez	a4, 0x3564 <.Lpcrel_hi.5+0x74c>
                	addi	a6, a1, 0x10
                	addi	s8, a2, 0x10
                	lbu	s9, 0x0(s8)
@@ -2840,8 +3460,8 @@ Disassembly of section .text:
                	sd	s10, 0x0(a6)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2b94 <.Lpcrel_hi.5+0x72c>
-               	j	0x2c40 <.Lpcrel_hi.5+0x7d8>
+               	bne	s9, t0, 0x3544 <.Lpcrel_hi.5+0x72c>
+               	j	0x35f0 <.Lpcrel_hi.5+0x7d8>
                	addi	a6, a1, 0x11
                	addi	s8, a2, 0x11
                	li	s9, 0x11
@@ -2851,9 +3471,9 @@ Disassembly of section .text:
                	sb	s10, 0x0(a6)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x2bc0 <.Lpcrel_hi.5+0x758>
-               	j	0x2c40 <.Lpcrel_hi.5+0x7d8>
-               	bnez	a4, 0x2c18 <.Lpcrel_hi.5+0x7b0>
+               	bne	s9, t0, 0x3570 <.Lpcrel_hi.5+0x758>
+               	j	0x35f0 <.Lpcrel_hi.5+0x7d8>
+               	bnez	a4, 0x35c8 <.Lpcrel_hi.5+0x7b0>
                	mv	a4, a1
                	mv	a6, a2
                	li	s8, 0x10
@@ -2863,10 +3483,10 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x2bf0 <.Lpcrel_hi.5+0x788>
+               	bne	s8, t0, 0x35a0 <.Lpcrel_hi.5+0x788>
                	lbu	s8, 0x0(a6)
                	sb	s8, 0x0(a4)
-               	j	0x2c40 <.Lpcrel_hi.5+0x7d8>
+               	j	0x35f0 <.Lpcrel_hi.5+0x7d8>
                	mv	a4, a1
                	mv	a1, a2
                	li	a2, 0x11
@@ -2876,7 +3496,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2c24 <.Lpcrel_hi.5+0x7bc>
+               	bne	a2, t0, 0x35d4 <.Lpcrel_hi.5+0x7bc>
                	addi	a1, s0, -0x268
                	sd	a1, 0x18(sp)
                	addi	a1, sp, 0x20
@@ -2884,8 +3504,8 @@ Disassembly of section .text:
                	or	a4, a1, a2
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a1, a2, 0x2cc4 <.Lpcrel_hi.5+0x85c>
-               	bnez	a4, 0x2c98 <.Lpcrel_hi.5+0x830>
+               	bltu	a1, a2, 0x3674 <.Lpcrel_hi.5+0x85c>
+               	bnez	a4, 0x3648 <.Lpcrel_hi.5+0x830>
                	addi	a6, a1, 0x8
                	addi	s6, a2, 0x8
                	lbu	s8, 0x0(s6)
@@ -2897,8 +3517,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(a6)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x2c78 <.Lpcrel_hi.5+0x810>
-               	j	0x2d24 <.Lpcrel_hi.5+0x8bc>
+               	bne	s8, t0, 0x3628 <.Lpcrel_hi.5+0x810>
+               	j	0x36d4 <.Lpcrel_hi.5+0x8bc>
                	addi	a6, a1, 0x9
                	addi	s6, a2, 0x9
                	li	s8, 0x9
@@ -2908,9 +3528,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(a6)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x2ca4 <.Lpcrel_hi.5+0x83c>
-               	j	0x2d24 <.Lpcrel_hi.5+0x8bc>
-               	bnez	a4, 0x2cfc <.Lpcrel_hi.5+0x894>
+               	bne	s8, t0, 0x3654 <.Lpcrel_hi.5+0x83c>
+               	j	0x36d4 <.Lpcrel_hi.5+0x8bc>
+               	bnez	a4, 0x36ac <.Lpcrel_hi.5+0x894>
                	mv	a4, a1
                	mv	a6, a2
                	li	s6, 0x8
@@ -2920,10 +3540,10 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x2cd4 <.Lpcrel_hi.5+0x86c>
+               	bne	s6, t0, 0x3684 <.Lpcrel_hi.5+0x86c>
                	lbu	s6, 0x0(a6)
                	sb	s6, 0x0(a4)
-               	j	0x2d24 <.Lpcrel_hi.5+0x8bc>
+               	j	0x36d4 <.Lpcrel_hi.5+0x8bc>
                	mv	a4, a1
                	mv	a1, a2
                	li	a2, 0x9
@@ -2933,14 +3553,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2d08 <.Lpcrel_hi.5+0x8a0>
+               	bne	a2, t0, 0x36b8 <.Lpcrel_hi.5+0x8a0>
                	addi	a1, sp, 0x30
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x2da0 <.Lpcrel_hi.5+0x938>
-               	bnez	a0, 0x2d74 <.Lpcrel_hi.5+0x90c>
+               	bltu	a1, a2, 0x3750 <.Lpcrel_hi.5+0x938>
+               	bnez	a0, 0x3724 <.Lpcrel_hi.5+0x90c>
                	addi	a4, a1, 0x8
                	addi	a6, a2, 0x8
                	lw	s6, 0x0(a6)
@@ -2952,8 +3572,8 @@ Disassembly of section .text:
                	sd	s8, 0x0(a4)
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x2d54 <.Lpcrel_hi.5+0x8ec>
-               	j	0x2e00 <.Lpcrel_hi.5+0x998>
+               	bne	s6, t0, 0x3704 <.Lpcrel_hi.5+0x8ec>
+               	j	0x37b0 <.Lpcrel_hi.5+0x998>
                	addi	a4, a1, 0xc
                	addi	a6, a2, 0xc
                	li	s6, 0xc
@@ -2963,9 +3583,9 @@ Disassembly of section .text:
                	sb	s8, 0x0(a4)
                	addi	s6, s6, -0x1
                	li	t0, 0x0
-               	bne	s6, t0, 0x2d80 <.Lpcrel_hi.5+0x918>
-               	j	0x2e00 <.Lpcrel_hi.5+0x998>
-               	bnez	a0, 0x2dd8 <.Lpcrel_hi.5+0x970>
+               	bne	s6, t0, 0x3730 <.Lpcrel_hi.5+0x918>
+               	j	0x37b0 <.Lpcrel_hi.5+0x998>
+               	bnez	a0, 0x3788 <.Lpcrel_hi.5+0x970>
                	mv	a0, a1
                	mv	a4, a2
                	li	a6, 0x8
@@ -2975,10 +3595,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2db0 <.Lpcrel_hi.5+0x948>
+               	bne	a6, t0, 0x3760 <.Lpcrel_hi.5+0x948>
                	lw	a6, 0x0(a4)
                	sw	a6, 0x0(a0)
-               	j	0x2e00 <.Lpcrel_hi.5+0x998>
+               	j	0x37b0 <.Lpcrel_hi.5+0x998>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0xc
@@ -2988,14 +3608,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2de4 <.Lpcrel_hi.5+0x97c>
+               	bne	a2, t0, 0x3794 <.Lpcrel_hi.5+0x97c>
                	addi	a0, sp, 0x40
                	mv	a1, a7
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x2e74 <.Lpcrel_hi.5+0xa0c>
-               	bnez	a2, 0x2e48 <.Lpcrel_hi.5+0x9e0>
+               	bltu	a0, a1, 0x3824 <.Lpcrel_hi.5+0xa0c>
+               	bnez	a2, 0x37f8 <.Lpcrel_hi.5+0x9e0>
                	addi	a4, a0, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -3005,8 +3625,8 @@ Disassembly of section .text:
                	sd	s6, 0x0(a4)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x2e28 <.Lpcrel_hi.5+0x9c0>
-               	j	0x2ecc <.Lpcrel_hi.5+0xa64>
+               	bne	a7, t0, 0x37d8 <.Lpcrel_hi.5+0x9c0>
+               	j	0x387c <.Lpcrel_hi.5+0xa64>
                	addi	a4, a0, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -3016,9 +3636,9 @@ Disassembly of section .text:
                	sb	s6, 0x0(a4)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x2e54 <.Lpcrel_hi.5+0x9ec>
-               	j	0x2ecc <.Lpcrel_hi.5+0xa64>
-               	bnez	a2, 0x2ea4 <.Lpcrel_hi.5+0xa3c>
+               	bne	a7, t0, 0x3804 <.Lpcrel_hi.5+0x9ec>
+               	j	0x387c <.Lpcrel_hi.5+0xa64>
+               	bnez	a2, 0x3854 <.Lpcrel_hi.5+0xa3c>
                	mv	a2, a0
                	mv	a4, a1
                	li	a6, 0x10
@@ -3028,8 +3648,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2e84 <.Lpcrel_hi.5+0xa1c>
-               	j	0x2ecc <.Lpcrel_hi.5+0xa64>
+               	bne	a6, t0, 0x3834 <.Lpcrel_hi.5+0xa1c>
+               	j	0x387c <.Lpcrel_hi.5+0xa64>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x10
@@ -3039,15 +3659,15 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2eb0 <.Lpcrel_hi.5+0xa48>
+               	bne	a1, t0, 0x3860 <.Lpcrel_hi.5+0xa48>
                	addi	a0, s0, -0x280
                	ld	t2, -0x328(s0)
                	mv	a1, t2
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x2f4c <.Lpcrel_hi.5+0xae4>
-               	bnez	a2, 0x2f20 <.Lpcrel_hi.5+0xab8>
+               	bltu	a0, a1, 0x38fc <.Lpcrel_hi.5+0xae4>
+               	bnez	a2, 0x38d0 <.Lpcrel_hi.5+0xab8>
                	addi	a4, a0, 0x10
                	addi	a6, a1, 0x10
                	lbu	a7, 0x0(a6)
@@ -3059,8 +3679,8 @@ Disassembly of section .text:
                	sd	s6, 0x0(a4)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x2f00 <.Lpcrel_hi.5+0xa98>
-               	j	0x2fac <.Lpcrel_hi.5+0xb44>
+               	bne	a7, t0, 0x38b0 <.Lpcrel_hi.5+0xa98>
+               	j	0x395c <.Lpcrel_hi.5+0xb44>
                	addi	a4, a0, 0x11
                	addi	a6, a1, 0x11
                	li	a7, 0x11
@@ -3070,9 +3690,9 @@ Disassembly of section .text:
                	sb	s6, 0x0(a4)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x2f2c <.Lpcrel_hi.5+0xac4>
-               	j	0x2fac <.Lpcrel_hi.5+0xb44>
-               	bnez	a2, 0x2f84 <.Lpcrel_hi.5+0xb1c>
+               	bne	a7, t0, 0x38dc <.Lpcrel_hi.5+0xac4>
+               	j	0x395c <.Lpcrel_hi.5+0xb44>
+               	bnez	a2, 0x3934 <.Lpcrel_hi.5+0xb1c>
                	mv	a2, a0
                	mv	a4, a1
                	li	a6, 0x10
@@ -3082,10 +3702,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2f5c <.Lpcrel_hi.5+0xaf4>
+               	bne	a6, t0, 0x390c <.Lpcrel_hi.5+0xaf4>
                	lbu	a6, 0x0(a4)
                	sb	a6, 0x0(a2)
-               	j	0x2fac <.Lpcrel_hi.5+0xb44>
+               	j	0x395c <.Lpcrel_hi.5+0xb44>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x11
@@ -3095,7 +3715,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2f90 <.Lpcrel_hi.5+0xb28>
+               	bne	a1, t0, 0x3940 <.Lpcrel_hi.5+0xb28>
                	addi	a0, s0, -0x280
                	sd	a0, 0x50(sp)
                	ld	t2, -0x320(s0)
@@ -3122,35 +3742,35 @@ Disassembly of section .text:
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x21b8 <corpus.cases.call.call_rec_edge.checksum+0x1fc>
-               	addi	a0, s0, -0xe3
+               	bltu	s5, t0, 0x2b68 <corpus.cases.call.call_rec_edge.checksum+0x2c8>
+               	addi	a0, s0, -0x83
                	mv	a1, a0
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x3050 <.Lpcrel_hi.5+0xbe8>
+               	bnez	a2, 0x3a00 <.Lpcrel_hi.5+0xbe8>
                	mv	a2, a1
                	li	a3, 0x8
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x3034 <.Lpcrel_hi.5+0xbcc>
+               	bne	a3, t0, 0x39e4 <.Lpcrel_hi.5+0xbcc>
                	sb	zero, 0x0(a2)
-               	j	0x306c <.Lpcrel_hi.5+0xc04>
+               	j	0x3a1c <.Lpcrel_hi.5+0xc04>
                	mv	a2, a1
                	li	a1, 0x9
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3058 <.Lpcrel_hi.5+0xbf0>
+               	bne	a1, t0, 0x3a08 <.Lpcrel_hi.5+0xbf0>
                	sext.w	a1, s4
                	mv	a2, a0
                	sb	a1, 0x0(a2)
                	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	a1, t0, 0x3088 <.Lpcrel_hi.5+0xc20>
-               	j	0x30b8 <.Lpcrel_hi.5+0xc50>
+               	bltu	a1, t0, 0x3a38 <.Lpcrel_hi.5+0xc20>
+               	j	0x3a68 <.Lpcrel_hi.5+0xc50>
                	li	t0, 0x8
                	mul	a2, a1, t0
                	srl	a3, s4, a2
@@ -3162,15 +3782,15 @@ Disassembly of section .text:
                	sb	a4, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0x8
-               	bltu	a1, t0, 0x3088 <.Lpcrel_hi.5+0xc20>
-               	addi	a1, s0, -0xec
+               	bltu	a1, t0, 0x3a38 <.Lpcrel_hi.5+0xc20>
+               	addi	a1, s0, -0x8c
                	mv	a2, a1
                	mv	a3, a0
                	or	a0, a2, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a2, a3, 0x3138 <.Lpcrel_hi.5+0xcd0>
-               	bnez	a0, 0x310c <.Lpcrel_hi.5+0xca4>
+               	bltu	a2, a3, 0x3ae8 <.Lpcrel_hi.5+0xcd0>
+               	bnez	a0, 0x3abc <.Lpcrel_hi.5+0xca4>
                	addi	a4, a2, 0x8
                	addi	a5, a3, 0x8
                	lbu	a6, 0x0(a5)
@@ -3182,8 +3802,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x30ec <.Lpcrel_hi.5+0xc84>
-               	j	0x3198 <.Lpcrel_hi.5+0xd30>
+               	bne	a6, t0, 0x3a9c <.Lpcrel_hi.5+0xc84>
+               	j	0x3b48 <.Lpcrel_hi.5+0xd30>
                	addi	a4, a2, 0x9
                	addi	a5, a3, 0x9
                	li	a6, 0x9
@@ -3193,9 +3813,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x3118 <.Lpcrel_hi.5+0xcb0>
-               	j	0x3198 <.Lpcrel_hi.5+0xd30>
-               	bnez	a0, 0x3170 <.Lpcrel_hi.5+0xd08>
+               	bne	a6, t0, 0x3ac8 <.Lpcrel_hi.5+0xcb0>
+               	j	0x3b48 <.Lpcrel_hi.5+0xd30>
+               	bnez	a0, 0x3b20 <.Lpcrel_hi.5+0xd08>
                	mv	a0, a2
                	mv	a4, a3
                	li	a5, 0x8
@@ -3205,10 +3825,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x3148 <.Lpcrel_hi.5+0xce0>
+               	bne	a5, t0, 0x3af8 <.Lpcrel_hi.5+0xce0>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a0)
-               	j	0x3198 <.Lpcrel_hi.5+0xd30>
+               	j	0x3b48 <.Lpcrel_hi.5+0xd30>
                	mv	a0, a2
                	mv	a2, a3
                	li	a3, 0x9
@@ -3218,10 +3838,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x317c <.Lpcrel_hi.5+0xd14>
+               	bne	a3, t0, 0x3b2c <.Lpcrel_hi.5+0xd14>
                	sext.w	t2, s4
                	sd	t2, -0x338(s0)
-               	addi	a0, s0, -0x104
+               	addi	a0, s0, -0x108
                	sext.w	a2, s4
                	mv	a4, a0
                	sw	a2, 0x0(a4)
@@ -3291,31 +3911,31 @@ Disassembly of section .text:
                	mv	t5, a6
                	li	t0, 0x7
                	and	t6, t5, t0
-               	bnez	t6, 0x32c8 <.Lpcrel_hi.8+0x58>
+               	bnez	t6, 0x3c78 <.Lpcrel_hi.8+0x58>
                	mv	t6, t5
                	li	s1, 0x10
                	sd	zero, 0x0(t6)
                	addi	t6, t6, 0x8
                	addi	s1, s1, -0x8
                	li	t0, 0x0
-               	bne	s1, t0, 0x32ac <.Lpcrel_hi.8+0x3c>
+               	bne	s1, t0, 0x3c5c <.Lpcrel_hi.8+0x3c>
                	sb	zero, 0x0(t6)
-               	j	0x32e4 <.Lpcrel_hi.8+0x74>
+               	j	0x3c94 <.Lpcrel_hi.8+0x74>
                	mv	t6, t5
                	li	t5, 0x11
                	sb	zero, 0x0(t6)
                	addi	t6, t6, 0x1
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x32d0 <.Lpcrel_hi.8+0x60>
+               	bne	t5, t0, 0x3c80 <.Lpcrel_hi.8+0x60>
                	srli	t5, s4, 0x7
                	sext.w	t6, t5
                	mv	t5, a6
                	sb	t6, 0x0(t5)
                	li	t5, 0x0
                	li	t0, 0x10
-               	bltu	t5, t0, 0x3304 <.Lpcrel_hi.8+0x94>
-               	j	0x3334 <.Lpcrel_hi.8+0xc4>
+               	bltu	t5, t0, 0x3cb4 <.Lpcrel_hi.8+0x94>
+               	j	0x3ce4 <.Lpcrel_hi.8+0xc4>
                	li	t0, 0x4
                	mul	t6, t5, t0
                	srl	s1, s4, t6
@@ -3327,15 +3947,15 @@ Disassembly of section .text:
                	sb	s5, 0x0(s1)
                	addi	t5, t5, 0x1
                	li	t0, 0x10
-               	bltu	t5, t0, 0x3304 <.Lpcrel_hi.8+0x94>
+               	bltu	t5, t0, 0x3cb4 <.Lpcrel_hi.8+0x94>
                	addi	t5, s0, -0x1ac
                	mv	t6, t5
                	mv	s1, a6
                	or	a6, t6, s1
                	li	t0, 0x7
                	and	a6, a6, t0
-               	bltu	t6, s1, 0x33b4 <.Lpcrel_hi.8+0x144>
-               	bnez	a6, 0x3388 <.Lpcrel_hi.8+0x118>
+               	bltu	t6, s1, 0x3d64 <.Lpcrel_hi.8+0x144>
+               	bnez	a6, 0x3d38 <.Lpcrel_hi.8+0x118>
                	addi	s5, t6, 0x10
                	addi	s6, s1, 0x10
                	lbu	s7, 0x0(s6)
@@ -3347,8 +3967,8 @@ Disassembly of section .text:
                	sd	s8, 0x0(s5)
                	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x3368 <.Lpcrel_hi.8+0xf8>
-               	j	0x3414 <.Lpcrel_hi.8+0x1a4>
+               	bne	s7, t0, 0x3d18 <.Lpcrel_hi.8+0xf8>
+               	j	0x3dc4 <.Lpcrel_hi.8+0x1a4>
                	addi	s5, t6, 0x11
                	addi	s6, s1, 0x11
                	li	s7, 0x11
@@ -3358,9 +3978,9 @@ Disassembly of section .text:
                	sb	s8, 0x0(s5)
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x3394 <.Lpcrel_hi.8+0x124>
-               	j	0x3414 <.Lpcrel_hi.8+0x1a4>
-               	bnez	a6, 0x33ec <.Lpcrel_hi.8+0x17c>
+               	bne	s7, t0, 0x3d44 <.Lpcrel_hi.8+0x124>
+               	j	0x3dc4 <.Lpcrel_hi.8+0x1a4>
+               	bnez	a6, 0x3d9c <.Lpcrel_hi.8+0x17c>
                	mv	a6, t6
                	mv	s5, s1
                	li	s6, 0x10
@@ -3370,10 +3990,10 @@ Disassembly of section .text:
                	addi	s5, s5, 0x8
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x33c4 <.Lpcrel_hi.8+0x154>
+               	bne	s6, t0, 0x3d74 <.Lpcrel_hi.8+0x154>
                	lbu	s6, 0x0(s5)
                	sb	s6, 0x0(a6)
-               	j	0x3414 <.Lpcrel_hi.8+0x1a4>
+               	j	0x3dc4 <.Lpcrel_hi.8+0x1a4>
                	mv	a6, t6
                	mv	t6, s1
                	li	s1, 0x11
@@ -3383,37 +4003,37 @@ Disassembly of section .text:
                	addi	t6, t6, 0x1
                	addi	s1, s1, -0x1
                	li	t0, 0x0
-               	bne	s1, t0, 0x33f8 <.Lpcrel_hi.8+0x188>
+               	bne	s1, t0, 0x3da8 <.Lpcrel_hi.8+0x188>
                	addi	a6, s2, 0x50
                	ld	t6, 0x0(a6)
                	addi	a6, s0, -0x1c7
                	mv	s1, a6
                	li	t0, 0x7
                	and	s5, s1, t0
-               	bnez	s5, 0x3454 <.Lpcrel_hi.8+0x1e4>
+               	bnez	s5, 0x3e04 <.Lpcrel_hi.8+0x1e4>
                	mv	s5, s1
                	li	s6, 0x8
                	sd	zero, 0x0(s5)
                	addi	s5, s5, 0x8
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x3438 <.Lpcrel_hi.8+0x1c8>
+               	bne	s6, t0, 0x3de8 <.Lpcrel_hi.8+0x1c8>
                	sb	zero, 0x0(s5)
-               	j	0x3470 <.Lpcrel_hi.8+0x200>
+               	j	0x3e20 <.Lpcrel_hi.8+0x200>
                	mv	s5, s1
                	li	s1, 0x9
                	sb	zero, 0x0(s5)
                	addi	s5, s5, 0x1
                	addi	s1, s1, -0x1
                	li	t0, 0x0
-               	bne	s1, t0, 0x345c <.Lpcrel_hi.8+0x1ec>
+               	bne	s1, t0, 0x3e0c <.Lpcrel_hi.8+0x1ec>
                	sext.w	s1, t6
                	mv	s5, a6
                	sb	s1, 0x0(s5)
                	li	s1, 0x0
                	li	t0, 0x8
-               	bltu	s1, t0, 0x348c <.Lpcrel_hi.8+0x21c>
-               	j	0x34bc <.Lpcrel_hi.8+0x24c>
+               	bltu	s1, t0, 0x3e3c <.Lpcrel_hi.8+0x21c>
+               	j	0x3e6c <.Lpcrel_hi.8+0x24c>
                	li	t0, 0x8
                	mul	s5, s1, t0
                	srl	s6, t6, s5
@@ -3425,15 +4045,15 @@ Disassembly of section .text:
                	sb	s7, 0x0(s6)
                	addi	s1, s1, 0x1
                	li	t0, 0x8
-               	bltu	s1, t0, 0x348c <.Lpcrel_hi.8+0x21c>
+               	bltu	s1, t0, 0x3e3c <.Lpcrel_hi.8+0x21c>
                	addi	t6, s0, -0x1d0
                	mv	s1, t6
                	mv	s5, a6
                	or	a6, s1, s5
                	li	t0, 0x7
                	and	a6, a6, t0
-               	bltu	s1, s5, 0x353c <.Lpcrel_hi.8+0x2cc>
-               	bnez	a6, 0x3510 <.Lpcrel_hi.8+0x2a0>
+               	bltu	s1, s5, 0x3eec <.Lpcrel_hi.8+0x2cc>
+               	bnez	a6, 0x3ec0 <.Lpcrel_hi.8+0x2a0>
                	addi	s6, s1, 0x8
                	addi	s7, s5, 0x8
                	lbu	s8, 0x0(s7)
@@ -3445,8 +4065,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(s6)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x34f0 <.Lpcrel_hi.8+0x280>
-               	j	0x359c <.Lpcrel_hi.8+0x32c>
+               	bne	s8, t0, 0x3ea0 <.Lpcrel_hi.8+0x280>
+               	j	0x3f4c <.Lpcrel_hi.8+0x32c>
                	addi	s6, s1, 0x9
                	addi	s7, s5, 0x9
                	li	s8, 0x9
@@ -3456,9 +4076,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(s6)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x351c <.Lpcrel_hi.8+0x2ac>
-               	j	0x359c <.Lpcrel_hi.8+0x32c>
-               	bnez	a6, 0x3574 <.Lpcrel_hi.8+0x304>
+               	bne	s8, t0, 0x3ecc <.Lpcrel_hi.8+0x2ac>
+               	j	0x3f4c <.Lpcrel_hi.8+0x32c>
+               	bnez	a6, 0x3f24 <.Lpcrel_hi.8+0x304>
                	mv	a6, s1
                	mv	s6, s5
                	li	s7, 0x8
@@ -3468,10 +4088,10 @@ Disassembly of section .text:
                	addi	s6, s6, 0x8
                	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x354c <.Lpcrel_hi.8+0x2dc>
+               	bne	s7, t0, 0x3efc <.Lpcrel_hi.8+0x2dc>
                	lbu	s7, 0x0(s6)
                	sb	s7, 0x0(a6)
-               	j	0x359c <.Lpcrel_hi.8+0x32c>
+               	j	0x3f4c <.Lpcrel_hi.8+0x32c>
                	mv	a6, s1
                	mv	s1, s5
                	li	s5, 0x9
@@ -3481,7 +4101,7 @@ Disassembly of section .text:
                	addi	s1, s1, 0x1
                	addi	s5, s5, -0x1
                	li	t0, 0x0
-               	bne	s5, t0, 0x3580 <.Lpcrel_hi.8+0x310>
+               	bne	s5, t0, 0x3f30 <.Lpcrel_hi.8+0x310>
                	addi	a6, s2, 0x58
                	ld	s1, 0x0(a6)
                	addi	a6, s0, -0x1e8
@@ -3512,31 +4132,31 @@ Disassembly of section .text:
                	mv	s7, s5
                	li	t0, 0x7
                	and	s8, s7, t0
-               	bnez	s8, 0x363c <.Lpcrel_hi.8+0x3cc>
+               	bnez	s8, 0x3fec <.Lpcrel_hi.8+0x3cc>
                	mv	s8, s7
                	li	s9, 0x10
                	sd	zero, 0x0(s8)
                	addi	s8, s8, 0x8
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x3620 <.Lpcrel_hi.8+0x3b0>
+               	bne	s9, t0, 0x3fd0 <.Lpcrel_hi.8+0x3b0>
                	sb	zero, 0x0(s8)
-               	j	0x3658 <.Lpcrel_hi.8+0x3e8>
+               	j	0x4008 <.Lpcrel_hi.8+0x3e8>
                	mv	s8, s7
                	li	s7, 0x11
                	sb	zero, 0x0(s8)
                	addi	s8, s8, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x3644 <.Lpcrel_hi.8+0x3d4>
+               	bne	s7, t0, 0x3ff4 <.Lpcrel_hi.8+0x3d4>
                	srli	s7, s6, 0x7
                	sext.w	s8, s7
                	mv	s7, s5
                	sb	s8, 0x0(s7)
                	li	s7, 0x0
                	li	t0, 0x10
-               	bltu	s7, t0, 0x3678 <.Lpcrel_hi.8+0x408>
-               	j	0x36a8 <.Lpcrel_hi.8+0x438>
+               	bltu	s7, t0, 0x4028 <.Lpcrel_hi.8+0x408>
+               	j	0x4058 <.Lpcrel_hi.8+0x438>
                	li	t0, 0x4
                	mul	s8, s7, t0
                	srl	s9, s6, s8
@@ -3548,15 +4168,15 @@ Disassembly of section .text:
                	sb	s10, 0x0(s9)
                	addi	s7, s7, 0x1
                	li	t0, 0x10
-               	bltu	s7, t0, 0x3678 <.Lpcrel_hi.8+0x408>
+               	bltu	s7, t0, 0x4028 <.Lpcrel_hi.8+0x408>
                	addi	s6, s0, -0x2a2
                	mv	s7, s6
                	mv	s8, s5
                	or	s5, s7, s8
                	li	t0, 0x7
                	and	s5, s5, t0
-               	bltu	s7, s8, 0x3728 <.Lpcrel_hi.8+0x4b8>
-               	bnez	s5, 0x36fc <.Lpcrel_hi.8+0x48c>
+               	bltu	s7, s8, 0x40d8 <.Lpcrel_hi.8+0x4b8>
+               	bnez	s5, 0x40ac <.Lpcrel_hi.8+0x48c>
                	addi	s9, s7, 0x10
                	addi	s10, s8, 0x10
                	lbu	s11, 0x0(s10)
@@ -3568,8 +4188,8 @@ Disassembly of section .text:
                	sd	a3, 0x0(s9)
                	addi	s11, s11, -0x8
                	li	t0, 0x0
-               	bne	s11, t0, 0x36dc <.Lpcrel_hi.8+0x46c>
-               	j	0x3788 <.Lpcrel_hi.8+0x518>
+               	bne	s11, t0, 0x408c <.Lpcrel_hi.8+0x46c>
+               	j	0x4138 <.Lpcrel_hi.8+0x518>
                	addi	a3, s7, 0x11
                	addi	s9, s8, 0x11
                	li	s10, 0x11
@@ -3579,9 +4199,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(a3)
                	addi	s10, s10, -0x1
                	li	t0, 0x0
-               	bne	s10, t0, 0x3708 <.Lpcrel_hi.8+0x498>
-               	j	0x3788 <.Lpcrel_hi.8+0x518>
-               	bnez	s5, 0x3760 <.Lpcrel_hi.8+0x4f0>
+               	bne	s10, t0, 0x40b8 <.Lpcrel_hi.8+0x498>
+               	j	0x4138 <.Lpcrel_hi.8+0x518>
+               	bnez	s5, 0x4110 <.Lpcrel_hi.8+0x4f0>
                	mv	a3, s7
                	mv	s5, s8
                	li	s9, 0x10
@@ -3591,10 +4211,10 @@ Disassembly of section .text:
                	addi	s5, s5, 0x8
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x3738 <.Lpcrel_hi.8+0x4c8>
+               	bne	s9, t0, 0x40e8 <.Lpcrel_hi.8+0x4c8>
                	lbu	s9, 0x0(s5)
                	sb	s9, 0x0(a3)
-               	j	0x3788 <.Lpcrel_hi.8+0x518>
+               	j	0x4138 <.Lpcrel_hi.8+0x518>
                	mv	a3, s7
                	mv	s5, s8
                	li	s7, 0x11
@@ -3604,7 +4224,7 @@ Disassembly of section .text:
                	addi	s5, s5, 0x1
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x376c <.Lpcrel_hi.8+0x4fc>
+               	bne	s7, t0, 0x411c <.Lpcrel_hi.8+0x4fc>
                	addi	a3, s2, 0x10
                	ld	s5, 0x0(a3)
                	li	t0, 0xff
@@ -3670,8 +4290,8 @@ Disassembly of section .text:
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x38ec <.Lpcrel_hi.8+0x67c>
-               	bnez	a2, 0x38c0 <.Lpcrel_hi.8+0x650>
+               	bltu	a0, a1, 0x429c <.Lpcrel_hi.8+0x67c>
+               	bnez	a2, 0x4270 <.Lpcrel_hi.8+0x650>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	li	s9, 0x10
@@ -3681,8 +4301,8 @@ Disassembly of section .text:
                	sd	s10, 0x0(a4)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x38a0 <.Lpcrel_hi.8+0x630>
-               	j	0x3944 <.Lpcrel_hi.8+0x6d4>
+               	bne	s9, t0, 0x4250 <.Lpcrel_hi.8+0x630>
+               	j	0x42f4 <.Lpcrel_hi.8+0x6d4>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	li	s9, 0x10
@@ -3692,9 +4312,9 @@ Disassembly of section .text:
                	sb	s10, 0x0(a4)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x38cc <.Lpcrel_hi.8+0x65c>
-               	j	0x3944 <.Lpcrel_hi.8+0x6d4>
-               	bnez	a2, 0x391c <.Lpcrel_hi.8+0x6ac>
+               	bne	s9, t0, 0x427c <.Lpcrel_hi.8+0x65c>
+               	j	0x42f4 <.Lpcrel_hi.8+0x6d4>
+               	bnez	a2, 0x42cc <.Lpcrel_hi.8+0x6ac>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x10
@@ -3704,8 +4324,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x38fc <.Lpcrel_hi.8+0x68c>
-               	j	0x3944 <.Lpcrel_hi.8+0x6d4>
+               	bne	a5, t0, 0x42ac <.Lpcrel_hi.8+0x68c>
+               	j	0x42f4 <.Lpcrel_hi.8+0x6d4>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x10
@@ -3715,7 +4335,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3928 <.Lpcrel_hi.8+0x6b8>
+               	bne	a1, t0, 0x42d8 <.Lpcrel_hi.8+0x6b8>
                	ld	t2, -0x340(s0)
                	sd	t2, 0x10(sp)
                	addi	a0, s0, -0x2e0
@@ -3723,8 +4343,8 @@ Disassembly of section .text:
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x39c8 <.Lpcrel_hi.8+0x758>
-               	bnez	a2, 0x399c <.Lpcrel_hi.8+0x72c>
+               	bltu	a0, a1, 0x4378 <.Lpcrel_hi.8+0x758>
+               	bnez	a2, 0x434c <.Lpcrel_hi.8+0x72c>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	lbu	t5, 0x0(a5)
@@ -3736,8 +4356,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(a4)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x397c <.Lpcrel_hi.8+0x70c>
-               	j	0x3a28 <.Lpcrel_hi.8+0x7b8>
+               	bne	t5, t0, 0x432c <.Lpcrel_hi.8+0x70c>
+               	j	0x43d8 <.Lpcrel_hi.8+0x7b8>
                	addi	a4, a0, 0x11
                	addi	a5, a1, 0x11
                	li	t5, 0x11
@@ -3747,9 +4367,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(a4)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x39a8 <.Lpcrel_hi.8+0x738>
-               	j	0x3a28 <.Lpcrel_hi.8+0x7b8>
-               	bnez	a2, 0x3a00 <.Lpcrel_hi.8+0x790>
+               	bne	t5, t0, 0x4358 <.Lpcrel_hi.8+0x738>
+               	j	0x43d8 <.Lpcrel_hi.8+0x7b8>
+               	bnez	a2, 0x43b0 <.Lpcrel_hi.8+0x790>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x10
@@ -3759,10 +4379,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x39d8 <.Lpcrel_hi.8+0x768>
+               	bne	a5, t0, 0x4388 <.Lpcrel_hi.8+0x768>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a2)
-               	j	0x3a28 <.Lpcrel_hi.8+0x7b8>
+               	j	0x43d8 <.Lpcrel_hi.8+0x7b8>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x11
@@ -3772,7 +4392,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3a0c <.Lpcrel_hi.8+0x79c>
+               	bne	a1, t0, 0x43bc <.Lpcrel_hi.8+0x79c>
                	addi	a0, s0, -0x2e0
                	sd	a0, 0x18(sp)
                	addi	a0, sp, 0x20
@@ -3780,8 +4400,8 @@ Disassembly of section .text:
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x3aac <.Lpcrel_hi.8+0x83c>
-               	bnez	a2, 0x3a80 <.Lpcrel_hi.8+0x810>
+               	bltu	a0, a1, 0x445c <.Lpcrel_hi.8+0x83c>
+               	bnez	a2, 0x4430 <.Lpcrel_hi.8+0x810>
                	addi	a4, a0, 0x8
                	addi	a5, a1, 0x8
                	lbu	t5, 0x0(a5)
@@ -3793,8 +4413,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a4)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x3a60 <.Lpcrel_hi.8+0x7f0>
-               	j	0x3b0c <.Lpcrel_hi.8+0x89c>
+               	bne	t5, t0, 0x4410 <.Lpcrel_hi.8+0x7f0>
+               	j	0x44bc <.Lpcrel_hi.8+0x89c>
                	addi	a4, a0, 0x9
                	addi	a5, a1, 0x9
                	li	t5, 0x9
@@ -3804,9 +4424,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a4)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x3a8c <.Lpcrel_hi.8+0x81c>
-               	j	0x3b0c <.Lpcrel_hi.8+0x89c>
-               	bnez	a2, 0x3ae4 <.Lpcrel_hi.8+0x874>
+               	bne	t5, t0, 0x443c <.Lpcrel_hi.8+0x81c>
+               	j	0x44bc <.Lpcrel_hi.8+0x89c>
+               	bnez	a2, 0x4494 <.Lpcrel_hi.8+0x874>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x8
@@ -3816,10 +4436,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x3abc <.Lpcrel_hi.8+0x84c>
+               	bne	a5, t0, 0x446c <.Lpcrel_hi.8+0x84c>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a2)
-               	j	0x3b0c <.Lpcrel_hi.8+0x89c>
+               	j	0x44bc <.Lpcrel_hi.8+0x89c>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x9
@@ -3829,14 +4449,14 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3af0 <.Lpcrel_hi.8+0x880>
+               	bne	a1, t0, 0x44a0 <.Lpcrel_hi.8+0x880>
                	addi	a0, sp, 0x30
                	mv	a1, a6
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x3b88 <.Lpcrel_hi.8+0x918>
-               	bnez	a2, 0x3b5c <.Lpcrel_hi.8+0x8ec>
+               	bltu	a0, a1, 0x4538 <.Lpcrel_hi.8+0x918>
+               	bnez	a2, 0x450c <.Lpcrel_hi.8+0x8ec>
                	addi	a4, a0, 0x8
                	addi	a5, a1, 0x8
                	lw	a6, 0x0(a5)
@@ -3848,8 +4468,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x3b3c <.Lpcrel_hi.8+0x8cc>
-               	j	0x3be8 <.Lpcrel_hi.8+0x978>
+               	bne	a6, t0, 0x44ec <.Lpcrel_hi.8+0x8cc>
+               	j	0x4598 <.Lpcrel_hi.8+0x978>
                	addi	a4, a0, 0xc
                	addi	a5, a1, 0xc
                	li	a6, 0xc
@@ -3859,9 +4479,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x3b68 <.Lpcrel_hi.8+0x8f8>
-               	j	0x3be8 <.Lpcrel_hi.8+0x978>
-               	bnez	a2, 0x3bc0 <.Lpcrel_hi.8+0x950>
+               	bne	a6, t0, 0x4518 <.Lpcrel_hi.8+0x8f8>
+               	j	0x4598 <.Lpcrel_hi.8+0x978>
+               	bnez	a2, 0x4570 <.Lpcrel_hi.8+0x950>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x8
@@ -3871,10 +4491,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x3b98 <.Lpcrel_hi.8+0x928>
+               	bne	a5, t0, 0x4548 <.Lpcrel_hi.8+0x928>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0x3be8 <.Lpcrel_hi.8+0x978>
+               	j	0x4598 <.Lpcrel_hi.8+0x978>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0xc
@@ -3884,14 +4504,14 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3bcc <.Lpcrel_hi.8+0x95c>
+               	bne	a1, t0, 0x457c <.Lpcrel_hi.8+0x95c>
                	addi	a0, sp, 0x40
                	mv	a1, s1
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x3c5c <.Lpcrel_hi.8+0x9ec>
-               	bnez	a2, 0x3c30 <.Lpcrel_hi.8+0x9c0>
+               	bltu	a0, a1, 0x460c <.Lpcrel_hi.8+0x9ec>
+               	bnez	a2, 0x45e0 <.Lpcrel_hi.8+0x9c0>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -3901,8 +4521,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x3c10 <.Lpcrel_hi.8+0x9a0>
-               	j	0x3cb4 <.Lpcrel_hi.8+0xa44>
+               	bne	a6, t0, 0x45c0 <.Lpcrel_hi.8+0x9a0>
+               	j	0x4664 <.Lpcrel_hi.8+0xa44>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -3912,9 +4532,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x3c3c <.Lpcrel_hi.8+0x9cc>
-               	j	0x3cb4 <.Lpcrel_hi.8+0xa44>
-               	bnez	a2, 0x3c8c <.Lpcrel_hi.8+0xa1c>
+               	bne	a6, t0, 0x45ec <.Lpcrel_hi.8+0x9cc>
+               	j	0x4664 <.Lpcrel_hi.8+0xa44>
+               	bnez	a2, 0x463c <.Lpcrel_hi.8+0xa1c>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x10
@@ -3924,8 +4544,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x3c6c <.Lpcrel_hi.8+0x9fc>
-               	j	0x3cb4 <.Lpcrel_hi.8+0xa44>
+               	bne	a5, t0, 0x461c <.Lpcrel_hi.8+0x9fc>
+               	j	0x4664 <.Lpcrel_hi.8+0xa44>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x10
@@ -3935,14 +4555,14 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3c98 <.Lpcrel_hi.8+0xa28>
+               	bne	a1, t0, 0x4648 <.Lpcrel_hi.8+0xa28>
                	addi	a0, s0, -0x2f8
                	mv	a1, s6
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x3d30 <.Lpcrel_hi.8+0xac0>
-               	bnez	a2, 0x3d04 <.Lpcrel_hi.8+0xa94>
+               	bltu	a0, a1, 0x46e0 <.Lpcrel_hi.8+0xac0>
+               	bnez	a2, 0x46b4 <.Lpcrel_hi.8+0xa94>
                	addi	a4, a0, 0x10
                	addi	a5, a1, 0x10
                	lbu	a6, 0x0(a5)
@@ -3954,8 +4574,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x3ce4 <.Lpcrel_hi.8+0xa74>
-               	j	0x3d90 <.Lpcrel_hi.8+0xb20>
+               	bne	a6, t0, 0x4694 <.Lpcrel_hi.8+0xa74>
+               	j	0x4740 <.Lpcrel_hi.8+0xb20>
                	addi	a4, a0, 0x11
                	addi	a5, a1, 0x11
                	li	a6, 0x11
@@ -3965,9 +4585,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x3d10 <.Lpcrel_hi.8+0xaa0>
-               	j	0x3d90 <.Lpcrel_hi.8+0xb20>
-               	bnez	a2, 0x3d68 <.Lpcrel_hi.8+0xaf8>
+               	bne	a6, t0, 0x46c0 <.Lpcrel_hi.8+0xaa0>
+               	j	0x4740 <.Lpcrel_hi.8+0xb20>
+               	bnez	a2, 0x4718 <.Lpcrel_hi.8+0xaf8>
                	mv	a2, a0
                	mv	a4, a1
                	li	a5, 0x10
@@ -3977,10 +4597,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x3d40 <.Lpcrel_hi.8+0xad0>
+               	bne	a5, t0, 0x46f0 <.Lpcrel_hi.8+0xad0>
                	lbu	a5, 0x0(a4)
                	sb	a5, 0x0(a2)
-               	j	0x3d90 <.Lpcrel_hi.8+0xb20>
+               	j	0x4740 <.Lpcrel_hi.8+0xb20>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x11
@@ -3990,7 +4610,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3d74 <.Lpcrel_hi.8+0xb04>
+               	bne	a1, t0, 0x4724 <.Lpcrel_hi.8+0xb04>
                	addi	a0, s0, -0x2f8
                	sd	a0, 0x50(sp)
                	ld	t2, -0x348(s0)

--- a/test/golden/riscv64-linux/call/call_rec_large.dis
+++ b/test/golden/riscv64-linux/call/call_rec_large.dis
@@ -26,206 +26,351 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l24>:
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	a4, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.call.call_rec_large.fold_l24+0x28>
+               	j	0xb0 <corpus.cases.call.call_rec_large.fold_l24+0x5c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.call.call_rec_large.fold_l24+0x28>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc0 <corpus.cases.call.call_rec_large.fold_l24+0x6c>
+               	j	0xf4 <corpus.cases.call.call_rec_large.fold_l24+0xa0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a4, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc0 <corpus.cases.call.call_rec_large.fold_l24+0x6c>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.call.call_rec_large.fold_l24+0xb0>
+               	j	0x138 <corpus.cases.call.call_rec_large.fold_l24+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.call.call_rec_large.fold_l24+0xb0>
+               	ret
+
+<corpus.cases.call.call_rec_large.fold_l24f>:
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fld	ft1, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	fld	ft2, 0x0(a2)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x168 <corpus.cases.call.call_rec_large.fold_l24f+0x2c>
+               	j	0x19c <corpus.cases.call.call_rec_large.fold_l24f+0x60>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x168 <corpus.cases.call.call_rec_large.fold_l24f+0x2c>
+               	fmv.x.d	a1, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b0 <corpus.cases.call.call_rec_large.fold_l24f+0x74>
+               	j	0x1e4 <corpus.cases.call.call_rec_large.fold_l24f+0xa8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b0 <corpus.cases.call.call_rec_large.fold_l24f+0x74>
+               	fmv.x.d	a1, ft2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1f8 <corpus.cases.call.call_rec_large.fold_l24f+0xbc>
+               	j	0x22c <corpus.cases.call.call_rec_large.fold_l24f+0xf0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1f8 <corpus.cases.call.call_rec_large.fold_l24f+0xbc>
+               	ret
+
+<corpus.cases.call.call_rec_large.fold_l24m>:
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fld	ft0, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x14
+               	lw	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.call.call_rec_large.fold_l24m+0x30>
+               	j	0x294 <corpus.cases.call.call_rec_large.fold_l24m+0x64>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.call.call_rec_large.fold_l24m+0x30>
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2a8 <corpus.cases.call.call_rec_large.fold_l24m+0x78>
+               	j	0x2dc <corpus.cases.call.call_rec_large.fold_l24m+0xac>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2a8 <corpus.cases.call.call_rec_large.fold_l24m+0x78>
+               	slli	a2, a4, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2f4 <corpus.cases.call.call_rec_large.fold_l24m+0xc4>
+               	j	0x328 <corpus.cases.call.call_rec_large.fold_l24m+0xf8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2f4 <corpus.cases.call.call_rec_large.fold_l24m+0xc4>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.call.call_rec_large.fold_l24m+0x110>
+               	j	0x374 <corpus.cases.call.call_rec_large.fold_l24m+0x144>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.call.call_rec_large.fold_l24m+0x110>
+               	ret
+
+<corpus.cases.call.call_rec_large.fold_l32>:
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	a4, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a5, 0x0(a2)
+               	addi	a2, a1, 0x18
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a8 <corpus.cases.call.call_rec_large.fold_l32+0x30>
+               	j	0x3dc <corpus.cases.call.call_rec_large.fold_l32+0x64>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a0, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a8 <corpus.cases.call.call_rec_large.fold_l32+0x30>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3ec <corpus.cases.call.call_rec_large.fold_l32+0x74>
+               	j	0x420 <corpus.cases.call.call_rec_large.fold_l32+0xa8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a6, a4, a3
+               	li	t0, 0xff
+               	and	a3, a6, t0
+               	xor	a6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3ec <corpus.cases.call.call_rec_large.fold_l32+0x74>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x430 <corpus.cases.call.call_rec_large.fold_l32+0xb8>
+               	j	0x464 <corpus.cases.call.call_rec_large.fold_l32+0xec>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a5, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x430 <corpus.cases.call.call_rec_large.fold_l32+0xb8>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x474 <corpus.cases.call.call_rec_large.fold_l32+0xfc>
+               	j	0x4a8 <corpus.cases.call.call_rec_large.fold_l32+0x130>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x474 <corpus.cases.call.call_rec_large.fold_l32+0xfc>
+               	ret
+
+<corpus.cases.call.call_rec_large.fold_l32n>:
                	addi	sp, sp, -0x20
                	sd	ra, 0x18(sp)
                	sd	s0, 0x10(sp)
                	addi	s0, sp, 0x20
                	sd	s1, 0x8(sp)
-               	sd	s2, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
+               	mv	a2, a1
+               	mv	a3, a2
                	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	ld	s1, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s2, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24+0x64>
-               	ld	s1, 0x8(sp)
-               	ld	s2, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
-               	ret
-
-<corpus.cases.call.call_rec_large.fold_l24f>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	fsd	fs0, 0x8(sp)
-               	fsd	fs1, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	fld	fa0, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	fld	fs0, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	fld	fs1, 0x0(a3)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24f+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24f+0x4c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24f+0x60>
-               	fld	fs0, 0x8(sp)
-               	fld	fs1, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
-               	ret
-
-<corpus.cases.call.call_rec_large.fold_l24m>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	fsd	fs0, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	fld	fs0, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	lw	s1, 0x0(a3)
-               	addi	a3, a1, 0x14
-               	lw	s2, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24m+0x48>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24m+0x5c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24m+0x70>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l24m+0x84>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	fld	fs0, 0x8(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
-               	ret
-
-<corpus.cases.call.call_rec_large.fold_l32>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	ld	s1, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s2, 0x0(a3)
-               	addi	a3, a1, 0x18
-               	ld	s3, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32+0x48>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32+0x5c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32+0x70>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32+0x84>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
-               	ret
-
-<corpus.cases.call.call_rec_large.fold_l32n>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	mv	a4, a3
-               	ld	a5, 0x0(a4)
-               	addi	a4, a3, 0x8
-               	ld	s1, 0x0(a4)
+               	addi	a3, a2, 0x8
+               	ld	a2, 0x0(a3)
                	addi	a3, a1, 0x10
                	mv	a1, a3
-               	ld	s2, 0x0(a1)
+               	ld	a5, 0x0(a1)
                	addi	a1, a3, 0x8
-               	ld	s3, 0x0(a1)
-               	mv	a0, a2
+               	ld	s1, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4f8 <corpus.cases.call.call_rec_large.fold_l32n+0x4c>
+               	j	0x52c <corpus.cases.call.call_rec_large.fold_l32n+0x80>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a6, a4, a3
+               	li	t0, 0xff
+               	and	a3, a6, t0
+               	xor	a6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4f8 <corpus.cases.call.call_rec_large.fold_l32n+0x4c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x53c <corpus.cases.call.call_rec_large.fold_l32n+0x90>
+               	j	0x570 <corpus.cases.call.call_rec_large.fold_l32n+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x53c <corpus.cases.call.call_rec_large.fold_l32n+0x90>
                	mv	a1, a5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0xc8>
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0x64>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0x78>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0x8c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l32n+0xd4>
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_large.fold_l48>:
@@ -320,36 +465,26 @@ Disassembly of section .text:
                	mv	a1, a4
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x6c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x78>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x88>
+               	slli	a1, s2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0x98>
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xa4>
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xd0>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xb0>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xe4>
+               	jalr	ra <corpus.cases.call.call_rec_large.fold_l48m+0xbc>
                	ld	s1, 0x28(sp)
                	ld	s2, 0x20(sp)
                	ld	s3, 0x18(sp)
@@ -457,45 +592,93 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_large.take_large>:
-               	addi	sp, sp, -0x1b0
-               	sd	ra, 0x1a8(sp)
-               	sd	s0, 0x1a0(sp)
-               	addi	s0, sp, 0x1b0
-               	sd	s1, 0x198(sp)
-               	sd	s2, 0x190(sp)
-               	sd	s3, 0x188(sp)
-               	sd	s4, 0x180(sp)
-               	sd	s5, 0x178(sp)
-               	sd	s6, 0x170(sp)
-               	sd	s7, 0x168(sp)
-               	sd	s8, 0x160(sp)
-               	sd	s9, 0x158(sp)
-               	sd	s10, 0x150(sp)
-               	sd	s11, 0x148(sp)
-               	fsd	fs0, 0x140(sp)
-               	fsd	fs1, 0x138(sp)
-               	fsd	fs2, 0x130(sp)
-               	fsd	fs3, 0x128(sp)
-               	fsd	fs4, 0x120(sp)
-               	fsd	fs5, 0x118(sp)
-               	fsd	fs6, 0x110(sp)
-               	fsd	fs7, 0x108(sp)
-               	mv	s1, a0
-               	mv	s2, a4
+               	addi	sp, sp, -0x390
+               	sd	ra, 0x388(sp)
+               	sd	s0, 0x380(sp)
+               	addi	s0, sp, 0x390
+               	sd	s1, 0x378(sp)
+               	sd	s2, 0x370(sp)
+               	sd	s3, 0x368(sp)
+               	sd	s4, 0x360(sp)
+               	sd	s5, 0x358(sp)
+               	sd	s6, 0x350(sp)
+               	sd	s7, 0x348(sp)
+               	sd	s8, 0x340(sp)
+               	sd	s9, 0x338(sp)
+               	sd	s10, 0x330(sp)
+               	sd	s11, 0x328(sp)
+               	fsd	fs0, 0x320(sp)
+               	fsd	fs1, 0x318(sp)
+               	fsd	fs2, 0x310(sp)
+               	fsd	fs3, 0x308(sp)
+               	fsd	fs4, 0x300(sp)
+               	fsd	fs5, 0x2f8(sp)
+               	fsd	fs6, 0x2f0(sp)
+               	fsd	fs7, 0x2e8(sp)
+               	mv	t2, a0
+               	sd	t2, -0x240(s0)
+               	mv	s1, a4
                	fmv.d	fs0, fa0
-               	ld	a4, 0x0(s0)
-               	ld	t2, 0x8(s0)
-               	sd	t2, -0xb0(s0)
-               	ld	t6, 0x10(s0)
-               	ld	s3, 0x18(s0)
+               	ld	a0, 0x0(s0)
+               	ld	a4, 0x8(s0)
+               	ld	t2, 0x10(s0)
+               	sd	t2, -0x248(s0)
+               	ld	t2, 0x18(s0)
+               	sd	t2, -0x250(s0)
                	fmv.s	fs1, fa1
-               	ld	s4, 0x20(s0)
-               	mv	s5, a1
-               	ld	s6, 0x0(s5)
-               	addi	s5, a1, 0x8
-               	ld	s7, 0x0(s5)
-               	addi	s5, a1, 0x10
-               	ld	s8, 0x0(s5)
+               	ld	s3, 0x20(s0)
+               	addi	s4, s0, -0xc0
+               	mv	s5, s4
+               	mv	s6, a1
+               	or	a1, s5, s6
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	s5, s6, 0x9f0 <corpus.cases.call.call_rec_large.take_large+0x104>
+               	bnez	a1, 0x9c4 <corpus.cases.call.call_rec_large.take_large+0xd8>
+               	addi	s7, s5, 0x18
+               	addi	s8, s6, 0x18
+               	li	s9, 0x18
+               	addi	s7, s7, -0x8
+               	addi	s8, s8, -0x8
+               	ld	s10, 0x0(s8)
+               	sd	s10, 0x0(s7)
+               	addi	s9, s9, -0x8
+               	li	t0, 0x0
+               	bne	s9, t0, 0x9a4 <corpus.cases.call.call_rec_large.take_large+0xb8>
+               	j	0xa48 <corpus.cases.call.call_rec_large.take_large+0x15c>
+               	addi	s7, s5, 0x18
+               	addi	s8, s6, 0x18
+               	li	s9, 0x18
+               	addi	s7, s7, -0x1
+               	addi	s8, s8, -0x1
+               	lbu	s10, 0x0(s8)
+               	sb	s10, 0x0(s7)
+               	addi	s9, s9, -0x1
+               	li	t0, 0x0
+               	bne	s9, t0, 0x9d0 <corpus.cases.call.call_rec_large.take_large+0xe4>
+               	j	0xa48 <corpus.cases.call.call_rec_large.take_large+0x15c>
+               	bnez	a1, 0xa20 <corpus.cases.call.call_rec_large.take_large+0x134>
+               	mv	a1, s5
+               	mv	s7, s6
+               	li	s8, 0x18
+               	ld	s9, 0x0(s7)
+               	sd	s9, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	s7, s7, 0x8
+               	addi	s8, s8, -0x8
+               	li	t0, 0x0
+               	bne	s8, t0, 0xa00 <corpus.cases.call.call_rec_large.take_large+0x114>
+               	j	0xa48 <corpus.cases.call.call_rec_large.take_large+0x15c>
+               	mv	a1, s5
+               	mv	s5, s6
+               	li	s6, 0x18
+               	lbu	s7, 0x0(s5)
+               	sb	s7, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	s5, s5, 0x1
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0xa2c <corpus.cases.call.call_rec_large.take_large+0x140>
                	mv	a1, a2
                	fld	fs2, 0x0(a1)
                	addi	a1, a2, 0x8
@@ -507,367 +690,1150 @@ Disassembly of section .text:
                	addi	a1, a3, 0x8
                	fld	fs5, 0x0(a1)
                	addi	a1, a3, 0x10
-               	lw	s9, 0x0(a1)
+               	lw	s6, 0x0(a1)
                	addi	a1, a3, 0x14
-               	lw	s10, 0x0(a1)
-               	mv	a1, a5
-               	ld	s11, 0x0(a1)
-               	addi	a1, a5, 0x8
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x168(s0)
-               	addi	a1, a5, 0x10
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x170(s0)
-               	addi	a1, a5, 0x18
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x178(s0)
+               	lw	s7, 0x0(a1)
+               	addi	s8, s0, -0xe0
+               	mv	a1, s8
+               	mv	a2, a5
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0xaf8 <corpus.cases.call.call_rec_large.take_large+0x20c>
+               	bnez	a3, 0xacc <corpus.cases.call.call_rec_large.take_large+0x1e0>
+               	addi	a5, a1, 0x20
+               	addi	s9, a2, 0x20
+               	li	s10, 0x20
+               	addi	a5, a5, -0x8
+               	addi	s9, s9, -0x8
+               	ld	s11, 0x0(s9)
+               	sd	s11, 0x0(a5)
+               	addi	s10, s10, -0x8
+               	li	t0, 0x0
+               	bne	s10, t0, 0xaac <corpus.cases.call.call_rec_large.take_large+0x1c0>
+               	j	0xb50 <corpus.cases.call.call_rec_large.take_large+0x264>
+               	addi	a5, a1, 0x20
+               	addi	s9, a2, 0x20
+               	li	s10, 0x20
+               	addi	a5, a5, -0x1
+               	addi	s9, s9, -0x1
+               	lbu	s11, 0x0(s9)
+               	sb	s11, 0x0(a5)
+               	addi	s10, s10, -0x1
+               	li	t0, 0x0
+               	bne	s10, t0, 0xad8 <corpus.cases.call.call_rec_large.take_large+0x1ec>
+               	j	0xb50 <corpus.cases.call.call_rec_large.take_large+0x264>
+               	bnez	a3, 0xb28 <corpus.cases.call.call_rec_large.take_large+0x23c>
+               	mv	a3, a1
+               	mv	a5, a2
+               	li	s9, 0x20
+               	ld	s10, 0x0(a5)
+               	sd	s10, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a5, a5, 0x8
+               	addi	s9, s9, -0x8
+               	li	t0, 0x0
+               	bne	s9, t0, 0xb08 <corpus.cases.call.call_rec_large.take_large+0x21c>
+               	j	0xb50 <corpus.cases.call.call_rec_large.take_large+0x264>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x20
+               	lbu	a5, 0x0(a1)
+               	sb	a5, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0xb34 <corpus.cases.call.call_rec_large.take_large+0x248>
                	mv	a1, a6
-               	mv	t5, a1
-               	ld	t2, 0x0(t5)
-               	sd	t2, -0xb8(s0)
-               	addi	t5, a1, 0x8
-               	ld	t2, 0x0(t5)
-               	sd	t2, -0xc0(s0)
+               	mv	a2, a1
+               	ld	s9, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	s10, 0x0(a2)
                	addi	a1, a6, 0x10
-               	mv	a6, a1
-               	ld	t2, 0x0(a6)
-               	sd	t2, -0x1a0(s0)
-               	addi	a6, a1, 0x8
-               	ld	t2, 0x0(a6)
-               	sd	t2, -0xc8(s0)
+               	mv	a2, a1
+               	ld	s11, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	t2, 0x0(a2)
+               	sd	t2, -0x388(s0)
                	mv	a1, a7
                	ld	t2, 0x0(a1)
-               	sd	t2, -0x180(s0)
+               	sd	t2, -0x350(s0)
                	addi	a1, a7, 0x8
                	ld	t2, 0x0(a1)
-               	sd	t2, -0xd0(s0)
+               	sd	t2, -0x358(s0)
                	addi	a1, a7, 0x10
                	ld	t2, 0x0(a1)
-               	sd	t2, -0xd8(s0)
+               	sd	t2, -0x360(s0)
                	addi	a1, a7, 0x18
                	ld	t2, 0x0(a1)
-               	sd	t2, -0xe0(s0)
+               	sd	t2, -0x200(s0)
                	addi	a1, a7, 0x20
                	ld	t2, 0x0(a1)
-               	sd	t2, -0xe8(s0)
+               	sd	t2, -0x208(s0)
                	addi	a1, a7, 0x28
                	ld	t2, 0x0(a1)
-               	sd	t2, -0x188(s0)
-               	mv	a1, a4
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0xf0(s0)
-               	addi	a1, a4, 0x8
-               	fld	fs6, 0x0(a1)
-               	addi	a1, a4, 0x10
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0xf8(s0)
-               	addi	a1, a4, 0x14
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0x100(s0)
-               	addi	a1, a4, 0x18
-               	fld	fs7, 0x0(a1)
-               	addi	a1, a4, 0x20
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x108(s0)
-               	addi	a1, a4, 0x28
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x190(s0)
-               	ld	t2, -0xb0(s0)
-               	mv	a1, t2
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x110(s0)
-               	ld	t2, -0xb0(s0)
-               	addi	a1, t2, 0x8
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x118(s0)
-               	ld	t2, -0xb0(s0)
-               	addi	a1, t2, 0x10
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x120(s0)
-               	mv	a1, t6
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x128(s0)
-               	addi	a1, t6, 0x8
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x130(s0)
-               	addi	a1, t6, 0x10
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x138(s0)
-               	addi	a1, t6, 0x18
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x198(s0)
-               	mv	a1, s3
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x140(s0)
-               	addi	a1, s3, 0x8
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x148(s0)
-               	addi	a1, s3, 0x10
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x150(s0)
-               	addi	a1, s3, 0x18
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x158(s0)
-               	addi	a1, s3, 0x20
-               	ld	t2, 0x0(a1)
-               	sd	t2, -0x160(s0)
-               	addi	a1, s3, 0x28
-               	ld	s3, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x270>
+               	sd	t2, -0x368(s0)
                	mv	a1, a0
+               	ld	t2, 0x0(a1)
+               	sd	t2, -0x210(s0)
+               	addi	a1, a0, 0x8
+               	fld	fs6, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	lw	t2, 0x0(a1)
+               	sd	t2, -0x218(s0)
+               	addi	a1, a0, 0x14
+               	lw	t2, 0x0(a1)
+               	sd	t2, -0x220(s0)
+               	addi	a1, a0, 0x18
+               	fld	fs7, 0x0(a1)
+               	addi	a1, a0, 0x20
+               	ld	t2, 0x0(a1)
+               	sd	t2, -0x228(s0)
+               	addi	a1, a0, 0x28
+               	ld	t2, 0x0(a1)
+               	sd	t2, -0x230(s0)
+               	addi	t2, s0, -0xf8
+               	sd	t2, -0x238(s0)
+               	ld	t3, -0x238(s0)
+               	mv	t2, t3
+               	sd	t2, -0x258(s0)
+               	mv	a1, a4
+               	ld	t2, -0x258(s0)
+               	or	a4, t2, a1
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	ld	t2, -0x258(s0)
+               	bltu	t2, a1, 0xca4 <corpus.cases.call.call_rec_large.take_large+0x3b8>
+               	bnez	a4, 0xc74 <corpus.cases.call.call_rec_large.take_large+0x388>
+               	ld	t2, -0x258(s0)
+               	addi	t5, t2, 0x18
+               	addi	t6, a1, 0x18
+               	li	s2, 0x18
+               	addi	t5, t5, -0x8
+               	addi	t6, t6, -0x8
+               	ld	a0, 0x0(t6)
+               	sd	a0, 0x0(t5)
+               	addi	s2, s2, -0x8
+               	li	t0, 0x0
+               	bne	s2, t0, 0xc54 <corpus.cases.call.call_rec_large.take_large+0x368>
+               	j	0xd04 <corpus.cases.call.call_rec_large.take_large+0x418>
+               	ld	t2, -0x258(s0)
+               	addi	a0, t2, 0x18
+               	addi	t5, a1, 0x18
+               	li	t6, 0x18
+               	addi	a0, a0, -0x1
+               	addi	t5, t5, -0x1
+               	lbu	s2, 0x0(t5)
+               	sb	s2, 0x0(a0)
+               	addi	t6, t6, -0x1
+               	li	t0, 0x0
+               	bne	t6, t0, 0xc84 <corpus.cases.call.call_rec_large.take_large+0x398>
+               	j	0xd04 <corpus.cases.call.call_rec_large.take_large+0x418>
+               	bnez	a4, 0xcd8 <corpus.cases.call.call_rec_large.take_large+0x3ec>
+               	ld	t2, -0x258(s0)
+               	mv	a0, t2
+               	mv	a4, a1
+               	li	t5, 0x18
+               	ld	t6, 0x0(a4)
+               	sd	t6, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a4, a4, 0x8
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0xcb8 <corpus.cases.call.call_rec_large.take_large+0x3cc>
+               	j	0xd04 <corpus.cases.call.call_rec_large.take_large+0x418>
+               	ld	t2, -0x258(s0)
+               	mv	a0, t2
+               	mv	a4, a1
+               	li	a1, 0x18
+               	lbu	t5, 0x0(a4)
+               	sb	t5, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a4, a4, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xce8 <corpus.cases.call.call_rec_large.take_large+0x3fc>
+               	addi	s2, s0, -0x118
+               	mv	t2, s2
+               	sd	t2, -0x260(s0)
+               	ld	t3, -0x248(s0)
+               	mv	t2, t3
+               	sd	t2, -0x268(s0)
+               	ld	t2, -0x260(s0)
+               	ld	t3, -0x268(s0)
+               	or	a4, t2, t3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	ld	t2, -0x260(s0)
+               	ld	t3, -0x268(s0)
+               	bltu	t2, t3, 0xda8 <corpus.cases.call.call_rec_large.take_large+0x4bc>
+               	bnez	a4, 0xd74 <corpus.cases.call.call_rec_large.take_large+0x488>
+               	ld	t2, -0x260(s0)
+               	addi	t5, t2, 0x20
+               	ld	t2, -0x268(s0)
+               	addi	t6, t2, 0x20
+               	li	a0, 0x20
+               	addi	t5, t5, -0x8
+               	addi	t6, t6, -0x8
+               	ld	a1, 0x0(t6)
+               	sd	a1, 0x0(t5)
+               	addi	a0, a0, -0x8
+               	li	t0, 0x0
+               	bne	a0, t0, 0xd54 <corpus.cases.call.call_rec_large.take_large+0x468>
+               	j	0xe10 <corpus.cases.call.call_rec_large.take_large+0x524>
+               	ld	t2, -0x260(s0)
+               	addi	a0, t2, 0x20
+               	ld	t2, -0x268(s0)
+               	addi	a1, t2, 0x20
+               	li	t5, 0x20
+               	addi	a0, a0, -0x1
+               	addi	a1, a1, -0x1
+               	lbu	t6, 0x0(a1)
+               	sb	t6, 0x0(a0)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0xd88 <corpus.cases.call.call_rec_large.take_large+0x49c>
+               	j	0xe10 <corpus.cases.call.call_rec_large.take_large+0x524>
+               	bnez	a4, 0xde0 <corpus.cases.call.call_rec_large.take_large+0x4f4>
+               	ld	t2, -0x260(s0)
+               	mv	a0, t2
+               	ld	t2, -0x268(s0)
+               	mv	a1, t2
+               	li	a4, 0x20
+               	ld	t5, 0x0(a1)
+               	sd	t5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0xdc0 <corpus.cases.call.call_rec_large.take_large+0x4d4>
+               	j	0xe10 <corpus.cases.call.call_rec_large.take_large+0x524>
+               	ld	t2, -0x260(s0)
+               	mv	a0, t2
+               	ld	t2, -0x268(s0)
+               	mv	a1, t2
+               	li	a4, 0x20
+               	lbu	t5, 0x0(a1)
+               	sb	t5, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0xdf4 <corpus.cases.call.call_rec_large.take_large+0x508>
+               	ld	t2, -0x250(s0)
+               	mv	a0, t2
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x370(s0)
+               	ld	t2, -0x250(s0)
+               	addi	a0, t2, 0x8
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x378(s0)
+               	ld	t2, -0x250(s0)
+               	addi	a0, t2, 0x10
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x380(s0)
+               	ld	t2, -0x250(s0)
+               	addi	a0, t2, 0x18
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x270(s0)
+               	ld	t2, -0x250(s0)
+               	addi	a0, t2, 0x20
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x278(s0)
+               	ld	t2, -0x250(s0)
+               	addi	a0, t2, 0x28
+               	ld	t2, 0x0(a0)
+               	sd	t2, -0x280(s0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	ld	t2, -0x240(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5ac>
+               	mv	t2, a0
+               	sd	t2, -0x288(s0)
+               	ld	t2, -0x288(s0)
+               	addi	t2, s0, -0x130
+               	sd	t2, -0x290(s0)
+               	ld	t3, -0x290(s0)
+               	mv	t2, t3
+               	sd	t2, -0x298(s0)
+               	mv	t2, s4
+               	sd	t2, -0x2a0(s0)
+               	ld	t3, -0x298(s0)
+               	ld	t4, -0x2a0(s0)
+               	or	t2, t3, t4
+               	sd	t2, -0x2a8(s0)
+               	ld	t2, -0x2a8(s0)
+               	li	t0, 0x7
+               	and	t2, t2, t0
+               	sd	t2, -0x2a8(s0)
+               	ld	t2, -0x298(s0)
+               	ld	t3, -0x2a0(s0)
+               	bltu	t2, t3, 0xf84 <corpus.cases.call.call_rec_large.take_large+0x698>
+               	ld	t2, -0x2a8(s0)
+               	bnez	t2, 0xf40 <corpus.cases.call.call_rec_large.take_large+0x654>
+               	ld	t3, -0x298(s0)
+               	addi	t2, t3, 0x18
+               	sd	t2, -0x2b0(s0)
+               	ld	t2, -0x2a0(s0)
+               	addi	a1, t2, 0x18
+               	li	s4, 0x18
+               	ld	t2, -0x2b0(s0)
+               	addi	t2, t2, -0x8
+               	sd	t2, -0x2b0(s0)
+               	addi	a1, a1, -0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x2b0(s0)
+               	sd	a0, 0x0(t2)
+               	addi	s4, s4, -0x8
+               	li	t0, 0x0
+               	bne	s4, t0, 0xf14 <corpus.cases.call.call_rec_large.take_large+0x628>
+               	j	0x1010 <corpus.cases.call.call_rec_large.take_large+0x724>
+               	ld	t3, -0x298(s0)
+               	addi	t2, t3, 0x18
+               	sd	t2, -0x2b8(s0)
+               	ld	t2, -0x2a0(s0)
+               	addi	a1, t2, 0x18
+               	li	s4, 0x18
+               	ld	t2, -0x2b8(s0)
+               	addi	t2, t2, -0x1
+               	sd	t2, -0x2b8(s0)
+               	addi	a1, a1, -0x1
+               	lbu	a0, 0x0(a1)
+               	ld	t2, -0x2b8(s0)
+               	sb	a0, 0x0(t2)
+               	addi	s4, s4, -0x1
+               	li	t0, 0x0
+               	bne	s4, t0, 0xf58 <corpus.cases.call.call_rec_large.take_large+0x66c>
+               	j	0x1010 <corpus.cases.call.call_rec_large.take_large+0x724>
+               	ld	t2, -0x2a8(s0)
+               	bnez	t2, 0xfd0 <corpus.cases.call.call_rec_large.take_large+0x6e4>
+               	ld	t3, -0x298(s0)
+               	mv	t2, t3
+               	sd	t2, -0x2c0(s0)
+               	ld	t2, -0x2a0(s0)
+               	mv	a1, t2
+               	li	s4, 0x18
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x2c0(s0)
+               	sd	a0, 0x0(t2)
+               	ld	t2, -0x2c0(s0)
+               	addi	t2, t2, 0x8
+               	sd	t2, -0x2c0(s0)
+               	addi	a1, a1, 0x8
+               	addi	s4, s4, -0x8
+               	li	t0, 0x0
+               	bne	s4, t0, 0xfa4 <corpus.cases.call.call_rec_large.take_large+0x6b8>
+               	j	0x1010 <corpus.cases.call.call_rec_large.take_large+0x724>
+               	ld	t3, -0x298(s0)
+               	mv	t2, t3
+               	sd	t2, -0x2c8(s0)
+               	ld	t2, -0x2a0(s0)
+               	mv	a1, t2
+               	li	s4, 0x18
+               	lbu	a0, 0x0(a1)
+               	ld	t2, -0x2c8(s0)
+               	sb	a0, 0x0(t2)
+               	ld	t2, -0x2c8(s0)
+               	addi	t2, t2, 0x1
+               	sd	t2, -0x2c8(s0)
+               	addi	a1, a1, 0x1
+               	addi	s4, s4, -0x1
+               	li	t0, 0x0
+               	bne	s4, t0, 0xfe8 <corpus.cases.call.call_rec_large.take_large+0x6fc>
+               	addi	t2, s0, -0x148
+               	sd	t2, -0x2d0(s0)
+               	ld	t3, -0x290(s0)
+               	mv	t2, t3
+               	sd	t2, -0x2d8(s0)
+               	ld	t3, -0x2d0(s0)
+               	ld	t4, -0x2d8(s0)
+               	or	t2, t3, t4
+               	sd	t2, -0x2e0(s0)
+               	ld	t2, -0x2e0(s0)
+               	li	t0, 0x7
+               	and	t2, t2, t0
+               	sd	t2, -0x2e0(s0)
+               	ld	t2, -0x2d0(s0)
+               	ld	t3, -0x2d8(s0)
+               	bltu	t2, t3, 0x10e0 <corpus.cases.call.call_rec_large.take_large+0x7f4>
+               	ld	t2, -0x2e0(s0)
+               	bnez	t2, 0x109c <corpus.cases.call.call_rec_large.take_large+0x7b0>
+               	ld	t3, -0x2d0(s0)
+               	addi	t2, t3, 0x18
+               	sd	t2, -0x2e8(s0)
+               	ld	t2, -0x2d8(s0)
+               	addi	a1, t2, 0x18
+               	li	s4, 0x18
+               	ld	t2, -0x2e8(s0)
+               	addi	t2, t2, -0x8
+               	sd	t2, -0x2e8(s0)
+               	addi	a1, a1, -0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x2e8(s0)
+               	sd	a0, 0x0(t2)
+               	addi	s4, s4, -0x8
+               	li	t0, 0x0
+               	bne	s4, t0, 0x1070 <corpus.cases.call.call_rec_large.take_large+0x784>
+               	j	0x116c <corpus.cases.call.call_rec_large.take_large+0x880>
+               	ld	t3, -0x2d0(s0)
+               	addi	t2, t3, 0x18
+               	sd	t2, -0x2f0(s0)
+               	ld	t2, -0x2d8(s0)
+               	addi	a1, t2, 0x18
+               	li	s4, 0x18
+               	ld	t2, -0x2f0(s0)
+               	addi	t2, t2, -0x1
+               	sd	t2, -0x2f0(s0)
+               	addi	a1, a1, -0x1
+               	lbu	a0, 0x0(a1)
+               	ld	t2, -0x2f0(s0)
+               	sb	a0, 0x0(t2)
+               	addi	s4, s4, -0x1
+               	li	t0, 0x0
+               	bne	s4, t0, 0x10b4 <corpus.cases.call.call_rec_large.take_large+0x7c8>
+               	j	0x116c <corpus.cases.call.call_rec_large.take_large+0x880>
+               	ld	t2, -0x2e0(s0)
+               	bnez	t2, 0x112c <corpus.cases.call.call_rec_large.take_large+0x840>
+               	ld	t3, -0x2d0(s0)
+               	mv	t2, t3
+               	sd	t2, -0x2f8(s0)
+               	ld	t2, -0x2d8(s0)
+               	mv	a1, t2
+               	li	s4, 0x18
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x2f8(s0)
+               	sd	a0, 0x0(t2)
+               	ld	t2, -0x2f8(s0)
+               	addi	t2, t2, 0x8
+               	sd	t2, -0x2f8(s0)
+               	addi	a1, a1, 0x8
+               	addi	s4, s4, -0x8
+               	li	t0, 0x0
+               	bne	s4, t0, 0x1100 <corpus.cases.call.call_rec_large.take_large+0x814>
+               	j	0x116c <corpus.cases.call.call_rec_large.take_large+0x880>
+               	ld	t3, -0x2d0(s0)
+               	mv	t2, t3
+               	sd	t2, -0x300(s0)
+               	ld	t2, -0x2d8(s0)
+               	mv	a1, t2
+               	li	s4, 0x18
+               	lbu	a0, 0x0(a1)
+               	ld	t2, -0x300(s0)
+               	sb	a0, 0x0(t2)
+               	ld	t2, -0x300(s0)
+               	addi	t2, t2, 0x1
+               	sd	t2, -0x300(s0)
+               	addi	a1, a1, 0x1
+               	addi	s4, s4, -0x1
+               	li	t0, 0x0
+               	bne	s4, t0, 0x1144 <corpus.cases.call.call_rec_large.take_large+0x858>
+               	addi	a1, s0, -0x148
+               	ld	t2, -0x288(s0)
+               	mv	a0, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x88c>
+               	fmv.x.d	t2, fs2
+               	sd	t2, -0x308(s0)
+               	mv	t2, a0
+               	sd	t2, -0x310(s0)
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x11a0 <corpus.cases.call.call_rec_large.take_large+0x8b4>
+               	j	0x11e4 <corpus.cases.call.call_rec_large.take_large+0x8f8>
+               	li	t0, 0x8
+               	mul	a1, s4, t0
+               	ld	t2, -0x308(s0)
+               	srl	a0, t2, a1
+               	li	t0, 0xff
+               	and	a1, a0, t0
+               	ld	t2, -0x310(s0)
+               	xor	a0, t2, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a0, t0
+               	addi	s4, s4, 0x1
+               	mv	t2, a1
+               	sd	t2, -0x310(s0)
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x11a0 <corpus.cases.call.call_rec_large.take_large+0x8b4>
+               	fmv.x.d	t2, fs3
+               	sd	t2, -0x318(s0)
+               	ld	t3, -0x310(s0)
+               	mv	t2, t3
+               	sd	t2, -0x320(s0)
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1208 <corpus.cases.call.call_rec_large.take_large+0x91c>
+               	j	0x124c <corpus.cases.call.call_rec_large.take_large+0x960>
+               	li	t0, 0x8
+               	mul	a0, s4, t0
+               	ld	t2, -0x318(s0)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	ld	t2, -0x320(s0)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	addi	s4, s4, 0x1
+               	mv	t2, a0
+               	sd	t2, -0x320(s0)
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1208 <corpus.cases.call.call_rec_large.take_large+0x91c>
+               	fmv.x.d	t2, fs4
+               	sd	t2, -0x328(s0)
+               	ld	t3, -0x320(s0)
+               	mv	t2, t3
+               	sd	t2, -0x330(s0)
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1270 <corpus.cases.call.call_rec_large.take_large+0x984>
+               	j	0x12b4 <corpus.cases.call.call_rec_large.take_large+0x9c8>
+               	li	t0, 0x8
+               	mul	a0, s4, t0
+               	ld	t2, -0x328(s0)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	ld	t2, -0x330(s0)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	addi	s4, s4, 0x1
+               	mv	t2, a0
+               	sd	t2, -0x330(s0)
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1270 <corpus.cases.call.call_rec_large.take_large+0x984>
+               	ld	t3, -0x330(s0)
+               	mv	t2, t3
+               	sd	t2, -0x338(s0)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12d0 <corpus.cases.call.call_rec_large.take_large+0x9e4>
+               	j	0x1310 <corpus.cases.call.call_rec_large.take_large+0xa24>
+               	li	t0, 0x8
+               	mul	s4, a1, t0
+               	srl	a0, s5, s4
+               	li	t0, 0xff
+               	and	s4, a0, t0
+               	ld	t2, -0x338(s0)
+               	xor	a0, t2, s4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a0, t0
+               	addi	a1, a1, 0x1
+               	mv	t2, s4
+               	sd	t2, -0x338(s0)
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12d0 <corpus.cases.call.call_rec_large.take_large+0x9e4>
+               	fmv.x.d	t2, fs5
+               	sd	t2, -0x340(s0)
+               	ld	t2, -0x338(s0)
+               	mv	a1, t2
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1330 <corpus.cases.call.call_rec_large.take_large+0xa44>
+               	j	0x1368 <corpus.cases.call.call_rec_large.take_large+0xa7c>
+               	li	t0, 0x8
+               	mul	s5, s4, t0
+               	ld	t2, -0x340(s0)
+               	srl	a0, t2, s5
+               	li	t0, 0xff
+               	and	s5, a0, t0
+               	xor	a0, a1, s5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a0, t0
+               	addi	s4, s4, 0x1
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1330 <corpus.cases.call.call_rec_large.take_large+0xa44>
+               	slli	a0, s6, 0x20
+               	srli	a0, a0, 0x20
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1380 <corpus.cases.call.call_rec_large.take_large+0xa94>
+               	j	0x13b4 <corpus.cases.call.call_rec_large.take_large+0xac8>
+               	li	t0, 0x8
+               	mul	s5, s4, t0
+               	srl	s6, a0, s5
+               	li	t0, 0xff
+               	and	s5, s6, t0
+               	xor	s6, a1, s5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, s6, t0
+               	addi	s4, s4, 0x1
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x1380 <corpus.cases.call.call_rec_large.take_large+0xa94>
+               	slli	a0, s7, 0x20
+               	srli	a0, a0, 0x20
+               	li	s4, 0x0
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x13cc <corpus.cases.call.call_rec_large.take_large+0xae0>
+               	j	0x1400 <corpus.cases.call.call_rec_large.take_large+0xb14>
+               	li	t0, 0x8
+               	mul	s5, s4, t0
+               	srl	s6, a0, s5
+               	li	t0, 0xff
+               	and	s5, s6, t0
+               	xor	s6, a1, s5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, s6, t0
+               	addi	s4, s4, 0x1
+               	li	t0, 0x8
+               	bltu	s4, t0, 0x13cc <corpus.cases.call.call_rec_large.take_large+0xae0>
+               	slli	s4, s1, 0x20
+               	srli	s4, s4, 0x20
                	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x284>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x290>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x29c>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2a8>
-               	fmv.d	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2b4>
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2c0>
-               	fmv.d	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2cc>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2d8>
-               	fmv.d	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2e4>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2f0>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x2fc>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x308>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x314>
-               	ld	t2, -0x168(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x324>
-               	ld	t2, -0x170(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x334>
-               	ld	t2, -0x178(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x344>
-               	ld	t2, -0xb8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x354>
-               	ld	t2, -0xc0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x364>
-               	ld	t2, -0x1a0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x374>
-               	ld	t2, -0xc8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x384>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x390>
-               	ld	t2, -0x180(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3a0>
-               	ld	t2, -0xd0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3b0>
-               	ld	t2, -0xd8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3c0>
-               	ld	t2, -0xe0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3d0>
-               	ld	t2, -0xe8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3e0>
-               	ld	t2, -0x188(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x3f0>
-               	ld	t2, -0xf0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x400>
-               	fmv.d	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x40c>
-               	ld	t2, -0xf8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x41c>
-               	ld	t2, -0x100(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x42c>
-               	fmv.d	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x438>
-               	ld	t2, -0x108(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x448>
-               	ld	t2, -0x190(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x458>
-               	ld	t2, -0x110(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x468>
-               	ld	t2, -0x118(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x478>
-               	ld	t2, -0x120(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x488>
-               	ld	t2, -0x128(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x498>
-               	ld	t2, -0x130(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4a8>
-               	ld	t2, -0x138(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4b8>
-               	ld	t2, -0x198(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4c8>
-               	ld	t2, -0x140(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4d8>
-               	ld	t2, -0x148(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4e8>
-               	ld	t2, -0x150(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x4f8>
-               	ld	t2, -0x158(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x508>
-               	ld	t2, -0x160(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x518>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x524>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x530>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x53c>
-               	ld	t2, -0x180(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xb24>
+               	mv	t2, a0
+               	sd	t2, -0x348(s0)
+               	ld	t2, -0x348(s0)
+               	addi	a1, s0, -0x168
+               	mv	s1, a1
+               	mv	s4, s8
+               	or	s5, s1, s4
+               	li	t0, 0x7
+               	and	s5, s5, t0
+               	bltu	s1, s4, 0x149c <corpus.cases.call.call_rec_large.take_large+0xbb0>
+               	bnez	s5, 0x1470 <corpus.cases.call.call_rec_large.take_large+0xb84>
+               	addi	s6, s1, 0x20
+               	addi	s7, s4, 0x20
+               	li	s8, 0x20
+               	addi	s6, s6, -0x8
+               	addi	s7, s7, -0x8
+               	ld	a0, 0x0(s7)
+               	sd	a0, 0x0(s6)
+               	addi	s8, s8, -0x8
+               	li	t0, 0x0
+               	bne	s8, t0, 0x1450 <corpus.cases.call.call_rec_large.take_large+0xb64>
+               	j	0x14f4 <corpus.cases.call.call_rec_large.take_large+0xc08>
+               	addi	a0, s1, 0x20
+               	addi	s6, s4, 0x20
+               	li	s7, 0x20
+               	addi	a0, a0, -0x1
+               	addi	s6, s6, -0x1
+               	lbu	s8, 0x0(s6)
+               	sb	s8, 0x0(a0)
+               	addi	s7, s7, -0x1
+               	li	t0, 0x0
+               	bne	s7, t0, 0x147c <corpus.cases.call.call_rec_large.take_large+0xb90>
+               	j	0x14f4 <corpus.cases.call.call_rec_large.take_large+0xc08>
+               	bnez	s5, 0x14cc <corpus.cases.call.call_rec_large.take_large+0xbe0>
+               	mv	a0, s1
+               	mv	s5, s4
+               	li	s6, 0x20
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	s5, s5, 0x8
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x14ac <corpus.cases.call.call_rec_large.take_large+0xbc0>
+               	j	0x14f4 <corpus.cases.call.call_rec_large.take_large+0xc08>
+               	mv	a0, s1
+               	mv	s1, s4
+               	li	s4, 0x20
+               	lbu	s5, 0x0(s1)
+               	sb	s5, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	s1, s1, 0x1
+               	addi	s4, s4, -0x1
+               	li	t0, 0x0
+               	bne	s4, t0, 0x14d8 <corpus.cases.call.call_rec_large.take_large+0xbec>
+               	addi	a0, s0, -0x188
+               	mv	s1, a1
+               	or	a1, a0, s1
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a0, s1, 0x1568 <corpus.cases.call.call_rec_large.take_large+0xc7c>
+               	bnez	a1, 0x153c <corpus.cases.call.call_rec_large.take_large+0xc50>
+               	addi	s4, a0, 0x20
+               	addi	s5, s1, 0x20
+               	li	s6, 0x20
+               	addi	s4, s4, -0x8
+               	addi	s5, s5, -0x8
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(s4)
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x151c <corpus.cases.call.call_rec_large.take_large+0xc30>
+               	j	0x15c0 <corpus.cases.call.call_rec_large.take_large+0xcd4>
+               	addi	s4, a0, 0x20
+               	addi	s5, s1, 0x20
+               	li	s6, 0x20
+               	addi	s4, s4, -0x1
+               	addi	s5, s5, -0x1
+               	lbu	s7, 0x0(s5)
+               	sb	s7, 0x0(s4)
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0x1548 <corpus.cases.call.call_rec_large.take_large+0xc5c>
+               	j	0x15c0 <corpus.cases.call.call_rec_large.take_large+0xcd4>
+               	bnez	a1, 0x1598 <corpus.cases.call.call_rec_large.take_large+0xcac>
+               	mv	a1, a0
+               	mv	s4, s1
+               	li	s5, 0x20
+               	ld	s6, 0x0(s4)
+               	sd	s6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	s4, s4, 0x8
+               	addi	s5, s5, -0x8
+               	li	t0, 0x0
+               	bne	s5, t0, 0x1578 <corpus.cases.call.call_rec_large.take_large+0xc8c>
+               	j	0x15c0 <corpus.cases.call.call_rec_large.take_large+0xcd4>
+               	mv	a1, a0
+               	mv	a0, s1
+               	li	s1, 0x20
+               	lbu	s4, 0x0(a0)
+               	sb	s4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, 0x1
+               	addi	s1, s1, -0x1
+               	li	t0, 0x0
+               	bne	s1, t0, 0x15a4 <corpus.cases.call.call_rec_large.take_large+0xcb8>
+               	addi	a1, s0, -0x188
+               	ld	t2, -0x348(s0)
+               	mv	a0, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xce0>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15e4 <corpus.cases.call.call_rec_large.take_large+0xcf8>
+               	j	0x1618 <corpus.cases.call.call_rec_large.take_large+0xd2c>
+               	li	t0, 0x8
+               	mul	s1, a1, t0
+               	srl	s4, s9, s1
+               	li	t0, 0xff
+               	and	s1, s4, t0
+               	xor	s4, a0, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15e4 <corpus.cases.call.call_rec_large.take_large+0xcf8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1628 <corpus.cases.call.call_rec_large.take_large+0xd3c>
+               	j	0x165c <corpus.cases.call.call_rec_large.take_large+0xd70>
+               	li	t0, 0x8
+               	mul	s1, a1, t0
+               	srl	s4, s10, s1
+               	li	t0, 0xff
+               	and	s1, s4, t0
+               	xor	s4, a0, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1628 <corpus.cases.call.call_rec_large.take_large+0xd3c>
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xd74>
+               	ld	t2, -0x388(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xd84>
+               	fmv.x.d	a1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xd90>
+               	ld	t2, -0x350(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xda0>
+               	ld	t2, -0x358(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xdb0>
+               	ld	t2, -0x360(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xdc0>
+               	ld	t2, -0x200(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xdd0>
+               	ld	t2, -0x208(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xde0>
+               	ld	t2, -0x368(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xdf0>
+               	ld	t2, -0x210(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe00>
+               	fmv.x.d	a1, fs6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe0c>
+               	ld	t2, -0x218(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe20>
+               	ld	t2, -0x220(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe34>
+               	fmv.x.d	a1, fs7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe40>
+               	ld	t2, -0x228(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe50>
+               	ld	t2, -0x230(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0xe60>
+               	addi	a1, s0, -0x1a0
+               	mv	a3, a1
+               	ld	t2, -0x238(s0)
+               	mv	s1, t2
+               	or	s4, a3, s1
+               	li	t0, 0x7
+               	and	s4, s4, t0
+               	bltu	a3, s1, 0x17d0 <corpus.cases.call.call_rec_large.take_large+0xee4>
+               	bnez	s4, 0x17a4 <corpus.cases.call.call_rec_large.take_large+0xeb8>
+               	addi	s5, a3, 0x18
+               	addi	s6, s1, 0x18
+               	li	s7, 0x18
+               	addi	s5, s5, -0x8
+               	addi	s6, s6, -0x8
+               	ld	s8, 0x0(s6)
+               	sd	s8, 0x0(s5)
+               	addi	s7, s7, -0x8
+               	li	t0, 0x0
+               	bne	s7, t0, 0x1784 <corpus.cases.call.call_rec_large.take_large+0xe98>
+               	j	0x1828 <corpus.cases.call.call_rec_large.take_large+0xf3c>
+               	addi	s5, a3, 0x18
+               	addi	s6, s1, 0x18
+               	li	s7, 0x18
+               	addi	s5, s5, -0x1
+               	addi	s6, s6, -0x1
+               	lbu	s8, 0x0(s6)
+               	sb	s8, 0x0(s5)
+               	addi	s7, s7, -0x1
+               	li	t0, 0x0
+               	bne	s7, t0, 0x17b0 <corpus.cases.call.call_rec_large.take_large+0xec4>
+               	j	0x1828 <corpus.cases.call.call_rec_large.take_large+0xf3c>
+               	bnez	s4, 0x1800 <corpus.cases.call.call_rec_large.take_large+0xf14>
+               	mv	s4, a3
+               	mv	s5, s1
+               	li	s6, 0x18
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(s4)
+               	addi	s4, s4, 0x8
+               	addi	s5, s5, 0x8
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x17e0 <corpus.cases.call.call_rec_large.take_large+0xef4>
+               	j	0x1828 <corpus.cases.call.call_rec_large.take_large+0xf3c>
+               	mv	s4, a3
+               	mv	a3, s1
+               	li	s1, 0x18
+               	lbu	s5, 0x0(a3)
+               	sb	s5, 0x0(s4)
+               	addi	s4, s4, 0x1
+               	addi	a3, a3, 0x1
+               	addi	s1, s1, -0x1
+               	li	t0, 0x0
+               	bne	s1, t0, 0x180c <corpus.cases.call.call_rec_large.take_large+0xf20>
+               	addi	a3, s0, -0x1b8
+               	mv	s1, a1
+               	or	a1, a3, s1
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, s1, 0x189c <corpus.cases.call.call_rec_large.take_large+0xfb0>
+               	bnez	a1, 0x1870 <corpus.cases.call.call_rec_large.take_large+0xf84>
+               	addi	s4, a3, 0x18
+               	addi	s5, s1, 0x18
+               	li	s6, 0x18
+               	addi	s4, s4, -0x8
+               	addi	s5, s5, -0x8
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(s4)
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x1850 <corpus.cases.call.call_rec_large.take_large+0xf64>
+               	j	0x18f4 <corpus.cases.call.call_rec_large.take_large+0x1008>
+               	addi	s4, a3, 0x18
+               	addi	s5, s1, 0x18
+               	li	s6, 0x18
+               	addi	s4, s4, -0x1
+               	addi	s5, s5, -0x1
+               	lbu	s7, 0x0(s5)
+               	sb	s7, 0x0(s4)
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0x187c <corpus.cases.call.call_rec_large.take_large+0xf90>
+               	j	0x18f4 <corpus.cases.call.call_rec_large.take_large+0x1008>
+               	bnez	a1, 0x18cc <corpus.cases.call.call_rec_large.take_large+0xfe0>
+               	mv	a1, a3
+               	mv	s4, s1
+               	li	s5, 0x18
+               	ld	s6, 0x0(s4)
+               	sd	s6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	s4, s4, 0x8
+               	addi	s5, s5, -0x8
+               	li	t0, 0x0
+               	bne	s5, t0, 0x18ac <corpus.cases.call.call_rec_large.take_large+0xfc0>
+               	j	0x18f4 <corpus.cases.call.call_rec_large.take_large+0x1008>
+               	mv	a1, a3
+               	mv	a3, s1
+               	li	s1, 0x18
+               	lbu	s4, 0x0(a3)
+               	sb	s4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	s1, s1, -0x1
+               	li	t0, 0x0
+               	bne	s1, t0, 0x18d8 <corpus.cases.call.call_rec_large.take_large+0xfec>
+               	addi	a1, s0, -0x1b8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x100c>
+               	addi	a1, s0, -0x1d8
+               	mv	a3, a1
+               	mv	s1, s2
+               	or	s2, a3, s1
+               	li	t0, 0x7
+               	and	s2, s2, t0
+               	bltu	a3, s1, 0x1978 <corpus.cases.call.call_rec_large.take_large+0x108c>
+               	bnez	s2, 0x194c <corpus.cases.call.call_rec_large.take_large+0x1060>
+               	addi	s4, a3, 0x20
+               	addi	s5, s1, 0x20
+               	li	s6, 0x20
+               	addi	s4, s4, -0x8
+               	addi	s5, s5, -0x8
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(s4)
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x192c <corpus.cases.call.call_rec_large.take_large+0x1040>
+               	j	0x19d0 <corpus.cases.call.call_rec_large.take_large+0x10e4>
+               	addi	s4, a3, 0x20
+               	addi	s5, s1, 0x20
+               	li	s6, 0x20
+               	addi	s4, s4, -0x1
+               	addi	s5, s5, -0x1
+               	lbu	s7, 0x0(s5)
+               	sb	s7, 0x0(s4)
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0x1958 <corpus.cases.call.call_rec_large.take_large+0x106c>
+               	j	0x19d0 <corpus.cases.call.call_rec_large.take_large+0x10e4>
+               	bnez	s2, 0x19a8 <corpus.cases.call.call_rec_large.take_large+0x10bc>
+               	mv	s2, a3
+               	mv	s4, s1
+               	li	s5, 0x20
+               	ld	s6, 0x0(s4)
+               	sd	s6, 0x0(s2)
+               	addi	s2, s2, 0x8
+               	addi	s4, s4, 0x8
+               	addi	s5, s5, -0x8
+               	li	t0, 0x0
+               	bne	s5, t0, 0x1988 <corpus.cases.call.call_rec_large.take_large+0x109c>
+               	j	0x19d0 <corpus.cases.call.call_rec_large.take_large+0x10e4>
+               	mv	s2, a3
+               	mv	a3, s1
+               	li	s1, 0x20
+               	lbu	s4, 0x0(a3)
+               	sb	s4, 0x0(s2)
+               	addi	s2, s2, 0x1
+               	addi	a3, a3, 0x1
+               	addi	s1, s1, -0x1
+               	li	t0, 0x0
+               	bne	s1, t0, 0x19b4 <corpus.cases.call.call_rec_large.take_large+0x10c8>
+               	addi	a3, s0, -0x1f8
+               	mv	s1, a1
+               	or	a1, a3, s1
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, s1, 0x1a44 <corpus.cases.call.call_rec_large.take_large+0x1158>
+               	bnez	a1, 0x1a18 <corpus.cases.call.call_rec_large.take_large+0x112c>
+               	addi	s2, a3, 0x20
+               	addi	s4, s1, 0x20
+               	li	s5, 0x20
+               	addi	s2, s2, -0x8
+               	addi	s4, s4, -0x8
+               	ld	s6, 0x0(s4)
+               	sd	s6, 0x0(s2)
+               	addi	s5, s5, -0x8
+               	li	t0, 0x0
+               	bne	s5, t0, 0x19f8 <corpus.cases.call.call_rec_large.take_large+0x110c>
+               	j	0x1a9c <corpus.cases.call.call_rec_large.take_large+0x11b0>
+               	addi	s2, a3, 0x20
+               	addi	s4, s1, 0x20
+               	li	s5, 0x20
+               	addi	s2, s2, -0x1
+               	addi	s4, s4, -0x1
+               	lbu	s6, 0x0(s4)
+               	sb	s6, 0x0(s2)
+               	addi	s5, s5, -0x1
+               	li	t0, 0x0
+               	bne	s5, t0, 0x1a24 <corpus.cases.call.call_rec_large.take_large+0x1138>
+               	j	0x1a9c <corpus.cases.call.call_rec_large.take_large+0x11b0>
+               	bnez	a1, 0x1a74 <corpus.cases.call.call_rec_large.take_large+0x1188>
+               	mv	a1, a3
+               	mv	s2, s1
+               	li	s4, 0x20
+               	ld	s5, 0x0(s2)
+               	sd	s5, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	s2, s2, 0x8
+               	addi	s4, s4, -0x8
+               	li	t0, 0x0
+               	bne	s4, t0, 0x1a54 <corpus.cases.call.call_rec_large.take_large+0x1168>
+               	j	0x1a9c <corpus.cases.call.call_rec_large.take_large+0x11b0>
+               	mv	a1, a3
+               	mv	a3, s1
+               	li	s1, 0x20
+               	lbu	s2, 0x0(a3)
+               	sb	s2, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	s1, s1, -0x1
+               	li	t0, 0x0
+               	bne	s1, t0, 0x1a80 <corpus.cases.call.call_rec_large.take_large+0x1194>
+               	addi	a1, s0, -0x1f8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x11b4>
+               	ld	t2, -0x370(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x11c4>
+               	ld	t2, -0x378(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x11d4>
+               	ld	t2, -0x380(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x11e4>
+               	ld	t2, -0x270(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x11f4>
+               	ld	t2, -0x278(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x1204>
+               	ld	t2, -0x280(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x1214>
+               	fmv.x.w	a1, fs1
+               	slli	a3, a1, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a1, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x122c>
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x1238>
+               	ld	t2, -0x350(s0)
                	addi	a1, t2, 0x1
-               	ld	t2, -0x188(s0)
+               	ld	t2, -0x368(s0)
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	xor	s1, t2, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x560>
-               	ld	t2, -0xd0(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x125c>
+               	ld	t2, -0x358(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x570>
-               	ld	t2, -0xd8(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x126c>
+               	ld	t2, -0x360(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x580>
-               	ld	t2, -0xe0(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x127c>
+               	ld	t2, -0x200(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x590>
-               	ld	t2, -0xe8(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x128c>
+               	ld	t2, -0x208(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5a0>
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x129c>
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5ac>
-               	ld	t2, -0x180(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12a8>
+               	ld	t2, -0x350(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5bc>
-               	ld	t2, -0xd0(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12b8>
+               	ld	t2, -0x358(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5cc>
-               	ld	t2, -0xd8(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12c8>
+               	ld	t2, -0x360(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5dc>
-               	ld	t2, -0xe0(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12d8>
+               	ld	t2, -0x200(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5ec>
-               	ld	t2, -0xe8(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12e8>
+               	ld	t2, -0x208(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x5fc>
-               	ld	t2, -0x188(s0)
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x12f8>
+               	ld	t2, -0x368(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x60c>
-               	ld	s1, 0x198(sp)
-               	ld	s2, 0x190(sp)
-               	ld	s3, 0x188(sp)
-               	ld	s4, 0x180(sp)
-               	ld	s5, 0x178(sp)
-               	ld	s6, 0x170(sp)
-               	ld	s7, 0x168(sp)
-               	ld	s8, 0x160(sp)
-               	ld	s9, 0x158(sp)
-               	ld	s10, 0x150(sp)
-               	ld	s11, 0x148(sp)
-               	fld	fs0, 0x140(sp)
-               	fld	fs1, 0x138(sp)
-               	fld	fs2, 0x130(sp)
-               	fld	fs3, 0x128(sp)
-               	fld	fs4, 0x120(sp)
-               	fld	fs5, 0x118(sp)
-               	fld	fs6, 0x110(sp)
-               	fld	fs7, 0x108(sp)
-               	ld	ra, 0x1a8(sp)
-               	ld	s0, 0x1a0(sp)
-               	addi	sp, sp, 0x1b0
+               	jalr	ra <corpus.cases.call.call_rec_large.take_large+0x1308>
+               	ld	s1, 0x378(sp)
+               	ld	s2, 0x370(sp)
+               	ld	s3, 0x368(sp)
+               	ld	s4, 0x360(sp)
+               	ld	s5, 0x358(sp)
+               	ld	s6, 0x350(sp)
+               	ld	s7, 0x348(sp)
+               	ld	s8, 0x340(sp)
+               	ld	s9, 0x338(sp)
+               	ld	s10, 0x330(sp)
+               	ld	s11, 0x328(sp)
+               	fld	fs0, 0x320(sp)
+               	fld	fs1, 0x318(sp)
+               	fld	fs2, 0x310(sp)
+               	fld	fs3, 0x308(sp)
+               	fld	fs4, 0x300(sp)
+               	fld	fs5, 0x2f8(sp)
+               	fld	fs6, 0x2f0(sp)
+               	fld	fs7, 0x2e8(sp)
+               	ld	ra, 0x388(sp)
+               	ld	s0, 0x380(sp)
+               	addi	sp, sp, 0x390
                	ret
 
 <corpus.cases.call.call_rec_large.mk24>:
@@ -893,8 +1859,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xdf8 <corpus.cases.call.call_rec_large.mk24+0xb8>
-               	bnez	a2, 0xdcc <corpus.cases.call.call_rec_large.mk24+0x8c>
+               	bltu	a1, a3, 0x1d10 <corpus.cases.call.call_rec_large.mk24+0xb8>
+               	bnez	a2, 0x1ce4 <corpus.cases.call.call_rec_large.mk24+0x8c>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -904,8 +1870,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdac <corpus.cases.call.call_rec_large.mk24+0x6c>
-               	j	0xe50 <corpus.cases.call.call_rec_large.mk24+0x110>
+               	bne	a6, t0, 0x1cc4 <corpus.cases.call.call_rec_large.mk24+0x6c>
+               	j	0x1d68 <corpus.cases.call.call_rec_large.mk24+0x110>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -915,9 +1881,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xdd8 <corpus.cases.call.call_rec_large.mk24+0x98>
-               	j	0xe50 <corpus.cases.call.call_rec_large.mk24+0x110>
-               	bnez	a2, 0xe28 <corpus.cases.call.call_rec_large.mk24+0xe8>
+               	bne	a6, t0, 0x1cf0 <corpus.cases.call.call_rec_large.mk24+0x98>
+               	j	0x1d68 <corpus.cases.call.call_rec_large.mk24+0x110>
+               	bnez	a2, 0x1d40 <corpus.cases.call.call_rec_large.mk24+0xe8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -927,8 +1893,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xe08 <corpus.cases.call.call_rec_large.mk24+0xc8>
-               	j	0xe50 <corpus.cases.call.call_rec_large.mk24+0x110>
+               	bne	a5, t0, 0x1d20 <corpus.cases.call.call_rec_large.mk24+0xc8>
+               	j	0x1d68 <corpus.cases.call.call_rec_large.mk24+0x110>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -938,7 +1904,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xe34 <corpus.cases.call.call_rec_large.mk24+0xf4>
+               	bne	a3, t0, 0x1d4c <corpus.cases.call.call_rec_large.mk24+0xf4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -988,8 +1954,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xf54 <.Lpcrel_hi.2+0x88>
-               	bnez	a2, 0xf28 <.Lpcrel_hi.2+0x5c>
+               	bltu	a1, a3, 0x1e6c <.Lpcrel_hi.2+0x88>
+               	bnez	a2, 0x1e40 <.Lpcrel_hi.2+0x5c>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -999,8 +1965,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xf08 <.Lpcrel_hi.2+0x3c>
-               	j	0xfac <.Lpcrel_hi.2+0xe0>
+               	bne	a6, t0, 0x1e20 <.Lpcrel_hi.2+0x3c>
+               	j	0x1ec4 <.Lpcrel_hi.2+0xe0>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1010,9 +1976,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xf34 <.Lpcrel_hi.2+0x68>
-               	j	0xfac <.Lpcrel_hi.2+0xe0>
-               	bnez	a2, 0xf84 <.Lpcrel_hi.2+0xb8>
+               	bne	a6, t0, 0x1e4c <.Lpcrel_hi.2+0x68>
+               	j	0x1ec4 <.Lpcrel_hi.2+0xe0>
+               	bnez	a2, 0x1e9c <.Lpcrel_hi.2+0xb8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -1022,8 +1988,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xf64 <.Lpcrel_hi.2+0x98>
-               	j	0xfac <.Lpcrel_hi.2+0xe0>
+               	bne	a5, t0, 0x1e7c <.Lpcrel_hi.2+0x98>
+               	j	0x1ec4 <.Lpcrel_hi.2+0xe0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -1033,7 +1999,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xf90 <.Lpcrel_hi.2+0xc4>
+               	bne	a3, t0, 0x1ea8 <.Lpcrel_hi.2+0xc4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -1070,8 +2036,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x108c <.Lpcrel_hi.3+0xa4>
-               	bnez	a2, 0x1060 <.Lpcrel_hi.3+0x78>
+               	bltu	a1, a3, 0x1fa4 <.Lpcrel_hi.3+0xa4>
+               	bnez	a2, 0x1f78 <.Lpcrel_hi.3+0x78>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1081,8 +2047,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1040 <.Lpcrel_hi.3+0x58>
-               	j	0x10e4 <.Lpcrel_hi.3+0xfc>
+               	bne	a6, t0, 0x1f58 <.Lpcrel_hi.3+0x58>
+               	j	0x1ffc <.Lpcrel_hi.3+0xfc>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1092,9 +2058,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x106c <.Lpcrel_hi.3+0x84>
-               	j	0x10e4 <.Lpcrel_hi.3+0xfc>
-               	bnez	a2, 0x10bc <.Lpcrel_hi.3+0xd4>
+               	bne	a6, t0, 0x1f84 <.Lpcrel_hi.3+0x84>
+               	j	0x1ffc <.Lpcrel_hi.3+0xfc>
+               	bnez	a2, 0x1fd4 <.Lpcrel_hi.3+0xd4>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -1104,8 +2070,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x109c <.Lpcrel_hi.3+0xb4>
-               	j	0x10e4 <.Lpcrel_hi.3+0xfc>
+               	bne	a5, t0, 0x1fb4 <.Lpcrel_hi.3+0xb4>
+               	j	0x1ffc <.Lpcrel_hi.3+0xfc>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -1115,7 +2081,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x10c8 <.Lpcrel_hi.3+0xe0>
+               	bne	a3, t0, 0x1fe0 <.Lpcrel_hi.3+0xe0>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -1144,8 +2110,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x11ac <corpus.cases.call.call_rec_large.mk32+0xb8>
-               	bnez	a2, 0x1180 <corpus.cases.call.call_rec_large.mk32+0x8c>
+               	bltu	a1, a3, 0x20c4 <corpus.cases.call.call_rec_large.mk32+0xb8>
+               	bnez	a2, 0x2098 <corpus.cases.call.call_rec_large.mk32+0x8c>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -1155,8 +2121,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1160 <corpus.cases.call.call_rec_large.mk32+0x6c>
-               	j	0x1204 <corpus.cases.call.call_rec_large.mk32+0x110>
+               	bne	a6, t0, 0x2078 <corpus.cases.call.call_rec_large.mk32+0x6c>
+               	j	0x211c <corpus.cases.call.call_rec_large.mk32+0x110>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -1166,9 +2132,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x118c <corpus.cases.call.call_rec_large.mk32+0x98>
-               	j	0x1204 <corpus.cases.call.call_rec_large.mk32+0x110>
-               	bnez	a2, 0x11dc <corpus.cases.call.call_rec_large.mk32+0xe8>
+               	bne	a6, t0, 0x20a4 <corpus.cases.call.call_rec_large.mk32+0x98>
+               	j	0x211c <corpus.cases.call.call_rec_large.mk32+0x110>
+               	bnez	a2, 0x20f4 <corpus.cases.call.call_rec_large.mk32+0xe8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x20
@@ -1178,8 +2144,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x11bc <corpus.cases.call.call_rec_large.mk32+0xc8>
-               	j	0x1204 <corpus.cases.call.call_rec_large.mk32+0x110>
+               	bne	a5, t0, 0x20d4 <corpus.cases.call.call_rec_large.mk32+0xc8>
+               	j	0x211c <corpus.cases.call.call_rec_large.mk32+0x110>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x20
@@ -1189,7 +2155,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x11e8 <corpus.cases.call.call_rec_large.mk32+0xf4>
+               	bne	a3, t0, 0x2100 <corpus.cases.call.call_rec_large.mk32+0xf4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -1213,8 +2179,8 @@ Disassembly of section .text:
                	or	a3, a5, a4
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a5, a4, 0x12b8 <corpus.cases.call.call_rec_large.mk32n+0xa4>
-               	bnez	a3, 0x128c <corpus.cases.call.call_rec_large.mk32n+0x78>
+               	bltu	a5, a4, 0x21d0 <corpus.cases.call.call_rec_large.mk32n+0xa4>
+               	bnez	a3, 0x21a4 <corpus.cases.call.call_rec_large.mk32n+0x78>
                	addi	a6, a5, 0x10
                	addi	a7, a4, 0x10
                	li	t5, 0x10
@@ -1224,8 +2190,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a6)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x126c <corpus.cases.call.call_rec_large.mk32n+0x58>
-               	j	0x1310 <corpus.cases.call.call_rec_large.mk32n+0xfc>
+               	bne	t5, t0, 0x2184 <corpus.cases.call.call_rec_large.mk32n+0x58>
+               	j	0x2228 <corpus.cases.call.call_rec_large.mk32n+0xfc>
                	addi	a6, a5, 0x10
                	addi	a7, a4, 0x10
                	li	t5, 0x10
@@ -1235,9 +2201,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a6)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x1298 <corpus.cases.call.call_rec_large.mk32n+0x84>
-               	j	0x1310 <corpus.cases.call.call_rec_large.mk32n+0xfc>
-               	bnez	a3, 0x12e8 <corpus.cases.call.call_rec_large.mk32n+0xd4>
+               	bne	t5, t0, 0x21b0 <corpus.cases.call.call_rec_large.mk32n+0x84>
+               	j	0x2228 <corpus.cases.call.call_rec_large.mk32n+0xfc>
+               	bnez	a3, 0x2200 <corpus.cases.call.call_rec_large.mk32n+0xd4>
                	mv	a3, a5
                	mv	a6, a4
                	li	a7, 0x10
@@ -1247,8 +2213,8 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x12c8 <corpus.cases.call.call_rec_large.mk32n+0xb4>
-               	j	0x1310 <corpus.cases.call.call_rec_large.mk32n+0xfc>
+               	bne	a7, t0, 0x21e0 <corpus.cases.call.call_rec_large.mk32n+0xb4>
+               	j	0x2228 <corpus.cases.call.call_rec_large.mk32n+0xfc>
                	mv	a3, a5
                	mv	a5, a4
                	li	a4, 0x10
@@ -1258,7 +2224,7 @@ Disassembly of section .text:
                	addi	a5, a5, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x12f4 <corpus.cases.call.call_rec_large.mk32n+0xe0>
+               	bne	a4, t0, 0x220c <corpus.cases.call.call_rec_large.mk32n+0xe0>
                	addi	a3, s0, -0x50
                	li	t0, 0x7
                	mul	a4, a1, t0
@@ -1273,8 +2239,8 @@ Disassembly of section .text:
                	or	a3, a4, a1
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a4, a1, 0x13a8 <corpus.cases.call.call_rec_large.mk32n+0x194>
-               	bnez	a3, 0x137c <corpus.cases.call.call_rec_large.mk32n+0x168>
+               	bltu	a4, a1, 0x22c0 <corpus.cases.call.call_rec_large.mk32n+0x194>
+               	bnez	a3, 0x2294 <corpus.cases.call.call_rec_large.mk32n+0x168>
                	addi	a5, a4, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -1284,8 +2250,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x135c <corpus.cases.call.call_rec_large.mk32n+0x148>
-               	j	0x1400 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
+               	bne	a7, t0, 0x2274 <corpus.cases.call.call_rec_large.mk32n+0x148>
+               	j	0x2318 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
                	addi	a5, a4, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -1295,9 +2261,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1388 <corpus.cases.call.call_rec_large.mk32n+0x174>
-               	j	0x1400 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
-               	bnez	a3, 0x13d8 <corpus.cases.call.call_rec_large.mk32n+0x1c4>
+               	bne	a7, t0, 0x22a0 <corpus.cases.call.call_rec_large.mk32n+0x174>
+               	j	0x2318 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
+               	bnez	a3, 0x22f0 <corpus.cases.call.call_rec_large.mk32n+0x1c4>
                	mv	a3, a4
                	mv	a5, a1
                	li	a6, 0x10
@@ -1307,8 +2273,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x13b8 <corpus.cases.call.call_rec_large.mk32n+0x1a4>
-               	j	0x1400 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
+               	bne	a6, t0, 0x22d0 <corpus.cases.call.call_rec_large.mk32n+0x1a4>
+               	j	0x2318 <corpus.cases.call.call_rec_large.mk32n+0x1ec>
                	mv	a3, a4
                	mv	a4, a1
                	li	a1, 0x10
@@ -1318,14 +2284,14 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x13e4 <corpus.cases.call.call_rec_large.mk32n+0x1d0>
+               	bne	a1, t0, 0x22fc <corpus.cases.call.call_rec_large.mk32n+0x1d0>
                	mv	a1, a0
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x1474 <corpus.cases.call.call_rec_large.mk32n+0x260>
-               	bnez	a2, 0x1448 <corpus.cases.call.call_rec_large.mk32n+0x234>
+               	bltu	a1, a3, 0x238c <corpus.cases.call.call_rec_large.mk32n+0x260>
+               	bnez	a2, 0x2360 <corpus.cases.call.call_rec_large.mk32n+0x234>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -1335,8 +2301,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1428 <corpus.cases.call.call_rec_large.mk32n+0x214>
-               	j	0x14cc <corpus.cases.call.call_rec_large.mk32n+0x2b8>
+               	bne	a6, t0, 0x2340 <corpus.cases.call.call_rec_large.mk32n+0x214>
+               	j	0x23e4 <corpus.cases.call.call_rec_large.mk32n+0x2b8>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -1346,9 +2312,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1454 <corpus.cases.call.call_rec_large.mk32n+0x240>
-               	j	0x14cc <corpus.cases.call.call_rec_large.mk32n+0x2b8>
-               	bnez	a2, 0x14a4 <corpus.cases.call.call_rec_large.mk32n+0x290>
+               	bne	a6, t0, 0x236c <corpus.cases.call.call_rec_large.mk32n+0x240>
+               	j	0x23e4 <corpus.cases.call.call_rec_large.mk32n+0x2b8>
+               	bnez	a2, 0x23bc <corpus.cases.call.call_rec_large.mk32n+0x290>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x20
@@ -1358,8 +2324,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1484 <corpus.cases.call.call_rec_large.mk32n+0x270>
-               	j	0x14cc <corpus.cases.call.call_rec_large.mk32n+0x2b8>
+               	bne	a5, t0, 0x239c <corpus.cases.call.call_rec_large.mk32n+0x270>
+               	j	0x23e4 <corpus.cases.call.call_rec_large.mk32n+0x2b8>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x20
@@ -1369,7 +2335,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x14b0 <corpus.cases.call.call_rec_large.mk32n+0x29c>
+               	bne	a3, t0, 0x23c8 <corpus.cases.call.call_rec_large.mk32n+0x29c>
                	ld	ra, 0x48(sp)
                	ld	s0, 0x40(sp)
                	addi	sp, sp, 0x50
@@ -1408,8 +2374,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x15bc <corpus.cases.call.call_rec_large.mk48+0xe0>
-               	bnez	a2, 0x1590 <corpus.cases.call.call_rec_large.mk48+0xb4>
+               	bltu	a1, a3, 0x24d4 <corpus.cases.call.call_rec_large.mk48+0xe0>
+               	bnez	a2, 0x24a8 <corpus.cases.call.call_rec_large.mk48+0xb4>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1419,8 +2385,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1570 <corpus.cases.call.call_rec_large.mk48+0x94>
-               	j	0x1614 <corpus.cases.call.call_rec_large.mk48+0x138>
+               	bne	a6, t0, 0x2488 <corpus.cases.call.call_rec_large.mk48+0x94>
+               	j	0x252c <corpus.cases.call.call_rec_large.mk48+0x138>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1430,9 +2396,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x159c <corpus.cases.call.call_rec_large.mk48+0xc0>
-               	j	0x1614 <corpus.cases.call.call_rec_large.mk48+0x138>
-               	bnez	a2, 0x15ec <corpus.cases.call.call_rec_large.mk48+0x110>
+               	bne	a6, t0, 0x24b4 <corpus.cases.call.call_rec_large.mk48+0xc0>
+               	j	0x252c <corpus.cases.call.call_rec_large.mk48+0x138>
+               	bnez	a2, 0x2504 <corpus.cases.call.call_rec_large.mk48+0x110>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -1442,8 +2408,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x15cc <corpus.cases.call.call_rec_large.mk48+0xf0>
-               	j	0x1614 <corpus.cases.call.call_rec_large.mk48+0x138>
+               	bne	a5, t0, 0x24e4 <corpus.cases.call.call_rec_large.mk48+0xf0>
+               	j	0x252c <corpus.cases.call.call_rec_large.mk48+0x138>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -1453,7 +2419,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x15f8 <corpus.cases.call.call_rec_large.mk48+0x11c>
+               	bne	a3, t0, 0x2510 <corpus.cases.call.call_rec_large.mk48+0x11c>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -1508,8 +2474,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x1734 <.Lpcrel_hi.5+0xa4>
-               	bnez	a2, 0x1708 <.Lpcrel_hi.5+0x78>
+               	bltu	a1, a3, 0x264c <.Lpcrel_hi.5+0xa4>
+               	bnez	a2, 0x2620 <.Lpcrel_hi.5+0x78>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1519,8 +2485,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x16e8 <.Lpcrel_hi.5+0x58>
-               	j	0x178c <.Lpcrel_hi.5+0xfc>
+               	bne	a6, t0, 0x2600 <.Lpcrel_hi.5+0x58>
+               	j	0x26a4 <.Lpcrel_hi.5+0xfc>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1530,9 +2496,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1714 <.Lpcrel_hi.5+0x84>
-               	j	0x178c <.Lpcrel_hi.5+0xfc>
-               	bnez	a2, 0x1764 <.Lpcrel_hi.5+0xd4>
+               	bne	a6, t0, 0x262c <.Lpcrel_hi.5+0x84>
+               	j	0x26a4 <.Lpcrel_hi.5+0xfc>
+               	bnez	a2, 0x267c <.Lpcrel_hi.5+0xd4>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -1542,8 +2508,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1744 <.Lpcrel_hi.5+0xb4>
-               	j	0x178c <.Lpcrel_hi.5+0xfc>
+               	bne	a5, t0, 0x265c <.Lpcrel_hi.5+0xb4>
+               	j	0x26a4 <.Lpcrel_hi.5+0xfc>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -1553,7 +2519,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1770 <.Lpcrel_hi.5+0xe0>
+               	bne	a3, t0, 0x2688 <.Lpcrel_hi.5+0xe0>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -1577,83 +2543,89 @@ Disassembly of section .text:
                	sd	s11, 0x648(sp)
                	fsd	fs0, 0x640(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x44>
-               	li	a1, 0x18
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x50>
-               	li	a1, 0x18
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x5c>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	li	a1, 0x18
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x68>
-               	li	a1, 0x20
+               	li	a1, 0x18
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x74>
-               	li	a1, 0x20
+               	li	a1, 0x18
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x80>
-               	li	a1, 0x30
+               	li	a1, 0x20
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x8c>
-               	li	a1, 0x30
+               	li	a1, 0x20
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x98>
-               	li	a1, 0x8
+               	li	a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xa4>
-               	li	a1, 0x8
+               	li	a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xb0>
                	li	a1, 0x8
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xbc>
-               	li	a1, 0x10
+               	li	a1, 0x8
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xc8>
-               	li	a1, 0x10
+               	li	a1, 0x8
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xd4>
-               	li	a1, 0x14
+               	li	a1, 0x10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xe0>
                	li	a1, 0x10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xec>
-               	li	a1, 0x28
+               	li	a1, 0x14
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0xf8>
-               	li	a1, 0x18
+               	li	a1, 0x10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x104>
                	li	a1, 0x28
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x110>
-               	addi	s2, s0, -0xd0
+               	li	a1, 0x18
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x11c>
+               	li	a1, 0x28
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_large.checksum+0x128>
+               	addi	s2, s0, -0x100
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x18e8 <corpus.cases.call.call_rec_large.checksum+0x14c>
+               	bnez	a2, 0x2818 <corpus.cases.call.call_rec_large.checksum+0x164>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x18d0 <corpus.cases.call.call_rec_large.checksum+0x134>
-               	j	0x1904 <corpus.cases.call.call_rec_large.checksum+0x168>
+               	bne	a3, t0, 0x2800 <corpus.cases.call.call_rec_large.checksum+0x14c>
+               	j	0x2834 <corpus.cases.call.call_rec_large.checksum+0x180>
                	mv	a2, a1
                	li	a1, 0x60
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x18f0 <corpus.cases.call.call_rec_large.checksum+0x154>
+               	bne	a1, t0, 0x2820 <corpus.cases.call.call_rec_large.checksum+0x16c>
                	li	a1, 0x0
                	li	t0, 0xc
-               	bltu	a1, t0, 0x1914 <corpus.cases.call.call_rec_large.checksum+0x178>
-               	j	0x1978 <corpus.cases.call.call_rec_large.checksum+0x1dc>
+               	bltu	a1, t0, 0x2844 <corpus.cases.call.call_rec_large.checksum+0x190>
+               	j	0x28a8 <corpus.cases.call.call_rec_large.checksum+0x1f4>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -1678,13 +2650,13 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0xc
-               	bltu	a1, t0, 0x1914 <corpus.cases.call.call_rec_large.checksum+0x178>
+               	bltu	a1, t0, 0x2844 <corpus.cases.call.call_rec_large.checksum+0x190>
                	mv	s3, a0
                	li	s4, 0x0
                	li	s5, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x1990 <corpus.cases.call.call_rec_large.checksum+0x1f4>
-               	j	0x2760 <.Lpcrel_hi.9+0xce0>
+               	bltu	s5, t0, 0x28c0 <corpus.cases.call.call_rec_large.checksum+0x20c>
+               	j	0x3690 <.Lpcrel_hi.9+0xce0>
                	li	t0, 0x13
                	mul	a0, s5, t0
                	add	a1, a0, s1
@@ -1693,7 +2665,7 @@ Disassembly of section .text:
                	add	s6, a2, a1
                	addi	a0, s2, 0x8
                	ld	a2, 0x0(a0)
-               	addi	s7, s0, -0xe8
+               	addi	s7, s0, -0x88
                	mv	a0, s7
                	sd	a2, 0x0(a0)
                	li	t0, 0x3
@@ -1801,8 +2773,8 @@ Disassembly of section .text:
                	or	a0, a4, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a4, a3, 0x1ba0 <.Lpcrel_hi.9+0x120>
-               	bnez	a0, 0x1b74 <.Lpcrel_hi.9+0xf4>
+               	bltu	a4, a3, 0x2ad0 <.Lpcrel_hi.9+0x120>
+               	bnez	a0, 0x2aa4 <.Lpcrel_hi.9+0xf4>
                	addi	a5, a4, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -1812,8 +2784,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1b54 <.Lpcrel_hi.9+0xd4>
-               	j	0x1bf8 <.Lpcrel_hi.9+0x178>
+               	bne	a7, t0, 0x2a84 <.Lpcrel_hi.9+0xd4>
+               	j	0x2b28 <.Lpcrel_hi.9+0x178>
                	addi	a5, a4, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -1823,9 +2795,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1b80 <.Lpcrel_hi.9+0x100>
-               	j	0x1bf8 <.Lpcrel_hi.9+0x178>
-               	bnez	a0, 0x1bd0 <.Lpcrel_hi.9+0x150>
+               	bne	a7, t0, 0x2ab0 <.Lpcrel_hi.9+0x100>
+               	j	0x2b28 <.Lpcrel_hi.9+0x178>
+               	bnez	a0, 0x2b00 <.Lpcrel_hi.9+0x150>
                	mv	a0, a4
                	mv	a5, a3
                	li	a6, 0x10
@@ -1835,8 +2807,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1bb0 <.Lpcrel_hi.9+0x130>
-               	j	0x1bf8 <.Lpcrel_hi.9+0x178>
+               	bne	a6, t0, 0x2ae0 <.Lpcrel_hi.9+0x130>
+               	j	0x2b28 <.Lpcrel_hi.9+0x178>
                	mv	a0, a4
                	mv	a4, a3
                	li	a3, 0x10
@@ -1846,7 +2818,7 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1bdc <.Lpcrel_hi.9+0x15c>
+               	bne	a3, t0, 0x2b0c <.Lpcrel_hi.9+0x15c>
                	addi	a0, s0, -0x1e0
                	li	t0, 0x7
                	mul	a3, a1, t0
@@ -1862,8 +2834,8 @@ Disassembly of section .text:
                	or	a0, a3, a1
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a3, a1, 0x1c94 <.Lpcrel_hi.9+0x214>
-               	bnez	a0, 0x1c68 <.Lpcrel_hi.9+0x1e8>
+               	bltu	a3, a1, 0x2bc4 <.Lpcrel_hi.9+0x214>
+               	bnez	a0, 0x2b98 <.Lpcrel_hi.9+0x1e8>
                	addi	a4, a3, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -1873,8 +2845,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1c48 <.Lpcrel_hi.9+0x1c8>
-               	j	0x1cec <.Lpcrel_hi.9+0x26c>
+               	bne	a6, t0, 0x2b78 <.Lpcrel_hi.9+0x1c8>
+               	j	0x2c1c <.Lpcrel_hi.9+0x26c>
                	addi	a4, a3, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -1884,9 +2856,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1c74 <.Lpcrel_hi.9+0x1f4>
-               	j	0x1cec <.Lpcrel_hi.9+0x26c>
-               	bnez	a0, 0x1cc4 <.Lpcrel_hi.9+0x244>
+               	bne	a6, t0, 0x2ba4 <.Lpcrel_hi.9+0x1f4>
+               	j	0x2c1c <.Lpcrel_hi.9+0x26c>
+               	bnez	a0, 0x2bf4 <.Lpcrel_hi.9+0x244>
                	mv	a0, a3
                	mv	a4, a1
                	li	a5, 0x10
@@ -1896,8 +2868,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1ca4 <.Lpcrel_hi.9+0x224>
-               	j	0x1cec <.Lpcrel_hi.9+0x26c>
+               	bne	a5, t0, 0x2bd4 <.Lpcrel_hi.9+0x224>
+               	j	0x2c1c <.Lpcrel_hi.9+0x26c>
                	mv	a0, a3
                	mv	a3, a1
                	li	a1, 0x10
@@ -1907,7 +2879,7 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1cd0 <.Lpcrel_hi.9+0x250>
+               	bne	a1, t0, 0x2c00 <.Lpcrel_hi.9+0x250>
                	addi	a0, s2, 0x38
                	ld	a1, 0x0(a0)
                	li	t0, 0x3ff
@@ -2031,8 +3003,8 @@ Disassembly of section .text:
                	or	t6, a6, t5
                	li	t0, 0x7
                	and	t6, t6, t0
-               	bltu	a6, t5, 0x1f38 <.Lpcrel_hi.9+0x4b8>
-               	bnez	t6, 0x1f0c <.Lpcrel_hi.9+0x48c>
+               	bltu	a6, t5, 0x2e68 <.Lpcrel_hi.9+0x4b8>
+               	bnez	t6, 0x2e3c <.Lpcrel_hi.9+0x48c>
                	addi	s7, a6, 0x18
                	addi	a7, t5, 0x18
                	li	a0, 0x18
@@ -2042,8 +3014,8 @@ Disassembly of section .text:
                	sd	a1, 0x0(s7)
                	addi	a0, a0, -0x8
                	li	t0, 0x0
-               	bne	a0, t0, 0x1eec <.Lpcrel_hi.9+0x46c>
-               	j	0x1f90 <.Lpcrel_hi.9+0x510>
+               	bne	a0, t0, 0x2e1c <.Lpcrel_hi.9+0x46c>
+               	j	0x2ec0 <.Lpcrel_hi.9+0x510>
                	addi	a0, a6, 0x18
                	addi	a1, t5, 0x18
                	li	a7, 0x18
@@ -2053,9 +3025,9 @@ Disassembly of section .text:
                	sb	s7, 0x0(a0)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1f18 <.Lpcrel_hi.9+0x498>
-               	j	0x1f90 <.Lpcrel_hi.9+0x510>
-               	bnez	t6, 0x1f68 <.Lpcrel_hi.9+0x4e8>
+               	bne	a7, t0, 0x2e48 <.Lpcrel_hi.9+0x498>
+               	j	0x2ec0 <.Lpcrel_hi.9+0x510>
+               	bnez	t6, 0x2e98 <.Lpcrel_hi.9+0x4e8>
                	mv	a0, a6
                	mv	a1, t5
                	li	a7, 0x18
@@ -2065,8 +3037,8 @@ Disassembly of section .text:
                	addi	a1, a1, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1f48 <.Lpcrel_hi.9+0x4c8>
-               	j	0x1f90 <.Lpcrel_hi.9+0x510>
+               	bne	a7, t0, 0x2e78 <.Lpcrel_hi.9+0x4c8>
+               	j	0x2ec0 <.Lpcrel_hi.9+0x510>
                	mv	a0, a6
                	mv	a1, t5
                	li	a6, 0x18
@@ -2076,15 +3048,15 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1f74 <.Lpcrel_hi.9+0x4f4>
+               	bne	a6, t0, 0x2ea4 <.Lpcrel_hi.9+0x4f4>
                	addi	a1, s0, -0x398
                	addi	a0, s0, -0x3b0
                	mv	a6, s8
                	or	a7, a0, a6
                	li	t0, 0x7
                	and	a7, a7, t0
-               	bltu	a0, a6, 0x2008 <.Lpcrel_hi.9+0x588>
-               	bnez	a7, 0x1fdc <.Lpcrel_hi.9+0x55c>
+               	bltu	a0, a6, 0x2f38 <.Lpcrel_hi.9+0x588>
+               	bnez	a7, 0x2f0c <.Lpcrel_hi.9+0x55c>
                	addi	t5, a0, 0x18
                	addi	t6, a6, 0x18
                	li	s7, 0x18
@@ -2094,8 +3066,8 @@ Disassembly of section .text:
                	sd	s8, 0x0(t5)
                	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x1fbc <.Lpcrel_hi.9+0x53c>
-               	j	0x2060 <.Lpcrel_hi.9+0x5e0>
+               	bne	s7, t0, 0x2eec <.Lpcrel_hi.9+0x53c>
+               	j	0x2f90 <.Lpcrel_hi.9+0x5e0>
                	addi	t5, a0, 0x18
                	addi	t6, a6, 0x18
                	li	s7, 0x18
@@ -2105,9 +3077,9 @@ Disassembly of section .text:
                	sb	s8, 0x0(t5)
                	addi	s7, s7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x1fe8 <.Lpcrel_hi.9+0x568>
-               	j	0x2060 <.Lpcrel_hi.9+0x5e0>
-               	bnez	a7, 0x2038 <.Lpcrel_hi.9+0x5b8>
+               	bne	s7, t0, 0x2f18 <.Lpcrel_hi.9+0x568>
+               	j	0x2f90 <.Lpcrel_hi.9+0x5e0>
+               	bnez	a7, 0x2f68 <.Lpcrel_hi.9+0x5b8>
                	mv	a7, a0
                	mv	t5, a6
                	li	t6, 0x18
@@ -2117,8 +3089,8 @@ Disassembly of section .text:
                	addi	t5, t5, 0x8
                	addi	t6, t6, -0x8
                	li	t0, 0x0
-               	bne	t6, t0, 0x2018 <.Lpcrel_hi.9+0x598>
-               	j	0x2060 <.Lpcrel_hi.9+0x5e0>
+               	bne	t6, t0, 0x2f48 <.Lpcrel_hi.9+0x598>
+               	j	0x2f90 <.Lpcrel_hi.9+0x5e0>
                	mv	a7, a0
                	mv	a0, a6
                	li	a6, 0x18
@@ -2128,15 +3100,15 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2044 <.Lpcrel_hi.9+0x5c4>
+               	bne	a6, t0, 0x2f74 <.Lpcrel_hi.9+0x5c4>
                	addi	a6, s0, -0x3b0
                	addi	a0, s0, -0x3c8
                	mv	a7, s9
                	or	t5, a0, a7
                	li	t0, 0x7
                	and	t5, t5, t0
-               	bltu	a0, a7, 0x20d8 <.Lpcrel_hi.9+0x658>
-               	bnez	t5, 0x20ac <.Lpcrel_hi.9+0x62c>
+               	bltu	a0, a7, 0x3008 <.Lpcrel_hi.9+0x658>
+               	bnez	t5, 0x2fdc <.Lpcrel_hi.9+0x62c>
                	addi	t6, a0, 0x18
                	addi	s7, a7, 0x18
                	li	s8, 0x18
@@ -2146,8 +3118,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(t6)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x208c <.Lpcrel_hi.9+0x60c>
-               	j	0x2130 <.Lpcrel_hi.9+0x6b0>
+               	bne	s8, t0, 0x2fbc <.Lpcrel_hi.9+0x60c>
+               	j	0x3060 <.Lpcrel_hi.9+0x6b0>
                	addi	t6, a0, 0x18
                	addi	s7, a7, 0x18
                	li	s8, 0x18
@@ -2157,9 +3129,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(t6)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x20b8 <.Lpcrel_hi.9+0x638>
-               	j	0x2130 <.Lpcrel_hi.9+0x6b0>
-               	bnez	t5, 0x2108 <.Lpcrel_hi.9+0x688>
+               	bne	s8, t0, 0x2fe8 <.Lpcrel_hi.9+0x638>
+               	j	0x3060 <.Lpcrel_hi.9+0x6b0>
+               	bnez	t5, 0x3038 <.Lpcrel_hi.9+0x688>
                	mv	t5, a0
                	mv	t6, a7
                	li	s7, 0x18
@@ -2169,8 +3141,8 @@ Disassembly of section .text:
                	addi	t6, t6, 0x8
                	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x20e8 <.Lpcrel_hi.9+0x668>
-               	j	0x2130 <.Lpcrel_hi.9+0x6b0>
+               	bne	s7, t0, 0x3018 <.Lpcrel_hi.9+0x668>
+               	j	0x3060 <.Lpcrel_hi.9+0x6b0>
                	mv	t5, a0
                	mv	a0, a7
                	li	a7, 0x18
@@ -2180,15 +3152,15 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x2114 <.Lpcrel_hi.9+0x694>
+               	bne	a7, t0, 0x3044 <.Lpcrel_hi.9+0x694>
                	addi	a7, s0, -0x3c8
                	addi	a0, s0, -0x3e8
                	mv	t5, s11
                	or	t6, a0, t5
                	li	t0, 0x7
                	and	t6, t6, t0
-               	bltu	a0, t5, 0x21a8 <.Lpcrel_hi.9+0x728>
-               	bnez	t6, 0x217c <.Lpcrel_hi.9+0x6fc>
+               	bltu	a0, t5, 0x30d8 <.Lpcrel_hi.9+0x728>
+               	bnez	t6, 0x30ac <.Lpcrel_hi.9+0x6fc>
                	addi	s7, a0, 0x20
                	addi	s8, t5, 0x20
                	li	s9, 0x20
@@ -2198,8 +3170,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(s7)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x215c <.Lpcrel_hi.9+0x6dc>
-               	j	0x2200 <.Lpcrel_hi.9+0x780>
+               	bne	s9, t0, 0x308c <.Lpcrel_hi.9+0x6dc>
+               	j	0x3130 <.Lpcrel_hi.9+0x780>
                	addi	s7, a0, 0x20
                	addi	s8, t5, 0x20
                	li	s9, 0x20
@@ -2209,9 +3181,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(s7)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x2188 <.Lpcrel_hi.9+0x708>
-               	j	0x2200 <.Lpcrel_hi.9+0x780>
-               	bnez	t6, 0x21d8 <.Lpcrel_hi.9+0x758>
+               	bne	s9, t0, 0x30b8 <.Lpcrel_hi.9+0x708>
+               	j	0x3130 <.Lpcrel_hi.9+0x780>
+               	bnez	t6, 0x3108 <.Lpcrel_hi.9+0x758>
                	mv	t6, a0
                	mv	s7, t5
                	li	s8, 0x20
@@ -2221,8 +3193,8 @@ Disassembly of section .text:
                	addi	s7, s7, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x21b8 <.Lpcrel_hi.9+0x738>
-               	j	0x2200 <.Lpcrel_hi.9+0x780>
+               	bne	s8, t0, 0x30e8 <.Lpcrel_hi.9+0x738>
+               	j	0x3130 <.Lpcrel_hi.9+0x780>
                	mv	t6, a0
                	mv	a0, t5
                	li	t5, 0x20
@@ -2232,7 +3204,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x21e4 <.Lpcrel_hi.9+0x764>
+               	bne	t5, t0, 0x3114 <.Lpcrel_hi.9+0x764>
                	addi	t5, s0, -0x3e8
                	addi	a0, s0, -0x408
                	ld	t2, -0x678(s0)
@@ -2240,8 +3212,8 @@ Disassembly of section .text:
                	or	a2, a0, t6
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, t6, 0x227c <.Lpcrel_hi.9+0x7fc>
-               	bnez	a2, 0x2250 <.Lpcrel_hi.9+0x7d0>
+               	bltu	a0, t6, 0x31ac <.Lpcrel_hi.9+0x7fc>
+               	bnez	a2, 0x3180 <.Lpcrel_hi.9+0x7d0>
                	addi	s7, a0, 0x20
                	addi	s8, t6, 0x20
                	li	s9, 0x20
@@ -2251,8 +3223,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(s7)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2230 <.Lpcrel_hi.9+0x7b0>
-               	j	0x22d4 <.Lpcrel_hi.9+0x854>
+               	bne	s9, t0, 0x3160 <.Lpcrel_hi.9+0x7b0>
+               	j	0x3204 <.Lpcrel_hi.9+0x854>
                	addi	s7, a0, 0x20
                	addi	s8, t6, 0x20
                	li	s9, 0x20
@@ -2262,9 +3234,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(s7)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x225c <.Lpcrel_hi.9+0x7dc>
-               	j	0x22d4 <.Lpcrel_hi.9+0x854>
-               	bnez	a2, 0x22ac <.Lpcrel_hi.9+0x82c>
+               	bne	s9, t0, 0x318c <.Lpcrel_hi.9+0x7dc>
+               	j	0x3204 <.Lpcrel_hi.9+0x854>
+               	bnez	a2, 0x31dc <.Lpcrel_hi.9+0x82c>
                	mv	a2, a0
                	mv	s7, t6
                	li	s8, 0x20
@@ -2274,8 +3246,8 @@ Disassembly of section .text:
                	addi	s7, s7, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x228c <.Lpcrel_hi.9+0x80c>
-               	j	0x22d4 <.Lpcrel_hi.9+0x854>
+               	bne	s8, t0, 0x31bc <.Lpcrel_hi.9+0x80c>
+               	j	0x3204 <.Lpcrel_hi.9+0x854>
                	mv	a2, a0
                	mv	a0, t6
                	li	t6, 0x20
@@ -2285,7 +3257,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	t6, t6, -0x1
                	li	t0, 0x0
-               	bne	t6, t0, 0x22b8 <.Lpcrel_hi.9+0x838>
+               	bne	t6, t0, 0x31e8 <.Lpcrel_hi.9+0x838>
                	addi	t6, s0, -0x408
                	addi	a0, s0, -0x438
                	ld	t2, -0x680(s0)
@@ -2293,8 +3265,8 @@ Disassembly of section .text:
                	or	a3, a0, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a0, a2, 0x2350 <.Lpcrel_hi.9+0x8d0>
-               	bnez	a3, 0x2324 <.Lpcrel_hi.9+0x8a4>
+               	bltu	a0, a2, 0x3280 <.Lpcrel_hi.9+0x8d0>
+               	bnez	a3, 0x3254 <.Lpcrel_hi.9+0x8a4>
                	addi	s7, a0, 0x30
                	addi	s8, a2, 0x30
                	li	s9, 0x30
@@ -2304,8 +3276,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(s7)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2304 <.Lpcrel_hi.9+0x884>
-               	j	0x23a8 <.Lpcrel_hi.9+0x928>
+               	bne	s9, t0, 0x3234 <.Lpcrel_hi.9+0x884>
+               	j	0x32d8 <.Lpcrel_hi.9+0x928>
                	addi	s7, a0, 0x30
                	addi	s8, a2, 0x30
                	li	s9, 0x30
@@ -2315,9 +3287,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(s7)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x2330 <.Lpcrel_hi.9+0x8b0>
-               	j	0x23a8 <.Lpcrel_hi.9+0x928>
-               	bnez	a3, 0x2380 <.Lpcrel_hi.9+0x900>
+               	bne	s9, t0, 0x3260 <.Lpcrel_hi.9+0x8b0>
+               	j	0x32d8 <.Lpcrel_hi.9+0x928>
+               	bnez	a3, 0x32b0 <.Lpcrel_hi.9+0x900>
                	mv	a3, a0
                	mv	s7, a2
                	li	s8, 0x30
@@ -2327,8 +3299,8 @@ Disassembly of section .text:
                	addi	s7, s7, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x2360 <.Lpcrel_hi.9+0x8e0>
-               	j	0x23a8 <.Lpcrel_hi.9+0x928>
+               	bne	s8, t0, 0x3290 <.Lpcrel_hi.9+0x8e0>
+               	j	0x32d8 <.Lpcrel_hi.9+0x928>
                	mv	a3, a0
                	mv	a0, a2
                	li	a2, 0x30
@@ -2338,7 +3310,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x238c <.Lpcrel_hi.9+0x90c>
+               	bne	a2, t0, 0x32bc <.Lpcrel_hi.9+0x90c>
                	addi	s7, s0, -0x438
                	addi	a0, s0, -0x468
                	ld	t2, -0x670(s0)
@@ -2346,8 +3318,8 @@ Disassembly of section .text:
                	or	a3, a0, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a0, a2, 0x2424 <.Lpcrel_hi.9+0x9a4>
-               	bnez	a3, 0x23f8 <.Lpcrel_hi.9+0x978>
+               	bltu	a0, a2, 0x3354 <.Lpcrel_hi.9+0x9a4>
+               	bnez	a3, 0x3328 <.Lpcrel_hi.9+0x978>
                	addi	a4, a0, 0x30
                	addi	s8, a2, 0x30
                	li	s9, 0x30
@@ -2357,8 +3329,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(a4)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x23d8 <.Lpcrel_hi.9+0x958>
-               	j	0x247c <.Lpcrel_hi.9+0x9fc>
+               	bne	s9, t0, 0x3308 <.Lpcrel_hi.9+0x958>
+               	j	0x33ac <.Lpcrel_hi.9+0x9fc>
                	addi	a4, a0, 0x30
                	addi	s8, a2, 0x30
                	li	s9, 0x30
@@ -2368,9 +3340,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(a4)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x2404 <.Lpcrel_hi.9+0x984>
-               	j	0x247c <.Lpcrel_hi.9+0x9fc>
-               	bnez	a3, 0x2454 <.Lpcrel_hi.9+0x9d4>
+               	bne	s9, t0, 0x3334 <.Lpcrel_hi.9+0x984>
+               	j	0x33ac <.Lpcrel_hi.9+0x9fc>
+               	bnez	a3, 0x3384 <.Lpcrel_hi.9+0x9d4>
                	mv	a3, a0
                	mv	a4, a2
                	li	s8, 0x30
@@ -2380,8 +3352,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x2434 <.Lpcrel_hi.9+0x9b4>
-               	j	0x247c <.Lpcrel_hi.9+0x9fc>
+               	bne	s8, t0, 0x3364 <.Lpcrel_hi.9+0x9b4>
+               	j	0x33ac <.Lpcrel_hi.9+0x9fc>
                	mv	a3, a0
                	mv	a0, a2
                	li	a2, 0x30
@@ -2391,7 +3363,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2460 <.Lpcrel_hi.9+0x9e0>
+               	bne	a2, t0, 0x3390 <.Lpcrel_hi.9+0x9e0>
                	addi	a0, s0, -0x468
                	sd	a0, 0x0(sp)
                	addi	a0, s0, -0x480
@@ -2400,8 +3372,8 @@ Disassembly of section .text:
                	or	a3, a0, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a0, a2, 0x24fc <.Lpcrel_hi.9+0xa7c>
-               	bnez	a3, 0x24d0 <.Lpcrel_hi.9+0xa50>
+               	bltu	a0, a2, 0x342c <.Lpcrel_hi.9+0xa7c>
+               	bnez	a3, 0x3400 <.Lpcrel_hi.9+0xa50>
                	addi	a4, a0, 0x18
                	addi	s8, a2, 0x18
                	li	s9, 0x18
@@ -2411,8 +3383,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(a4)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x24b0 <.Lpcrel_hi.9+0xa30>
-               	j	0x2554 <.Lpcrel_hi.9+0xad4>
+               	bne	s9, t0, 0x33e0 <.Lpcrel_hi.9+0xa30>
+               	j	0x3484 <.Lpcrel_hi.9+0xad4>
                	addi	a4, a0, 0x18
                	addi	s8, a2, 0x18
                	li	s9, 0x18
@@ -2422,9 +3394,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(a4)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x24dc <.Lpcrel_hi.9+0xa5c>
-               	j	0x2554 <.Lpcrel_hi.9+0xad4>
-               	bnez	a3, 0x252c <.Lpcrel_hi.9+0xaac>
+               	bne	s9, t0, 0x340c <.Lpcrel_hi.9+0xa5c>
+               	j	0x3484 <.Lpcrel_hi.9+0xad4>
+               	bnez	a3, 0x345c <.Lpcrel_hi.9+0xaac>
                	mv	a3, a0
                	mv	a4, a2
                	li	s8, 0x18
@@ -2434,8 +3406,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x250c <.Lpcrel_hi.9+0xa8c>
-               	j	0x2554 <.Lpcrel_hi.9+0xad4>
+               	bne	s8, t0, 0x343c <.Lpcrel_hi.9+0xa8c>
+               	j	0x3484 <.Lpcrel_hi.9+0xad4>
                	mv	a3, a0
                	mv	a0, a2
                	li	a2, 0x18
@@ -2445,7 +3417,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2538 <.Lpcrel_hi.9+0xab8>
+               	bne	a2, t0, 0x3468 <.Lpcrel_hi.9+0xab8>
                	addi	a0, s0, -0x480
                	sd	a0, 0x8(sp)
                	addi	a0, s0, -0x4a0
@@ -2454,8 +3426,8 @@ Disassembly of section .text:
                	or	a3, a0, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a0, a2, 0x25d4 <.Lpcrel_hi.9+0xb54>
-               	bnez	a3, 0x25a8 <.Lpcrel_hi.9+0xb28>
+               	bltu	a0, a2, 0x3504 <.Lpcrel_hi.9+0xb54>
+               	bnez	a3, 0x34d8 <.Lpcrel_hi.9+0xb28>
                	addi	a4, a0, 0x20
                	addi	s8, a2, 0x20
                	li	s9, 0x20
@@ -2465,8 +3437,8 @@ Disassembly of section .text:
                	sd	s11, 0x0(a4)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x2588 <.Lpcrel_hi.9+0xb08>
-               	j	0x262c <.Lpcrel_hi.9+0xbac>
+               	bne	s9, t0, 0x34b8 <.Lpcrel_hi.9+0xb08>
+               	j	0x355c <.Lpcrel_hi.9+0xbac>
                	addi	a4, a0, 0x20
                	addi	s8, a2, 0x20
                	li	s9, 0x20
@@ -2476,9 +3448,9 @@ Disassembly of section .text:
                	sb	s11, 0x0(a4)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x25b4 <.Lpcrel_hi.9+0xb34>
-               	j	0x262c <.Lpcrel_hi.9+0xbac>
-               	bnez	a3, 0x2604 <.Lpcrel_hi.9+0xb84>
+               	bne	s9, t0, 0x34e4 <.Lpcrel_hi.9+0xb34>
+               	j	0x355c <.Lpcrel_hi.9+0xbac>
+               	bnez	a3, 0x3534 <.Lpcrel_hi.9+0xb84>
                	mv	a3, a0
                	mv	a4, a2
                	li	s8, 0x20
@@ -2488,8 +3460,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x25e4 <.Lpcrel_hi.9+0xb64>
-               	j	0x262c <.Lpcrel_hi.9+0xbac>
+               	bne	s8, t0, 0x3514 <.Lpcrel_hi.9+0xb64>
+               	j	0x355c <.Lpcrel_hi.9+0xbac>
                	mv	a3, a0
                	mv	a0, a2
                	li	a2, 0x20
@@ -2499,7 +3471,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2610 <.Lpcrel_hi.9+0xb90>
+               	bne	a2, t0, 0x3540 <.Lpcrel_hi.9+0xb90>
                	addi	a0, s0, -0x4a0
                	sd	a0, 0x10(sp)
                	addi	a0, s0, -0x4d0
@@ -2507,8 +3479,8 @@ Disassembly of section .text:
                	or	a3, a0, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a0, a2, 0x26a8 <.Lpcrel_hi.9+0xc28>
-               	bnez	a3, 0x267c <.Lpcrel_hi.9+0xbfc>
+               	bltu	a0, a2, 0x35d8 <.Lpcrel_hi.9+0xc28>
+               	bnez	a3, 0x35ac <.Lpcrel_hi.9+0xbfc>
                	addi	a4, a0, 0x30
                	addi	a5, a2, 0x30
                	li	s8, 0x30
@@ -2518,8 +3490,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(a4)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x265c <.Lpcrel_hi.9+0xbdc>
-               	j	0x2700 <.Lpcrel_hi.9+0xc80>
+               	bne	s8, t0, 0x358c <.Lpcrel_hi.9+0xbdc>
+               	j	0x3630 <.Lpcrel_hi.9+0xc80>
                	addi	a4, a0, 0x30
                	addi	a5, a2, 0x30
                	li	s8, 0x30
@@ -2529,9 +3501,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(a4)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x2688 <.Lpcrel_hi.9+0xc08>
-               	j	0x2700 <.Lpcrel_hi.9+0xc80>
-               	bnez	a3, 0x26d8 <.Lpcrel_hi.9+0xc58>
+               	bne	s8, t0, 0x35b8 <.Lpcrel_hi.9+0xc08>
+               	j	0x3630 <.Lpcrel_hi.9+0xc80>
+               	bnez	a3, 0x3608 <.Lpcrel_hi.9+0xc58>
                	mv	a3, a0
                	mv	a4, a2
                	li	a5, 0x30
@@ -2541,8 +3513,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x26b8 <.Lpcrel_hi.9+0xc38>
-               	j	0x2700 <.Lpcrel_hi.9+0xc80>
+               	bne	a5, t0, 0x35e8 <.Lpcrel_hi.9+0xc38>
+               	j	0x3630 <.Lpcrel_hi.9+0xc80>
                	mv	a3, a0
                	mv	a0, a2
                	li	a2, 0x30
@@ -2552,7 +3524,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x26e4 <.Lpcrel_hi.9+0xc64>
+               	bne	a2, t0, 0x3614 <.Lpcrel_hi.9+0xc64>
                	addi	a0, s0, -0x4d0
                	sd	a0, 0x18(sp)
                	ld	t2, -0x658(s0)
@@ -2576,8 +3548,8 @@ Disassembly of section .text:
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x1990 <corpus.cases.call.call_rec_large.checksum+0x1f4>
-               	addi	s1, s0, -0x100
+               	bltu	s5, t0, 0x28c0 <corpus.cases.call.call_rec_large.checksum+0x20c>
+               	addi	s1, s0, -0xa0
                	mv	a0, s1
                	sd	s4, 0x0(a0)
                	li	t0, 0x3
@@ -2672,8 +3644,8 @@ Disassembly of section .text:
                	or	a0, a2, a1
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a2, a1, 0x291c <.Lpcrel_hi.13+0xfc>
-               	bnez	a0, 0x28f0 <.Lpcrel_hi.13+0xd0>
+               	bltu	a2, a1, 0x384c <.Lpcrel_hi.13+0xfc>
+               	bnez	a0, 0x3820 <.Lpcrel_hi.13+0xd0>
                	addi	a3, a2, 0x10
                	addi	a4, a1, 0x10
                	li	a5, 0x10
@@ -2683,8 +3655,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x28d0 <.Lpcrel_hi.13+0xb0>
-               	j	0x2974 <.Lpcrel_hi.13+0x154>
+               	bne	a5, t0, 0x3800 <.Lpcrel_hi.13+0xb0>
+               	j	0x38a4 <.Lpcrel_hi.13+0x154>
                	addi	a3, a2, 0x10
                	addi	a4, a1, 0x10
                	li	a5, 0x10
@@ -2694,9 +3666,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x28fc <.Lpcrel_hi.13+0xdc>
-               	j	0x2974 <.Lpcrel_hi.13+0x154>
-               	bnez	a0, 0x294c <.Lpcrel_hi.13+0x12c>
+               	bne	a5, t0, 0x382c <.Lpcrel_hi.13+0xdc>
+               	j	0x38a4 <.Lpcrel_hi.13+0x154>
+               	bnez	a0, 0x387c <.Lpcrel_hi.13+0x12c>
                	mv	a0, a2
                	mv	a3, a1
                	li	a4, 0x10
@@ -2706,8 +3678,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x292c <.Lpcrel_hi.13+0x10c>
-               	j	0x2974 <.Lpcrel_hi.13+0x154>
+               	bne	a4, t0, 0x385c <.Lpcrel_hi.13+0x10c>
+               	j	0x38a4 <.Lpcrel_hi.13+0x154>
                	mv	a0, a2
                	mv	a2, a1
                	li	a1, 0x10
@@ -2717,7 +3689,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2958 <.Lpcrel_hi.13+0x138>
+               	bne	a1, t0, 0x3888 <.Lpcrel_hi.13+0x138>
                	addi	a0, s0, -0x220
                	li	t0, 0x7
                	mul	a1, s4, t0
@@ -2732,8 +3704,8 @@ Disassembly of section .text:
                	or	a0, a2, a1
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a2, a1, 0x2a0c <.Lpcrel_hi.13+0x1ec>
-               	bnez	a0, 0x29e0 <.Lpcrel_hi.13+0x1c0>
+               	bltu	a2, a1, 0x393c <.Lpcrel_hi.13+0x1ec>
+               	bnez	a0, 0x3910 <.Lpcrel_hi.13+0x1c0>
                	addi	a3, a2, 0x10
                	addi	a4, a1, 0x10
                	li	a5, 0x10
@@ -2743,8 +3715,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x29c0 <.Lpcrel_hi.13+0x1a0>
-               	j	0x2a64 <.Lpcrel_hi.13+0x244>
+               	bne	a5, t0, 0x38f0 <.Lpcrel_hi.13+0x1a0>
+               	j	0x3994 <.Lpcrel_hi.13+0x244>
                	addi	a3, a2, 0x10
                	addi	a4, a1, 0x10
                	li	a5, 0x10
@@ -2754,9 +3726,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x29ec <.Lpcrel_hi.13+0x1cc>
-               	j	0x2a64 <.Lpcrel_hi.13+0x244>
-               	bnez	a0, 0x2a3c <.Lpcrel_hi.13+0x21c>
+               	bne	a5, t0, 0x391c <.Lpcrel_hi.13+0x1cc>
+               	j	0x3994 <.Lpcrel_hi.13+0x244>
+               	bnez	a0, 0x396c <.Lpcrel_hi.13+0x21c>
                	mv	a0, a2
                	mv	a3, a1
                	li	a4, 0x10
@@ -2766,8 +3738,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2a1c <.Lpcrel_hi.13+0x1fc>
-               	j	0x2a64 <.Lpcrel_hi.13+0x244>
+               	bne	a4, t0, 0x394c <.Lpcrel_hi.13+0x1fc>
+               	j	0x3994 <.Lpcrel_hi.13+0x244>
                	mv	a0, a2
                	mv	a2, a1
                	li	a1, 0x10
@@ -2777,7 +3749,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2a48 <.Lpcrel_hi.13+0x228>
+               	bne	a1, t0, 0x3978 <.Lpcrel_hi.13+0x228>
                	li	t0, 0x3ff
                	and	a0, s4, t0
                	fcvt.d.lu	fs0, a0
@@ -2876,8 +3848,8 @@ Disassembly of section .text:
                	or	a6, a3, a5
                	li	t0, 0x7
                	and	a6, a6, t0
-               	bltu	a3, a5, 0x2c4c <.Lpcrel_hi.13+0x42c>
-               	bnez	a6, 0x2c20 <.Lpcrel_hi.13+0x400>
+               	bltu	a3, a5, 0x3b7c <.Lpcrel_hi.13+0x42c>
+               	bnez	a6, 0x3b50 <.Lpcrel_hi.13+0x400>
                	addi	a7, a3, 0x18
                	addi	t5, a5, 0x18
                	li	t6, 0x18
@@ -2887,8 +3859,8 @@ Disassembly of section .text:
                	sd	s1, 0x0(a7)
                	addi	t6, t6, -0x8
                	li	t0, 0x0
-               	bne	t6, t0, 0x2c00 <.Lpcrel_hi.13+0x3e0>
-               	j	0x2ca4 <.Lpcrel_hi.13+0x484>
+               	bne	t6, t0, 0x3b30 <.Lpcrel_hi.13+0x3e0>
+               	j	0x3bd4 <.Lpcrel_hi.13+0x484>
                	addi	a7, a3, 0x18
                	addi	t5, a5, 0x18
                	li	t6, 0x18
@@ -2898,9 +3870,9 @@ Disassembly of section .text:
                	sb	s1, 0x0(a7)
                	addi	t6, t6, -0x1
                	li	t0, 0x0
-               	bne	t6, t0, 0x2c2c <.Lpcrel_hi.13+0x40c>
-               	j	0x2ca4 <.Lpcrel_hi.13+0x484>
-               	bnez	a6, 0x2c7c <.Lpcrel_hi.13+0x45c>
+               	bne	t6, t0, 0x3b5c <.Lpcrel_hi.13+0x40c>
+               	j	0x3bd4 <.Lpcrel_hi.13+0x484>
+               	bnez	a6, 0x3bac <.Lpcrel_hi.13+0x45c>
                	mv	a6, a3
                	mv	a7, a5
                	li	t5, 0x18
@@ -2910,8 +3882,8 @@ Disassembly of section .text:
                	addi	a7, a7, 0x8
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x2c5c <.Lpcrel_hi.13+0x43c>
-               	j	0x2ca4 <.Lpcrel_hi.13+0x484>
+               	bne	t5, t0, 0x3b8c <.Lpcrel_hi.13+0x43c>
+               	j	0x3bd4 <.Lpcrel_hi.13+0x484>
                	mv	a6, a3
                	mv	a3, a5
                	li	a5, 0x18
@@ -2921,15 +3893,15 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2c88 <.Lpcrel_hi.13+0x468>
+               	bne	a5, t0, 0x3bb8 <.Lpcrel_hi.13+0x468>
                	addi	a3, s0, -0x518
                	addi	a5, s0, -0x530
                	mv	a6, s5
                	or	a7, a5, a6
                	li	t0, 0x7
                	and	a7, a7, t0
-               	bltu	a5, a6, 0x2d1c <.Lpcrel_hi.13+0x4fc>
-               	bnez	a7, 0x2cf0 <.Lpcrel_hi.13+0x4d0>
+               	bltu	a5, a6, 0x3c4c <.Lpcrel_hi.13+0x4fc>
+               	bnez	a7, 0x3c20 <.Lpcrel_hi.13+0x4d0>
                	addi	t5, a5, 0x18
                	addi	t6, a6, 0x18
                	li	s1, 0x18
@@ -2939,8 +3911,8 @@ Disassembly of section .text:
                	sd	s2, 0x0(t5)
                	addi	s1, s1, -0x8
                	li	t0, 0x0
-               	bne	s1, t0, 0x2cd0 <.Lpcrel_hi.13+0x4b0>
-               	j	0x2d74 <.Lpcrel_hi.13+0x554>
+               	bne	s1, t0, 0x3c00 <.Lpcrel_hi.13+0x4b0>
+               	j	0x3ca4 <.Lpcrel_hi.13+0x554>
                	addi	t5, a5, 0x18
                	addi	t6, a6, 0x18
                	li	s1, 0x18
@@ -2950,9 +3922,9 @@ Disassembly of section .text:
                	sb	s2, 0x0(t5)
                	addi	s1, s1, -0x1
                	li	t0, 0x0
-               	bne	s1, t0, 0x2cfc <.Lpcrel_hi.13+0x4dc>
-               	j	0x2d74 <.Lpcrel_hi.13+0x554>
-               	bnez	a7, 0x2d4c <.Lpcrel_hi.13+0x52c>
+               	bne	s1, t0, 0x3c2c <.Lpcrel_hi.13+0x4dc>
+               	j	0x3ca4 <.Lpcrel_hi.13+0x554>
+               	bnez	a7, 0x3c7c <.Lpcrel_hi.13+0x52c>
                	mv	a7, a5
                	mv	t5, a6
                	li	t6, 0x18
@@ -2962,8 +3934,8 @@ Disassembly of section .text:
                	addi	t5, t5, 0x8
                	addi	t6, t6, -0x8
                	li	t0, 0x0
-               	bne	t6, t0, 0x2d2c <.Lpcrel_hi.13+0x50c>
-               	j	0x2d74 <.Lpcrel_hi.13+0x554>
+               	bne	t6, t0, 0x3c5c <.Lpcrel_hi.13+0x50c>
+               	j	0x3ca4 <.Lpcrel_hi.13+0x554>
                	mv	a7, a5
                	mv	a5, a6
                	li	a6, 0x18
@@ -2973,15 +3945,15 @@ Disassembly of section .text:
                	addi	a5, a5, 0x1
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2d58 <.Lpcrel_hi.13+0x538>
+               	bne	a6, t0, 0x3c88 <.Lpcrel_hi.13+0x538>
                	addi	a5, s0, -0x530
                	addi	a6, s0, -0x548
                	mv	a7, s6
                	or	t5, a6, a7
                	li	t0, 0x7
                	and	t5, t5, t0
-               	bltu	a6, a7, 0x2dec <.Lpcrel_hi.13+0x5cc>
-               	bnez	t5, 0x2dc0 <.Lpcrel_hi.13+0x5a0>
+               	bltu	a6, a7, 0x3d1c <.Lpcrel_hi.13+0x5cc>
+               	bnez	t5, 0x3cf0 <.Lpcrel_hi.13+0x5a0>
                	addi	t6, a6, 0x18
                	addi	s1, a7, 0x18
                	li	s2, 0x18
@@ -2991,8 +3963,8 @@ Disassembly of section .text:
                	sd	s5, 0x0(t6)
                	addi	s2, s2, -0x8
                	li	t0, 0x0
-               	bne	s2, t0, 0x2da0 <.Lpcrel_hi.13+0x580>
-               	j	0x2e44 <.Lpcrel_hi.13+0x624>
+               	bne	s2, t0, 0x3cd0 <.Lpcrel_hi.13+0x580>
+               	j	0x3d74 <.Lpcrel_hi.13+0x624>
                	addi	t6, a6, 0x18
                	addi	s1, a7, 0x18
                	li	s2, 0x18
@@ -3002,9 +3974,9 @@ Disassembly of section .text:
                	sb	s5, 0x0(t6)
                	addi	s2, s2, -0x1
                	li	t0, 0x0
-               	bne	s2, t0, 0x2dcc <.Lpcrel_hi.13+0x5ac>
-               	j	0x2e44 <.Lpcrel_hi.13+0x624>
-               	bnez	t5, 0x2e1c <.Lpcrel_hi.13+0x5fc>
+               	bne	s2, t0, 0x3cfc <.Lpcrel_hi.13+0x5ac>
+               	j	0x3d74 <.Lpcrel_hi.13+0x624>
+               	bnez	t5, 0x3d4c <.Lpcrel_hi.13+0x5fc>
                	mv	t5, a6
                	mv	t6, a7
                	li	s1, 0x18
@@ -3014,8 +3986,8 @@ Disassembly of section .text:
                	addi	t6, t6, 0x8
                	addi	s1, s1, -0x8
                	li	t0, 0x0
-               	bne	s1, t0, 0x2dfc <.Lpcrel_hi.13+0x5dc>
-               	j	0x2e44 <.Lpcrel_hi.13+0x624>
+               	bne	s1, t0, 0x3d2c <.Lpcrel_hi.13+0x5dc>
+               	j	0x3d74 <.Lpcrel_hi.13+0x624>
                	mv	t5, a6
                	mv	a6, a7
                	li	a7, 0x18
@@ -3025,15 +3997,15 @@ Disassembly of section .text:
                	addi	a6, a6, 0x1
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x2e28 <.Lpcrel_hi.13+0x608>
+               	bne	a7, t0, 0x3d58 <.Lpcrel_hi.13+0x608>
                	addi	a6, s0, -0x548
                	addi	a7, s0, -0x568
                	mv	t5, s8
                	or	t6, a7, t5
                	li	t0, 0x7
                	and	t6, t6, t0
-               	bltu	a7, t5, 0x2ebc <.Lpcrel_hi.13+0x69c>
-               	bnez	t6, 0x2e90 <.Lpcrel_hi.13+0x670>
+               	bltu	a7, t5, 0x3dec <.Lpcrel_hi.13+0x69c>
+               	bnez	t6, 0x3dc0 <.Lpcrel_hi.13+0x670>
                	addi	s1, a7, 0x20
                	addi	s2, t5, 0x20
                	li	s5, 0x20
@@ -3043,8 +4015,8 @@ Disassembly of section .text:
                	sd	s6, 0x0(s1)
                	addi	s5, s5, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x2e70 <.Lpcrel_hi.13+0x650>
-               	j	0x2f14 <.Lpcrel_hi.13+0x6f4>
+               	bne	s5, t0, 0x3da0 <.Lpcrel_hi.13+0x650>
+               	j	0x3e44 <.Lpcrel_hi.13+0x6f4>
                	addi	s1, a7, 0x20
                	addi	s2, t5, 0x20
                	li	s5, 0x20
@@ -3054,9 +4026,9 @@ Disassembly of section .text:
                	sb	s6, 0x0(s1)
                	addi	s5, s5, -0x1
                	li	t0, 0x0
-               	bne	s5, t0, 0x2e9c <.Lpcrel_hi.13+0x67c>
-               	j	0x2f14 <.Lpcrel_hi.13+0x6f4>
-               	bnez	t6, 0x2eec <.Lpcrel_hi.13+0x6cc>
+               	bne	s5, t0, 0x3dcc <.Lpcrel_hi.13+0x67c>
+               	j	0x3e44 <.Lpcrel_hi.13+0x6f4>
+               	bnez	t6, 0x3e1c <.Lpcrel_hi.13+0x6cc>
                	mv	t6, a7
                	mv	s1, t5
                	li	s2, 0x20
@@ -3066,8 +4038,8 @@ Disassembly of section .text:
                	addi	s1, s1, 0x8
                	addi	s2, s2, -0x8
                	li	t0, 0x0
-               	bne	s2, t0, 0x2ecc <.Lpcrel_hi.13+0x6ac>
-               	j	0x2f14 <.Lpcrel_hi.13+0x6f4>
+               	bne	s2, t0, 0x3dfc <.Lpcrel_hi.13+0x6ac>
+               	j	0x3e44 <.Lpcrel_hi.13+0x6f4>
                	mv	t6, a7
                	mv	a7, t5
                	li	t5, 0x20
@@ -3077,15 +4049,15 @@ Disassembly of section .text:
                	addi	a7, a7, 0x1
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x2ef8 <.Lpcrel_hi.13+0x6d8>
+               	bne	t5, t0, 0x3e28 <.Lpcrel_hi.13+0x6d8>
                	addi	a7, s0, -0x568
                	addi	t5, s0, -0x588
                	mv	t6, s9
                	or	s1, t5, t6
                	li	t0, 0x7
                	and	s1, s1, t0
-               	bltu	t5, t6, 0x2f8c <.Lpcrel_hi.13+0x76c>
-               	bnez	s1, 0x2f60 <.Lpcrel_hi.13+0x740>
+               	bltu	t5, t6, 0x3ebc <.Lpcrel_hi.13+0x76c>
+               	bnez	s1, 0x3e90 <.Lpcrel_hi.13+0x740>
                	addi	s2, t5, 0x20
                	addi	s5, t6, 0x20
                	li	s6, 0x20
@@ -3095,8 +4067,8 @@ Disassembly of section .text:
                	sd	s8, 0x0(s2)
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x2f40 <.Lpcrel_hi.13+0x720>
-               	j	0x2fe4 <.Lpcrel_hi.13+0x7c4>
+               	bne	s6, t0, 0x3e70 <.Lpcrel_hi.13+0x720>
+               	j	0x3f14 <.Lpcrel_hi.13+0x7c4>
                	addi	s2, t5, 0x20
                	addi	s5, t6, 0x20
                	li	s6, 0x20
@@ -3106,9 +4078,9 @@ Disassembly of section .text:
                	sb	s8, 0x0(s2)
                	addi	s6, s6, -0x1
                	li	t0, 0x0
-               	bne	s6, t0, 0x2f6c <.Lpcrel_hi.13+0x74c>
-               	j	0x2fe4 <.Lpcrel_hi.13+0x7c4>
-               	bnez	s1, 0x2fbc <.Lpcrel_hi.13+0x79c>
+               	bne	s6, t0, 0x3e9c <.Lpcrel_hi.13+0x74c>
+               	j	0x3f14 <.Lpcrel_hi.13+0x7c4>
+               	bnez	s1, 0x3eec <.Lpcrel_hi.13+0x79c>
                	mv	s1, t5
                	mv	s2, t6
                	li	s5, 0x20
@@ -3118,8 +4090,8 @@ Disassembly of section .text:
                	addi	s2, s2, 0x8
                	addi	s5, s5, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x2f9c <.Lpcrel_hi.13+0x77c>
-               	j	0x2fe4 <.Lpcrel_hi.13+0x7c4>
+               	bne	s5, t0, 0x3ecc <.Lpcrel_hi.13+0x77c>
+               	j	0x3f14 <.Lpcrel_hi.13+0x7c4>
                	mv	s1, t5
                	mv	t5, t6
                	li	t6, 0x20
@@ -3129,15 +4101,15 @@ Disassembly of section .text:
                	addi	t5, t5, 0x1
                	addi	t6, t6, -0x1
                	li	t0, 0x0
-               	bne	t6, t0, 0x2fc8 <.Lpcrel_hi.13+0x7a8>
+               	bne	t6, t0, 0x3ef8 <.Lpcrel_hi.13+0x7a8>
                	addi	t5, s0, -0x588
                	addi	t6, s0, -0x5b8
                	mv	s1, s10
                	or	s2, t6, s1
                	li	t0, 0x7
                	and	s2, s2, t0
-               	bltu	t6, s1, 0x305c <.Lpcrel_hi.13+0x83c>
-               	bnez	s2, 0x3030 <.Lpcrel_hi.13+0x810>
+               	bltu	t6, s1, 0x3f8c <.Lpcrel_hi.13+0x83c>
+               	bnez	s2, 0x3f60 <.Lpcrel_hi.13+0x810>
                	addi	s5, t6, 0x30
                	addi	s6, s1, 0x30
                	li	s8, 0x30
@@ -3147,8 +4119,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(s5)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x3010 <.Lpcrel_hi.13+0x7f0>
-               	j	0x30b4 <.Lpcrel_hi.13+0x894>
+               	bne	s8, t0, 0x3f40 <.Lpcrel_hi.13+0x7f0>
+               	j	0x3fe4 <.Lpcrel_hi.13+0x894>
                	addi	s5, t6, 0x30
                	addi	s6, s1, 0x30
                	li	s8, 0x30
@@ -3158,9 +4130,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(s5)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x303c <.Lpcrel_hi.13+0x81c>
-               	j	0x30b4 <.Lpcrel_hi.13+0x894>
-               	bnez	s2, 0x308c <.Lpcrel_hi.13+0x86c>
+               	bne	s8, t0, 0x3f6c <.Lpcrel_hi.13+0x81c>
+               	j	0x3fe4 <.Lpcrel_hi.13+0x894>
+               	bnez	s2, 0x3fbc <.Lpcrel_hi.13+0x86c>
                	mv	s2, t6
                	mv	s5, s1
                	li	s6, 0x30
@@ -3170,8 +4142,8 @@ Disassembly of section .text:
                	addi	s5, s5, 0x8
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x306c <.Lpcrel_hi.13+0x84c>
-               	j	0x30b4 <.Lpcrel_hi.13+0x894>
+               	bne	s6, t0, 0x3f9c <.Lpcrel_hi.13+0x84c>
+               	j	0x3fe4 <.Lpcrel_hi.13+0x894>
                	mv	s2, t6
                	mv	t6, s1
                	li	s1, 0x30
@@ -3181,15 +4153,15 @@ Disassembly of section .text:
                	addi	t6, t6, 0x1
                	addi	s1, s1, -0x1
                	li	t0, 0x0
-               	bne	s1, t0, 0x3098 <.Lpcrel_hi.13+0x878>
+               	bne	s1, t0, 0x3fc8 <.Lpcrel_hi.13+0x878>
                	addi	t6, s0, -0x5b8
                	addi	s1, s0, -0x5e8
                	mv	s2, s11
                	or	s5, s1, s2
                	li	t0, 0x7
                	and	s5, s5, t0
-               	bltu	s1, s2, 0x312c <.Lpcrel_hi.13+0x90c>
-               	bnez	s5, 0x3100 <.Lpcrel_hi.13+0x8e0>
+               	bltu	s1, s2, 0x405c <.Lpcrel_hi.13+0x90c>
+               	bnez	s5, 0x4030 <.Lpcrel_hi.13+0x8e0>
                	addi	s6, s1, 0x30
                	addi	s8, s2, 0x30
                	li	s9, 0x30
@@ -3199,8 +4171,8 @@ Disassembly of section .text:
                	sd	s10, 0x0(s6)
                	addi	s9, s9, -0x8
                	li	t0, 0x0
-               	bne	s9, t0, 0x30e0 <.Lpcrel_hi.13+0x8c0>
-               	j	0x3184 <.Lpcrel_hi.13+0x964>
+               	bne	s9, t0, 0x4010 <.Lpcrel_hi.13+0x8c0>
+               	j	0x40b4 <.Lpcrel_hi.13+0x964>
                	addi	s6, s1, 0x30
                	addi	s8, s2, 0x30
                	li	s9, 0x30
@@ -3210,9 +4182,9 @@ Disassembly of section .text:
                	sb	s10, 0x0(s6)
                	addi	s9, s9, -0x1
                	li	t0, 0x0
-               	bne	s9, t0, 0x310c <.Lpcrel_hi.13+0x8ec>
-               	j	0x3184 <.Lpcrel_hi.13+0x964>
-               	bnez	s5, 0x315c <.Lpcrel_hi.13+0x93c>
+               	bne	s9, t0, 0x403c <.Lpcrel_hi.13+0x8ec>
+               	j	0x40b4 <.Lpcrel_hi.13+0x964>
+               	bnez	s5, 0x408c <.Lpcrel_hi.13+0x93c>
                	mv	s5, s1
                	mv	s6, s2
                	li	s8, 0x30
@@ -3222,8 +4194,8 @@ Disassembly of section .text:
                	addi	s6, s6, 0x8
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x313c <.Lpcrel_hi.13+0x91c>
-               	j	0x3184 <.Lpcrel_hi.13+0x964>
+               	bne	s8, t0, 0x406c <.Lpcrel_hi.13+0x91c>
+               	j	0x40b4 <.Lpcrel_hi.13+0x964>
                	mv	s5, s1
                	mv	s1, s2
                	li	s2, 0x30
@@ -3233,7 +4205,7 @@ Disassembly of section .text:
                	addi	s1, s1, 0x1
                	addi	s2, s2, -0x1
                	li	t0, 0x0
-               	bne	s2, t0, 0x3168 <.Lpcrel_hi.13+0x948>
+               	bne	s2, t0, 0x4098 <.Lpcrel_hi.13+0x948>
                	addi	s1, s0, -0x5e8
                	sd	s1, 0x0(sp)
                	addi	s1, s0, -0x600
@@ -3241,8 +4213,8 @@ Disassembly of section .text:
                	or	a0, s1, s2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	s1, s2, 0x3200 <.Lpcrel_hi.13+0x9e0>
-               	bnez	a0, 0x31d4 <.Lpcrel_hi.13+0x9b4>
+               	bltu	s1, s2, 0x4130 <.Lpcrel_hi.13+0x9e0>
+               	bnez	a0, 0x4104 <.Lpcrel_hi.13+0x9b4>
                	addi	s5, s1, 0x18
                	addi	s6, s2, 0x18
                	li	s8, 0x18
@@ -3252,8 +4224,8 @@ Disassembly of section .text:
                	sd	s9, 0x0(s5)
                	addi	s8, s8, -0x8
                	li	t0, 0x0
-               	bne	s8, t0, 0x31b4 <.Lpcrel_hi.13+0x994>
-               	j	0x3258 <.Lpcrel_hi.13+0xa38>
+               	bne	s8, t0, 0x40e4 <.Lpcrel_hi.13+0x994>
+               	j	0x4188 <.Lpcrel_hi.13+0xa38>
                	addi	s5, s1, 0x18
                	addi	s6, s2, 0x18
                	li	s8, 0x18
@@ -3263,9 +4235,9 @@ Disassembly of section .text:
                	sb	s9, 0x0(s5)
                	addi	s8, s8, -0x1
                	li	t0, 0x0
-               	bne	s8, t0, 0x31e0 <.Lpcrel_hi.13+0x9c0>
-               	j	0x3258 <.Lpcrel_hi.13+0xa38>
-               	bnez	a0, 0x3230 <.Lpcrel_hi.13+0xa10>
+               	bne	s8, t0, 0x4110 <.Lpcrel_hi.13+0x9c0>
+               	j	0x4188 <.Lpcrel_hi.13+0xa38>
+               	bnez	a0, 0x4160 <.Lpcrel_hi.13+0xa10>
                	mv	a0, s1
                	mv	s5, s2
                	li	s6, 0x18
@@ -3275,8 +4247,8 @@ Disassembly of section .text:
                	addi	s5, s5, 0x8
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x3210 <.Lpcrel_hi.13+0x9f0>
-               	j	0x3258 <.Lpcrel_hi.13+0xa38>
+               	bne	s6, t0, 0x4140 <.Lpcrel_hi.13+0x9f0>
+               	j	0x4188 <.Lpcrel_hi.13+0xa38>
                	mv	a0, s1
                	mv	s1, s2
                	li	s2, 0x18
@@ -3286,7 +4258,7 @@ Disassembly of section .text:
                	addi	s1, s1, 0x1
                	addi	s2, s2, -0x1
                	li	t0, 0x0
-               	bne	s2, t0, 0x323c <.Lpcrel_hi.13+0xa1c>
+               	bne	s2, t0, 0x416c <.Lpcrel_hi.13+0xa1c>
                	addi	a0, s0, -0x600
                	sd	a0, 0x8(sp)
                	addi	a0, s0, -0x620
@@ -3294,8 +4266,8 @@ Disassembly of section .text:
                	or	a1, a0, s1
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a0, s1, 0x32d4 <.Lpcrel_hi.13+0xab4>
-               	bnez	a1, 0x32a8 <.Lpcrel_hi.13+0xa88>
+               	bltu	a0, s1, 0x4204 <.Lpcrel_hi.13+0xab4>
+               	bnez	a1, 0x41d8 <.Lpcrel_hi.13+0xa88>
                	addi	s2, a0, 0x20
                	addi	s5, s1, 0x20
                	li	s6, 0x20
@@ -3305,8 +4277,8 @@ Disassembly of section .text:
                	sd	s8, 0x0(s2)
                	addi	s6, s6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x3288 <.Lpcrel_hi.13+0xa68>
-               	j	0x332c <.Lpcrel_hi.13+0xb0c>
+               	bne	s6, t0, 0x41b8 <.Lpcrel_hi.13+0xa68>
+               	j	0x425c <.Lpcrel_hi.13+0xb0c>
                	addi	s2, a0, 0x20
                	addi	s5, s1, 0x20
                	li	s6, 0x20
@@ -3316,9 +4288,9 @@ Disassembly of section .text:
                	sb	s8, 0x0(s2)
                	addi	s6, s6, -0x1
                	li	t0, 0x0
-               	bne	s6, t0, 0x32b4 <.Lpcrel_hi.13+0xa94>
-               	j	0x332c <.Lpcrel_hi.13+0xb0c>
-               	bnez	a1, 0x3304 <.Lpcrel_hi.13+0xae4>
+               	bne	s6, t0, 0x41e4 <.Lpcrel_hi.13+0xa94>
+               	j	0x425c <.Lpcrel_hi.13+0xb0c>
+               	bnez	a1, 0x4234 <.Lpcrel_hi.13+0xae4>
                	mv	a1, a0
                	mv	s2, s1
                	li	s5, 0x20
@@ -3328,8 +4300,8 @@ Disassembly of section .text:
                	addi	s2, s2, 0x8
                	addi	s5, s5, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x32e4 <.Lpcrel_hi.13+0xac4>
-               	j	0x332c <.Lpcrel_hi.13+0xb0c>
+               	bne	s5, t0, 0x4214 <.Lpcrel_hi.13+0xac4>
+               	j	0x425c <.Lpcrel_hi.13+0xb0c>
                	mv	a1, a0
                	mv	a0, s1
                	li	s1, 0x20
@@ -3339,7 +4311,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	s1, s1, -0x1
                	li	t0, 0x0
-               	bne	s1, t0, 0x3310 <.Lpcrel_hi.13+0xaf0>
+               	bne	s1, t0, 0x4240 <.Lpcrel_hi.13+0xaf0>
                	addi	a0, s0, -0x620
                	sd	a0, 0x10(sp)
                	addi	a0, s0, -0x650
@@ -3347,8 +4319,8 @@ Disassembly of section .text:
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x33a8 <.Lpcrel_hi.13+0xb88>
-               	bnez	a2, 0x337c <.Lpcrel_hi.13+0xb5c>
+               	bltu	a0, a1, 0x42d8 <.Lpcrel_hi.13+0xb88>
+               	bnez	a2, 0x42ac <.Lpcrel_hi.13+0xb5c>
                	addi	s1, a0, 0x30
                	addi	s2, a1, 0x30
                	li	s5, 0x30
@@ -3358,8 +4330,8 @@ Disassembly of section .text:
                	sd	s6, 0x0(s1)
                	addi	s5, s5, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x335c <.Lpcrel_hi.13+0xb3c>
-               	j	0x3400 <.Lpcrel_hi.13+0xbe0>
+               	bne	s5, t0, 0x428c <.Lpcrel_hi.13+0xb3c>
+               	j	0x4330 <.Lpcrel_hi.13+0xbe0>
                	addi	s1, a0, 0x30
                	addi	s2, a1, 0x30
                	li	s5, 0x30
@@ -3369,9 +4341,9 @@ Disassembly of section .text:
                	sb	s6, 0x0(s1)
                	addi	s5, s5, -0x1
                	li	t0, 0x0
-               	bne	s5, t0, 0x3388 <.Lpcrel_hi.13+0xb68>
-               	j	0x3400 <.Lpcrel_hi.13+0xbe0>
-               	bnez	a2, 0x33d8 <.Lpcrel_hi.13+0xbb8>
+               	bne	s5, t0, 0x42b8 <.Lpcrel_hi.13+0xb68>
+               	j	0x4330 <.Lpcrel_hi.13+0xbe0>
+               	bnez	a2, 0x4308 <.Lpcrel_hi.13+0xbb8>
                	mv	a2, a0
                	mv	s1, a1
                	li	s2, 0x30
@@ -3381,8 +4353,8 @@ Disassembly of section .text:
                	addi	s1, s1, 0x8
                	addi	s2, s2, -0x8
                	li	t0, 0x0
-               	bne	s2, t0, 0x33b8 <.Lpcrel_hi.13+0xb98>
-               	j	0x3400 <.Lpcrel_hi.13+0xbe0>
+               	bne	s2, t0, 0x42e8 <.Lpcrel_hi.13+0xb98>
+               	j	0x4330 <.Lpcrel_hi.13+0xbe0>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x30
@@ -3392,7 +4364,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x33e4 <.Lpcrel_hi.13+0xbc4>
+               	bne	a1, t0, 0x4314 <.Lpcrel_hi.13+0xbc4>
                	addi	a0, s0, -0x650
                	sd	a0, 0x18(sp)
                	sd	a4, 0x20(sp)

--- a/test/golden/riscv64-linux/call/call_rec_small.dis
+++ b/test/golden/riscv64-linux/call/call_rec_small.dis
@@ -30,116 +30,226 @@ Disassembly of section .text:
                	sd	ra, 0x18(sp)
                	sd	s0, 0x10(sp)
                	addi	s0, sp, 0x20
-               	mv	a2, a0
                	sd	a1, -0x18(s0)
                	addi	a1, s0, -0x18
-               	lbu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r1+0x28>
+               	lbu	a2, 0x0(a1)
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x84 <corpus.cases.call.call_rec_small.fold_r1+0x30>
+               	j	0xb8 <corpus.cases.call.call_rec_small.fold_r1+0x64>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x84 <corpus.cases.call.call_rec_small.fold_r1+0x30>
                	ld	ra, 0x18(sp)
                	ld	s0, 0x10(sp)
                	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_small.fold_r2>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a2, a0
-               	sd	a1, -0x20(s0)
-               	addi	a1, s0, -0x20
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x18
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s0, -0x17
                	lbu	a3, 0x0(a1)
-               	addi	a1, s0, -0x1f
-               	lbu	s1, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r2+0x34>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r2+0x48>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x100 <corpus.cases.call.call_rec_small.fold_r2+0x38>
+               	j	0x134 <corpus.cases.call.call_rec_small.fold_r2+0x6c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x100 <corpus.cases.call.call_rec_small.fold_r2+0x38>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x148 <corpus.cases.call.call_rec_small.fold_r2+0x80>
+               	j	0x17c <corpus.cases.call.call_rec_small.fold_r2+0xb4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x148 <corpus.cases.call.call_rec_small.fold_r2+0x80>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_small.fold_r4>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a2, a0
-               	sd	a1, -0x28(s0)
-               	addi	a1, s0, -0x28
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x18
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s0, -0x17
                	lbu	a3, 0x0(a1)
-               	addi	a1, s0, -0x27
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s0, -0x26
-               	lhu	s2, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r4+0x40>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r4+0x54>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r4+0x68>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x16
+               	lhu	a4, 0x0(a1)
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1cc <corpus.cases.call.call_rec_small.fold_r4+0x40>
+               	j	0x200 <corpus.cases.call.call_rec_small.fold_r4+0x74>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1cc <corpus.cases.call.call_rec_small.fold_r4+0x40>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x214 <corpus.cases.call.call_rec_small.fold_r4+0x88>
+               	j	0x248 <corpus.cases.call.call_rec_small.fold_r4+0xbc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x214 <corpus.cases.call.call_rec_small.fold_r4+0x88>
+               	slli	a1, a4, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.call.call_rec_small.fold_r4+0xd4>
+               	j	0x294 <corpus.cases.call.call_rec_small.fold_r4+0x108>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.call.call_rec_small.fold_r4+0xd4>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_small.fold_r8>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a2, a0
-               	sd	a1, -0x28(s0)
-               	addi	a1, s0, -0x28
-               	lw	a3, 0x0(a1)
-               	addi	a1, s0, -0x24
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s0, -0x22
-               	lbu	s2, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r8+0x40>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r8+0x54>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.fold_r8+0x68>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x18
+               	lw	a2, 0x0(a1)
+               	addi	a1, s0, -0x14
+               	lhu	a3, 0x0(a1)
+               	addi	a1, s0, -0x12
+               	lbu	a4, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e8 <corpus.cases.call.call_rec_small.fold_r8+0x44>
+               	j	0x31c <corpus.cases.call.call_rec_small.fold_r8+0x78>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e8 <corpus.cases.call.call_rec_small.fold_r8+0x44>
+               	slli	a1, a3, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <corpus.cases.call.call_rec_small.fold_r8+0x90>
+               	j	0x368 <corpus.cases.call.call_rec_small.fold_r8+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <corpus.cases.call.call_rec_small.fold_r8+0x90>
+               	zext.b	a1, a4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x37c <corpus.cases.call.call_rec_small.fold_r8+0xd8>
+               	j	0x3b0 <corpus.cases.call.call_rec_small.fold_r8+0x10c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x37c <corpus.cases.call.call_rec_small.fold_r8+0xd8>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_rec_small.layout>:
@@ -147,282 +257,593 @@ Disassembly of section .text:
                	sd	ra, 0x8(sp)
                	sd	s0, 0x0(sp)
                	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x30>
-               	mv	a1, a0
-               	mv	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e0 <corpus.cases.call.call_rec_small.layout+0x20>
+               	j	0x418 <corpus.cases.call.call_rec_small.layout+0x58>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e0 <corpus.cases.call.call_rec_small.layout+0x20>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x428 <corpus.cases.call.call_rec_small.layout+0x68>
+               	j	0x460 <corpus.cases.call.call_rec_small.layout+0xa0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x2
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x428 <corpus.cases.call.call_rec_small.layout+0x68>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x470 <corpus.cases.call.call_rec_small.layout+0xb0>
+               	j	0x4a8 <corpus.cases.call.call_rec_small.layout+0xe8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x4
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x470 <corpus.cases.call.call_rec_small.layout+0xb0>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4b8 <corpus.cases.call.call_rec_small.layout+0xf8>
+               	j	0x4f0 <corpus.cases.call.call_rec_small.layout+0x130>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x8
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4b8 <corpus.cases.call.call_rec_small.layout+0xf8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x500 <corpus.cases.call.call_rec_small.layout+0x140>
+               	j	0x538 <corpus.cases.call.call_rec_small.layout+0x178>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x500 <corpus.cases.call.call_rec_small.layout+0x140>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x548 <corpus.cases.call.call_rec_small.layout+0x188>
+               	j	0x580 <corpus.cases.call.call_rec_small.layout+0x1c0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x548 <corpus.cases.call.call_rec_small.layout+0x188>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x590 <corpus.cases.call.call_rec_small.layout+0x1d0>
+               	j	0x5c8 <corpus.cases.call.call_rec_small.layout+0x208>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x2
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x590 <corpus.cases.call.call_rec_small.layout+0x1d0>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x20c>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x6c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x218>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x224>
                	li	a1, 0x2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x230>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0xd0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0xe4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0xf8>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x23c>
                	li	a1, 0x6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x10c>
+               	jalr	ra <corpus.cases.call.call_rec_small.layout+0x248>
                	ld	ra, 0x8(sp)
                	ld	s0, 0x0(sp)
                	addi	sp, sp, 0x10
                	ret
 
 <corpus.cases.call.call_rec_small.take_small>:
-               	addi	sp, sp, -0x100
-               	sd	ra, 0xf8(sp)
-               	sd	s0, 0xf0(sp)
-               	addi	s0, sp, 0x100
-               	sd	s1, 0xe8(sp)
-               	sd	s2, 0xe0(sp)
-               	sd	s3, 0xd8(sp)
-               	sd	s4, 0xd0(sp)
-               	sd	s5, 0xc8(sp)
-               	sd	s6, 0xc0(sp)
-               	sd	s7, 0xb8(sp)
-               	sd	s8, 0xb0(sp)
-               	sd	s9, 0xa8(sp)
-               	sd	s10, 0xa0(sp)
-               	sd	s11, 0x98(sp)
-               	fsd	fs0, 0x90(sp)
-               	fsd	fs1, 0x88(sp)
-               	mv	s1, a0
+               	addi	sp, sp, -0x160
+               	sd	ra, 0x158(sp)
+               	sd	s0, 0x150(sp)
+               	addi	s0, sp, 0x160
+               	sd	s1, 0x148(sp)
+               	sd	s2, 0x140(sp)
+               	sd	s3, 0x138(sp)
+               	sd	s4, 0x130(sp)
+               	sd	s5, 0x128(sp)
+               	sd	s6, 0x120(sp)
+               	sd	s7, 0x118(sp)
+               	sd	s8, 0x110(sp)
+               	sd	s9, 0x108(sp)
+               	sd	s10, 0x100(sp)
+               	sd	s11, 0xf8(sp)
+               	fsd	fs0, 0xf0(sp)
+               	fsd	fs1, 0xe8(sp)
+               	mv	t5, a0
                	sd	a1, -0x80(s0)
-               	mv	s2, a2
+               	mv	s1, a2
                	sd	a3, -0x88(s0)
                	fmv.d	fs0, fa0
                	sd	a4, -0x90(s0)
-               	mv	s3, a5
+               	mv	s2, a5
                	sd	a6, -0x98(s0)
                	sd	a7, -0xa0(s0)
-               	mv	a1, s0
-               	addi	a2, s0, 0x8
-               	addi	a3, s0, 0x10
+               	mv	a0, s0
+               	addi	a1, s0, 0x8
+               	addi	a2, s0, 0x10
                	fmv.s	fs1, fa1
-               	ld	s4, 0x18(s0)
-               	addi	a4, s0, -0x80
-               	lbu	s5, 0x0(a4)
-               	addi	a4, s0, -0x88
-               	lbu	s6, 0x0(a4)
-               	addi	a4, s0, -0x87
-               	lbu	s7, 0x0(a4)
-               	addi	a4, s0, -0x90
-               	lbu	s8, 0x0(a4)
-               	addi	a4, s0, -0x8f
-               	lbu	s9, 0x0(a4)
-               	addi	a4, s0, -0x8e
-               	lhu	s10, 0x0(a4)
-               	addi	a4, s0, -0x98
-               	lw	s11, 0x0(a4)
-               	addi	a4, s0, -0x94
-               	lhu	t2, 0x0(a4)
-               	sd	t2, -0xc0(s0)
-               	addi	a4, s0, -0x92
-               	lbu	t2, 0x0(a4)
-               	sd	t2, -0xc8(s0)
-               	addi	a4, s0, -0xa0
-               	lbu	t2, 0x0(a4)
-               	sd	t2, -0xd0(s0)
-               	mv	a4, a1
-               	lbu	t2, 0x0(a4)
-               	sd	t2, -0xd8(s0)
-               	addi	a4, a1, 0x1
-               	lbu	t2, 0x0(a4)
-               	sd	t2, -0xe0(s0)
-               	mv	a1, a2
-               	lbu	t2, 0x0(a1)
-               	sd	t2, -0xe8(s0)
-               	addi	a1, a2, 0x1
-               	lbu	t2, 0x0(a1)
-               	sd	t2, -0xa8(s0)
-               	addi	a1, a2, 0x2
-               	lhu	t2, 0x0(a1)
-               	sd	t2, -0xf0(s0)
-               	mv	a1, a3
-               	lw	t2, 0x0(a1)
-               	sd	t2, -0xb0(s0)
-               	addi	a1, a3, 0x4
-               	lhu	t2, 0x0(a1)
-               	sd	t2, -0xb8(s0)
-               	addi	a1, a3, 0x6
-               	lbu	t2, 0x0(a1)
-               	sd	t2, -0xf8(s0)
+               	ld	s3, 0x18(s0)
+               	addi	a3, s0, -0x80
+               	lbu	s4, 0x0(a3)
+               	addi	s5, s0, -0xa2
+               	lbu	a3, -0x88(s0)
+               	lbu	a4, -0x87(s0)
+               	sb	a3, 0x0(s5)
+               	sb	a4, 0x1(s5)
+               	addi	s6, s0, -0xa6
+               	lbu	a3, -0x90(s0)
+               	lbu	a4, -0x8f(s0)
+               	lbu	a5, -0x8e(s0)
+               	lbu	a6, -0x8d(s0)
+               	sb	a3, 0x0(s6)
+               	sb	a4, 0x1(s6)
+               	sb	a5, 0x2(s6)
+               	sb	a6, 0x3(s6)
+               	addi	s7, s0, -0xb0
+               	lbu	a3, -0x98(s0)
+               	lbu	a4, -0x97(s0)
+               	lbu	a5, -0x96(s0)
+               	lbu	a6, -0x95(s0)
+               	lbu	a7, -0x94(s0)
+               	lbu	t6, -0x93(s0)
+               	lbu	s8, -0x92(s0)
+               	lbu	s9, -0x91(s0)
+               	sb	a3, 0x0(s7)
+               	sb	a4, 0x1(s7)
+               	sb	a5, 0x2(s7)
+               	sb	a6, 0x3(s7)
+               	sb	a7, 0x4(s7)
+               	sb	t6, 0x5(s7)
+               	sb	s8, 0x6(s7)
+               	sb	s9, 0x7(s7)
+               	addi	a3, s0, -0xa0
+               	lbu	s8, 0x0(a3)
+               	addi	s9, s0, -0xb2
+               	lbu	a3, 0x0(a0)
+               	lbu	a4, 0x1(a0)
+               	sb	a3, 0x0(s9)
+               	sb	a4, 0x1(s9)
+               	addi	s10, s0, -0xb6
+               	lbu	a0, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	sb	a0, 0x0(s10)
+               	sb	a3, 0x1(s10)
+               	sb	a4, 0x2(s10)
+               	sb	a5, 0x3(s10)
+               	addi	s11, s0, -0xc0
+               	lbu	a0, 0x0(a2)
+               	lbu	a1, 0x1(a2)
+               	lbu	a3, 0x2(a2)
+               	lbu	a4, 0x3(a2)
+               	lbu	a5, 0x4(a2)
+               	lbu	a6, 0x5(a2)
+               	lbu	a7, 0x6(a2)
+               	lbu	t6, 0x7(a2)
+               	sb	a0, 0x0(s11)
+               	sb	a1, 0x1(s11)
+               	sb	a3, 0x2(s11)
+               	sb	a4, 0x3(s11)
+               	sb	a5, 0x4(s11)
+               	sb	a6, 0x5(s11)
+               	sb	a7, 0x6(s11)
+               	sb	t6, 0x7(s11)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, t5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x138>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1a8>
+               	zext.b	a1, s4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7e4 <corpus.cases.call.call_rec_small.take_small+0x1c4>
+               	j	0x818 <corpus.cases.call.call_rec_small.take_small+0x1f8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7e4 <corpus.cases.call.call_rec_small.take_small+0x1c4>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x14c>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x158>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x164>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x170>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x17c>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x188>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x194>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1a0>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1ac>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1b8>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1c4>
-               	ld	t2, -0xc0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1d4>
-               	ld	t2, -0xc8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1e4>
-               	ld	t2, -0xd0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x1f4>
-               	ld	t2, -0xd8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x204>
-               	ld	t2, -0xe0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x214>
-               	ld	t2, -0xe8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x224>
-               	ld	t2, -0xa8(s0)
-               	mv	a1, t2
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x200>
+               	addi	a1, s0, -0xc2
+               	lbu	a2, 0x0(s5)
+               	lbu	a3, 0x1(s5)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sd	zero, -0xd0(s0)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	sb	a2, -0xd0(s0)
+               	sb	a3, -0xcf(s0)
+               	ld	a1, -0xd0(s0)
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x234>
-               	ld	t2, -0xf0(s0)
-               	mv	a1, t2
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x244>
-               	ld	t2, -0xb0(s0)
-               	mv	a1, t2
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x240>
+               	addi	a1, s0, -0xd4
+               	lbu	a2, 0x0(s6)
+               	lbu	a3, 0x1(s6)
+               	lbu	a4, 0x2(s6)
+               	lbu	a5, 0x3(s6)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sd	zero, -0xe0(s0)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	sb	a2, -0xe0(s0)
+               	sb	a3, -0xdf(s0)
+               	sb	a4, -0xde(s0)
+               	sb	a5, -0xdd(s0)
+               	ld	a1, -0xe0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x254>
-               	ld	t2, -0xb8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x264>
-               	ld	t2, -0xf8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x274>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x280>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x28c>
-               	addiw	a1, s11, 0x1
-               	ld	t2, -0xc0(s0)
-               	addiw	s1, t2, 0x2
-               	ld	t2, -0xc8(s0)
-               	addiw	s2, t2, 0x3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2a8>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2b4>
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x294>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2c0>
-               	mv	a1, s11
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2a0>
+               	addi	a1, s0, -0xe8
+               	lbu	a2, 0x0(s7)
+               	lbu	a3, 0x1(s7)
+               	lbu	a4, 0x2(s7)
+               	lbu	a5, 0x3(s7)
+               	lbu	a6, 0x4(s7)
+               	lbu	a7, 0x5(s7)
+               	lbu	t5, 0x6(s7)
+               	lbu	t6, 0x7(s7)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0xf0(s0)
+               	sb	a3, -0xef(s0)
+               	sb	a4, -0xee(s0)
+               	sb	a5, -0xed(s0)
+               	sb	a6, -0xec(s0)
+               	sb	a7, -0xeb(s0)
+               	sb	t5, -0xea(s0)
+               	sb	t6, -0xe9(s0)
+               	ld	a1, -0xf0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2cc>
-               	ld	t2, -0xc0(s0)
-               	mv	a1, t2
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x330>
+               	zext.b	a1, s8
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x96c <corpus.cases.call.call_rec_small.take_small+0x34c>
+               	j	0x9a0 <corpus.cases.call.call_rec_small.take_small+0x380>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x96c <corpus.cases.call.call_rec_small.take_small+0x34c>
+               	addi	a1, s0, -0xf2
+               	lbu	a2, 0x0(s9)
+               	lbu	a3, 0x1(s9)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sd	zero, -0x100(s0)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	sb	a2, -0x100(s0)
+               	sb	a3, -0xff(s0)
+               	ld	a1, -0x100(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2dc>
-               	ld	t2, -0xc8(s0)
-               	mv	a1, t2
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x3ac>
+               	addi	a1, s0, -0x104
+               	lbu	a2, 0x0(s10)
+               	lbu	a3, 0x1(s10)
+               	lbu	a4, 0x2(s10)
+               	lbu	a5, 0x3(s10)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sd	zero, -0x110(s0)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	sb	a2, -0x110(s0)
+               	sb	a3, -0x10f(s0)
+               	sb	a4, -0x10e(s0)
+               	sb	a5, -0x10d(s0)
+               	ld	a1, -0x110(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x2ec>
-               	ld	s1, 0xe8(sp)
-               	ld	s2, 0xe0(sp)
-               	ld	s3, 0xd8(sp)
-               	ld	s4, 0xd0(sp)
-               	ld	s5, 0xc8(sp)
-               	ld	s6, 0xc0(sp)
-               	ld	s7, 0xb8(sp)
-               	ld	s8, 0xb0(sp)
-               	ld	s9, 0xa8(sp)
-               	ld	s10, 0xa0(sp)
-               	ld	s11, 0x98(sp)
-               	fld	fs0, 0x90(sp)
-               	fld	fs1, 0x88(sp)
-               	ld	ra, 0xf8(sp)
-               	ld	s0, 0xf0(sp)
-               	addi	sp, sp, 0x100
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x400>
+               	addi	a1, s0, -0x118
+               	lbu	a2, 0x0(s11)
+               	lbu	a3, 0x1(s11)
+               	lbu	a4, 0x2(s11)
+               	lbu	a5, 0x3(s11)
+               	lbu	a6, 0x4(s11)
+               	lbu	a7, 0x5(s11)
+               	lbu	t5, 0x6(s11)
+               	lbu	t6, 0x7(s11)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x120(s0)
+               	sb	a3, -0x11f(s0)
+               	sb	a4, -0x11e(s0)
+               	sb	a5, -0x11d(s0)
+               	sb	a6, -0x11c(s0)
+               	sb	a7, -0x11b(s0)
+               	sb	t5, -0x11a(s0)
+               	sb	t6, -0x119(s0)
+               	ld	a1, -0x120(s0)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x490>
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x4a8>
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x4b4>
+               	addi	a1, s0, -0x128
+               	addi	a2, s0, -0x130
+               	lbu	a3, 0x0(s7)
+               	lbu	a4, 0x1(s7)
+               	lbu	a5, 0x2(s7)
+               	lbu	a6, 0x3(s7)
+               	lbu	a7, 0x4(s7)
+               	lbu	t5, 0x5(s7)
+               	lbu	t6, 0x6(s7)
+               	lbu	s1, 0x7(s7)
+               	sb	a3, 0x0(a2)
+               	sb	a4, 0x1(a2)
+               	sb	a5, 0x2(a2)
+               	sb	a6, 0x3(a2)
+               	sb	a7, 0x4(a2)
+               	sb	t5, 0x5(a2)
+               	sb	t6, 0x6(a2)
+               	sb	s1, 0x7(a2)
+               	lbu	a3, 0x0(a2)
+               	lbu	a4, 0x1(a2)
+               	lbu	a5, 0x2(a2)
+               	lbu	a6, 0x3(a2)
+               	lbu	a7, 0x4(a2)
+               	lbu	t5, 0x5(a2)
+               	lbu	t6, 0x6(a2)
+               	lbu	s1, 0x7(a2)
+               	sb	a3, 0x0(a1)
+               	sb	a4, 0x1(a1)
+               	sb	a5, 0x2(a1)
+               	sb	a6, 0x3(a1)
+               	sb	a7, 0x4(a1)
+               	sb	t5, 0x5(a1)
+               	sb	t6, 0x6(a1)
+               	sb	s1, 0x7(a1)
+               	mv	a2, a1
+               	lw	a3, 0x0(a2)
+               	addiw	a4, a3, 0x1
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lhu	a3, 0x0(a2)
+               	addiw	a4, a3, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a3, 0x0(a2)
+               	addiw	a4, a3, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, s0, -0x138
+               	lbu	a3, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s1, 0x7(a1)
+               	sb	a3, 0x0(a2)
+               	sb	a4, 0x1(a2)
+               	sb	a5, 0x2(a2)
+               	sb	a6, 0x3(a2)
+               	sb	a7, 0x4(a2)
+               	sb	t5, 0x5(a2)
+               	sb	t6, 0x6(a2)
+               	sb	s1, 0x7(a2)
+               	lbu	a1, 0x0(a2)
+               	lbu	a3, 0x1(a2)
+               	lbu	a4, 0x2(a2)
+               	lbu	a5, 0x3(a2)
+               	lbu	a6, 0x4(a2)
+               	lbu	a7, 0x5(a2)
+               	lbu	t5, 0x6(a2)
+               	lbu	t6, 0x7(a2)
+               	sb	a1, -0x140(s0)
+               	sb	a3, -0x13f(s0)
+               	sb	a4, -0x13e(s0)
+               	sb	a5, -0x13d(s0)
+               	sb	a6, -0x13c(s0)
+               	sb	a7, -0x13b(s0)
+               	sb	t5, -0x13a(s0)
+               	sb	t6, -0x139(s0)
+               	ld	a1, -0x140(s0)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x5fc>
+               	addi	a1, s0, -0x148
+               	lbu	a2, 0x0(s7)
+               	lbu	a3, 0x1(s7)
+               	lbu	a4, 0x2(s7)
+               	lbu	a5, 0x3(s7)
+               	lbu	a6, 0x4(s7)
+               	lbu	a7, 0x5(s7)
+               	lbu	t5, 0x6(s7)
+               	lbu	t6, 0x7(s7)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x150(s0)
+               	sb	a3, -0x14f(s0)
+               	sb	a4, -0x14e(s0)
+               	sb	a5, -0x14d(s0)
+               	sb	a6, -0x14c(s0)
+               	sb	a7, -0x14b(s0)
+               	sb	t5, -0x14a(s0)
+               	sb	t6, -0x149(s0)
+               	ld	a1, -0x150(s0)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_rec_small.take_small+0x68c>
+               	ld	s1, 0x148(sp)
+               	ld	s2, 0x140(sp)
+               	ld	s3, 0x138(sp)
+               	ld	s4, 0x130(sp)
+               	ld	s5, 0x128(sp)
+               	ld	s6, 0x120(sp)
+               	ld	s7, 0x118(sp)
+               	ld	s8, 0x110(sp)
+               	ld	s9, 0x108(sp)
+               	ld	s10, 0x100(sp)
+               	ld	s11, 0xf8(sp)
+               	fld	fs0, 0xf0(sp)
+               	fld	fs1, 0xe8(sp)
+               	ld	ra, 0x158(sp)
+               	ld	s0, 0x150(sp)
+               	addi	sp, sp, 0x160
                	ret
 
 <corpus.cases.call.call_rec_small.mk1>:
@@ -539,87 +960,198 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_rec_small.checksum>:
-               	addi	sp, sp, -0x1a0
-               	sd	ra, 0x198(sp)
-               	sd	s0, 0x190(sp)
-               	addi	s0, sp, 0x1a0
-               	sd	s1, 0x188(sp)
-               	sd	s2, 0x180(sp)
-               	sd	s3, 0x178(sp)
-               	sd	s4, 0x170(sp)
-               	sd	s5, 0x168(sp)
-               	sd	s6, 0x160(sp)
-               	sd	s7, 0x158(sp)
-               	sd	s8, 0x150(sp)
-               	sd	s9, 0x148(sp)
-               	sd	s10, 0x140(sp)
-               	sd	s11, 0x138(sp)
+               	addi	sp, sp, -0x1b0
+               	sd	ra, 0x1a8(sp)
+               	sd	s0, 0x1a0(sp)
+               	addi	s0, sp, 0x1b0
+               	sd	s1, 0x198(sp)
+               	sd	s2, 0x190(sp)
+               	sd	s3, 0x188(sp)
+               	sd	s4, 0x180(sp)
+               	sd	s5, 0x178(sp)
+               	sd	s6, 0x170(sp)
+               	sd	s7, 0x168(sp)
+               	sd	s8, 0x160(sp)
+               	sd	s9, 0x158(sp)
+               	sd	s10, 0x150(sp)
+               	sd	s11, 0x148(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x40>
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x4c>
-               	li	a1, 0x2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x58>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0c <corpus.cases.call.call_rec_small.checksum+0x70>
+               	j	0xf44 <corpus.cases.call.call_rec_small.checksum+0xa8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0c <corpus.cases.call.call_rec_small.checksum+0x70>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf54 <corpus.cases.call.call_rec_small.checksum+0xb8>
+               	j	0xf8c <corpus.cases.call.call_rec_small.checksum+0xf0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x2
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf54 <corpus.cases.call.call_rec_small.checksum+0xb8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf9c <corpus.cases.call.call_rec_small.checksum+0x100>
+               	j	0xfd4 <corpus.cases.call.call_rec_small.checksum+0x138>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x4
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf9c <corpus.cases.call.call_rec_small.checksum+0x100>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xfe4 <corpus.cases.call.call_rec_small.checksum+0x148>
+               	j	0x101c <corpus.cases.call.call_rec_small.checksum+0x180>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x8
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xfe4 <corpus.cases.call.call_rec_small.checksum+0x148>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x102c <corpus.cases.call.call_rec_small.checksum+0x190>
+               	j	0x1064 <corpus.cases.call.call_rec_small.checksum+0x1c8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x102c <corpus.cases.call.call_rec_small.checksum+0x190>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1074 <corpus.cases.call.call_rec_small.checksum+0x1d8>
+               	j	0x10ac <corpus.cases.call.call_rec_small.checksum+0x210>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1074 <corpus.cases.call.call_rec_small.checksum+0x1d8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x10bc <corpus.cases.call.call_rec_small.checksum+0x220>
+               	j	0x10f4 <corpus.cases.call.call_rec_small.checksum+0x258>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x2
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x10bc <corpus.cases.call.call_rec_small.checksum+0x220>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x64>
-               	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x70>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x25c>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x7c>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x268>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x88>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x274>
                	li	a1, 0x2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x94>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x280>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xa0>
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xac>
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xb8>
-               	li	a1, 0x2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xc4>
-               	li	a1, 0x4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xd0>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x28c>
                	li	a1, 0x6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0xdc>
-               	addi	s2, s0, -0xc8
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x298>
+               	addi	s2, s0, -0xd0
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x920 <corpus.cases.call.call_rec_small.checksum+0x118>
+               	bnez	a2, 0x1170 <corpus.cases.call.call_rec_small.checksum+0x2d4>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x908 <corpus.cases.call.call_rec_small.checksum+0x100>
-               	j	0x93c <corpus.cases.call.call_rec_small.checksum+0x134>
+               	bne	a3, t0, 0x1158 <corpus.cases.call.call_rec_small.checksum+0x2bc>
+               	j	0x118c <corpus.cases.call.call_rec_small.checksum+0x2f0>
                	mv	a2, a1
                	li	a1, 0x60
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x928 <corpus.cases.call.call_rec_small.checksum+0x120>
+               	bne	a1, t0, 0x1178 <corpus.cases.call.call_rec_small.checksum+0x2dc>
                	li	a1, 0x0
                	li	t0, 0xc
-               	bltu	a1, t0, 0x94c <corpus.cases.call.call_rec_small.checksum+0x144>
-               	j	0x9b0 <corpus.cases.call.call_rec_small.checksum+0x1a8>
+               	bltu	a1, t0, 0x119c <corpus.cases.call.call_rec_small.checksum+0x300>
+               	j	0x1200 <corpus.cases.call.call_rec_small.checksum+0x364>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -644,33 +1176,33 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0xc
-               	bltu	a1, t0, 0x94c <corpus.cases.call.call_rec_small.checksum+0x144>
+               	bltu	a1, t0, 0x119c <corpus.cases.call.call_rec_small.checksum+0x300>
                	mv	s3, a0
                	li	s4, 0x0
                	li	s5, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x9c8 <corpus.cases.call.call_rec_small.checksum+0x1c0>
-               	j	0xd10 <corpus.cases.call.call_rec_small.checksum+0x508>
+               	bltu	s5, t0, 0x1218 <corpus.cases.call.call_rec_small.checksum+0x37c>
+               	j	0x1560 <corpus.cases.call.call_rec_small.checksum+0x6c4>
                	li	t0, 0xd
                	mul	a0, s5, t0
                	add	a1, a0, s1
                	mv	a0, s2
                	ld	a2, 0x0(a0)
                	add	t2, a2, a1
-               	sd	t2, -0x160(s0)
+               	sd	t2, -0x168(s0)
                	addi	a2, s2, 0x8
                	ld	a3, 0x0(a2)
-               	addi	a2, s0, -0xc9
+               	addi	a2, s0, -0x69
                	sext.w	a4, a3
                	mv	a3, a2
                	sb	a4, 0x0(a3)
                	addi	a3, s2, 0x10
                	ld	a4, 0x0(a3)
                	sext.w	t2, a4
-               	sd	t2, -0x168(s0)
+               	sd	t2, -0x170(s0)
                	addi	a4, s2, 0x18
                	ld	a5, 0x0(a4)
-               	addi	a4, s0, -0xcc
+               	addi	a4, s0, -0xd2
                	sext.w	a6, a5
                	mv	a7, a4
                	sb	a6, 0x0(a7)
@@ -685,7 +1217,7 @@ Disassembly of section .text:
                	fcvt.d.lu	fa0, a5
                	addi	a5, s2, 0x28
                	ld	a6, 0x0(a5)
-               	addi	a5, s0, -0xd2
+               	addi	a5, s0, -0xd8
                	sext.w	a7, a6
                	mv	t5, a5
                	sb	a7, 0x0(t5)
@@ -699,11 +1231,11 @@ Disassembly of section .text:
                	sh	a6, 0x0(a7)
                	addi	a6, s2, 0x30
                	ld	t2, 0x0(a6)
-               	sd	t2, -0x170(s0)
+               	sd	t2, -0x178(s0)
                	addi	a6, s2, 0x38
                	ld	t5, 0x0(a6)
                	add	a6, t5, a1
-               	addi	a1, s0, -0xe0
+               	addi	a1, s0, -0xe4
                	sext.w	t5, a6
                	mv	t6, a1
                	sw	t5, 0x0(t6)
@@ -717,13 +1249,13 @@ Disassembly of section .text:
                	sb	a6, 0x0(t5)
                	addi	a6, s2, 0x40
                	ld	t5, 0x0(a6)
-               	addi	a6, s0, -0xe9
+               	addi	a6, s0, -0xed
                	sext.w	t6, t5
                	mv	t5, a6
                	sb	t6, 0x0(t5)
                	addi	t5, s2, 0x48
                	ld	t6, 0x0(t5)
-               	addi	t5, s0, -0xec
+               	addi	t5, s0, -0xf0
                	sext.w	s6, t6
                	mv	s7, t5
                	sb	s6, 0x0(s7)
@@ -733,7 +1265,7 @@ Disassembly of section .text:
                	sb	t6, 0x0(s6)
                	addi	t6, s2, 0x50
                	ld	s6, 0x0(t6)
-               	addi	t6, s0, -0xf2
+               	addi	t6, s0, -0xf6
                	sext.w	s7, s6
                	mv	s8, t6
                	sb	s7, 0x0(s8)
@@ -747,7 +1279,7 @@ Disassembly of section .text:
                	sh	s6, 0x0(s7)
                	addi	s6, s2, 0x58
                	ld	s7, 0x0(s6)
-               	addi	s6, s0, -0x100
+               	addi	s6, s0, -0x104
                	sext.w	s8, s7
                	mv	s9, s6
                	sw	s8, 0x0(s9)
@@ -766,27 +1298,27 @@ Disassembly of section .text:
                	fcvt.s.lu	ft0, s7
                	addi	s7, s2, 0x8
                	ld	t2, 0x0(s7)
-               	sd	t2, -0x178(s0)
-               	sd	zero, -0x108(s0)
-               	lbu	s7, 0x0(a2)
-               	sb	s7, -0x108(s0)
-               	ld	a2, -0x108(s0)
+               	sd	t2, -0x180(s0)
                	sd	zero, -0x110(s0)
+               	lbu	s7, 0x0(a2)
+               	sb	s7, -0x110(s0)
+               	ld	a2, -0x110(s0)
+               	sd	zero, -0x118(s0)
                	lbu	s7, 0x0(a4)
                	lbu	s9, 0x1(a4)
-               	sb	s7, -0x110(s0)
-               	sb	s9, -0x10f(s0)
-               	ld	a4, -0x110(s0)
-               	sd	zero, -0x118(s0)
+               	sb	s7, -0x118(s0)
+               	sb	s9, -0x117(s0)
+               	ld	a4, -0x118(s0)
+               	sd	zero, -0x120(s0)
                	lbu	s7, 0x0(a5)
                	lbu	s9, 0x1(a5)
                	lbu	s10, 0x2(a5)
                	lbu	s11, 0x3(a5)
-               	sb	s7, -0x118(s0)
-               	sb	s9, -0x117(s0)
-               	sb	s10, -0x116(s0)
-               	sb	s11, -0x115(s0)
-               	ld	a5, -0x118(s0)
+               	sb	s7, -0x120(s0)
+               	sb	s9, -0x11f(s0)
+               	sb	s10, -0x11e(s0)
+               	sb	s11, -0x11d(s0)
+               	ld	a5, -0x120(s0)
                	lbu	s7, 0x0(a1)
                	lbu	s9, 0x1(a1)
                	lbu	s10, 0x2(a1)
@@ -795,19 +1327,19 @@ Disassembly of section .text:
                	lbu	a3, 0x5(a1)
                	lbu	a7, 0x6(a1)
                	lbu	s8, 0x7(a1)
-               	sb	s7, -0x120(s0)
-               	sb	s9, -0x11f(s0)
-               	sb	s10, -0x11e(s0)
-               	sb	s11, -0x11d(s0)
-               	sb	a0, -0x11c(s0)
-               	sb	a3, -0x11b(s0)
-               	sb	a7, -0x11a(s0)
-               	sb	s8, -0x119(s0)
-               	ld	a7, -0x120(s0)
-               	sd	zero, -0x128(s0)
+               	sb	s7, -0x128(s0)
+               	sb	s9, -0x127(s0)
+               	sb	s10, -0x126(s0)
+               	sb	s11, -0x125(s0)
+               	sb	a0, -0x124(s0)
+               	sb	a3, -0x123(s0)
+               	sb	a7, -0x122(s0)
+               	sb	s8, -0x121(s0)
+               	ld	a7, -0x128(s0)
+               	sd	zero, -0x130(s0)
                	lbu	a0, 0x0(a6)
-               	sb	a0, -0x128(s0)
-               	ld	s7, -0x128(s0)
+               	sb	a0, -0x130(s0)
+               	ld	s7, -0x130(s0)
                	lbu	a0, 0x0(t5)
                	lbu	a1, 0x1(t5)
                	sb	a0, 0x0(sp)
@@ -836,37 +1368,37 @@ Disassembly of section .text:
                	sb	t6, 0x15(sp)
                	sb	s8, 0x16(sp)
                	sb	s9, 0x17(sp)
-               	ld	t2, -0x178(s0)
+               	ld	t2, -0x180(s0)
                	sd	t2, 0x18(sp)
-               	ld	t2, -0x160(s0)
+               	ld	t2, -0x168(s0)
                	mv	a0, t2
                	mv	a1, a2
-               	ld	t2, -0x168(s0)
+               	ld	t2, -0x170(s0)
                	mv	a2, t2
                	mv	a3, a4
                	mv	a4, a5
-               	ld	t2, -0x170(s0)
+               	ld	t2, -0x178(s0)
                	mv	a5, t2
                	mv	a6, a7
                	mv	a7, s7
                	fmv.s	fa1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x4dc>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x698>
                	mv	s4, a0
                	mv	a0, s3
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x4f0>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x6ac>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x9c8 <corpus.cases.call.call_rec_small.checksum+0x1c0>
-               	addi	a0, s0, -0xca
+               	bltu	s5, t0, 0x1218 <corpus.cases.call.call_rec_small.checksum+0x37c>
+               	addi	a0, s0, -0x6a
                	sext.w	a1, s4
                	mv	a2, a0
                	sb	a1, 0x0(a2)
                	sext.w	a2, s4
-               	addi	a1, s0, -0xce
+               	addi	a1, s0, -0xd4
                	sext.w	a3, s4
                	mv	a4, a1
                	sb	a3, 0x0(a4)
@@ -877,7 +1409,7 @@ Disassembly of section .text:
                	li	t0, 0x3ff
                	and	a3, s4, t0
                	fcvt.d.lu	fa0, a3
-               	addi	a3, s0, -0xd6
+               	addi	a3, s0, -0xdc
                	sext.w	a4, s4
                	mv	a5, a3
                	sb	a4, 0x0(a5)
@@ -891,7 +1423,7 @@ Disassembly of section .text:
                	sh	a5, 0x0(a4)
                	addi	a4, s2, 0x30
                	ld	a5, 0x0(a4)
-               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xec
                	sext.w	a6, s4
                	mv	a7, a4
                	sw	a6, 0x0(a7)
@@ -905,13 +1437,13 @@ Disassembly of section .text:
                	sb	a7, 0x0(a6)
                	addi	a6, s2, 0x40
                	ld	a7, 0x0(a6)
-               	addi	a6, s0, -0xea
+               	addi	a6, s0, -0xee
                	sext.w	t5, a7
                	mv	a7, a6
                	sb	t5, 0x0(a7)
                	addi	a7, s2, 0x48
                	ld	t5, 0x0(a7)
-               	addi	a7, s0, -0xee
+               	addi	a7, s0, -0xf2
                	sext.w	t6, t5
                	mv	s1, a7
                	sb	t6, 0x0(s1)
@@ -921,7 +1453,7 @@ Disassembly of section .text:
                	sb	t5, 0x0(t6)
                	addi	t5, s2, 0x50
                	ld	t6, 0x0(t5)
-               	addi	t5, s0, -0xf6
+               	addi	t5, s0, -0xfa
                	sext.w	s1, t6
                	mv	s5, t5
                	sb	s1, 0x0(s5)
@@ -935,7 +1467,7 @@ Disassembly of section .text:
                	sh	t6, 0x0(s1)
                	addi	t6, s2, 0x58
                	ld	s1, 0x0(t6)
-               	addi	t6, s0, -0x130
+               	addi	t6, s0, -0x138
                	sext.w	s5, s1
                	mv	s6, t6
                	sw	s5, 0x0(s6)
@@ -954,26 +1486,26 @@ Disassembly of section .text:
                	fcvt.s.lu	ft0, s1
                	addi	s1, s2, 0x10
                	ld	s2, 0x0(s1)
-               	sd	zero, -0x138(s0)
-               	lbu	s1, 0x0(a0)
-               	sb	s1, -0x138(s0)
-               	ld	s1, -0x138(s0)
                	sd	zero, -0x140(s0)
+               	lbu	s1, 0x0(a0)
+               	sb	s1, -0x140(s0)
+               	ld	s1, -0x140(s0)
+               	sd	zero, -0x148(s0)
                	lbu	a0, 0x0(a1)
                	lbu	s5, 0x1(a1)
-               	sb	a0, -0x140(s0)
-               	sb	s5, -0x13f(s0)
-               	ld	s5, -0x140(s0)
-               	sd	zero, -0x148(s0)
+               	sb	a0, -0x148(s0)
+               	sb	s5, -0x147(s0)
+               	ld	s5, -0x148(s0)
+               	sd	zero, -0x150(s0)
                	lbu	a0, 0x0(a3)
                	lbu	a1, 0x1(a3)
                	lbu	s6, 0x2(a3)
                	lbu	s7, 0x3(a3)
-               	sb	a0, -0x148(s0)
-               	sb	a1, -0x147(s0)
-               	sb	s6, -0x146(s0)
-               	sb	s7, -0x145(s0)
-               	ld	s6, -0x148(s0)
+               	sb	a0, -0x150(s0)
+               	sb	a1, -0x14f(s0)
+               	sb	s6, -0x14e(s0)
+               	sb	s7, -0x14d(s0)
+               	ld	s6, -0x150(s0)
                	lbu	a0, 0x0(a4)
                	lbu	a1, 0x1(a4)
                	lbu	a3, 0x2(a4)
@@ -982,19 +1514,19 @@ Disassembly of section .text:
                	lbu	s9, 0x5(a4)
                	lbu	s10, 0x6(a4)
                	lbu	s11, 0x7(a4)
-               	sb	a0, -0x150(s0)
-               	sb	a1, -0x14f(s0)
-               	sb	a3, -0x14e(s0)
-               	sb	s7, -0x14d(s0)
-               	sb	s8, -0x14c(s0)
-               	sb	s9, -0x14b(s0)
-               	sb	s10, -0x14a(s0)
-               	sb	s11, -0x149(s0)
-               	ld	s7, -0x150(s0)
-               	sd	zero, -0x158(s0)
-               	lbu	a0, 0x0(a6)
                	sb	a0, -0x158(s0)
-               	ld	s8, -0x158(s0)
+               	sb	a1, -0x157(s0)
+               	sb	a3, -0x156(s0)
+               	sb	s7, -0x155(s0)
+               	sb	s8, -0x154(s0)
+               	sb	s9, -0x153(s0)
+               	sb	s10, -0x152(s0)
+               	sb	s11, -0x151(s0)
+               	ld	s7, -0x158(s0)
+               	sd	zero, -0x160(s0)
+               	lbu	a0, 0x0(a6)
+               	sb	a0, -0x160(s0)
+               	ld	s8, -0x160(s0)
                	lbu	a0, 0x0(a7)
                	lbu	a1, 0x1(a7)
                	sb	a0, 0x0(sp)
@@ -1032,23 +1564,23 @@ Disassembly of section .text:
                	mv	a7, s8
                	fmv.s	fa1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x7b0>
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x96c>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x7c0>
-               	ld	s1, 0x188(sp)
-               	ld	s2, 0x180(sp)
-               	ld	s3, 0x178(sp)
-               	ld	s4, 0x170(sp)
-               	ld	s5, 0x168(sp)
-               	ld	s6, 0x160(sp)
-               	ld	s7, 0x158(sp)
-               	ld	s8, 0x150(sp)
-               	ld	s9, 0x148(sp)
-               	ld	s10, 0x140(sp)
-               	ld	s11, 0x138(sp)
-               	ld	ra, 0x198(sp)
-               	ld	s0, 0x190(sp)
-               	addi	sp, sp, 0x1a0
+               	jalr	ra <corpus.cases.call.call_rec_small.checksum+0x97c>
+               	ld	s1, 0x198(sp)
+               	ld	s2, 0x190(sp)
+               	ld	s3, 0x188(sp)
+               	ld	s4, 0x180(sp)
+               	ld	s5, 0x178(sp)
+               	ld	s6, 0x170(sp)
+               	ld	s7, 0x168(sp)
+               	ld	s8, 0x160(sp)
+               	ld	s9, 0x158(sp)
+               	ld	s10, 0x150(sp)
+               	ld	s11, 0x148(sp)
+               	ld	ra, 0x1a8(sp)
+               	ld	s0, 0x1a0(sp)
+               	addi	sp, sp, 0x1b0
                	ret

--- a/test/golden/riscv64-linux/call/call_recursive.dis
+++ b/test/golden/riscv64-linux/call/call_recursive.dis
@@ -26,40 +26,39 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_recursive.descend>:
-               	addi	sp, sp, -0x80
-               	sd	ra, 0x78(sp)
-               	sd	s0, 0x70(sp)
-               	addi	s0, sp, 0x80
-               	sd	s1, 0x68(sp)
-               	sd	s2, 0x60(sp)
-               	sd	s3, 0x58(sp)
-               	sd	s4, 0x50(sp)
-               	sd	s5, 0x48(sp)
+               	addi	sp, sp, -0x70
+               	sd	ra, 0x68(sp)
+               	sd	s0, 0x60(sp)
+               	addi	s0, sp, 0x70
+               	sd	s1, 0x58(sp)
+               	sd	s2, 0x50(sp)
+               	sd	s3, 0x48(sp)
+               	sd	s4, 0x40(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x78
+               	addi	s2, s0, -0x70
                	mv	a0, s2
                	li	t0, 0x7
                	and	a3, a0, t0
-               	bnez	a3, 0xb0 <corpus.cases.call.call_recursive.descend+0x5c>
+               	bnez	a3, 0xac <corpus.cases.call.call_recursive.descend+0x58>
                	mv	a3, a0
                	li	a4, 0x40
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x98 <corpus.cases.call.call_recursive.descend+0x44>
-               	j	0xcc <corpus.cases.call.call_recursive.descend+0x78>
+               	bne	a4, t0, 0x94 <corpus.cases.call.call_recursive.descend+0x40>
+               	j	0xc8 <corpus.cases.call.call_recursive.descend+0x74>
                	mv	a3, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xb8 <corpus.cases.call.call_recursive.descend+0x64>
+               	bne	a0, t0, 0xb4 <corpus.cases.call.call_recursive.descend+0x60>
                	li	a0, 0x0
                	li	t0, 0x8
-               	bltu	a0, t0, 0xdc <corpus.cases.call.call_recursive.descend+0x88>
-               	j	0x100 <corpus.cases.call.call_recursive.descend+0xac>
+               	bltu	a0, t0, 0xd8 <corpus.cases.call.call_recursive.descend+0x84>
+               	j	0xfc <corpus.cases.call.call_recursive.descend+0xa8>
                	addi	a3, a0, 0x1
                	mul	a4, a1, a3
                	add	a5, a4, s1
@@ -68,48 +67,90 @@ Disassembly of section .text:
                	sd	a5, 0x0(a4)
                	mv	a0, a3
                	li	t0, 0x8
-               	bltu	a0, t0, 0xdc <corpus.cases.call.call_recursive.descend+0x88>
+               	bltu	a0, t0, 0xd8 <corpus.cases.call.call_recursive.descend+0x84>
                	xor	s3, a1, s1
                	li	t1, 0x0
-               	bltu	t1, s1, 0x114 <corpus.cases.call.call_recursive.descend+0xc0>
+               	bltu	t1, s1, 0x110 <corpus.cases.call.call_recursive.descend+0xbc>
                	mv	s4, a2
-               	j	0x130 <corpus.cases.call.call_recursive.descend+0xdc>
+               	j	0x12c <corpus.cases.call.call_recursive.descend+0xd8>
                	addi	a0, s1, -0x1
                	li	t0, 0x3
                	mul	a3, a1, t0
                	addi	a1, a3, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.descend+0xd0>
+               	jalr	ra <corpus.cases.call.call_recursive.descend+0xcc>
                	mv	s4, a0
-               	li	s5, 0x0
+               	li	a0, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x140 <corpus.cases.call.call_recursive.descend+0xec>
-               	j	0x168 <corpus.cases.call.call_recursive.descend+0x114>
-               	slli	t0, s5, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.descend+0xfc>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a0, t0, 0x13c <corpus.cases.call.call_recursive.descend+0xe8>
+               	j	0x1a0 <corpus.cases.call.call_recursive.descend+0x14c>
+               	slli	t0, a0, 0x3
+               	add	a1, s2, t0
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	li	a3, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x140 <corpus.cases.call.call_recursive.descend+0xec>
+               	bltu	a3, t0, 0x15c <corpus.cases.call.call_recursive.descend+0x108>
+               	j	0x190 <corpus.cases.call.call_recursive.descend+0x13c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.call.call_recursive.descend+0x108>
+               	addi	a0, a0, 0x1
+               	mv	s4, a1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x13c <corpus.cases.call.call_recursive.descend+0xe8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1b0 <corpus.cases.call.call_recursive.descend+0x15c>
+               	j	0x1e4 <corpus.cases.call.call_recursive.descend+0x190>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s3, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s4, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1b0 <corpus.cases.call.call_recursive.descend+0x15c>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1f4 <corpus.cases.call.call_recursive.descend+0x1a0>
+               	j	0x228 <corpus.cases.call.call_recursive.descend+0x1d4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s1, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s4, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1f4 <corpus.cases.call.call_recursive.descend+0x1a0>
                	mv	a0, s4
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.descend+0x11c>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.descend+0x128>
-               	ld	s1, 0x68(sp)
-               	ld	s2, 0x60(sp)
-               	ld	s3, 0x58(sp)
-               	ld	s4, 0x50(sp)
-               	ld	s5, 0x48(sp)
-               	ld	ra, 0x78(sp)
-               	ld	s0, 0x70(sp)
-               	addi	sp, sp, 0x80
+               	ld	s1, 0x58(sp)
+               	ld	s2, 0x50(sp)
+               	ld	s3, 0x48(sp)
+               	ld	s4, 0x40(sp)
+               	ld	ra, 0x68(sp)
+               	ld	s0, 0x60(sp)
+               	addi	sp, sp, 0x70
                	ret
 
 <corpus.cases.call.call_recursive.ping>:
@@ -120,32 +161,31 @@ Disassembly of section .text:
                	sd	s1, 0x38(sp)
                	sd	s2, 0x30(sp)
                	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x50
+               	addi	s2, s0, -0x48
                	mv	a0, s2
                	li	t0, 0x7
                	and	a3, a0, t0
-               	bnez	a3, 0x200 <corpus.cases.call.call_recursive.ping+0x58>
+               	bnez	a3, 0x2a0 <corpus.cases.call.call_recursive.ping+0x54>
                	mv	a3, a0
                	li	a4, 0x20
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x1e8 <corpus.cases.call.call_recursive.ping+0x40>
-               	j	0x21c <corpus.cases.call.call_recursive.ping+0x74>
+               	bne	a4, t0, 0x288 <corpus.cases.call.call_recursive.ping+0x3c>
+               	j	0x2bc <corpus.cases.call.call_recursive.ping+0x70>
                	mv	a3, a0
                	li	a0, 0x20
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x208 <corpus.cases.call.call_recursive.ping+0x60>
+               	bne	a0, t0, 0x2a8 <corpus.cases.call.call_recursive.ping+0x5c>
                	li	a0, 0x0
                	li	t0, 0x4
-               	bltu	a0, t0, 0x22c <corpus.cases.call.call_recursive.ping+0x84>
-               	j	0x254 <corpus.cases.call.call_recursive.ping+0xac>
+               	bltu	a0, t0, 0x2cc <corpus.cases.call.call_recursive.ping+0x80>
+               	j	0x2f4 <corpus.cases.call.call_recursive.ping+0xa8>
                	li	t0, 0x7
                	mul	a3, a0, t0
                	add	a4, a1, a3
@@ -155,82 +195,110 @@ Disassembly of section .text:
                	sd	a3, 0x0(a4)
                	addi	a0, a0, 0x1
                	li	t0, 0x4
-               	bltu	a0, t0, 0x22c <corpus.cases.call.call_recursive.ping+0x84>
+               	bltu	a0, t0, 0x2cc <corpus.cases.call.call_recursive.ping+0x80>
                	li	t1, 0x0
-               	bltu	t1, s1, 0x264 <corpus.cases.call.call_recursive.ping+0xbc>
+               	bltu	t1, s1, 0x304 <corpus.cases.call.call_recursive.ping+0xb8>
                	mv	s3, a2
-               	j	0x284 <corpus.cases.call.call_recursive.ping+0xdc>
+               	j	0x324 <corpus.cases.call.call_recursive.ping+0xd8>
                	addi	a0, s1, -0x1
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	xor	a3, a1, t0
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.ping+0xd0>
+               	jalr	ra <corpus.cases.call.call_recursive.ping+0xcc>
                	mv	s3, a0
-               	li	s4, 0x0
+               	li	a0, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x294 <corpus.cases.call.call_recursive.ping+0xec>
-               	j	0x2bc <corpus.cases.call.call_recursive.ping+0x114>
-               	slli	t0, s4, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.ping+0xfc>
-               	addi	s4, s4, 0x1
-               	mv	s3, a0
+               	bltu	a0, t0, 0x334 <corpus.cases.call.call_recursive.ping+0xe8>
+               	j	0x398 <corpus.cases.call.call_recursive.ping+0x14c>
+               	slli	t0, a0, 0x3
+               	add	a1, s2, t0
+               	ld	a2, 0x0(a1)
+               	mv	a1, s3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x354 <corpus.cases.call.call_recursive.ping+0x108>
+               	j	0x388 <corpus.cases.call.call_recursive.ping+0x13c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x354 <corpus.cases.call.call_recursive.ping+0x108>
+               	addi	a0, a0, 0x1
+               	mv	s3, a1
                	li	t0, 0x4
-               	bltu	s4, t0, 0x294 <corpus.cases.call.call_recursive.ping+0xec>
+               	bltu	a0, t0, 0x334 <corpus.cases.call.call_recursive.ping+0xe8>
                	li	t0, 0x2
-               	mul	a1, s1, t0
+               	mul	a0, s1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b0 <corpus.cases.call.call_recursive.ping+0x164>
+               	j	0x3e4 <corpus.cases.call.call_recursive.ping+0x198>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s3, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s3, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b0 <corpus.cases.call.call_recursive.ping+0x164>
                	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.ping+0x120>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
                	ld	ra, 0x48(sp)
                	ld	s0, 0x40(sp)
                	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.call.call_recursive.pong>:
-               	addi	sp, sp, -0x70
-               	sd	ra, 0x68(sp)
-               	sd	s0, 0x60(sp)
-               	addi	s0, sp, 0x70
-               	sd	s1, 0x58(sp)
-               	sd	s2, 0x50(sp)
-               	sd	s3, 0x48(sp)
-               	sd	s4, 0x40(sp)
-               	sd	s5, 0x38(sp)
+               	addi	sp, sp, -0x60
+               	sd	ra, 0x58(sp)
+               	sd	s0, 0x50(sp)
+               	addi	s0, sp, 0x60
+               	sd	s1, 0x48(sp)
+               	sd	s2, 0x40(sp)
+               	sd	s3, 0x38(sp)
+               	sd	s4, 0x30(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x68
+               	addi	s2, s0, -0x60
                	mv	a0, s2
                	li	t0, 0x7
                	and	a3, a0, t0
-               	bnez	a3, 0x34c <corpus.cases.call.call_recursive.pong+0x5c>
+               	bnez	a3, 0x45c <corpus.cases.call.call_recursive.pong+0x58>
                	mv	a3, a0
                	li	a4, 0x30
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x334 <corpus.cases.call.call_recursive.pong+0x44>
-               	j	0x368 <corpus.cases.call.call_recursive.pong+0x78>
+               	bne	a4, t0, 0x444 <corpus.cases.call.call_recursive.pong+0x40>
+               	j	0x478 <corpus.cases.call.call_recursive.pong+0x74>
                	mv	a3, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x354 <corpus.cases.call.call_recursive.pong+0x64>
+               	bne	a0, t0, 0x464 <corpus.cases.call.call_recursive.pong+0x60>
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0x378 <corpus.cases.call.call_recursive.pong+0x88>
-               	j	0x39c <corpus.cases.call.call_recursive.pong+0xac>
+               	bltu	a0, t0, 0x488 <corpus.cases.call.call_recursive.pong+0x84>
+               	j	0x4ac <corpus.cases.call.call_recursive.pong+0xa8>
                	addi	a3, a0, 0x3
                	mul	a4, a1, a3
                	sub	a3, a4, s1
@@ -239,406 +307,279 @@ Disassembly of section .text:
                	sd	a3, 0x0(a4)
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0x378 <corpus.cases.call.call_recursive.pong+0x88>
+               	bltu	a0, t0, 0x488 <corpus.cases.call.call_recursive.pong+0x84>
                	not	s3, a1
                	li	t1, 0x0
-               	bltu	t1, s1, 0x3b0 <corpus.cases.call.call_recursive.pong+0xc0>
+               	bltu	t1, s1, 0x4c0 <corpus.cases.call.call_recursive.pong+0xbc>
                	mv	s4, a2
-               	j	0x3c8 <corpus.cases.call.call_recursive.pong+0xd8>
+               	j	0x4d8 <corpus.cases.call.call_recursive.pong+0xd4>
                	addi	a0, s1, -0x1
                	addi	a3, a1, 0xb
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.pong+0xcc>
+               	jalr	ra <corpus.cases.call.call_recursive.pong+0xc8>
                	mv	s4, a0
-               	li	s5, 0x0
+               	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x3d8 <corpus.cases.call.call_recursive.pong+0xe8>
-               	j	0x400 <corpus.cases.call.call_recursive.pong+0x110>
-               	slli	t0, s5, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.pong+0xf8>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a0, t0, 0x4e8 <corpus.cases.call.call_recursive.pong+0xe4>
+               	j	0x54c <corpus.cases.call.call_recursive.pong+0x148>
+               	slli	t0, a0, 0x3
+               	add	a1, s2, t0
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x508 <corpus.cases.call.call_recursive.pong+0x104>
+               	j	0x53c <corpus.cases.call.call_recursive.pong+0x138>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x508 <corpus.cases.call.call_recursive.pong+0x104>
+               	addi	a0, a0, 0x1
+               	mv	s4, a1
                	li	t0, 0x6
-               	bltu	s5, t0, 0x3d8 <corpus.cases.call.call_recursive.pong+0xe8>
-               	mv	a0, s4
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.pong+0x118>
+               	bltu	a0, t0, 0x4e8 <corpus.cases.call.call_recursive.pong+0xe4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x55c <corpus.cases.call.call_recursive.pong+0x158>
+               	j	0x590 <corpus.cases.call.call_recursive.pong+0x18c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s3, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s4, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x55c <corpus.cases.call.call_recursive.pong+0x158>
                	li	t0, 0x3
-               	mul	a1, s1, t0
-               	addi	a2, a1, 0x1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.pong+0x130>
-               	ld	s1, 0x58(sp)
-               	ld	s2, 0x50(sp)
-               	ld	s3, 0x48(sp)
-               	ld	s4, 0x40(sp)
-               	ld	s5, 0x38(sp)
-               	ld	ra, 0x68(sp)
-               	ld	s0, 0x60(sp)
-               	addi	sp, sp, 0x70
+               	mul	a0, s1, t0
+               	addi	a1, a0, 0x1
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5ac <corpus.cases.call.call_recursive.pong+0x1a8>
+               	j	0x5e0 <corpus.cases.call.call_recursive.pong+0x1dc>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5ac <corpus.cases.call.call_recursive.pong+0x1a8>
+               	mv	a0, s4
+               	ld	s1, 0x48(sp)
+               	ld	s2, 0x40(sp)
+               	ld	s3, 0x38(sp)
+               	ld	s4, 0x30(sp)
+               	ld	ra, 0x58(sp)
+               	ld	s0, 0x50(sp)
+               	addi	sp, sp, 0x60
                	ret
 
 <corpus.cases.call.call_recursive.tree>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	sd	s2, 0x40(sp)
-               	sd	s3, 0x38(sp)
-               	sd	s4, 0x30(sp)
-               	sd	s5, 0x28(sp)
-               	sd	s6, 0x20(sp)
-               	sd	s7, 0x18(sp)
-               	sd	s8, 0x10(sp)
-               	sd	s9, 0x8(sp)
-               	sd	s10, 0x0(sp)
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
                	mv	s1, a0
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	a3, a1, t0
-               	add	s2, a3, s1
-               	mv	a0, a2
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x5c>
+               	mul	a0, a1, t0
+               	add	s2, a0, s1
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x64c <corpus.cases.call.call_recursive.tree+0x48>
+               	j	0x680 <corpus.cases.call.call_recursive.tree+0x7c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a3, s2, a1
+               	li	t0, 0xff
+               	and	a1, a3, t0
+               	xor	a3, a2, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x64c <corpus.cases.call.call_recursive.tree+0x48>
                	li	t1, 0x0
-               	bltu	t1, s1, 0x4c0 <corpus.cases.call.call_recursive.tree+0x74>
-               	mv	s3, a0
-               	j	0x818 <corpus.cases.call.call_recursive.tree+0x3cc>
-               	addi	s4, s1, -0x1
+               	bltu	t1, s1, 0x690 <corpus.cases.call.call_recursive.tree+0x8c>
+               	mv	s3, a2
+               	j	0x70c <corpus.cases.call.call_recursive.tree+0x108>
+               	addi	a0, s1, -0x1
                	addi	a1, s2, 0x1
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s5, a2, s4
-               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x98>
-               	li	t1, 0x0
-               	bltu	t1, s4, 0x4fc <corpus.cases.call.call_recursive.tree+0xb0>
-               	mv	s6, a0
-               	j	0x64c <corpus.cases.call.call_recursive.tree+0x200>
-               	addi	s7, s4, -0x1
-               	addi	a1, s5, 0x1
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s8, a2, s7
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0xd4>
+               	jalr	ra <corpus.cases.call.call_recursive.tree+0x94>
                	mv	a2, a0
-               	li	t1, 0x0
-               	bltu	t1, s7, 0x53c <corpus.cases.call.call_recursive.tree+0xf0>
-               	mv	s9, a2
-               	j	0x584 <corpus.cases.call.call_recursive.tree+0x138>
-               	addi	s10, s7, -0x1
-               	addi	a1, s8, 0x1
-               	mv	a0, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0xfc>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x108>
-               	mv	a2, a0
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6b4 <corpus.cases.call.call_recursive.tree+0xb0>
+               	j	0x6e8 <corpus.cases.call.call_recursive.tree+0xe4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a3, s2, a1
+               	li	t0, 0xff
+               	and	a1, a3, t0
+               	xor	a3, a2, a1
+               	lui	t0, 0x10000
                	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s8, t0
-               	mv	a0, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x12c>
-               	mv	s9, a0
-               	mv	a0, s9
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x140>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x14c>
-               	addi	s7, s4, -0x1
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s5, t0
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s4, a2, s7
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x188>
-               	mv	a2, a0
-               	li	t1, 0x0
-               	bltu	t1, s7, 0x5f0 <corpus.cases.call.call_recursive.tree+0x1a4>
-               	mv	s8, a2
-               	j	0x638 <corpus.cases.call.call_recursive.tree+0x1ec>
-               	addi	s9, s7, -0x1
-               	addi	a1, s4, 0x1
-               	mv	a0, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x1b0>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x1bc>
-               	mv	a2, a0
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s4, t0
-               	mv	a0, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x1e0>
-               	mv	s8, a0
-               	mv	a0, s8
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x1f4>
-               	mv	s6, a0
-               	mv	a0, s6
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x208>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x214>
-               	addi	s4, s1, -0x1
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6b4 <corpus.cases.call.call_recursive.tree+0xb0>
+               	addi	a0, s1, -0x1
                	lui	t0, 0xab
                	addiw	t0, t0, -0x555
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x556
                	xor	a1, s2, t0
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s1, a2, s4
-               	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x250>
-               	li	t1, 0x0
-               	bltu	t1, s4, 0x6b4 <corpus.cases.call.call_recursive.tree+0x268>
-               	mv	s5, a0
-               	j	0x804 <corpus.cases.call.call_recursive.tree+0x3b8>
-               	addi	s6, s4, -0x1
-               	addi	a1, s1, 0x1
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s7, a2, s6
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x28c>
-               	mv	a2, a0
-               	li	t1, 0x0
-               	bltu	t1, s6, 0x6f4 <corpus.cases.call.call_recursive.tree+0x2a8>
-               	mv	s8, a2
-               	j	0x73c <corpus.cases.call.call_recursive.tree+0x2f0>
-               	addi	s9, s6, -0x1
-               	addi	a1, s7, 0x1
-               	mv	a0, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x2b4>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x2c0>
-               	mv	a2, a0
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s7, t0
-               	mv	a0, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x2e4>
-               	mv	s8, a0
-               	mv	a0, s8
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x2f8>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x304>
-               	addi	s6, s4, -0x1
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s1, t0
-               	lui	t0, 0x9e
-               	addiw	t0, t0, 0x378
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	s4, a2, s6
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x340>
-               	mv	a2, a0
-               	li	t1, 0x0
-               	bltu	t1, s6, 0x7a8 <corpus.cases.call.call_recursive.tree+0x35c>
-               	mv	s7, a2
-               	j	0x7f0 <corpus.cases.call.call_recursive.tree+0x3a4>
-               	addi	s8, s6, -0x1
-               	addi	a1, s4, 0x1
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x368>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x374>
-               	mv	a2, a0
-               	lui	t0, 0xab
-               	addiw	t0, t0, -0x555
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x556
-               	xor	a1, s4, t0
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x398>
-               	mv	s7, a0
-               	mv	a0, s7
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x3ac>
-               	mv	s5, a0
-               	mv	a0, s5
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x3c0>
+               	jalr	ra <corpus.cases.call.call_recursive.tree+0xfc>
                	mv	s3, a0
-               	mv	a0, s3
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tree+0x3d4>
-               	ld	s1, 0x48(sp)
-               	ld	s2, 0x40(sp)
-               	ld	s3, 0x38(sp)
-               	ld	s4, 0x30(sp)
-               	ld	s5, 0x28(sp)
-               	ld	s6, 0x20(sp)
-               	ld	s7, 0x18(sp)
-               	ld	s8, 0x10(sp)
-               	ld	s9, 0x8(sp)
-               	ld	s10, 0x0(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
-               	ret
-
-<corpus.cases.call.call_recursive.tail>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	sd	s2, 0x40(sp)
-               	sd	s3, 0x38(sp)
-               	sd	s4, 0x30(sp)
-               	sd	s5, 0x28(sp)
-               	mv	s1, a0
-               	mv	s2, a1
-               	addi	s3, s0, -0x58
-               	mv	a0, s3
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x8c0 <corpus.cases.call.call_recursive.tail+0x60>
-               	mv	a1, a0
-               	li	a3, 0x20
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x8a8 <corpus.cases.call.call_recursive.tail+0x48>
-               	j	0x8dc <corpus.cases.call.call_recursive.tail+0x7c>
-               	mv	a1, a0
-               	li	a0, 0x20
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x8c8 <corpus.cases.call.call_recursive.tail+0x68>
                	li	a0, 0x0
-               	li	t0, 0x4
-               	bltu	a0, t0, 0x8ec <corpus.cases.call.call_recursive.tail+0x8c>
-               	j	0x91c <corpus.cases.call.call_recursive.tail+0xbc>
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x71c <corpus.cases.call.call_recursive.tree+0x118>
+               	j	0x750 <corpus.cases.call.call_recursive.tree+0x14c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s3, a1
                	lui	t0, 0x10000
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1b3
-               	mul	a1, a0, t0
-               	add	a3, a1, s1
-               	xor	a1, s2, a3
-               	slli	t0, a0, 0x3
-               	add	a3, s3, t0
-               	sd	a1, 0x0(a3)
+               	mul	s3, a2, t0
                	addi	a0, a0, 0x1
-               	li	t0, 0x4
-               	bltu	a0, t0, 0x8ec <corpus.cases.call.call_recursive.tail+0x8c>
-               	li	s4, 0x0
-               	mv	s5, a2
-               	li	t0, 0x4
-               	bltu	s4, t0, 0x930 <corpus.cases.call.call_recursive.tail+0xd0>
-               	j	0x958 <corpus.cases.call.call_recursive.tail+0xf8>
-               	slli	t0, s4, 0x3
-               	add	a0, s3, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tail+0xe0>
-               	addi	s4, s4, 0x1
-               	mv	s5, a0
-               	li	t0, 0x4
-               	bltu	s4, t0, 0x930 <corpus.cases.call.call_recursive.tail+0xd0>
-               	li	t0, 0x0
-               	beq	s1, t0, 0x9a4 <corpus.cases.call.call_recursive.tail+0x144>
-               	addi	a0, s1, -0x1
-               	li	t0, 0x5
-               	mul	a1, s2, t0
-               	addi	a2, a1, 0x3
-               	mv	a1, a2
-               	mv	a2, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.tail+0x118>
-               	ld	s1, 0x48(sp)
-               	ld	s2, 0x40(sp)
-               	ld	s3, 0x38(sp)
-               	ld	s4, 0x30(sp)
-               	ld	s5, 0x28(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x71c <corpus.cases.call.call_recursive.tree+0x118>
+               	mv	a0, s3
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
-               	mv	a0, s5
-               	ld	s1, 0x48(sp)
-               	ld	s2, 0x40(sp)
-               	ld	s3, 0x38(sp)
-               	ld	s4, 0x30(sp)
-               	ld	s5, 0x28(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+
+<corpus.cases.call.call_recursive.tail>:
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	addi	a3, s0, -0x38
+               	mv	a4, a3
+               	li	t0, 0x7
+               	and	a5, a4, t0
+               	bnez	a5, 0x7b8 <corpus.cases.call.call_recursive.tail+0x48>
+               	mv	a5, a4
+               	li	a6, 0x20
+               	sd	zero, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x7a0 <corpus.cases.call.call_recursive.tail+0x30>
+               	j	0x7d4 <corpus.cases.call.call_recursive.tail+0x64>
+               	mv	a5, a4
+               	li	a4, 0x20
+               	sb	zero, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x7c0 <corpus.cases.call.call_recursive.tail+0x50>
+               	li	a4, 0x0
+               	li	t0, 0x4
+               	bltu	a4, t0, 0x7e4 <corpus.cases.call.call_recursive.tail+0x74>
+               	j	0x814 <corpus.cases.call.call_recursive.tail+0xa4>
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a4, t0
+               	add	a6, a5, a0
+               	xor	a5, a1, a6
+               	slli	t0, a4, 0x3
+               	add	a6, a3, t0
+               	sd	a5, 0x0(a6)
+               	addi	a4, a4, 0x1
+               	li	t0, 0x4
+               	bltu	a4, t0, 0x7e4 <corpus.cases.call.call_recursive.tail+0x74>
+               	li	a4, 0x0
+               	mv	s1, a2
+               	li	t0, 0x4
+               	bltu	a4, t0, 0x828 <corpus.cases.call.call_recursive.tail+0xb8>
+               	j	0x88c <corpus.cases.call.call_recursive.tail+0x11c>
+               	slli	t0, a4, 0x3
+               	add	a2, a3, t0
+               	ld	a5, 0x0(a2)
+               	mv	a2, s1
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x848 <corpus.cases.call.call_recursive.tail+0xd8>
+               	j	0x87c <corpus.cases.call.call_recursive.tail+0x10c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x848 <corpus.cases.call.call_recursive.tail+0xd8>
+               	addi	a4, a4, 0x1
+               	mv	s1, a2
+               	li	t0, 0x4
+               	bltu	a4, t0, 0x828 <corpus.cases.call.call_recursive.tail+0xb8>
+               	li	t0, 0x0
+               	beq	a0, t0, 0x8c8 <corpus.cases.call.call_recursive.tail+0x158>
+               	addi	a2, a0, -0x1
+               	li	t0, 0x5
+               	mul	a0, a1, t0
+               	addi	a1, a0, 0x3
+               	mv	a0, a2
+               	mv	a2, s1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_recursive.tail+0x13c>
+               	ld	s1, 0x28(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
+               	ret
+               	mv	a0, s1
+               	ld	s1, 0x28(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.call.call_recursive.gather>:
@@ -654,22 +595,22 @@ Disassembly of section .text:
                	mv	a0, s2
                	li	t0, 0x7
                	and	a3, a0, t0
-               	bnez	a3, 0xa20 <corpus.cases.call.call_recursive.gather+0x54>
+               	bnez	a3, 0x934 <corpus.cases.call.call_recursive.gather+0x54>
                	mv	a3, a0
                	li	a4, 0x18
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xa08 <corpus.cases.call.call_recursive.gather+0x3c>
-               	j	0xa3c <corpus.cases.call.call_recursive.gather+0x70>
+               	bne	a4, t0, 0x91c <corpus.cases.call.call_recursive.gather+0x3c>
+               	j	0x950 <corpus.cases.call.call_recursive.gather+0x70>
                	mv	a3, a0
                	li	a0, 0x18
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xa28 <corpus.cases.call.call_recursive.gather+0x5c>
+               	bne	a0, t0, 0x93c <corpus.cases.call.call_recursive.gather+0x5c>
                	add	a0, a2, a1
                	mv	a3, s2
                	sd	a0, 0x0(a3)
@@ -683,7 +624,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0x10
                	sd	a3, 0x0(a0)
                	li	t0, 0x0
-               	beq	a1, t0, 0xbdc <corpus.cases.call.call_recursive.gather+0x210>
+               	beq	a1, t0, 0xaf0 <corpus.cases.call.call_recursive.gather+0x210>
                	addi	a3, a1, -0x1
                	li	t0, 0x7
                	mul	a0, a2, t0
@@ -720,8 +661,8 @@ Disassembly of section .text:
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0xb64 <corpus.cases.call.call_recursive.gather+0x198>
-               	bnez	a0, 0xb38 <corpus.cases.call.call_recursive.gather+0x16c>
+               	bltu	a1, a2, 0xa78 <corpus.cases.call.call_recursive.gather+0x198>
+               	bnez	a0, 0xa4c <corpus.cases.call.call_recursive.gather+0x16c>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -731,8 +672,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xb18 <corpus.cases.call.call_recursive.gather+0x14c>
-               	j	0xbbc <corpus.cases.call.call_recursive.gather+0x1f0>
+               	bne	a5, t0, 0xa2c <corpus.cases.call.call_recursive.gather+0x14c>
+               	j	0xad0 <corpus.cases.call.call_recursive.gather+0x1f0>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -742,9 +683,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0xb44 <corpus.cases.call.call_recursive.gather+0x178>
-               	j	0xbbc <corpus.cases.call.call_recursive.gather+0x1f0>
-               	bnez	a0, 0xb94 <corpus.cases.call.call_recursive.gather+0x1c8>
+               	bne	a5, t0, 0xa58 <corpus.cases.call.call_recursive.gather+0x178>
+               	j	0xad0 <corpus.cases.call.call_recursive.gather+0x1f0>
+               	bnez	a0, 0xaa8 <corpus.cases.call.call_recursive.gather+0x1c8>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x18
@@ -754,8 +695,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xb74 <corpus.cases.call.call_recursive.gather+0x1a8>
-               	j	0xbbc <corpus.cases.call.call_recursive.gather+0x1f0>
+               	bne	a4, t0, 0xa88 <corpus.cases.call.call_recursive.gather+0x1a8>
+               	j	0xad0 <corpus.cases.call.call_recursive.gather+0x1f0>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -765,7 +706,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xba0 <corpus.cases.call.call_recursive.gather+0x1d4>
+               	bne	a2, t0, 0xab4 <corpus.cases.call.call_recursive.gather+0x1d4>
                	mv	a0, s1
                	ld	s1, 0x78(sp)
                	ld	s2, 0x70(sp)
@@ -780,8 +721,8 @@ Disassembly of section .text:
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0xc54 <corpus.cases.call.call_recursive.gather+0x288>
-               	bnez	a3, 0xc28 <corpus.cases.call.call_recursive.gather+0x25c>
+               	bltu	a1, a2, 0xb68 <corpus.cases.call.call_recursive.gather+0x288>
+               	bnez	a3, 0xb3c <corpus.cases.call.call_recursive.gather+0x25c>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -791,8 +732,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xc08 <corpus.cases.call.call_recursive.gather+0x23c>
-               	j	0xcac <corpus.cases.call.call_recursive.gather+0x2e0>
+               	bne	a6, t0, 0xb1c <corpus.cases.call.call_recursive.gather+0x23c>
+               	j	0xbc0 <corpus.cases.call.call_recursive.gather+0x2e0>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -802,9 +743,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xc34 <corpus.cases.call.call_recursive.gather+0x268>
-               	j	0xcac <corpus.cases.call.call_recursive.gather+0x2e0>
-               	bnez	a3, 0xc84 <corpus.cases.call.call_recursive.gather+0x2b8>
+               	bne	a6, t0, 0xb48 <corpus.cases.call.call_recursive.gather+0x268>
+               	j	0xbc0 <corpus.cases.call.call_recursive.gather+0x2e0>
+               	bnez	a3, 0xb98 <corpus.cases.call.call_recursive.gather+0x2b8>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x18
@@ -814,8 +755,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xc64 <corpus.cases.call.call_recursive.gather+0x298>
-               	j	0xcac <corpus.cases.call.call_recursive.gather+0x2e0>
+               	bne	a5, t0, 0xb78 <corpus.cases.call.call_recursive.gather+0x298>
+               	j	0xbc0 <corpus.cases.call.call_recursive.gather+0x2e0>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -825,14 +766,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xc90 <corpus.cases.call.call_recursive.gather+0x2c4>
+               	bne	a2, t0, 0xba4 <corpus.cases.call.call_recursive.gather+0x2c4>
                	mv	a1, s1
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0xd20 <corpus.cases.call.call_recursive.gather+0x354>
-               	bnez	a0, 0xcf4 <corpus.cases.call.call_recursive.gather+0x328>
+               	bltu	a1, a2, 0xc34 <corpus.cases.call.call_recursive.gather+0x354>
+               	bnez	a0, 0xc08 <corpus.cases.call.call_recursive.gather+0x328>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -842,8 +783,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xcd4 <corpus.cases.call.call_recursive.gather+0x308>
-               	j	0xd78 <corpus.cases.call.call_recursive.gather+0x3ac>
+               	bne	a5, t0, 0xbe8 <corpus.cases.call.call_recursive.gather+0x308>
+               	j	0xc8c <corpus.cases.call.call_recursive.gather+0x3ac>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -853,9 +794,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0xd00 <corpus.cases.call.call_recursive.gather+0x334>
-               	j	0xd78 <corpus.cases.call.call_recursive.gather+0x3ac>
-               	bnez	a0, 0xd50 <corpus.cases.call.call_recursive.gather+0x384>
+               	bne	a5, t0, 0xc14 <corpus.cases.call.call_recursive.gather+0x334>
+               	j	0xc8c <corpus.cases.call.call_recursive.gather+0x3ac>
+               	bnez	a0, 0xc64 <corpus.cases.call.call_recursive.gather+0x384>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x18
@@ -865,8 +806,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xd30 <corpus.cases.call.call_recursive.gather+0x364>
-               	j	0xd78 <corpus.cases.call.call_recursive.gather+0x3ac>
+               	bne	a4, t0, 0xc44 <corpus.cases.call.call_recursive.gather+0x364>
+               	j	0xc8c <corpus.cases.call.call_recursive.gather+0x3ac>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -876,7 +817,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xd5c <corpus.cases.call.call_recursive.gather+0x390>
+               	bne	a2, t0, 0xc70 <corpus.cases.call.call_recursive.gather+0x390>
                	mv	a0, s1
                	ld	s1, 0x78(sp)
                	ld	s2, 0x70(sp)
@@ -887,45 +828,41 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_recursive.checksum>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	sd	s2, 0x80(sp)
-               	sd	s3, 0x78(sp)
-               	sd	s4, 0x70(sp)
-               	sd	s5, 0x68(sp)
-               	sd	s6, 0x60(sp)
-               	sd	s7, 0x58(sp)
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	sd	s1, 0x78(sp)
+               	sd	s2, 0x70(sp)
+               	sd	s3, 0x68(sp)
+               	sd	s4, 0x60(sp)
+               	sd	s5, 0x58(sp)
+               	sd	s6, 0x50(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x30>
-               	mv	a2, a0
-               	addi	s2, s0, -0x78
+               	addi	s2, s0, -0x88
                	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xe08 <corpus.cases.call.call_recursive.checksum+0x70>
+               	bnez	a1, 0xd0c <corpus.cases.call.call_recursive.checksum+0x60>
                	mv	a1, a0
-               	li	a3, 0x30
+               	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	a3, a3, -0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xdf0 <corpus.cases.call.call_recursive.checksum+0x58>
-               	j	0xe24 <corpus.cases.call.call_recursive.checksum+0x8c>
+               	bne	a2, t0, 0xcf4 <corpus.cases.call.call_recursive.checksum+0x48>
+               	j	0xd28 <corpus.cases.call.call_recursive.checksum+0x7c>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xe10 <corpus.cases.call.call_recursive.checksum+0x78>
+               	bne	a0, t0, 0xd14 <corpus.cases.call.call_recursive.checksum+0x68>
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0xe34 <corpus.cases.call.call_recursive.checksum+0x9c>
-               	j	0xe98 <corpus.cases.call.call_recursive.checksum+0x100>
+               	bltu	a0, t0, 0xd38 <corpus.cases.call.call_recursive.checksum+0x8c>
+               	j	0xd9c <corpus.cases.call.call_recursive.checksum+0xf0>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -943,21 +880,29 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a1, t0
-               	add	a1, a3, s1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
                	slli	t0, a0, 0x3
-               	add	a3, s2, t0
-               	sd	a1, 0x0(a3)
+               	add	a2, s2, t0
+               	sd	a1, 0x0(a2)
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0xe34 <corpus.cases.call.call_recursive.checksum+0x9c>
+               	bltu	a0, t0, 0xd38 <corpus.cases.call.call_recursive.checksum+0x8c>
                	li	t1, 0x28
                	add	a0, t1, s1
                	mv	a1, s2
-               	ld	a3, 0x0(a1)
-               	mv	a1, a3
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x114>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x124>
                	mv	a2, a0
                	li	t1, 0x21
                	add	s3, t1, s1
@@ -965,13 +910,13 @@ Disassembly of section .text:
                	ld	a1, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x134>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x144>
                	mv	a2, a0
                	addi	a0, s2, 0x10
                	ld	a1, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x14c>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x15c>
                	mv	a2, a0
                	addi	a0, s2, 0x18
                	ld	a1, 0x0(a0)
@@ -979,7 +924,7 @@ Disassembly of section .text:
                	li	a0, 0x8
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x16c>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x17c>
                	mv	a2, a0
                	li	t1, 0x30
                	add	a0, t1, s1
@@ -987,51 +932,93 @@ Disassembly of section .text:
                	ld	a3, 0x0(a1)
                	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x18c>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x19c>
                	li	t1, 0x18
                	add	s3, t1, s1
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0xf48 <corpus.cases.call.call_recursive.checksum+0x1b0>
-               	j	0xfb8 <corpus.cases.call.call_recursive.checksum+0x220>
+               	bltu	s5, t0, 0xe6c <corpus.cases.call.call_recursive.checksum+0x1c0>
+               	j	0xf88 <corpus.cases.call.call_recursive.checksum+0x2dc>
                	slli	t0, s5, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	a2, a1, s1
-               	addi	s6, s0, -0x90
+               	addi	s6, s0, -0x58
                	mv	a0, s6
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x1cc>
+               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x1dc>
                	mv	a0, s6
                	ld	a1, 0x0(a0)
                	addi	a0, s6, 0x8
-               	ld	s7, 0x0(a0)
+               	ld	a2, 0x0(a0)
                	addi	a0, s6, 0x10
-               	ld	s6, 0x0(a0)
+               	ld	a3, 0x0(a0)
                	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x1f0>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x1fc>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_recursive.checksum+0x208>
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xebc <corpus.cases.call.call_recursive.checksum+0x210>
+               	j	0xef0 <corpus.cases.call.call_recursive.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xebc <corpus.cases.call.call_recursive.checksum+0x210>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf00 <corpus.cases.call.call_recursive.checksum+0x254>
+               	j	0xf34 <corpus.cases.call.call_recursive.checksum+0x288>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf00 <corpus.cases.call.call_recursive.checksum+0x254>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf44 <corpus.cases.call.call_recursive.checksum+0x298>
+               	j	0xf78 <corpus.cases.call.call_recursive.checksum+0x2cc>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a4, a3, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf44 <corpus.cases.call.call_recursive.checksum+0x298>
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0xf48 <corpus.cases.call.call_recursive.checksum+0x1b0>
+               	bltu	s5, t0, 0xe6c <corpus.cases.call.call_recursive.checksum+0x1c0>
                	mv	a0, s4
-               	ld	s1, 0x88(sp)
-               	ld	s2, 0x80(sp)
-               	ld	s3, 0x78(sp)
-               	ld	s4, 0x70(sp)
-               	ld	s5, 0x68(sp)
-               	ld	s6, 0x60(sp)
-               	ld	s7, 0x58(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	ld	s1, 0x78(sp)
+               	ld	s2, 0x70(sp)
+               	ld	s3, 0x68(sp)
+               	ld	s4, 0x60(sp)
+               	ld	s5, 0x58(sp)
+               	ld	s6, 0x50(sp)
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret

--- a/test/golden/riscv64-linux/call/call_ret_large.dis
+++ b/test/golden/riscv64-linux/call/call_ret_large.dis
@@ -26,128 +26,316 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_ret_large.fold20>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	lw	a4, 0x0(a3)
-               	addi	a3, a1, 0x4
-               	lw	s1, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	lw	s2, 0x0(a3)
-               	addi	a3, a1, 0xc
-               	lw	s3, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	lw	s4, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold20+0x54>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold20+0x68>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold20+0x7c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold20+0x90>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold20+0xa4>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mv	a2, a1
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lw	a5, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lw	a6, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	lw	a1, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.call.call_ret_large.fold20+0x40>
+               	j	0xc8 <corpus.cases.call.call_ret_large.fold20+0x74>
+               	li	t0, 0x8
+               	mul	a7, a3, t0
+               	srl	t5, a2, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a0, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, t5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.call.call_ret_large.fold20+0x40>
+               	slli	a2, a4, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe0 <corpus.cases.call.call_ret_large.fold20+0x8c>
+               	j	0x114 <corpus.cases.call.call_ret_large.fold20+0xc0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a7, a2, a4
+               	li	t0, 0xff
+               	and	a4, a7, t0
+               	xor	a7, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe0 <corpus.cases.call.call_ret_large.fold20+0x8c>
+               	slli	a2, a5, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x12c <corpus.cases.call.call_ret_large.fold20+0xd8>
+               	j	0x160 <corpus.cases.call.call_ret_large.fold20+0x10c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x12c <corpus.cases.call.call_ret_large.fold20+0xd8>
+               	slli	a2, a6, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x178 <corpus.cases.call.call_ret_large.fold20+0x124>
+               	j	0x1ac <corpus.cases.call.call_ret_large.fold20+0x158>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x178 <corpus.cases.call.call_ret_large.fold20+0x124>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c4 <corpus.cases.call.call_ret_large.fold20+0x170>
+               	j	0x1f8 <corpus.cases.call.call_ret_large.fold20+0x1a4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c4 <corpus.cases.call.call_ret_large.fold20+0x170>
                	ret
 
 <corpus.cases.call.call_ret_large.fold24>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	sd	s2, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	ld	s1, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s2, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24+0x64>
-               	ld	s1, 0x8(sp)
-               	ld	s2, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	a4, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x224 <corpus.cases.call.call_ret_large.fold24+0x28>
+               	j	0x258 <corpus.cases.call.call_ret_large.fold24+0x5c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x224 <corpus.cases.call.call_ret_large.fold24+0x28>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x268 <corpus.cases.call.call_ret_large.fold24+0x6c>
+               	j	0x29c <corpus.cases.call.call_ret_large.fold24+0xa0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a4, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x268 <corpus.cases.call.call_ret_large.fold24+0x6c>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2ac <corpus.cases.call.call_ret_large.fold24+0xb0>
+               	j	0x2e0 <corpus.cases.call.call_ret_large.fold24+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2ac <corpus.cases.call.call_ret_large.fold24+0xb0>
                	ret
 
 <corpus.cases.call.call_ret_large.fold24f>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	fsd	fs0, 0x8(sp)
-               	fsd	fs1, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	fld	fa0, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	fld	fs0, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	fld	fs1, 0x0(a3)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24f+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24f+0x4c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold24f+0x60>
-               	fld	fs0, 0x8(sp)
-               	fld	fs1, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fld	ft1, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	fld	ft2, 0x0(a2)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x310 <corpus.cases.call.call_ret_large.fold24f+0x2c>
+               	j	0x344 <corpus.cases.call.call_ret_large.fold24f+0x60>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x310 <corpus.cases.call.call_ret_large.fold24f+0x2c>
+               	fmv.x.d	a1, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x358 <corpus.cases.call.call_ret_large.fold24f+0x74>
+               	j	0x38c <corpus.cases.call.call_ret_large.fold24f+0xa8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x358 <corpus.cases.call.call_ret_large.fold24f+0x74>
+               	fmv.x.d	a1, ft2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a0 <corpus.cases.call.call_ret_large.fold24f+0xbc>
+               	j	0x3d4 <corpus.cases.call.call_ret_large.fold24f+0xf0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a0 <corpus.cases.call.call_ret_large.fold24f+0xbc>
                	ret
 
 <corpus.cases.call.call_ret_large.fold32>:
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	ld	a4, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a5, 0x0(a2)
+               	addi	a2, a1, 0x18
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x408 <corpus.cases.call.call_ret_large.fold32+0x30>
+               	j	0x43c <corpus.cases.call.call_ret_large.fold32+0x64>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a0, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x408 <corpus.cases.call.call_ret_large.fold32+0x30>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44c <corpus.cases.call.call_ret_large.fold32+0x74>
+               	j	0x480 <corpus.cases.call.call_ret_large.fold32+0xa8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a6, a4, a3
+               	li	t0, 0xff
+               	and	a3, a6, t0
+               	xor	a6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44c <corpus.cases.call.call_ret_large.fold32+0x74>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.call.call_ret_large.fold32+0xb8>
+               	j	0x4c4 <corpus.cases.call.call_ret_large.fold32+0xec>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a5, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.call.call_ret_large.fold32+0xb8>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4d4 <corpus.cases.call.call_ret_large.fold32+0xfc>
+               	j	0x508 <corpus.cases.call.call_ret_large.fold32+0x130>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4d4 <corpus.cases.call.call_ret_large.fold32+0xfc>
+               	ret
+
+<corpus.cases.call.call_ret_large.fold40m>:
                	addi	sp, sp, -0x30
                	sd	ra, 0x28(sp)
                	sd	s0, 0x20(sp)
@@ -155,102 +343,60 @@ Disassembly of section .text:
                	sd	s1, 0x18(sp)
                	sd	s2, 0x10(sp)
                	sd	s3, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	ld	s1, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s2, 0x0(a3)
-               	addi	a3, a1, 0x18
-               	ld	s3, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
+               	fsd	fs0, 0x0(sp)
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fld	ft0, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	lw	s1, 0x0(a2)
+               	addi	a2, a1, 0x14
+               	lw	s2, 0x0(a2)
+               	addi	a2, a1, 0x18
+               	fld	fs0, 0x0(a2)
+               	addi	a2, a1, 0x20
+               	ld	s3, 0x0(a2)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x56c <corpus.cases.call.call_ret_large.fold40m+0x60>
+               	j	0x5a0 <corpus.cases.call.call_ret_large.fold40m+0x94>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a4, a3, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x56c <corpus.cases.call.call_ret_large.fold40m+0x60>
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold32+0x48>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
+               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0x98>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold32+0x5c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xa8>
+               	slli	a1, s2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold32+0x70>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xb8>
+               	fmv.x.d	a1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xc4>
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold32+0x84>
+               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xd0>
                	ld	s1, 0x18(sp)
                	ld	s2, 0x10(sp)
                	ld	s3, 0x8(sp)
+               	fld	fs0, 0x0(sp)
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
-               	ret
-
-<corpus.cases.call.call_ret_large.fold40m>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	fsd	fs0, 0x10(sp)
-               	fsd	fs1, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	ld	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	fld	fs0, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	lw	s1, 0x0(a3)
-               	addi	a3, a1, 0x14
-               	lw	s2, 0x0(a3)
-               	addi	a3, a1, 0x18
-               	fld	fs1, 0x0(a3)
-               	addi	a3, a1, 0x20
-               	ld	s3, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0x60>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0x74>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0x88>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0x9c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xb0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold40m+0xc4>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	fld	fs0, 0x10(sp)
-               	fld	fs1, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.call.call_ret_large.fold48>:
@@ -316,57 +462,193 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_ret_large.fold_nest>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	a2, a0
+               	addi	sp, sp, -0x80
+               	sd	ra, 0x78(sp)
+               	sd	s0, 0x70(sp)
+               	addi	s0, sp, 0x80
+               	sd	s1, 0x68(sp)
+               	sd	s2, 0x60(sp)
+               	addi	s1, s0, -0x50
+               	mv	a2, s1
                	mv	a3, a1
-               	lw	a4, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	mv	a5, a3
-               	ld	s1, 0x0(a5)
-               	addi	a5, a3, 0x8
-               	ld	s2, 0x0(a5)
-               	addi	a5, a3, 0x10
-               	ld	s3, 0x0(a5)
-               	addi	a3, a1, 0x20
-               	mv	a1, a3
-               	ld	s4, 0x0(a1)
-               	addi	a1, a3, 0x8
-               	ld	s5, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x68>
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x784 <corpus.cases.call.call_ret_large.fold_nest+0x90>
+               	bnez	a1, 0x758 <corpus.cases.call.call_ret_large.fold_nest+0x64>
+               	addi	a4, a2, 0x30
+               	addi	a5, a3, 0x30
+               	li	a6, 0x30
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x738 <corpus.cases.call.call_ret_large.fold_nest+0x44>
+               	j	0x7dc <corpus.cases.call.call_ret_large.fold_nest+0xe8>
+               	addi	a4, a2, 0x30
+               	addi	a5, a3, 0x30
+               	li	a6, 0x30
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x764 <corpus.cases.call.call_ret_large.fold_nest+0x70>
+               	j	0x7dc <corpus.cases.call.call_ret_large.fold_nest+0xe8>
+               	bnez	a1, 0x7b4 <corpus.cases.call.call_ret_large.fold_nest+0xc0>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x30
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x794 <corpus.cases.call.call_ret_large.fold_nest+0xa0>
+               	j	0x7dc <corpus.cases.call.call_ret_large.fold_nest+0xe8>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x30
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x7c0 <corpus.cases.call.call_ret_large.fold_nest+0xcc>
                	mv	a1, s1
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x74>
+               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0xf8>
+               	addi	a1, s1, 0x8
+               	addi	a2, s0, -0x68
+               	mv	a3, a2
+               	mv	a4, a1
+               	or	a1, a3, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, a4, 0x870 <corpus.cases.call.call_ret_large.fold_nest+0x17c>
+               	bnez	a1, 0x844 <corpus.cases.call.call_ret_large.fold_nest+0x150>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x824 <corpus.cases.call.call_ret_large.fold_nest+0x130>
+               	j	0x8c8 <corpus.cases.call.call_ret_large.fold_nest+0x1d4>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x850 <corpus.cases.call.call_ret_large.fold_nest+0x15c>
+               	j	0x8c8 <corpus.cases.call.call_ret_large.fold_nest+0x1d4>
+               	bnez	a1, 0x8a0 <corpus.cases.call.call_ret_large.fold_nest+0x1ac>
+               	mv	a1, a3
+               	mv	a5, a4
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x880 <corpus.cases.call.call_ret_large.fold_nest+0x18c>
+               	j	0x8c8 <corpus.cases.call.call_ret_large.fold_nest+0x1d4>
+               	mv	a1, a3
+               	mv	a3, a4
+               	li	a4, 0x18
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x8ac <corpus.cases.call.call_ret_large.fold_nest+0x1b8>
+               	addi	a1, s0, -0x80
+               	mv	a3, a2
+               	or	a2, a1, a3
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a1, a3, 0x93c <corpus.cases.call.call_ret_large.fold_nest+0x248>
+               	bnez	a2, 0x910 <corpus.cases.call.call_ret_large.fold_nest+0x21c>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x8f0 <corpus.cases.call.call_ret_large.fold_nest+0x1fc>
+               	j	0x994 <corpus.cases.call.call_ret_large.fold_nest+0x2a0>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x91c <corpus.cases.call.call_ret_large.fold_nest+0x228>
+               	j	0x994 <corpus.cases.call.call_ret_large.fold_nest+0x2a0>
+               	bnez	a2, 0x96c <corpus.cases.call.call_ret_large.fold_nest+0x278>
+               	mv	a2, a1
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x94c <corpus.cases.call.call_ret_large.fold_nest+0x258>
+               	j	0x994 <corpus.cases.call.call_ret_large.fold_nest+0x2a0>
+               	mv	a2, a1
+               	mv	a1, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x978 <corpus.cases.call.call_ret_large.fold_nest+0x284>
+               	addi	a1, s0, -0x80
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x2a4>
+               	addi	s2, s1, 0x20
                	mv	a1, s2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x80>
-               	mv	a1, s3
+               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x2bc>
+               	addi	a1, s2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x8c>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x98>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0xa4>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <corpus.cases.call.call_ret_large.fold_nest+0x2d0>
+               	ld	s1, 0x68(sp)
+               	ld	s2, 0x60(sp)
+               	ld	ra, 0x78(sp)
+               	ld	s0, 0x70(sp)
+               	addi	sp, sp, 0x80
                	ret
 
 <corpus.cases.call.call_ret_large.layout>:
@@ -454,8 +736,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x72c <corpus.cases.call.call_ret_large.mk20+0xdc>
-               	bnez	a2, 0x700 <corpus.cases.call.call_ret_large.mk20+0xb0>
+               	bltu	a1, a3, 0xb94 <corpus.cases.call.call_ret_large.mk20+0xdc>
+               	bnez	a2, 0xb68 <corpus.cases.call.call_ret_large.mk20+0xb0>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -467,8 +749,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x6e0 <corpus.cases.call.call_ret_large.mk20+0x90>
-               	j	0x78c <corpus.cases.call.call_ret_large.mk20+0x13c>
+               	bne	a6, t0, 0xb48 <corpus.cases.call.call_ret_large.mk20+0x90>
+               	j	0xbf4 <corpus.cases.call.call_ret_large.mk20+0x13c>
                	addi	a4, a1, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -478,9 +760,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x70c <corpus.cases.call.call_ret_large.mk20+0xbc>
-               	j	0x78c <corpus.cases.call.call_ret_large.mk20+0x13c>
-               	bnez	a2, 0x764 <corpus.cases.call.call_ret_large.mk20+0x114>
+               	bne	a6, t0, 0xb74 <corpus.cases.call.call_ret_large.mk20+0xbc>
+               	j	0xbf4 <corpus.cases.call.call_ret_large.mk20+0x13c>
+               	bnez	a2, 0xbcc <corpus.cases.call.call_ret_large.mk20+0x114>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -490,10 +772,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x73c <corpus.cases.call.call_ret_large.mk20+0xec>
+               	bne	a5, t0, 0xba4 <corpus.cases.call.call_ret_large.mk20+0xec>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0x78c <corpus.cases.call.call_ret_large.mk20+0x13c>
+               	j	0xbf4 <corpus.cases.call.call_ret_large.mk20+0x13c>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x14
@@ -503,7 +785,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x770 <corpus.cases.call.call_ret_large.mk20+0x120>
+               	bne	a3, t0, 0xbd8 <corpus.cases.call.call_ret_large.mk20+0x120>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -530,8 +812,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x84c <corpus.cases.call.call_ret_large.mk24+0xb0>
-               	bnez	a2, 0x820 <corpus.cases.call.call_ret_large.mk24+0x84>
+               	bltu	a1, a3, 0xcb4 <corpus.cases.call.call_ret_large.mk24+0xb0>
+               	bnez	a2, 0xc88 <corpus.cases.call.call_ret_large.mk24+0x84>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -541,8 +823,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x800 <corpus.cases.call.call_ret_large.mk24+0x64>
-               	j	0x8a4 <corpus.cases.call.call_ret_large.mk24+0x108>
+               	bne	a6, t0, 0xc68 <corpus.cases.call.call_ret_large.mk24+0x64>
+               	j	0xd0c <corpus.cases.call.call_ret_large.mk24+0x108>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -552,9 +834,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x82c <corpus.cases.call.call_ret_large.mk24+0x90>
-               	j	0x8a4 <corpus.cases.call.call_ret_large.mk24+0x108>
-               	bnez	a2, 0x87c <corpus.cases.call.call_ret_large.mk24+0xe0>
+               	bne	a6, t0, 0xc94 <corpus.cases.call.call_ret_large.mk24+0x90>
+               	j	0xd0c <corpus.cases.call.call_ret_large.mk24+0x108>
+               	bnez	a2, 0xce4 <corpus.cases.call.call_ret_large.mk24+0xe0>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -564,8 +846,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x85c <corpus.cases.call.call_ret_large.mk24+0xc0>
-               	j	0x8a4 <corpus.cases.call.call_ret_large.mk24+0x108>
+               	bne	a5, t0, 0xcc4 <corpus.cases.call.call_ret_large.mk24+0xc0>
+               	j	0xd0c <corpus.cases.call.call_ret_large.mk24+0x108>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -575,7 +857,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x888 <corpus.cases.call.call_ret_large.mk24+0xec>
+               	bne	a3, t0, 0xcf0 <corpus.cases.call.call_ret_large.mk24+0xec>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -625,8 +907,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x9a8 <.Lpcrel_hi.2+0x88>
-               	bnez	a2, 0x97c <.Lpcrel_hi.2+0x5c>
+               	bltu	a1, a3, 0xe10 <.Lpcrel_hi.2+0x88>
+               	bnez	a2, 0xde4 <.Lpcrel_hi.2+0x5c>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -636,8 +918,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x95c <.Lpcrel_hi.2+0x3c>
-               	j	0xa00 <.Lpcrel_hi.2+0xe0>
+               	bne	a6, t0, 0xdc4 <.Lpcrel_hi.2+0x3c>
+               	j	0xe68 <.Lpcrel_hi.2+0xe0>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -647,9 +929,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x988 <.Lpcrel_hi.2+0x68>
-               	j	0xa00 <.Lpcrel_hi.2+0xe0>
-               	bnez	a2, 0x9d8 <.Lpcrel_hi.2+0xb8>
+               	bne	a6, t0, 0xdf0 <.Lpcrel_hi.2+0x68>
+               	j	0xe68 <.Lpcrel_hi.2+0xe0>
+               	bnez	a2, 0xe40 <.Lpcrel_hi.2+0xb8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -659,8 +941,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x9b8 <.Lpcrel_hi.2+0x98>
-               	j	0xa00 <.Lpcrel_hi.2+0xe0>
+               	bne	a5, t0, 0xe20 <.Lpcrel_hi.2+0x98>
+               	j	0xe68 <.Lpcrel_hi.2+0xe0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -670,7 +952,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x9e4 <.Lpcrel_hi.2+0xc4>
+               	bne	a3, t0, 0xe4c <.Lpcrel_hi.2+0xc4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -699,8 +981,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xac8 <corpus.cases.call.call_ret_large.mk32+0xb8>
-               	bnez	a2, 0xa9c <corpus.cases.call.call_ret_large.mk32+0x8c>
+               	bltu	a1, a3, 0xf30 <corpus.cases.call.call_ret_large.mk32+0xb8>
+               	bnez	a2, 0xf04 <corpus.cases.call.call_ret_large.mk32+0x8c>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -710,8 +992,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xa7c <corpus.cases.call.call_ret_large.mk32+0x6c>
-               	j	0xb20 <corpus.cases.call.call_ret_large.mk32+0x110>
+               	bne	a6, t0, 0xee4 <corpus.cases.call.call_ret_large.mk32+0x6c>
+               	j	0xf88 <corpus.cases.call.call_ret_large.mk32+0x110>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -721,9 +1003,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xaa8 <corpus.cases.call.call_ret_large.mk32+0x98>
-               	j	0xb20 <corpus.cases.call.call_ret_large.mk32+0x110>
-               	bnez	a2, 0xaf8 <corpus.cases.call.call_ret_large.mk32+0xe8>
+               	bne	a6, t0, 0xf10 <corpus.cases.call.call_ret_large.mk32+0x98>
+               	j	0xf88 <corpus.cases.call.call_ret_large.mk32+0x110>
+               	bnez	a2, 0xf60 <corpus.cases.call.call_ret_large.mk32+0xe8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x20
@@ -733,8 +1015,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xad8 <corpus.cases.call.call_ret_large.mk32+0xc8>
-               	j	0xb20 <corpus.cases.call.call_ret_large.mk32+0x110>
+               	bne	a5, t0, 0xf40 <corpus.cases.call.call_ret_large.mk32+0xc8>
+               	j	0xf88 <corpus.cases.call.call_ret_large.mk32+0x110>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x20
@@ -744,7 +1026,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xb04 <corpus.cases.call.call_ret_large.mk32+0xf4>
+               	bne	a3, t0, 0xf6c <corpus.cases.call.call_ret_large.mk32+0xf4>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -796,8 +1078,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xc34 <.Lpcrel_hi.4+0x98>
-               	bnez	a2, 0xc08 <.Lpcrel_hi.4+0x6c>
+               	bltu	a1, a3, 0x109c <.Lpcrel_hi.4+0x98>
+               	bnez	a2, 0x1070 <.Lpcrel_hi.4+0x6c>
                	addi	a4, a1, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -807,8 +1089,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xbe8 <.Lpcrel_hi.4+0x4c>
-               	j	0xc8c <.Lpcrel_hi.4+0xf0>
+               	bne	a6, t0, 0x1050 <.Lpcrel_hi.4+0x4c>
+               	j	0x10f4 <.Lpcrel_hi.4+0xf0>
                	addi	a4, a1, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -818,9 +1100,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xc14 <.Lpcrel_hi.4+0x78>
-               	j	0xc8c <.Lpcrel_hi.4+0xf0>
-               	bnez	a2, 0xc64 <.Lpcrel_hi.4+0xc8>
+               	bne	a6, t0, 0x107c <.Lpcrel_hi.4+0x78>
+               	j	0x10f4 <.Lpcrel_hi.4+0xf0>
+               	bnez	a2, 0x10cc <.Lpcrel_hi.4+0xc8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x28
@@ -830,8 +1112,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xc44 <.Lpcrel_hi.4+0xa8>
-               	j	0xc8c <.Lpcrel_hi.4+0xf0>
+               	bne	a5, t0, 0x10ac <.Lpcrel_hi.4+0xa8>
+               	j	0x10f4 <.Lpcrel_hi.4+0xf0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x28
@@ -841,7 +1123,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xc70 <.Lpcrel_hi.4+0xd4>
+               	bne	a3, t0, 0x10d8 <.Lpcrel_hi.4+0xd4>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -880,8 +1162,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xd7c <corpus.cases.call.call_ret_large.mk48+0xe0>
-               	bnez	a2, 0xd50 <corpus.cases.call.call_ret_large.mk48+0xb4>
+               	bltu	a1, a3, 0x11e4 <corpus.cases.call.call_ret_large.mk48+0xe0>
+               	bnez	a2, 0x11b8 <corpus.cases.call.call_ret_large.mk48+0xb4>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -891,8 +1173,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xd30 <corpus.cases.call.call_ret_large.mk48+0x94>
-               	j	0xdd4 <corpus.cases.call.call_ret_large.mk48+0x138>
+               	bne	a6, t0, 0x1198 <corpus.cases.call.call_ret_large.mk48+0x94>
+               	j	0x123c <corpus.cases.call.call_ret_large.mk48+0x138>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -902,9 +1184,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xd5c <corpus.cases.call.call_ret_large.mk48+0xc0>
-               	j	0xdd4 <corpus.cases.call.call_ret_large.mk48+0x138>
-               	bnez	a2, 0xdac <corpus.cases.call.call_ret_large.mk48+0x110>
+               	bne	a6, t0, 0x11c4 <corpus.cases.call.call_ret_large.mk48+0xc0>
+               	j	0x123c <corpus.cases.call.call_ret_large.mk48+0x138>
+               	bnez	a2, 0x1214 <corpus.cases.call.call_ret_large.mk48+0x110>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -914,8 +1196,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xd8c <corpus.cases.call.call_ret_large.mk48+0xf0>
-               	j	0xdd4 <corpus.cases.call.call_ret_large.mk48+0x138>
+               	bne	a5, t0, 0x11f4 <corpus.cases.call.call_ret_large.mk48+0xf0>
+               	j	0x123c <corpus.cases.call.call_ret_large.mk48+0x138>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -925,7 +1207,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xdb8 <corpus.cases.call.call_ret_large.mk48+0x11c>
+               	bne	a3, t0, 0x1220 <corpus.cases.call.call_ret_large.mk48+0x11c>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -957,8 +1239,8 @@ Disassembly of section .text:
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0xea8 <corpus.cases.call.call_ret_large.bump24+0xc4>
-               	bnez	a3, 0xe7c <corpus.cases.call.call_ret_large.bump24+0x98>
+               	bltu	a1, a2, 0x1310 <corpus.cases.call.call_ret_large.bump24+0xc4>
+               	bnez	a3, 0x12e4 <corpus.cases.call.call_ret_large.bump24+0x98>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -968,8 +1250,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xe5c <corpus.cases.call.call_ret_large.bump24+0x78>
-               	j	0xf00 <corpus.cases.call.call_ret_large.bump24+0x11c>
+               	bne	a6, t0, 0x12c4 <corpus.cases.call.call_ret_large.bump24+0x78>
+               	j	0x1368 <corpus.cases.call.call_ret_large.bump24+0x11c>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -979,9 +1261,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xe88 <corpus.cases.call.call_ret_large.bump24+0xa4>
-               	j	0xf00 <corpus.cases.call.call_ret_large.bump24+0x11c>
-               	bnez	a3, 0xed8 <corpus.cases.call.call_ret_large.bump24+0xf4>
+               	bne	a6, t0, 0x12f0 <corpus.cases.call.call_ret_large.bump24+0xa4>
+               	j	0x1368 <corpus.cases.call.call_ret_large.bump24+0x11c>
+               	bnez	a3, 0x1340 <corpus.cases.call.call_ret_large.bump24+0xf4>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x18
@@ -991,8 +1273,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xeb8 <corpus.cases.call.call_ret_large.bump24+0xd4>
-               	j	0xf00 <corpus.cases.call.call_ret_large.bump24+0x11c>
+               	bne	a5, t0, 0x1320 <corpus.cases.call.call_ret_large.bump24+0xd4>
+               	j	0x1368 <corpus.cases.call.call_ret_large.bump24+0x11c>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -1002,7 +1284,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xee4 <corpus.cases.call.call_ret_large.bump24+0x100>
+               	bne	a2, t0, 0x134c <corpus.cases.call.call_ret_large.bump24+0x100>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -1050,8 +1332,8 @@ Disassembly of section .text:
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0x1014 <corpus.cases.call.call_ret_large.bump48+0x104>
-               	bnez	a3, 0xfe8 <corpus.cases.call.call_ret_large.bump48+0xd8>
+               	bltu	a1, a2, 0x147c <corpus.cases.call.call_ret_large.bump48+0x104>
+               	bnez	a3, 0x1450 <corpus.cases.call.call_ret_large.bump48+0xd8>
                	addi	a4, a1, 0x30
                	addi	a5, a2, 0x30
                	li	a6, 0x30
@@ -1061,8 +1343,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xfc8 <corpus.cases.call.call_ret_large.bump48+0xb8>
-               	j	0x106c <corpus.cases.call.call_ret_large.bump48+0x15c>
+               	bne	a6, t0, 0x1430 <corpus.cases.call.call_ret_large.bump48+0xb8>
+               	j	0x14d4 <corpus.cases.call.call_ret_large.bump48+0x15c>
                	addi	a4, a1, 0x30
                	addi	a5, a2, 0x30
                	li	a6, 0x30
@@ -1072,9 +1354,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xff4 <corpus.cases.call.call_ret_large.bump48+0xe4>
-               	j	0x106c <corpus.cases.call.call_ret_large.bump48+0x15c>
-               	bnez	a3, 0x1044 <corpus.cases.call.call_ret_large.bump48+0x134>
+               	bne	a6, t0, 0x145c <corpus.cases.call.call_ret_large.bump48+0xe4>
+               	j	0x14d4 <corpus.cases.call.call_ret_large.bump48+0x15c>
+               	bnez	a3, 0x14ac <corpus.cases.call.call_ret_large.bump48+0x134>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x30
@@ -1084,8 +1366,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1024 <corpus.cases.call.call_ret_large.bump48+0x114>
-               	j	0x106c <corpus.cases.call.call_ret_large.bump48+0x15c>
+               	bne	a5, t0, 0x148c <corpus.cases.call.call_ret_large.bump48+0x114>
+               	j	0x14d4 <corpus.cases.call.call_ret_large.bump48+0x15c>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x30
@@ -1095,7 +1377,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x1050 <corpus.cases.call.call_ret_large.bump48+0x140>
+               	bne	a2, t0, 0x14b8 <corpus.cases.call.call_ret_large.bump48+0x140>
                	ld	s1, 0x38(sp)
                	ld	ra, 0x48(sp)
                	ld	s0, 0x40(sp)
@@ -1134,8 +1416,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x115c <corpus.cases.call.call_ret_large.widen+0xdc>
-               	bnez	a2, 0x1130 <corpus.cases.call.call_ret_large.widen+0xb0>
+               	bltu	a1, a3, 0x15c4 <corpus.cases.call.call_ret_large.widen+0xdc>
+               	bnez	a2, 0x1598 <corpus.cases.call.call_ret_large.widen+0xb0>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1145,8 +1427,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1110 <corpus.cases.call.call_ret_large.widen+0x90>
-               	j	0x11b4 <corpus.cases.call.call_ret_large.widen+0x134>
+               	bne	a6, t0, 0x1578 <corpus.cases.call.call_ret_large.widen+0x90>
+               	j	0x161c <corpus.cases.call.call_ret_large.widen+0x134>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1156,9 +1438,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x113c <corpus.cases.call.call_ret_large.widen+0xbc>
-               	j	0x11b4 <corpus.cases.call.call_ret_large.widen+0x134>
-               	bnez	a2, 0x118c <corpus.cases.call.call_ret_large.widen+0x10c>
+               	bne	a6, t0, 0x15a4 <corpus.cases.call.call_ret_large.widen+0xbc>
+               	j	0x161c <corpus.cases.call.call_ret_large.widen+0x134>
+               	bnez	a2, 0x15f4 <corpus.cases.call.call_ret_large.widen+0x10c>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -1168,8 +1450,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x116c <corpus.cases.call.call_ret_large.widen+0xec>
-               	j	0x11b4 <corpus.cases.call.call_ret_large.widen+0x134>
+               	bne	a5, t0, 0x15d4 <corpus.cases.call.call_ret_large.widen+0xec>
+               	j	0x161c <corpus.cases.call.call_ret_large.widen+0x134>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -1179,7 +1461,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1198 <corpus.cases.call.call_ret_large.widen+0x118>
+               	bne	a3, t0, 0x1600 <corpus.cases.call.call_ret_large.widen+0x118>
                	ld	ra, 0x38(sp)
                	ld	s0, 0x30(sp)
                	addi	sp, sp, 0x40
@@ -1217,8 +1499,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x12a0 <corpus.cases.call.call_ret_large.narrow+0xdc>
-               	bnez	a2, 0x1274 <corpus.cases.call.call_ret_large.narrow+0xb0>
+               	bltu	a1, a3, 0x1708 <corpus.cases.call.call_ret_large.narrow+0xdc>
+               	bnez	a2, 0x16dc <corpus.cases.call.call_ret_large.narrow+0xb0>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1228,8 +1510,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1254 <corpus.cases.call.call_ret_large.narrow+0x90>
-               	j	0x12f8 <corpus.cases.call.call_ret_large.narrow+0x134>
+               	bne	a6, t0, 0x16bc <corpus.cases.call.call_ret_large.narrow+0x90>
+               	j	0x1760 <corpus.cases.call.call_ret_large.narrow+0x134>
                	addi	a4, a1, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -1239,9 +1521,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1280 <corpus.cases.call.call_ret_large.narrow+0xbc>
-               	j	0x12f8 <corpus.cases.call.call_ret_large.narrow+0x134>
-               	bnez	a2, 0x12d0 <corpus.cases.call.call_ret_large.narrow+0x10c>
+               	bne	a6, t0, 0x16e8 <corpus.cases.call.call_ret_large.narrow+0xbc>
+               	j	0x1760 <corpus.cases.call.call_ret_large.narrow+0x134>
+               	bnez	a2, 0x1738 <corpus.cases.call.call_ret_large.narrow+0x10c>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x18
@@ -1251,8 +1533,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x12b0 <corpus.cases.call.call_ret_large.narrow+0xec>
-               	j	0x12f8 <corpus.cases.call.call_ret_large.narrow+0x134>
+               	bne	a5, t0, 0x1718 <corpus.cases.call.call_ret_large.narrow+0xec>
+               	j	0x1760 <corpus.cases.call.call_ret_large.narrow+0x134>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x18
@@ -1262,7 +1544,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x12dc <corpus.cases.call.call_ret_large.narrow+0x118>
+               	bne	a3, t0, 0x1744 <corpus.cases.call.call_ret_large.narrow+0x118>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -1294,8 +1576,8 @@ Disassembly of section .text:
                	or	a3, a5, a4
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a5, a4, 0x13cc <corpus.cases.call.call_ret_large.nest_of+0xc4>
-               	bnez	a3, 0x13a0 <corpus.cases.call.call_ret_large.nest_of+0x98>
+               	bltu	a5, a4, 0x1834 <corpus.cases.call.call_ret_large.nest_of+0xc4>
+               	bnez	a3, 0x1808 <corpus.cases.call.call_ret_large.nest_of+0x98>
                	addi	a6, a5, 0x18
                	addi	a7, a4, 0x18
                	li	t5, 0x18
@@ -1305,8 +1587,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a6)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x1380 <corpus.cases.call.call_ret_large.nest_of+0x78>
-               	j	0x1424 <corpus.cases.call.call_ret_large.nest_of+0x11c>
+               	bne	t5, t0, 0x17e8 <corpus.cases.call.call_ret_large.nest_of+0x78>
+               	j	0x188c <corpus.cases.call.call_ret_large.nest_of+0x11c>
                	addi	a6, a5, 0x18
                	addi	a7, a4, 0x18
                	li	t5, 0x18
@@ -1316,9 +1598,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a6)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x13ac <corpus.cases.call.call_ret_large.nest_of+0xa4>
-               	j	0x1424 <corpus.cases.call.call_ret_large.nest_of+0x11c>
-               	bnez	a3, 0x13fc <corpus.cases.call.call_ret_large.nest_of+0xf4>
+               	bne	t5, t0, 0x1814 <corpus.cases.call.call_ret_large.nest_of+0xa4>
+               	j	0x188c <corpus.cases.call.call_ret_large.nest_of+0x11c>
+               	bnez	a3, 0x1864 <corpus.cases.call.call_ret_large.nest_of+0xf4>
                	mv	a3, a5
                	mv	a6, a4
                	li	a7, 0x18
@@ -1328,8 +1610,8 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x13dc <corpus.cases.call.call_ret_large.nest_of+0xd4>
-               	j	0x1424 <corpus.cases.call.call_ret_large.nest_of+0x11c>
+               	bne	a7, t0, 0x1844 <corpus.cases.call.call_ret_large.nest_of+0xd4>
+               	j	0x188c <corpus.cases.call.call_ret_large.nest_of+0x11c>
                	mv	a3, a5
                	mv	a5, a4
                	li	a4, 0x18
@@ -1339,7 +1621,7 @@ Disassembly of section .text:
                	addi	a5, a5, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x1408 <corpus.cases.call.call_ret_large.nest_of+0x100>
+               	bne	a4, t0, 0x1870 <corpus.cases.call.call_ret_large.nest_of+0x100>
                	addi	a3, s0, -0x68
                	li	t0, 0xb
                	mul	a4, a1, t0
@@ -1354,8 +1636,8 @@ Disassembly of section .text:
                	or	a3, a4, a1
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a4, a1, 0x14bc <corpus.cases.call.call_ret_large.nest_of+0x1b4>
-               	bnez	a3, 0x1490 <corpus.cases.call.call_ret_large.nest_of+0x188>
+               	bltu	a4, a1, 0x1924 <corpus.cases.call.call_ret_large.nest_of+0x1b4>
+               	bnez	a3, 0x18f8 <corpus.cases.call.call_ret_large.nest_of+0x188>
                	addi	a5, a4, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -1365,8 +1647,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1470 <corpus.cases.call.call_ret_large.nest_of+0x168>
-               	j	0x1514 <corpus.cases.call.call_ret_large.nest_of+0x20c>
+               	bne	a7, t0, 0x18d8 <corpus.cases.call.call_ret_large.nest_of+0x168>
+               	j	0x197c <corpus.cases.call.call_ret_large.nest_of+0x20c>
                	addi	a5, a4, 0x10
                	addi	a6, a1, 0x10
                	li	a7, 0x10
@@ -1376,9 +1658,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x149c <corpus.cases.call.call_ret_large.nest_of+0x194>
-               	j	0x1514 <corpus.cases.call.call_ret_large.nest_of+0x20c>
-               	bnez	a3, 0x14ec <corpus.cases.call.call_ret_large.nest_of+0x1e4>
+               	bne	a7, t0, 0x1904 <corpus.cases.call.call_ret_large.nest_of+0x194>
+               	j	0x197c <corpus.cases.call.call_ret_large.nest_of+0x20c>
+               	bnez	a3, 0x1954 <corpus.cases.call.call_ret_large.nest_of+0x1e4>
                	mv	a3, a4
                	mv	a5, a1
                	li	a6, 0x10
@@ -1388,8 +1670,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x14cc <corpus.cases.call.call_ret_large.nest_of+0x1c4>
-               	j	0x1514 <corpus.cases.call.call_ret_large.nest_of+0x20c>
+               	bne	a6, t0, 0x1934 <corpus.cases.call.call_ret_large.nest_of+0x1c4>
+               	j	0x197c <corpus.cases.call.call_ret_large.nest_of+0x20c>
                	mv	a3, a4
                	mv	a4, a1
                	li	a1, 0x10
@@ -1399,14 +1681,14 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x14f8 <corpus.cases.call.call_ret_large.nest_of+0x1f0>
+               	bne	a1, t0, 0x1960 <corpus.cases.call.call_ret_large.nest_of+0x1f0>
                	mv	a1, a0
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x1588 <corpus.cases.call.call_ret_large.nest_of+0x280>
-               	bnez	a2, 0x155c <corpus.cases.call.call_ret_large.nest_of+0x254>
+               	bltu	a1, a3, 0x19f0 <corpus.cases.call.call_ret_large.nest_of+0x280>
+               	bnez	a2, 0x19c4 <corpus.cases.call.call_ret_large.nest_of+0x254>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1416,8 +1698,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x153c <corpus.cases.call.call_ret_large.nest_of+0x234>
-               	j	0x15e0 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
+               	bne	a6, t0, 0x19a4 <corpus.cases.call.call_ret_large.nest_of+0x234>
+               	j	0x1a48 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1427,9 +1709,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1568 <corpus.cases.call.call_ret_large.nest_of+0x260>
-               	j	0x15e0 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
-               	bnez	a2, 0x15b8 <corpus.cases.call.call_ret_large.nest_of+0x2b0>
+               	bne	a6, t0, 0x19d0 <corpus.cases.call.call_ret_large.nest_of+0x260>
+               	j	0x1a48 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
+               	bnez	a2, 0x1a20 <corpus.cases.call.call_ret_large.nest_of+0x2b0>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -1439,8 +1721,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1598 <corpus.cases.call.call_ret_large.nest_of+0x290>
-               	j	0x15e0 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
+               	bne	a5, t0, 0x1a00 <corpus.cases.call.call_ret_large.nest_of+0x290>
+               	j	0x1a48 <corpus.cases.call.call_ret_large.nest_of+0x2d8>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -1450,166 +1732,359 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x15c4 <corpus.cases.call.call_ret_large.nest_of+0x2bc>
+               	bne	a3, t0, 0x1a2c <corpus.cases.call.call_ret_large.nest_of+0x2bc>
                	ld	ra, 0x68(sp)
                	ld	s0, 0x60(sp)
                	addi	sp, sp, 0x70
                	ret
 
 <corpus.cases.call.call_ret_large.take_two>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	sd	s2, 0x40(sp)
-               	sd	s3, 0x38(sp)
-               	sd	s4, 0x30(sp)
-               	sd	s5, 0x28(sp)
-               	sd	s6, 0x20(sp)
-               	sd	s7, 0x18(sp)
-               	sd	s8, 0x10(sp)
-               	sd	s9, 0x8(sp)
-               	sd	s10, 0x0(sp)
-               	mv	a3, a0
+               	addi	sp, sp, -0xa0
+               	sd	ra, 0x98(sp)
+               	sd	s0, 0x90(sp)
+               	addi	s0, sp, 0xa0
+               	sd	s1, 0x88(sp)
+               	sd	s2, 0x80(sp)
+               	sd	s3, 0x78(sp)
+               	sd	s4, 0x70(sp)
+               	sd	s5, 0x68(sp)
+               	sd	s6, 0x60(sp)
+               	sd	s7, 0x58(sp)
                	mv	s1, a2
-               	mv	a2, a3
+               	mv	a2, a0
+               	ld	a3, 0x0(a2)
+               	addi	a2, a0, 0x8
                	ld	s2, 0x0(a2)
-               	addi	a2, a3, 0x8
+               	addi	a2, a0, 0x10
                	ld	s3, 0x0(a2)
-               	addi	a2, a3, 0x10
+               	addi	a2, a0, 0x18
                	ld	s4, 0x0(a2)
-               	addi	a2, a3, 0x18
+               	addi	a2, a0, 0x20
                	ld	s5, 0x0(a2)
-               	addi	a2, a3, 0x20
+               	addi	a2, a0, 0x28
                	ld	s6, 0x0(a2)
-               	addi	a2, a3, 0x28
-               	ld	s7, 0x0(a2)
+               	addi	s7, s0, -0x60
+               	mv	a0, s7
                	mv	a2, a1
-               	ld	s8, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	ld	s9, 0x0(a2)
-               	addi	a2, a1, 0x10
-               	ld	s10, 0x0(a2)
+               	or	a1, a0, a2
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a0, a2, 0x1b30 <corpus.cases.call.call_ret_large.take_two+0xd8>
+               	bnez	a1, 0x1b04 <corpus.cases.call.call_ret_large.take_two+0xac>
+               	addi	a4, a0, 0x18
+               	addi	a5, a2, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1ae4 <corpus.cases.call.call_ret_large.take_two+0x8c>
+               	j	0x1b88 <corpus.cases.call.call_ret_large.take_two+0x130>
+               	addi	a4, a0, 0x18
+               	addi	a5, a2, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1b10 <corpus.cases.call.call_ret_large.take_two+0xb8>
+               	j	0x1b88 <corpus.cases.call.call_ret_large.take_two+0x130>
+               	bnez	a1, 0x1b60 <corpus.cases.call.call_ret_large.take_two+0x108>
+               	mv	a1, a0
+               	mv	a4, a2
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x1b40 <corpus.cases.call.call_ret_large.take_two+0xe8>
+               	j	0x1b88 <corpus.cases.call.call_ret_large.take_two+0x130>
+               	mv	a1, a0
+               	mv	a0, a2
+               	li	a2, 0x18
+               	lbu	a4, 0x0(a0)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x1b6c <corpus.cases.call.call_ret_large.take_two+0x114>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x88>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x154>
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x94>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x160>
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xa0>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x16c>
                	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xac>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x178>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xb8>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x184>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xc4>
-               	mv	a1, s7
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x190>
+               	addi	a1, s0, -0x78
+               	mv	a2, a1
+               	mv	a3, s7
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x1c68 <corpus.cases.call.call_ret_large.take_two+0x210>
+               	bnez	a4, 0x1c3c <corpus.cases.call.call_ret_large.take_two+0x1e4>
+               	addi	a5, a2, 0x18
+               	addi	a6, a3, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1c1c <corpus.cases.call.call_ret_large.take_two+0x1c4>
+               	j	0x1cc0 <corpus.cases.call.call_ret_large.take_two+0x268>
+               	addi	a5, a2, 0x18
+               	addi	a6, a3, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1c48 <corpus.cases.call.call_ret_large.take_two+0x1f0>
+               	j	0x1cc0 <corpus.cases.call.call_ret_large.take_two+0x268>
+               	bnez	a4, 0x1c98 <corpus.cases.call.call_ret_large.take_two+0x240>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1c78 <corpus.cases.call.call_ret_large.take_two+0x220>
+               	j	0x1cc0 <corpus.cases.call.call_ret_large.take_two+0x268>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x18
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1ca4 <corpus.cases.call.call_ret_large.take_two+0x24c>
+               	addi	a2, s0, -0x90
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x1d34 <corpus.cases.call.call_ret_large.take_two+0x2dc>
+               	bnez	a1, 0x1d08 <corpus.cases.call.call_ret_large.take_two+0x2b0>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1ce8 <corpus.cases.call.call_ret_large.take_two+0x290>
+               	j	0x1d8c <corpus.cases.call.call_ret_large.take_two+0x334>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1d14 <corpus.cases.call.call_ret_large.take_two+0x2bc>
+               	j	0x1d8c <corpus.cases.call.call_ret_large.take_two+0x334>
+               	bnez	a1, 0x1d64 <corpus.cases.call.call_ret_large.take_two+0x30c>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x1d44 <corpus.cases.call.call_ret_large.take_two+0x2ec>
+               	j	0x1d8c <corpus.cases.call.call_ret_large.take_two+0x334>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1d70 <corpus.cases.call.call_ret_large.take_two+0x318>
+               	addi	a1, s0, -0x90
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xd0>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xdc>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xe8>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0xf4>
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x338>
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x100>
-               	ld	s1, 0x48(sp)
-               	ld	s2, 0x40(sp)
-               	ld	s3, 0x38(sp)
-               	ld	s4, 0x30(sp)
-               	ld	s5, 0x28(sp)
-               	ld	s6, 0x20(sp)
-               	ld	s7, 0x18(sp)
-               	ld	s8, 0x10(sp)
-               	ld	s9, 0x8(sp)
-               	ld	s10, 0x0(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	jalr	ra <corpus.cases.call.call_ret_large.take_two+0x344>
+               	ld	s1, 0x88(sp)
+               	ld	s2, 0x80(sp)
+               	ld	s3, 0x78(sp)
+               	ld	s4, 0x70(sp)
+               	ld	s5, 0x68(sp)
+               	ld	s6, 0x60(sp)
+               	ld	s7, 0x58(sp)
+               	ld	ra, 0x98(sp)
+               	ld	s0, 0x90(sp)
+               	addi	sp, sp, 0xa0
                	ret
 
 <corpus.cases.call.call_ret_large.checksum>:
-               	addi	sp, sp, -0x700
-               	sd	ra, 0x6f8(sp)
-               	sd	s0, 0x6f0(sp)
-               	addi	s0, sp, 0x700
-               	sd	s1, 0x6e8(sp)
-               	sd	s2, 0x6e0(sp)
-               	sd	s3, 0x6d8(sp)
-               	sd	s4, 0x6d0(sp)
-               	sd	s5, 0x6c8(sp)
-               	sd	s6, 0x6c0(sp)
-               	sd	s7, 0x6b8(sp)
-               	sd	s8, 0x6b0(sp)
-               	sd	s9, 0x6a8(sp)
-               	sd	s10, 0x6a0(sp)
-               	sd	s11, 0x698(sp)
-               	fsd	fs0, 0x690(sp)
-               	fsd	fs1, 0x688(sp)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x700
+               	sub	sp, sp, t0
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x708
+               	add	t1, sp, t1
+               	sd	ra, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x710
+               	add	t1, sp, t1
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x700
+               	add	s0, sp, t0
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x718
+               	add	t1, sp, t1
+               	sd	s1, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x720
+               	add	t1, sp, t1
+               	sd	s2, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x728
+               	add	t1, sp, t1
+               	sd	s3, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x730
+               	add	t1, sp, t1
+               	sd	s4, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x738
+               	add	t1, sp, t1
+               	sd	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x740
+               	add	t1, sp, t1
+               	sd	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x748
+               	add	t1, sp, t1
+               	sd	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x750
+               	add	t1, sp, t1
+               	sd	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x758
+               	add	t1, sp, t1
+               	sd	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x760
+               	add	t1, sp, t1
+               	sd	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x768
+               	add	t1, sp, t1
+               	sd	s11, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x770
+               	add	t1, sp, t1
+               	fsd	fs0, 0x0(t1)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x48>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	li	a1, 0x14
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x54>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x120>
                	li	a1, 0x18
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x60>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x12c>
                	li	a1, 0x18
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x6c>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x138>
                	li	a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x78>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x144>
                	li	a1, 0x28
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x84>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x150>
                	li	a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x90>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x15c>
                	li	a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x9c>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x168>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0xa8>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x174>
                	li	a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0xb4>
-               	addi	s2, s0, -0x268
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x180>
+               	addi	s2, s0, -0x3c8
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x1820 <corpus.cases.call.call_ret_large.checksum+0xf0>
+               	bnez	a2, 0x1f8c <corpus.cases.call.call_ret_large.checksum+0x1bc>
                	mv	a2, a1
                	li	a3, 0x40
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x1808 <corpus.cases.call.call_ret_large.checksum+0xd8>
-               	j	0x183c <corpus.cases.call.call_ret_large.checksum+0x10c>
+               	bne	a3, t0, 0x1f74 <corpus.cases.call.call_ret_large.checksum+0x1a4>
+               	j	0x1fa8 <corpus.cases.call.call_ret_large.checksum+0x1d8>
                	mv	a2, a1
                	li	a1, 0x40
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1828 <corpus.cases.call.call_ret_large.checksum+0xf8>
+               	bne	a1, t0, 0x1f94 <corpus.cases.call.call_ret_large.checksum+0x1c4>
                	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	a1, t0, 0x184c <corpus.cases.call.call_ret_large.checksum+0x11c>
-               	j	0x18b0 <corpus.cases.call.call_ret_large.checksum+0x180>
+               	bltu	a1, t0, 0x1fb8 <corpus.cases.call.call_ret_large.checksum+0x1e8>
+               	j	0x201c <corpus.cases.call.call_ret_large.checksum+0x24c>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -1634,53 +2109,186 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0x8
-               	bltu	a1, t0, 0x184c <corpus.cases.call.call_ret_large.checksum+0x11c>
+               	bltu	a1, t0, 0x1fb8 <corpus.cases.call.call_ret_large.checksum+0x1e8>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x18c4 <corpus.cases.call.call_ret_large.checksum+0x194>
-               	j	0x1e04 <.Lpcrel_hi.9+0x3b0>
+               	bltu	s4, t0, 0x2030 <corpus.cases.call.call_ret_large.checksum+0x260>
+               	j	0x2b68 <.Lpcrel_hi.9+0x610>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	s5, a1, s1
-               	sext.w	a1, s5
-               	srli	a0, s5, 0x8
-               	sext.w	s6, a0
-               	srli	a0, s5, 0x10
-               	sext.w	s7, a0
-               	srli	a0, s5, 0x18
-               	sext.w	s8, a0
-               	srli	a0, s5, 0x20
-               	sext.w	s9, a0
+               	sext.w	a0, s5
+               	srli	a1, s5, 0x8
+               	sext.w	a2, a1
+               	srli	a1, s5, 0x10
+               	sext.w	a3, a1
+               	srli	a1, s5, 0x18
+               	sext.w	a4, a1
+               	srli	a1, s5, 0x20
+               	sext.w	a5, a1
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
                	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x1cc>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x1d8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x1e4>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x1f0>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x1fc>
-               	not	s6, s5
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2080 <corpus.cases.call.call_ret_large.checksum+0x2b0>
+               	j	0x20b4 <corpus.cases.call.call_ret_large.checksum+0x2e4>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a1, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a0, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2080 <corpus.cases.call.call_ret_large.checksum+0x2b0>
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20cc <corpus.cases.call.call_ret_large.checksum+0x2fc>
+               	j	0x2100 <corpus.cases.call.call_ret_large.checksum+0x330>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a7, a1, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a0, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20cc <corpus.cases.call.call_ret_large.checksum+0x2fc>
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2118 <corpus.cases.call.call_ret_large.checksum+0x348>
+               	j	0x214c <corpus.cases.call.call_ret_large.checksum+0x37c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a6, a1, a3
+               	li	t0, 0xff
+               	and	a3, a6, t0
+               	xor	a6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2118 <corpus.cases.call.call_ret_large.checksum+0x348>
+               	slli	a1, a4, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2164 <corpus.cases.call.call_ret_large.checksum+0x394>
+               	j	0x2198 <corpus.cases.call.call_ret_large.checksum+0x3c8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2164 <corpus.cases.call.call_ret_large.checksum+0x394>
+               	slli	a1, a5, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21b0 <corpus.cases.call.call_ret_large.checksum+0x3e0>
+               	j	0x21e4 <corpus.cases.call.call_ret_large.checksum+0x414>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21b0 <corpus.cases.call.call_ret_large.checksum+0x3e0>
+               	addi	a1, s0, -0x4b0
+               	mv	a2, a1
+               	sd	s5, 0x0(a2)
+               	not	a2, s5
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
                	li	t0, 0x3
-               	mul	a1, s5, t0
-               	addi	s7, a1, 0x1
-               	mv	a1, s5
+               	mul	a2, s5, t0
+               	addi	a3, a2, 0x1
+               	addi	a2, a1, 0x10
+               	sd	a3, 0x0(a2)
+               	addi	a2, s0, -0x4c8
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x2284 <corpus.cases.call.call_ret_large.checksum+0x4b4>
+               	bnez	a1, 0x2258 <corpus.cases.call.call_ret_large.checksum+0x488>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2238 <corpus.cases.call.call_ret_large.checksum+0x468>
+               	j	0x22dc <corpus.cases.call.call_ret_large.checksum+0x50c>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2264 <corpus.cases.call.call_ret_large.checksum+0x494>
+               	j	0x22dc <corpus.cases.call.call_ret_large.checksum+0x50c>
+               	bnez	a1, 0x22b4 <corpus.cases.call.call_ret_large.checksum+0x4e4>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2294 <corpus.cases.call.call_ret_large.checksum+0x4c4>
+               	j	0x22dc <corpus.cases.call.call_ret_large.checksum+0x50c>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x22c0 <corpus.cases.call.call_ret_large.checksum+0x4f0>
+               	addi	a1, s0, -0x4c8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x218>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x224>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x230>
+               	jalr	ra <corpus.cases.call.call_ret_large.checksum+0x510>
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
                	and	a1, s5, t0
@@ -1689,7 +2297,7 @@ Disassembly of section .text:
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a1, s5, t0
@@ -1698,7 +2306,7 @@ Disassembly of section .text:
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fsub.d	fs0, ft0, ft10
+               	fsub.d	ft2, ft0, ft10
                	lui	t0, 0x40
                	addiw	t0, t0, -0x1
                	and	a1, s5, t0
@@ -1707,31 +2315,128 @@ Disassembly of section .text:
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs1, ft0, ft10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0xc>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x18>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x24>
-               	addi	s6, s5, 0x1
+               	fdiv.d	ft3, ft0, ft10
+               	fmv.x.d	a1, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2350 <.Lpcrel_hi.7+0x20>
+               	j	0x2384 <.Lpcrel_hi.7+0x54>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2350 <.Lpcrel_hi.7+0x20>
+               	fmv.x.d	a1, ft2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2398 <.Lpcrel_hi.7+0x68>
+               	j	0x23cc <.Lpcrel_hi.7+0x9c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2398 <.Lpcrel_hi.7+0x68>
+               	fmv.x.d	a1, ft3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23e0 <.Lpcrel_hi.7+0xb0>
+               	j	0x2414 <.Lpcrel_hi.7+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23e0 <.Lpcrel_hi.7+0xb0>
+               	addi	a1, s0, -0x650
+               	mv	a2, a1
+               	sd	s5, 0x0(a2)
+               	addi	a2, s5, 0x1
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
                	li	t0, 0x5
-               	mul	s7, s5, t0
-               	not	s8, s5
-               	mv	a1, s5
+               	mul	a2, s5, t0
+               	addi	a3, a1, 0x10
+               	sd	a2, 0x0(a3)
+               	not	a2, s5
+               	addi	a3, a1, 0x18
+               	sd	a2, 0x0(a3)
+               	addi	a2, s0, -0x670
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x24bc <.Lpcrel_hi.7+0x18c>
+               	bnez	a1, 0x2490 <.Lpcrel_hi.7+0x160>
+               	addi	a4, a2, 0x20
+               	addi	a5, a3, 0x20
+               	li	a6, 0x20
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2470 <.Lpcrel_hi.7+0x140>
+               	j	0x2514 <.Lpcrel_hi.7+0x1e4>
+               	addi	a4, a2, 0x20
+               	addi	a5, a3, 0x20
+               	li	a6, 0x20
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x249c <.Lpcrel_hi.7+0x16c>
+               	j	0x2514 <.Lpcrel_hi.7+0x1e4>
+               	bnez	a1, 0x24ec <.Lpcrel_hi.7+0x1bc>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x20
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x24cc <.Lpcrel_hi.7+0x19c>
+               	j	0x2514 <.Lpcrel_hi.7+0x1e4>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x20
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x24f8 <.Lpcrel_hi.7+0x1c8>
+               	addi	a1, s0, -0x670
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x40>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x4c>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x58>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x64>
+               	jalr	ra <.Lpcrel_hi.7+0x1e8>
                	lui	t0, 0x2
                	addiw	t0, t0, -0x1
                	and	a1, s5, t0
@@ -1740,7 +2445,7 @@ Disassembly of section .text:
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
                	sext.w	s6, s5
                	srli	a1, s5, 0x10
                	sext.w	s7, a1
@@ -1752,27 +2457,43 @@ Disassembly of section .text:
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs1, ft0, ft10
+               	fdiv.d	fs0, ft0, ft10
                	li	t0, 0x7
                	mul	s8, s5, t0
-               	mv	a1, s5
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x257c <.Lpcrel_hi.9+0x24>
+               	j	0x25b0 <.Lpcrel_hi.9+0x58>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s5, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x257c <.Lpcrel_hi.9+0x24>
+               	fmv.x.d	a1, ft1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x18>
-               	fmv.d	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.9+0x5c>
+               	slli	a1, s6, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x24>
-               	mv	a1, s6
+               	jalr	ra <.Lpcrel_hi.9+0x6c>
+               	slli	a1, s7, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x30>
-               	mv	a1, s7
+               	jalr	ra <.Lpcrel_hi.9+0x7c>
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x3c>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x48>
+               	jalr	ra <.Lpcrel_hi.9+0x88>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x54>
+               	jalr	ra <.Lpcrel_hi.9+0x94>
                	addi	s6, s5, 0x1
                	addi	s7, s5, 0x2
                	li	t0, 0x9
@@ -1785,27 +2506,31 @@ Disassembly of section .text:
                	xor	s10, s5, t0
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x88>
+               	jalr	ra <.Lpcrel_hi.9+0xc8>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x94>
+               	jalr	ra <.Lpcrel_hi.9+0xd4>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xa0>
+               	jalr	ra <.Lpcrel_hi.9+0xe0>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xac>
+               	jalr	ra <.Lpcrel_hi.9+0xec>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xb8>
+               	jalr	ra <.Lpcrel_hi.9+0xf8>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xc4>
-               	addi	a1, s0, -0x688
+               	jalr	ra <.Lpcrel_hi.9+0x104>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x798
+               	add	a1, s0, t0
                	sext.w	a2, s5
                	mv	a3, a1
                	sw	a2, 0x0(a3)
-               	addi	a2, s0, -0x6a0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x780
+               	add	a2, s0, t0
                	mv	a3, a2
                	sd	s5, 0x0(a3)
                	not	a3, s5
@@ -1822,8 +2547,8 @@ Disassembly of section .text:
                	or	a2, a4, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a4, a3, 0x1bd4 <.Lpcrel_hi.9+0x180>
-               	bnez	a2, 0x1ba8 <.Lpcrel_hi.9+0x154>
+               	bltu	a4, a3, 0x2728 <.Lpcrel_hi.9+0x1d0>
+               	bnez	a2, 0x26fc <.Lpcrel_hi.9+0x1a4>
                	addi	a5, a4, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -1833,8 +2558,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1b88 <.Lpcrel_hi.9+0x134>
-               	j	0x1c2c <.Lpcrel_hi.9+0x1d8>
+               	bne	a7, t0, 0x26dc <.Lpcrel_hi.9+0x184>
+               	j	0x2780 <.Lpcrel_hi.9+0x228>
                	addi	a5, a4, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -1844,9 +2569,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1bb4 <.Lpcrel_hi.9+0x160>
-               	j	0x1c2c <.Lpcrel_hi.9+0x1d8>
-               	bnez	a2, 0x1c04 <.Lpcrel_hi.9+0x1b0>
+               	bne	a7, t0, 0x2708 <.Lpcrel_hi.9+0x1b0>
+               	j	0x2780 <.Lpcrel_hi.9+0x228>
+               	bnez	a2, 0x2758 <.Lpcrel_hi.9+0x200>
                	mv	a2, a4
                	mv	a5, a3
                	li	a6, 0x18
@@ -1856,8 +2581,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1be4 <.Lpcrel_hi.9+0x190>
-               	j	0x1c2c <.Lpcrel_hi.9+0x1d8>
+               	bne	a6, t0, 0x2738 <.Lpcrel_hi.9+0x1e0>
+               	j	0x2780 <.Lpcrel_hi.9+0x228>
                	mv	a2, a4
                	mv	a4, a3
                	li	a3, 0x18
@@ -1867,8 +2592,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1c10 <.Lpcrel_hi.9+0x1bc>
-               	addi	a2, s0, -0x6b0
+               	bne	a3, t0, 0x2764 <.Lpcrel_hi.9+0x20c>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x770
+               	add	a2, s0, t0
                	li	t0, 0xb
                	mul	a3, s5, t0
                	mv	a4, a2
@@ -1882,8 +2609,8 @@ Disassembly of section .text:
                	or	a2, a4, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a4, a3, 0x1cc4 <.Lpcrel_hi.9+0x270>
-               	bnez	a2, 0x1c98 <.Lpcrel_hi.9+0x244>
+               	bltu	a4, a3, 0x2820 <.Lpcrel_hi.9+0x2c8>
+               	bnez	a2, 0x27f4 <.Lpcrel_hi.9+0x29c>
                	addi	a5, a4, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -1893,8 +2620,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1c78 <.Lpcrel_hi.9+0x224>
-               	j	0x1d1c <.Lpcrel_hi.9+0x2c8>
+               	bne	a7, t0, 0x27d4 <.Lpcrel_hi.9+0x27c>
+               	j	0x2878 <.Lpcrel_hi.9+0x320>
                	addi	a5, a4, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -1904,9 +2631,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1ca4 <.Lpcrel_hi.9+0x250>
-               	j	0x1d1c <.Lpcrel_hi.9+0x2c8>
-               	bnez	a2, 0x1cf4 <.Lpcrel_hi.9+0x2a0>
+               	bne	a7, t0, 0x2800 <.Lpcrel_hi.9+0x2a8>
+               	j	0x2878 <.Lpcrel_hi.9+0x320>
+               	bnez	a2, 0x2850 <.Lpcrel_hi.9+0x2f8>
                	mv	a2, a4
                	mv	a5, a3
                	li	a6, 0x10
@@ -1916,8 +2643,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1cd4 <.Lpcrel_hi.9+0x280>
-               	j	0x1d1c <.Lpcrel_hi.9+0x2c8>
+               	bne	a6, t0, 0x2830 <.Lpcrel_hi.9+0x2d8>
+               	j	0x2878 <.Lpcrel_hi.9+0x320>
                	mv	a2, a4
                	mv	a4, a3
                	li	a3, 0x10
@@ -1927,14 +2654,17 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1d00 <.Lpcrel_hi.9+0x2ac>
-               	addi	a2, s0, -0x6e0
+               	bne	a3, t0, 0x285c <.Lpcrel_hi.9+0x304>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x740
+               	add	s5, s0, t0
+               	mv	a2, s5
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1d90 <.Lpcrel_hi.9+0x33c>
-               	bnez	a1, 0x1d64 <.Lpcrel_hi.9+0x310>
+               	bltu	a2, a3, 0x28f8 <.Lpcrel_hi.9+0x3a0>
+               	bnez	a1, 0x28cc <.Lpcrel_hi.9+0x374>
                	addi	a4, a2, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1944,8 +2674,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1d44 <.Lpcrel_hi.9+0x2f0>
-               	j	0x1de8 <.Lpcrel_hi.9+0x394>
+               	bne	a6, t0, 0x28ac <.Lpcrel_hi.9+0x354>
+               	j	0x2950 <.Lpcrel_hi.9+0x3f8>
                	addi	a4, a2, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -1955,9 +2685,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1d70 <.Lpcrel_hi.9+0x31c>
-               	j	0x1de8 <.Lpcrel_hi.9+0x394>
-               	bnez	a1, 0x1dc0 <.Lpcrel_hi.9+0x36c>
+               	bne	a6, t0, 0x28d8 <.Lpcrel_hi.9+0x380>
+               	j	0x2950 <.Lpcrel_hi.9+0x3f8>
+               	bnez	a1, 0x2928 <.Lpcrel_hi.9+0x3d0>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x30
@@ -1967,8 +2697,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1da0 <.Lpcrel_hi.9+0x34c>
-               	j	0x1de8 <.Lpcrel_hi.9+0x394>
+               	bne	a5, t0, 0x2908 <.Lpcrel_hi.9+0x3b0>
+               	j	0x2950 <.Lpcrel_hi.9+0x3f8>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x30
@@ -1978,52 +2708,393 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1dcc <.Lpcrel_hi.9+0x378>
-               	addi	a1, s0, -0x6e0
+               	bne	a3, t0, 0x2934 <.Lpcrel_hi.9+0x3dc>
+               	mv	a1, s5
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x398>
+               	jalr	ra <.Lpcrel_hi.9+0x408>
+               	addi	a1, s5, 0x8
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x728
+               	add	a2, s0, t0
+               	mv	a3, a2
+               	mv	a4, a1
+               	or	a1, a3, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, a4, 0x29ec <.Lpcrel_hi.9+0x494>
+               	bnez	a1, 0x29c0 <.Lpcrel_hi.9+0x468>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x29a0 <.Lpcrel_hi.9+0x448>
+               	j	0x2a44 <.Lpcrel_hi.9+0x4ec>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x29cc <.Lpcrel_hi.9+0x474>
+               	j	0x2a44 <.Lpcrel_hi.9+0x4ec>
+               	bnez	a1, 0x2a1c <.Lpcrel_hi.9+0x4c4>
+               	mv	a1, a3
+               	mv	a5, a4
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x29fc <.Lpcrel_hi.9+0x4a4>
+               	j	0x2a44 <.Lpcrel_hi.9+0x4ec>
+               	mv	a1, a3
+               	mv	a3, a4
+               	li	a4, 0x18
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x2a28 <.Lpcrel_hi.9+0x4d0>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x710
+               	add	a1, s0, t0
+               	mv	a3, a2
+               	or	a2, a1, a3
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a1, a3, 0x2ac0 <.Lpcrel_hi.9+0x568>
+               	bnez	a2, 0x2a94 <.Lpcrel_hi.9+0x53c>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2a74 <.Lpcrel_hi.9+0x51c>
+               	j	0x2b18 <.Lpcrel_hi.9+0x5c0>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2aa0 <.Lpcrel_hi.9+0x548>
+               	j	0x2b18 <.Lpcrel_hi.9+0x5c0>
+               	bnez	a2, 0x2af0 <.Lpcrel_hi.9+0x598>
+               	mv	a2, a1
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2ad0 <.Lpcrel_hi.9+0x578>
+               	j	0x2b18 <.Lpcrel_hi.9+0x5c0>
+               	mv	a2, a1
+               	mv	a1, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x2afc <.Lpcrel_hi.9+0x5a4>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x710
+               	add	a1, s0, t0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x5cc>
+               	addi	s6, s5, 0x20
+               	mv	a1, s6
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x5e4>
+               	addi	a1, s6, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x5f8>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x18c4 <corpus.cases.call.call_ret_large.checksum+0x194>
+               	bltu	s4, t0, 0x2030 <corpus.cases.call.call_ret_large.checksum+0x260>
+               	addi	s4, s0, -0x88
                	addi	a0, s1, 0x1
-               	not	a1, a0
+               	addi	a1, s0, -0x290
+               	mv	a2, a1
+               	sd	a0, 0x0(a2)
+               	not	a2, a0
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
                	li	t0, 0x3
                	mul	a2, a0, t0
-               	addi	a3, a2, 0x1
-               	li	s4, 0x0
-               	mv	s5, a0
-               	mv	s6, a1
-               	mv	s7, a3
+               	addi	a0, a2, 0x1
+               	addi	a2, a1, 0x10
+               	sd	a0, 0x0(a2)
+               	mv	a0, s4
+               	mv	a2, a1
+               	or	a1, a0, a2
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a0, a2, 0x2c10 <.Lpcrel_hi.9+0x6b8>
+               	bnez	a1, 0x2be4 <.Lpcrel_hi.9+0x68c>
+               	addi	a3, a0, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2bc4 <.Lpcrel_hi.9+0x66c>
+               	j	0x2c68 <.Lpcrel_hi.9+0x710>
+               	addi	a3, a0, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2bf0 <.Lpcrel_hi.9+0x698>
+               	j	0x2c68 <.Lpcrel_hi.9+0x710>
+               	bnez	a1, 0x2c40 <.Lpcrel_hi.9+0x6e8>
+               	mv	a1, a0
+               	mv	a3, a2
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x2c20 <.Lpcrel_hi.9+0x6c8>
+               	j	0x2c68 <.Lpcrel_hi.9+0x710>
+               	mv	a1, a0
+               	mv	a0, a2
+               	li	a2, 0x18
+               	lbu	a3, 0x0(a0)
+               	sb	a3, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x2c4c <.Lpcrel_hi.9+0x6f4>
+               	li	s5, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1e34 <.Lpcrel_hi.9+0x3e0>
-               	j	0x1e90 <.Lpcrel_hi.9+0x43c>
-               	slli	t0, s4, 0x3
-               	add	a0, s2, t0
+               	bltu	s5, t0, 0x2c78 <.Lpcrel_hi.9+0x720>
+               	j	0x2f4c <.Lpcrel_hi.9+0x9f4>
+               	mv	a0, s4
                	ld	a1, 0x0(a0)
-               	add	s8, s5, a1
-               	xor	s9, s6, a1
-               	add	s10, s7, s5
+               	addi	a0, s4, 0x8
+               	ld	a2, 0x0(a0)
+               	addi	a0, s4, 0x10
+               	ld	a3, 0x0(a0)
+               	slli	t0, s5, 0x3
+               	add	a0, s2, t0
+               	ld	a4, 0x0(a0)
+               	addi	a0, s0, -0x2a8
+               	add	a5, a1, a4
+               	mv	a6, a0
+               	sd	a5, 0x0(a6)
+               	xor	a5, a2, a4
+               	addi	a2, a0, 0x8
+               	sd	a5, 0x0(a2)
+               	add	a2, a3, a1
+               	addi	a1, a0, 0x10
+               	sd	a2, 0x0(a1)
+               	mv	a1, s4
+               	mv	a2, a0
+               	or	a0, a1, a2
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a1, a2, 0x2d38 <.Lpcrel_hi.9+0x7e0>
+               	bnez	a0, 0x2d0c <.Lpcrel_hi.9+0x7b4>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2cec <.Lpcrel_hi.9+0x794>
+               	j	0x2d90 <.Lpcrel_hi.9+0x838>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2d18 <.Lpcrel_hi.9+0x7c0>
+               	j	0x2d90 <.Lpcrel_hi.9+0x838>
+               	bnez	a0, 0x2d68 <.Lpcrel_hi.9+0x810>
+               	mv	a0, a1
+               	mv	a3, a2
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x2d48 <.Lpcrel_hi.9+0x7f0>
+               	j	0x2d90 <.Lpcrel_hi.9+0x838>
+               	mv	a0, a1
+               	mv	a1, a2
+               	li	a2, 0x18
+               	lbu	a3, 0x0(a1)
+               	sb	a3, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x2d74 <.Lpcrel_hi.9+0x81c>
+               	addi	a0, s0, -0x2c0
+               	mv	a1, a0
+               	mv	a2, s4
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0x2e08 <.Lpcrel_hi.9+0x8b0>
+               	bnez	a3, 0x2ddc <.Lpcrel_hi.9+0x884>
+               	addi	a4, a1, 0x18
+               	addi	a5, a2, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2dbc <.Lpcrel_hi.9+0x864>
+               	j	0x2e60 <.Lpcrel_hi.9+0x908>
+               	addi	a4, a1, 0x18
+               	addi	a5, a2, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x2de8 <.Lpcrel_hi.9+0x890>
+               	j	0x2e60 <.Lpcrel_hi.9+0x908>
+               	bnez	a3, 0x2e38 <.Lpcrel_hi.9+0x8e0>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2e18 <.Lpcrel_hi.9+0x8c0>
+               	j	0x2e60 <.Lpcrel_hi.9+0x908>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x18
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x2e44 <.Lpcrel_hi.9+0x8ec>
+               	addi	a1, s0, -0x2d8
+               	mv	a2, a0
+               	or	a0, a1, a2
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a1, a2, 0x2ed4 <.Lpcrel_hi.9+0x97c>
+               	bnez	a0, 0x2ea8 <.Lpcrel_hi.9+0x950>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2e88 <.Lpcrel_hi.9+0x930>
+               	j	0x2f2c <.Lpcrel_hi.9+0x9d4>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2eb4 <.Lpcrel_hi.9+0x95c>
+               	j	0x2f2c <.Lpcrel_hi.9+0x9d4>
+               	bnez	a0, 0x2f04 <.Lpcrel_hi.9+0x9ac>
+               	mv	a0, a1
+               	mv	a3, a2
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x2ee4 <.Lpcrel_hi.9+0x98c>
+               	j	0x2f2c <.Lpcrel_hi.9+0x9d4>
+               	mv	a0, a1
+               	mv	a1, a2
+               	li	a2, 0x18
+               	lbu	a3, 0x0(a1)
+               	sb	a3, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x2f10 <.Lpcrel_hi.9+0x9b8>
+               	addi	a1, s0, -0x2d8
                	mv	a0, s3
-               	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x400>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x40c>
-               	mv	a1, s10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x418>
-               	addi	s4, s4, 0x1
+               	jalr	ra <.Lpcrel_hi.9+0x9dc>
+               	addi	s5, s5, 0x1
                	mv	s3, a0
-               	mv	s5, s8
-               	mv	s6, s9
-               	mv	s7, s10
                	li	t0, 0x8
-               	bltu	s4, t0, 0x1e34 <.Lpcrel_hi.9+0x3e0>
-               	addi	s4, s0, -0xa8
+               	bltu	s5, t0, 0x2c78 <.Lpcrel_hi.9+0x720>
+               	addi	s4, s0, -0xb8
                	addi	a0, s1, 0x2
-               	addi	a1, s0, -0x298
+               	addi	a1, s0, -0x308
                	mv	a2, a1
                	sd	a0, 0x0(a2)
                	addi	a2, a0, 0x1
@@ -2051,8 +3122,8 @@ Disassembly of section .text:
                	or	a1, a0, a2
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a0, a2, 0x1f68 <.Lpcrel_hi.9+0x514>
-               	bnez	a1, 0x1f3c <.Lpcrel_hi.9+0x4e8>
+               	bltu	a0, a2, 0x3024 <.Lpcrel_hi.9+0xacc>
+               	bnez	a1, 0x2ff8 <.Lpcrel_hi.9+0xaa0>
                	addi	a3, a0, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2062,8 +3133,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1f1c <.Lpcrel_hi.9+0x4c8>
-               	j	0x1fc0 <.Lpcrel_hi.9+0x56c>
+               	bne	a5, t0, 0x2fd8 <.Lpcrel_hi.9+0xa80>
+               	j	0x307c <.Lpcrel_hi.9+0xb24>
                	addi	a3, a0, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2073,9 +3144,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x1f48 <.Lpcrel_hi.9+0x4f4>
-               	j	0x1fc0 <.Lpcrel_hi.9+0x56c>
-               	bnez	a1, 0x1f98 <.Lpcrel_hi.9+0x544>
+               	bne	a5, t0, 0x3004 <.Lpcrel_hi.9+0xaac>
+               	j	0x307c <.Lpcrel_hi.9+0xb24>
+               	bnez	a1, 0x3054 <.Lpcrel_hi.9+0xafc>
                	mv	a1, a0
                	mv	a3, a2
                	li	a4, 0x30
@@ -2085,8 +3156,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x1f78 <.Lpcrel_hi.9+0x524>
-               	j	0x1fc0 <.Lpcrel_hi.9+0x56c>
+               	bne	a4, t0, 0x3034 <.Lpcrel_hi.9+0xadc>
+               	j	0x307c <.Lpcrel_hi.9+0xb24>
                	mv	a1, a0
                	mv	a0, a2
                	li	a2, 0x30
@@ -2096,19 +3167,19 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x1fa4 <.Lpcrel_hi.9+0x550>
+               	bne	a2, t0, 0x3060 <.Lpcrel_hi.9+0xb08>
                	li	s5, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x1fd0 <.Lpcrel_hi.9+0x57c>
-               	j	0x22e0 <.Lpcrel_hi.9+0x88c>
-               	addi	a0, s0, -0xd8
+               	bltu	s5, t0, 0x308c <.Lpcrel_hi.9+0xb34>
+               	j	0x339c <.Lpcrel_hi.9+0xe44>
+               	addi	a0, s0, -0xe8
                	mv	a1, a0
                	mv	a2, s4
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0x2048 <.Lpcrel_hi.9+0x5f4>
-               	bnez	a3, 0x201c <.Lpcrel_hi.9+0x5c8>
+               	bltu	a1, a2, 0x3104 <.Lpcrel_hi.9+0xbac>
+               	bnez	a3, 0x30d8 <.Lpcrel_hi.9+0xb80>
                	addi	a4, a1, 0x30
                	addi	a5, a2, 0x30
                	li	a6, 0x30
@@ -2118,8 +3189,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1ffc <.Lpcrel_hi.9+0x5a8>
-               	j	0x20a0 <.Lpcrel_hi.9+0x64c>
+               	bne	a6, t0, 0x30b8 <.Lpcrel_hi.9+0xb60>
+               	j	0x315c <.Lpcrel_hi.9+0xc04>
                	addi	a4, a1, 0x30
                	addi	a5, a2, 0x30
                	li	a6, 0x30
@@ -2129,9 +3200,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2028 <.Lpcrel_hi.9+0x5d4>
-               	j	0x20a0 <.Lpcrel_hi.9+0x64c>
-               	bnez	a3, 0x2078 <.Lpcrel_hi.9+0x624>
+               	bne	a6, t0, 0x30e4 <.Lpcrel_hi.9+0xb8c>
+               	j	0x315c <.Lpcrel_hi.9+0xc04>
+               	bnez	a3, 0x3134 <.Lpcrel_hi.9+0xbdc>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x30
@@ -2141,8 +3212,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2058 <.Lpcrel_hi.9+0x604>
-               	j	0x20a0 <.Lpcrel_hi.9+0x64c>
+               	bne	a5, t0, 0x3114 <.Lpcrel_hi.9+0xbbc>
+               	j	0x315c <.Lpcrel_hi.9+0xc04>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x30
@@ -2152,18 +3223,18 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2084 <.Lpcrel_hi.9+0x630>
+               	bne	a2, t0, 0x3140 <.Lpcrel_hi.9+0xbe8>
                	slli	t0, s5, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
-               	addi	s6, s0, -0x108
-               	addi	a1, s0, -0x138
+               	addi	s6, s0, -0x118
+               	addi	a1, s0, -0x148
                	mv	a3, a0
                	or	a0, a1, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a3, 0x2124 <.Lpcrel_hi.9+0x6d0>
-               	bnez	a0, 0x20f8 <.Lpcrel_hi.9+0x6a4>
+               	bltu	a1, a3, 0x31e0 <.Lpcrel_hi.9+0xc88>
+               	bnez	a0, 0x31b4 <.Lpcrel_hi.9+0xc5c>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -2173,8 +3244,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x20d8 <.Lpcrel_hi.9+0x684>
-               	j	0x217c <.Lpcrel_hi.9+0x728>
+               	bne	a6, t0, 0x3194 <.Lpcrel_hi.9+0xc3c>
+               	j	0x3238 <.Lpcrel_hi.9+0xce0>
                	addi	a4, a1, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -2184,9 +3255,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2104 <.Lpcrel_hi.9+0x6b0>
-               	j	0x217c <.Lpcrel_hi.9+0x728>
-               	bnez	a0, 0x2154 <.Lpcrel_hi.9+0x700>
+               	bne	a6, t0, 0x31c0 <.Lpcrel_hi.9+0xc68>
+               	j	0x3238 <.Lpcrel_hi.9+0xce0>
+               	bnez	a0, 0x3210 <.Lpcrel_hi.9+0xcb8>
                	mv	a0, a1
                	mv	a4, a3
                	li	a5, 0x30
@@ -2196,8 +3267,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2134 <.Lpcrel_hi.9+0x6e0>
-               	j	0x217c <.Lpcrel_hi.9+0x728>
+               	bne	a5, t0, 0x31f0 <.Lpcrel_hi.9+0xc98>
+               	j	0x3238 <.Lpcrel_hi.9+0xce0>
                	mv	a0, a1
                	mv	a1, a3
                	li	a3, 0x30
@@ -2207,18 +3278,18 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2160 <.Lpcrel_hi.9+0x70c>
-               	addi	a1, s0, -0x138
+               	bne	a3, t0, 0x321c <.Lpcrel_hi.9+0xcc4>
+               	addi	a1, s0, -0x148
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x730>
+               	jalr	ra <.Lpcrel_hi.9+0xce8>
                	mv	a0, s4
                	mv	a1, s6
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x2200 <.Lpcrel_hi.9+0x7ac>
-               	bnez	a2, 0x21d4 <.Lpcrel_hi.9+0x780>
+               	bltu	a0, a1, 0x32bc <.Lpcrel_hi.9+0xd64>
+               	bnez	a2, 0x3290 <.Lpcrel_hi.9+0xd38>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -2228,8 +3299,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x21b4 <.Lpcrel_hi.9+0x760>
-               	j	0x2258 <.Lpcrel_hi.9+0x804>
+               	bne	a5, t0, 0x3270 <.Lpcrel_hi.9+0xd18>
+               	j	0x3314 <.Lpcrel_hi.9+0xdbc>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -2239,9 +3310,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x21e0 <.Lpcrel_hi.9+0x78c>
-               	j	0x2258 <.Lpcrel_hi.9+0x804>
-               	bnez	a2, 0x2230 <.Lpcrel_hi.9+0x7dc>
+               	bne	a5, t0, 0x329c <.Lpcrel_hi.9+0xd44>
+               	j	0x3314 <.Lpcrel_hi.9+0xdbc>
+               	bnez	a2, 0x32ec <.Lpcrel_hi.9+0xd94>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x30
@@ -2251,8 +3322,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2210 <.Lpcrel_hi.9+0x7bc>
-               	j	0x2258 <.Lpcrel_hi.9+0x804>
+               	bne	a4, t0, 0x32cc <.Lpcrel_hi.9+0xd74>
+               	j	0x3314 <.Lpcrel_hi.9+0xdbc>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x30
@@ -2262,7 +3333,7 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x223c <.Lpcrel_hi.9+0x7e8>
+               	bne	a1, t0, 0x32f8 <.Lpcrel_hi.9+0xda0>
                	mv	a0, s4
                	ld	a1, 0x0(a0)
                	addi	a0, s4, 0x8
@@ -2277,55 +3348,55 @@ Disassembly of section .text:
                	ld	s10, 0x0(a0)
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x838>
+               	jalr	ra <.Lpcrel_hi.9+0xdf0>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x844>
+               	jalr	ra <.Lpcrel_hi.9+0xdfc>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x850>
+               	jalr	ra <.Lpcrel_hi.9+0xe08>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x85c>
+               	jalr	ra <.Lpcrel_hi.9+0xe14>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x868>
+               	jalr	ra <.Lpcrel_hi.9+0xe20>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x874>
+               	jalr	ra <.Lpcrel_hi.9+0xe2c>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x1fd0 <.Lpcrel_hi.9+0x57c>
-               	addi	s4, s0, -0x1f8
+               	bltu	s5, t0, 0x308c <.Lpcrel_hi.9+0xb34>
+               	addi	s4, s0, -0x208
                	mv	a0, s4
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x2314 <.Lpcrel_hi.9+0x8c0>
+               	bnez	a1, 0x33d0 <.Lpcrel_hi.9+0xe78>
                	mv	a1, a0
                	li	a2, 0xc0
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x22fc <.Lpcrel_hi.9+0x8a8>
-               	j	0x2330 <.Lpcrel_hi.9+0x8dc>
+               	bne	a2, t0, 0x33b8 <.Lpcrel_hi.9+0xe60>
+               	j	0x33ec <.Lpcrel_hi.9+0xe94>
                	mv	a1, a0
                	li	a0, 0xc0
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x231c <.Lpcrel_hi.9+0x8c8>
+               	bne	a0, t0, 0x33d8 <.Lpcrel_hi.9+0xe80>
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0x2340 <.Lpcrel_hi.9+0x8ec>
-               	j	0x2468 <.Lpcrel_hi.9+0xa14>
+               	bltu	a0, t0, 0x33fc <.Lpcrel_hi.9+0xea4>
+               	j	0x3524 <.Lpcrel_hi.9+0xfcc>
                	slli	t0, a0, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	add	a1, a2, s1
-               	addi	a2, s0, -0x2b8
+               	addi	a2, s0, -0x328
                	mv	a3, a2
                	sd	a1, 0x0(a3)
                	addi	a3, a1, 0x1
@@ -2346,8 +3417,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x2404 <.Lpcrel_hi.9+0x9b0>
-               	bnez	a2, 0x23d8 <.Lpcrel_hi.9+0x984>
+               	bltu	a1, a3, 0x34c0 <.Lpcrel_hi.9+0xf68>
+               	bnez	a2, 0x3494 <.Lpcrel_hi.9+0xf3c>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -2357,8 +3428,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x23b8 <.Lpcrel_hi.9+0x964>
-               	j	0x245c <.Lpcrel_hi.9+0xa08>
+               	bne	a6, t0, 0x3474 <.Lpcrel_hi.9+0xf1c>
+               	j	0x3518 <.Lpcrel_hi.9+0xfc0>
                	addi	a4, a1, 0x20
                	addi	a5, a3, 0x20
                	li	a6, 0x20
@@ -2368,9 +3439,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x23e4 <.Lpcrel_hi.9+0x990>
-               	j	0x245c <.Lpcrel_hi.9+0xa08>
-               	bnez	a2, 0x2434 <.Lpcrel_hi.9+0x9e0>
+               	bne	a6, t0, 0x34a0 <.Lpcrel_hi.9+0xf48>
+               	j	0x3518 <.Lpcrel_hi.9+0xfc0>
+               	bnez	a2, 0x34f0 <.Lpcrel_hi.9+0xf98>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x20
@@ -2380,8 +3451,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2414 <.Lpcrel_hi.9+0x9c0>
-               	j	0x245c <.Lpcrel_hi.9+0xa08>
+               	bne	a5, t0, 0x34d0 <.Lpcrel_hi.9+0xf78>
+               	j	0x3518 <.Lpcrel_hi.9+0xfc0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x20
@@ -2391,62 +3462,148 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2440 <.Lpcrel_hi.9+0x9ec>
+               	bne	a3, t0, 0x34fc <.Lpcrel_hi.9+0xfa4>
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0x2340 <.Lpcrel_hi.9+0x8ec>
+               	bltu	a0, t0, 0x33fc <.Lpcrel_hi.9+0xea4>
                	li	s5, 0x0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x2478 <.Lpcrel_hi.9+0xa24>
-               	j	0x24e8 <.Lpcrel_hi.9+0xa94>
+               	bltu	s5, t0, 0x3534 <.Lpcrel_hi.9+0xfdc>
+               	j	0x36fc <.Lpcrel_hi.9+0x11a4>
                	li	t0, 0x20
                	mul	a0, s5, t0
                	add	a1, s4, a0
-               	mv	a0, a1
-               	ld	a2, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s6, 0x0(a0)
-               	addi	a0, a1, 0x10
-               	ld	s7, 0x0(a0)
-               	addi	a0, a1, 0x18
-               	ld	s8, 0x0(a0)
-               	mv	a0, s3
+               	addi	a0, s0, -0x228
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x35b8 <.Lpcrel_hi.9+0x1060>
+               	bnez	a1, 0x358c <.Lpcrel_hi.9+0x1034>
+               	addi	a4, a2, 0x20
+               	addi	a5, a3, 0x20
+               	li	a6, 0x20
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x356c <.Lpcrel_hi.9+0x1014>
+               	j	0x3610 <.Lpcrel_hi.9+0x10b8>
+               	addi	a4, a2, 0x20
+               	addi	a5, a3, 0x20
+               	li	a6, 0x20
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x3598 <.Lpcrel_hi.9+0x1040>
+               	j	0x3610 <.Lpcrel_hi.9+0x10b8>
+               	bnez	a1, 0x35e8 <.Lpcrel_hi.9+0x1090>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x20
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x35c8 <.Lpcrel_hi.9+0x1070>
+               	j	0x3610 <.Lpcrel_hi.9+0x10b8>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x20
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x35f4 <.Lpcrel_hi.9+0x109c>
+               	addi	a1, s0, -0x248
+               	mv	a2, a0
+               	or	a0, a1, a2
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a1, a2, 0x3684 <.Lpcrel_hi.9+0x112c>
+               	bnez	a0, 0x3658 <.Lpcrel_hi.9+0x1100>
+               	addi	a3, a1, 0x20
+               	addi	a4, a2, 0x20
+               	li	a5, 0x20
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x3638 <.Lpcrel_hi.9+0x10e0>
+               	j	0x36dc <.Lpcrel_hi.9+0x1184>
+               	addi	a3, a1, 0x20
+               	addi	a4, a2, 0x20
+               	li	a5, 0x20
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x3664 <.Lpcrel_hi.9+0x110c>
+               	j	0x36dc <.Lpcrel_hi.9+0x1184>
+               	bnez	a0, 0x36b4 <.Lpcrel_hi.9+0x115c>
+               	mv	a0, a1
+               	mv	a3, a2
+               	li	a4, 0x20
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x3694 <.Lpcrel_hi.9+0x113c>
+               	j	0x36dc <.Lpcrel_hi.9+0x1184>
+               	mv	a0, a1
+               	mv	a1, a2
+               	li	a2, 0x20
+               	lbu	a3, 0x0(a1)
+               	sb	a3, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x36c0 <.Lpcrel_hi.9+0x1168>
+               	addi	a1, s0, -0x248
+               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xa58>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xa64>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xa70>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xa7c>
+               	jalr	ra <.Lpcrel_hi.9+0x118c>
                	addi	s5, s5, 0x1
                	mv	s3, a0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x2478 <.Lpcrel_hi.9+0xa24>
-               	addi	a0, s0, -0x228
+               	bltu	s5, t0, 0x3534 <.Lpcrel_hi.9+0xfdc>
+               	addi	a0, s0, -0x278
                	mv	a1, a0
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x251c <.Lpcrel_hi.9+0xac8>
+               	bnez	a2, 0x3730 <.Lpcrel_hi.9+0x11d8>
                	mv	a2, a1
                	li	a3, 0x30
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x2504 <.Lpcrel_hi.9+0xab0>
-               	j	0x2538 <.Lpcrel_hi.9+0xae4>
+               	bne	a3, t0, 0x3718 <.Lpcrel_hi.9+0x11c0>
+               	j	0x374c <.Lpcrel_hi.9+0x11f4>
                	mv	a2, a1
                	li	a1, 0x30
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2524 <.Lpcrel_hi.9+0xad0>
+               	bne	a1, t0, 0x3738 <.Lpcrel_hi.9+0x11e0>
                	mv	a1, a0
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
@@ -2458,7 +3615,7 @@ Disassembly of section .text:
                	addi	a4, a3, 0x1
                	mv	a3, s2
                	ld	a5, 0x0(a3)
-               	addi	a3, s0, -0x330
+               	addi	a3, s0, -0x3e0
                	add	a6, a1, a5
                	mv	a7, a3
                	sd	a6, 0x0(a7)
@@ -2474,8 +3631,8 @@ Disassembly of section .text:
                	or	a3, a2, a1
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a2, a1, 0x2604 <.Lpcrel_hi.9+0xbb0>
-               	bnez	a3, 0x25d8 <.Lpcrel_hi.9+0xb84>
+               	bltu	a2, a1, 0x3818 <.Lpcrel_hi.9+0x12c0>
+               	bnez	a3, 0x37ec <.Lpcrel_hi.9+0x1294>
                	addi	a4, a2, 0x18
                	addi	a5, a1, 0x18
                	li	a6, 0x18
@@ -2485,8 +3642,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x25b8 <.Lpcrel_hi.9+0xb64>
-               	j	0x265c <.Lpcrel_hi.9+0xc08>
+               	bne	a6, t0, 0x37cc <.Lpcrel_hi.9+0x1274>
+               	j	0x3870 <.Lpcrel_hi.9+0x1318>
                	addi	a4, a2, 0x18
                	addi	a5, a1, 0x18
                	li	a6, 0x18
@@ -2496,9 +3653,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x25e4 <.Lpcrel_hi.9+0xb90>
-               	j	0x265c <.Lpcrel_hi.9+0xc08>
-               	bnez	a3, 0x2634 <.Lpcrel_hi.9+0xbe0>
+               	bne	a6, t0, 0x37f8 <.Lpcrel_hi.9+0x12a0>
+               	j	0x3870 <.Lpcrel_hi.9+0x1318>
+               	bnez	a3, 0x3848 <.Lpcrel_hi.9+0x12f0>
                	mv	a3, a2
                	mv	a4, a1
                	li	a5, 0x18
@@ -2508,8 +3665,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2614 <.Lpcrel_hi.9+0xbc0>
-               	j	0x265c <.Lpcrel_hi.9+0xc08>
+               	bne	a5, t0, 0x3828 <.Lpcrel_hi.9+0x12d0>
+               	j	0x3870 <.Lpcrel_hi.9+0x1318>
                	mv	a3, a2
                	mv	a2, a1
                	li	a1, 0x18
@@ -2519,8 +3676,8 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2640 <.Lpcrel_hi.9+0xbec>
-               	addi	a1, s0, -0x340
+               	bne	a1, t0, 0x3854 <.Lpcrel_hi.9+0x12fc>
+               	addi	a1, s0, -0x3f0
                	addi	a2, s2, 0x8
                	ld	a3, 0x0(a2)
                	mv	a2, a1
@@ -2535,8 +3692,8 @@ Disassembly of section .text:
                	or	a1, a3, a2
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a2, 0x26f8 <.Lpcrel_hi.9+0xca4>
-               	bnez	a1, 0x26cc <.Lpcrel_hi.9+0xc78>
+               	bltu	a3, a2, 0x390c <.Lpcrel_hi.9+0x13b4>
+               	bnez	a1, 0x38e0 <.Lpcrel_hi.9+0x1388>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -2546,8 +3703,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x26ac <.Lpcrel_hi.9+0xc58>
-               	j	0x2750 <.Lpcrel_hi.9+0xcfc>
+               	bne	a6, t0, 0x38c0 <.Lpcrel_hi.9+0x1368>
+               	j	0x3964 <.Lpcrel_hi.9+0x140c>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -2557,9 +3714,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x26d8 <.Lpcrel_hi.9+0xc84>
-               	j	0x2750 <.Lpcrel_hi.9+0xcfc>
-               	bnez	a1, 0x2728 <.Lpcrel_hi.9+0xcd4>
+               	bne	a6, t0, 0x38ec <.Lpcrel_hi.9+0x1394>
+               	j	0x3964 <.Lpcrel_hi.9+0x140c>
+               	bnez	a1, 0x393c <.Lpcrel_hi.9+0x13e4>
                	mv	a1, a3
                	mv	a4, a2
                	li	a5, 0x10
@@ -2569,8 +3726,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2708 <.Lpcrel_hi.9+0xcb4>
-               	j	0x2750 <.Lpcrel_hi.9+0xcfc>
+               	bne	a5, t0, 0x391c <.Lpcrel_hi.9+0x13c4>
+               	j	0x3964 <.Lpcrel_hi.9+0x140c>
                	mv	a1, a3
                	mv	a3, a2
                	li	a2, 0x10
@@ -2580,15 +3737,15 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2734 <.Lpcrel_hi.9+0xce0>
-               	addi	a1, s0, -0x370
+               	bne	a2, t0, 0x3948 <.Lpcrel_hi.9+0x13f0>
+               	addi	a1, s0, -0x420
                	mv	a2, a1
                	mv	a3, a0
                	or	a0, a2, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a2, a3, 0x27c8 <.Lpcrel_hi.9+0xd74>
-               	bnez	a0, 0x279c <.Lpcrel_hi.9+0xd48>
+               	bltu	a2, a3, 0x39dc <.Lpcrel_hi.9+0x1484>
+               	bnez	a0, 0x39b0 <.Lpcrel_hi.9+0x1458>
                	addi	a4, a2, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -2598,8 +3755,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x277c <.Lpcrel_hi.9+0xd28>
-               	j	0x2820 <.Lpcrel_hi.9+0xdcc>
+               	bne	a6, t0, 0x3990 <.Lpcrel_hi.9+0x1438>
+               	j	0x3a34 <.Lpcrel_hi.9+0x14dc>
                	addi	a4, a2, 0x30
                	addi	a5, a3, 0x30
                	li	a6, 0x30
@@ -2609,9 +3766,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x27a8 <.Lpcrel_hi.9+0xd54>
-               	j	0x2820 <.Lpcrel_hi.9+0xdcc>
-               	bnez	a0, 0x27f8 <.Lpcrel_hi.9+0xda4>
+               	bne	a6, t0, 0x39bc <.Lpcrel_hi.9+0x1464>
+               	j	0x3a34 <.Lpcrel_hi.9+0x14dc>
+               	bnez	a0, 0x3a0c <.Lpcrel_hi.9+0x14b4>
                	mv	a0, a2
                	mv	a4, a3
                	li	a5, 0x30
@@ -2621,8 +3778,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x27d8 <.Lpcrel_hi.9+0xd84>
-               	j	0x2820 <.Lpcrel_hi.9+0xdcc>
+               	bne	a5, t0, 0x39ec <.Lpcrel_hi.9+0x1494>
+               	j	0x3a34 <.Lpcrel_hi.9+0x14dc>
                	mv	a0, a2
                	mv	a2, a3
                	li	a3, 0x30
@@ -2632,14 +3789,15 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2804 <.Lpcrel_hi.9+0xdb0>
-               	addi	a0, s0, -0x3a0
+               	bne	a3, t0, 0x3a18 <.Lpcrel_hi.9+0x14c0>
+               	addi	s4, s0, -0x4f8
+               	mv	a0, s4
                	mv	a2, a1
                	or	a1, a0, a2
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a0, a2, 0x2894 <.Lpcrel_hi.9+0xe40>
-               	bnez	a1, 0x2868 <.Lpcrel_hi.9+0xe14>
+               	bltu	a0, a2, 0x3aac <.Lpcrel_hi.9+0x1554>
+               	bnez	a1, 0x3a80 <.Lpcrel_hi.9+0x1528>
                	addi	a3, a0, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2649,8 +3807,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2848 <.Lpcrel_hi.9+0xdf4>
-               	j	0x28ec <.Lpcrel_hi.9+0xe98>
+               	bne	a5, t0, 0x3a60 <.Lpcrel_hi.9+0x1508>
+               	j	0x3b04 <.Lpcrel_hi.9+0x15ac>
                	addi	a3, a0, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2660,9 +3818,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2874 <.Lpcrel_hi.9+0xe20>
-               	j	0x28ec <.Lpcrel_hi.9+0xe98>
-               	bnez	a1, 0x28c4 <.Lpcrel_hi.9+0xe70>
+               	bne	a5, t0, 0x3a8c <.Lpcrel_hi.9+0x1534>
+               	j	0x3b04 <.Lpcrel_hi.9+0x15ac>
+               	bnez	a1, 0x3adc <.Lpcrel_hi.9+0x1584>
                	mv	a1, a0
                	mv	a3, a2
                	li	a4, 0x30
@@ -2672,8 +3830,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x28a4 <.Lpcrel_hi.9+0xe50>
-               	j	0x28ec <.Lpcrel_hi.9+0xe98>
+               	bne	a4, t0, 0x3abc <.Lpcrel_hi.9+0x1564>
+               	j	0x3b04 <.Lpcrel_hi.9+0x15ac>
                	mv	a1, a0
                	mv	a0, a2
                	li	a2, 0x30
@@ -2683,21 +3841,143 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x28d0 <.Lpcrel_hi.9+0xe7c>
-               	addi	a1, s0, -0x3a0
+               	bne	a2, t0, 0x3ae8 <.Lpcrel_hi.9+0x1590>
+               	mv	a0, s4
+               	lw	a1, 0x0(a0)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a0, s3
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xea0>
+               	jalr	ra <.Lpcrel_hi.9+0x15c4>
+               	addi	a1, s4, 0x8
+               	addi	a2, s0, -0x510
+               	mv	a3, a2
+               	mv	a4, a1
+               	or	a1, a3, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, a4, 0x3ba0 <.Lpcrel_hi.9+0x1648>
+               	bnez	a1, 0x3b74 <.Lpcrel_hi.9+0x161c>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x3b54 <.Lpcrel_hi.9+0x15fc>
+               	j	0x3bf8 <.Lpcrel_hi.9+0x16a0>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x3b80 <.Lpcrel_hi.9+0x1628>
+               	j	0x3bf8 <.Lpcrel_hi.9+0x16a0>
+               	bnez	a1, 0x3bd0 <.Lpcrel_hi.9+0x1678>
+               	mv	a1, a3
+               	mv	a5, a4
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x3bb0 <.Lpcrel_hi.9+0x1658>
+               	j	0x3bf8 <.Lpcrel_hi.9+0x16a0>
+               	mv	a1, a3
+               	mv	a3, a4
+               	li	a4, 0x18
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x3bdc <.Lpcrel_hi.9+0x1684>
+               	addi	a1, s0, -0x528
+               	mv	a3, a2
+               	or	a2, a1, a3
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a1, a3, 0x3c6c <.Lpcrel_hi.9+0x1714>
+               	bnez	a2, 0x3c40 <.Lpcrel_hi.9+0x16e8>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x3c20 <.Lpcrel_hi.9+0x16c8>
+               	j	0x3cc4 <.Lpcrel_hi.9+0x176c>
+               	addi	a4, a1, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x3c4c <.Lpcrel_hi.9+0x16f4>
+               	j	0x3cc4 <.Lpcrel_hi.9+0x176c>
+               	bnez	a2, 0x3c9c <.Lpcrel_hi.9+0x1744>
+               	mv	a2, a1
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x3c7c <.Lpcrel_hi.9+0x1724>
+               	j	0x3cc4 <.Lpcrel_hi.9+0x176c>
+               	mv	a2, a1
+               	mv	a1, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x3ca8 <.Lpcrel_hi.9+0x1750>
+               	addi	a1, s0, -0x528
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x1770>
+               	addi	s3, s4, 0x20
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x1788>
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x179c>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x2910 <.Lpcrel_hi.9+0xebc>
-               	j	0x339c <.Lpcrel_hi.9+0x1948>
+               	bltu	s4, t0, 0x3d10 <.Lpcrel_hi.9+0x17b8>
+               	j	0x4b9c <.Lpcrel_hi.9+0x2644>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	s5, a1, s1
-               	addi	a0, s0, -0x2d0
+               	addi	a0, s0, -0x340
                	mv	a1, a0
                	sd	s5, 0x0(a1)
                	not	a1, s5
@@ -2708,14 +3988,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0x1
                	addi	a1, a0, 0x10
                	sd	a2, 0x0(a1)
-               	addi	s6, s0, -0x300
-               	addi	a1, s0, -0x318
+               	addi	s6, s0, -0x370
+               	addi	a1, s0, -0x388
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x29c4 <.Lpcrel_hi.9+0xf70>
-               	bnez	a0, 0x2998 <.Lpcrel_hi.9+0xf44>
+               	bltu	a1, a2, 0x3dc4 <.Lpcrel_hi.9+0x186c>
+               	bnez	a0, 0x3d98 <.Lpcrel_hi.9+0x1840>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -2725,8 +4005,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2978 <.Lpcrel_hi.9+0xf24>
-               	j	0x2a1c <.Lpcrel_hi.9+0xfc8>
+               	bne	a5, t0, 0x3d78 <.Lpcrel_hi.9+0x1820>
+               	j	0x3e1c <.Lpcrel_hi.9+0x18c4>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -2736,9 +4016,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x29a4 <.Lpcrel_hi.9+0xf50>
-               	j	0x2a1c <.Lpcrel_hi.9+0xfc8>
-               	bnez	a0, 0x29f4 <.Lpcrel_hi.9+0xfa0>
+               	bne	a5, t0, 0x3da4 <.Lpcrel_hi.9+0x184c>
+               	j	0x3e1c <.Lpcrel_hi.9+0x18c4>
+               	bnez	a0, 0x3df4 <.Lpcrel_hi.9+0x189c>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x18
@@ -2748,8 +4028,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x29d4 <.Lpcrel_hi.9+0xf80>
-               	j	0x2a1c <.Lpcrel_hi.9+0xfc8>
+               	bne	a4, t0, 0x3dd4 <.Lpcrel_hi.9+0x187c>
+               	j	0x3e1c <.Lpcrel_hi.9+0x18c4>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -2759,12 +4039,12 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2a00 <.Lpcrel_hi.9+0xfac>
-               	addi	a1, s0, -0x318
+               	bne	a2, t0, 0x3e00 <.Lpcrel_hi.9+0x18a8>
+               	addi	a1, s0, -0x388
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0xfd0>
-               	addi	a0, s0, -0x3d0
+               	jalr	ra <.Lpcrel_hi.9+0x18cc>
+               	addi	a0, s0, -0x450
                	mv	a1, a0
                	sd	s5, 0x0(a1)
                	addi	a1, s5, 0x1
@@ -2787,14 +4067,14 @@ Disassembly of section .text:
                	xor	a1, s5, t0
                	addi	a2, a0, 0x28
                	sd	a1, 0x0(a2)
-               	addi	s7, s0, -0x3e8
-               	addi	a1, s0, -0x418
+               	addi	s7, s0, -0x468
+               	addi	a1, s0, -0x498
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x2b00 <.Lpcrel_hi.9+0x10ac>
-               	bnez	a0, 0x2ad4 <.Lpcrel_hi.9+0x1080>
+               	bltu	a1, a2, 0x3f00 <.Lpcrel_hi.9+0x19a8>
+               	bnez	a0, 0x3ed4 <.Lpcrel_hi.9+0x197c>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2804,8 +4084,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2ab4 <.Lpcrel_hi.9+0x1060>
-               	j	0x2b58 <.Lpcrel_hi.9+0x1104>
+               	bne	a5, t0, 0x3eb4 <.Lpcrel_hi.9+0x195c>
+               	j	0x3f58 <.Lpcrel_hi.9+0x1a00>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2815,9 +4095,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2ae0 <.Lpcrel_hi.9+0x108c>
-               	j	0x2b58 <.Lpcrel_hi.9+0x1104>
-               	bnez	a0, 0x2b30 <.Lpcrel_hi.9+0x10dc>
+               	bne	a5, t0, 0x3ee0 <.Lpcrel_hi.9+0x1988>
+               	j	0x3f58 <.Lpcrel_hi.9+0x1a00>
+               	bnez	a0, 0x3f30 <.Lpcrel_hi.9+0x19d8>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x30
@@ -2827,8 +4107,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2b10 <.Lpcrel_hi.9+0x10bc>
-               	j	0x2b58 <.Lpcrel_hi.9+0x1104>
+               	bne	a4, t0, 0x3f10 <.Lpcrel_hi.9+0x19b8>
+               	j	0x3f58 <.Lpcrel_hi.9+0x1a00>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x30
@@ -2838,73 +4118,227 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2b3c <.Lpcrel_hi.9+0x10e8>
-               	addi	a1, s0, -0x418
+               	bne	a2, t0, 0x3f3c <.Lpcrel_hi.9+0x19e4>
+               	addi	a1, s0, -0x498
                	mv	a0, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x110c>
+               	jalr	ra <.Lpcrel_hi.9+0x1a08>
                	mv	a0, s6
-               	ld	s8, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	addi	a0, s6, 0x8
-               	ld	s9, 0x0(a0)
+               	ld	s8, 0x0(a0)
                	addi	a0, s6, 0x10
-               	ld	s10, 0x0(a0)
+               	ld	s9, 0x0(a0)
                	addi	a0, s6, 0x18
-               	ld	s11, 0x0(a0)
+               	ld	s10, 0x0(a0)
                	addi	a0, s6, 0x20
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x6e8(s0)
+               	ld	s11, 0x0(a0)
                	addi	a0, s6, 0x28
                	ld	s6, 0x0(a0)
-               	mv	a0, s7
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x6f0(s0)
-               	addi	a0, s7, 0x8
-               	ld	t2, 0x0(a0)
-               	sd	t2, -0x6f8(s0)
-               	addi	a0, s7, 0x10
-               	ld	s7, 0x0(a0)
+               	addi	t2, s0, -0x540
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a3, s7
+               	or	a4, a0, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a0, a3, 0x4030 <.Lpcrel_hi.9+0x1ad8>
+               	bnez	a4, 0x4004 <.Lpcrel_hi.9+0x1aac>
+               	addi	a5, a0, 0x18
+               	addi	a6, a3, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x3fe4 <.Lpcrel_hi.9+0x1a8c>
+               	j	0x4088 <.Lpcrel_hi.9+0x1b30>
+               	addi	a5, a0, 0x18
+               	addi	a6, a3, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x4010 <.Lpcrel_hi.9+0x1ab8>
+               	j	0x4088 <.Lpcrel_hi.9+0x1b30>
+               	bnez	a4, 0x4060 <.Lpcrel_hi.9+0x1b08>
+               	mv	a4, a0
+               	mv	a5, a3
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x4040 <.Lpcrel_hi.9+0x1ae8>
+               	j	0x4088 <.Lpcrel_hi.9+0x1b30>
+               	mv	a4, a0
+               	mv	a0, a3
+               	li	a3, 0x18
+               	lbu	a5, 0x0(a0)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x406c <.Lpcrel_hi.9+0x1b14>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1168>
+               	jalr	ra <.Lpcrel_hi.9+0x1b50>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1174>
+               	jalr	ra <.Lpcrel_hi.9+0x1b5c>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1180>
+               	jalr	ra <.Lpcrel_hi.9+0x1b68>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x118c>
+               	jalr	ra <.Lpcrel_hi.9+0x1b74>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1198>
-               	ld	t2, -0x6e8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11a8>
+               	jalr	ra <.Lpcrel_hi.9+0x1b80>
                	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11b4>
-               	ld	t2, -0x6f0(s0)
-               	mv	a1, t2
+               	jalr	ra <.Lpcrel_hi.9+0x1b8c>
+               	addi	a1, s0, -0x558
+               	mv	a3, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a4, t2
+               	or	a2, a3, a4
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x4174 <.Lpcrel_hi.9+0x1c1c>
+               	bnez	a2, 0x4148 <.Lpcrel_hi.9+0x1bf0>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x4128 <.Lpcrel_hi.9+0x1bd0>
+               	j	0x41cc <.Lpcrel_hi.9+0x1c74>
+               	addi	a5, a3, 0x18
+               	addi	a6, a4, 0x18
+               	li	a7, 0x18
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x4154 <.Lpcrel_hi.9+0x1bfc>
+               	j	0x41cc <.Lpcrel_hi.9+0x1c74>
+               	bnez	a2, 0x41a4 <.Lpcrel_hi.9+0x1c4c>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x18
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x4184 <.Lpcrel_hi.9+0x1c2c>
+               	j	0x41cc <.Lpcrel_hi.9+0x1c74>
+               	mv	a2, a3
+               	mv	a3, a4
+               	li	a4, 0x18
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x41b0 <.Lpcrel_hi.9+0x1c58>
+               	addi	a2, s0, -0x570
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x4240 <.Lpcrel_hi.9+0x1ce8>
+               	bnez	a1, 0x4214 <.Lpcrel_hi.9+0x1cbc>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x41f4 <.Lpcrel_hi.9+0x1c9c>
+               	j	0x4298 <.Lpcrel_hi.9+0x1d40>
+               	addi	a4, a2, 0x18
+               	addi	a5, a3, 0x18
+               	li	a6, 0x18
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x4220 <.Lpcrel_hi.9+0x1cc8>
+               	j	0x4298 <.Lpcrel_hi.9+0x1d40>
+               	bnez	a1, 0x4270 <.Lpcrel_hi.9+0x1d18>
+               	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x18
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x4250 <.Lpcrel_hi.9+0x1cf8>
+               	j	0x4298 <.Lpcrel_hi.9+0x1d40>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x18
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x427c <.Lpcrel_hi.9+0x1d24>
+               	addi	a1, s0, -0x570
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11c4>
-               	ld	t2, -0x6f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11d4>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11e0>
+               	jalr	ra <.Lpcrel_hi.9+0x1d44>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11ec>
+               	jalr	ra <.Lpcrel_hi.9+0x1d50>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x11fc>
+               	jalr	ra <.Lpcrel_hi.9+0x1d60>
                	mv	s6, a0
-               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x5a0
                	mv	a1, a0
                	sd	s5, 0x0(a1)
                	addi	a1, s5, 0x1
@@ -2927,14 +4361,14 @@ Disassembly of section .text:
                	xor	a1, s5, t0
                	addi	a2, a0, 0x28
                	sd	a1, 0x0(a2)
-               	addi	s7, s0, -0x460
-               	addi	a1, s0, -0x490
+               	addi	s7, s0, -0x5b8
+               	addi	a1, s0, -0x5e8
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x2d30 <.Lpcrel_hi.9+0x12dc>
-               	bnez	a0, 0x2d04 <.Lpcrel_hi.9+0x12b0>
+               	bltu	a1, a2, 0x4398 <.Lpcrel_hi.9+0x1e40>
+               	bnez	a0, 0x436c <.Lpcrel_hi.9+0x1e14>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2944,8 +4378,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2ce4 <.Lpcrel_hi.9+0x1290>
-               	j	0x2d88 <.Lpcrel_hi.9+0x1334>
+               	bne	a5, t0, 0x434c <.Lpcrel_hi.9+0x1df4>
+               	j	0x43f0 <.Lpcrel_hi.9+0x1e98>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -2955,9 +4389,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2d10 <.Lpcrel_hi.9+0x12bc>
-               	j	0x2d88 <.Lpcrel_hi.9+0x1334>
-               	bnez	a0, 0x2d60 <.Lpcrel_hi.9+0x130c>
+               	bne	a5, t0, 0x4378 <.Lpcrel_hi.9+0x1e20>
+               	j	0x43f0 <.Lpcrel_hi.9+0x1e98>
+               	bnez	a0, 0x43c8 <.Lpcrel_hi.9+0x1e70>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x30
@@ -2967,8 +4401,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2d40 <.Lpcrel_hi.9+0x12ec>
-               	j	0x2d88 <.Lpcrel_hi.9+0x1334>
+               	bne	a4, t0, 0x43a8 <.Lpcrel_hi.9+0x1e50>
+               	j	0x43f0 <.Lpcrel_hi.9+0x1e98>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x30
@@ -2978,19 +4412,19 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2d6c <.Lpcrel_hi.9+0x1318>
-               	addi	a1, s0, -0x490
+               	bne	a2, t0, 0x43d4 <.Lpcrel_hi.9+0x1e7c>
+               	addi	a1, s0, -0x5e8
                	mv	a0, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x133c>
-               	addi	s8, s0, -0x4c0
-               	addi	a0, s0, -0x4d8
+               	jalr	ra <.Lpcrel_hi.9+0x1ea0>
+               	addi	s8, s0, -0x618
+               	addi	a0, s0, -0x630
                	mv	a1, s7
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x2e10 <.Lpcrel_hi.9+0x13bc>
-               	bnez	a2, 0x2de4 <.Lpcrel_hi.9+0x1390>
+               	bltu	a0, a1, 0x4478 <.Lpcrel_hi.9+0x1f20>
+               	bnez	a2, 0x444c <.Lpcrel_hi.9+0x1ef4>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -3000,8 +4434,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2dc4 <.Lpcrel_hi.9+0x1370>
-               	j	0x2e68 <.Lpcrel_hi.9+0x1414>
+               	bne	a5, t0, 0x442c <.Lpcrel_hi.9+0x1ed4>
+               	j	0x44d0 <.Lpcrel_hi.9+0x1f78>
                	addi	a3, a0, 0x18
                	addi	a4, a1, 0x18
                	li	a5, 0x18
@@ -3011,9 +4445,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2df0 <.Lpcrel_hi.9+0x139c>
-               	j	0x2e68 <.Lpcrel_hi.9+0x1414>
-               	bnez	a2, 0x2e40 <.Lpcrel_hi.9+0x13ec>
+               	bne	a5, t0, 0x4458 <.Lpcrel_hi.9+0x1f00>
+               	j	0x44d0 <.Lpcrel_hi.9+0x1f78>
+               	bnez	a2, 0x44a8 <.Lpcrel_hi.9+0x1f50>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x18
@@ -3023,8 +4457,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2e20 <.Lpcrel_hi.9+0x13cc>
-               	j	0x2e68 <.Lpcrel_hi.9+0x1414>
+               	bne	a4, t0, 0x4488 <.Lpcrel_hi.9+0x1f30>
+               	j	0x44d0 <.Lpcrel_hi.9+0x1f78>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x18
@@ -3034,11 +4468,11 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2e4c <.Lpcrel_hi.9+0x13f8>
-               	addi	a1, s0, -0x4d8
+               	bne	a1, t0, 0x44b4 <.Lpcrel_hi.9+0x1f5c>
+               	addi	a1, s0, -0x630
                	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x141c>
+               	jalr	ra <.Lpcrel_hi.9+0x1f80>
                	mv	a0, s8
                	ld	a1, 0x0(a0)
                	addi	a0, s8, 0x8
@@ -3053,24 +4487,24 @@ Disassembly of section .text:
                	ld	s8, 0x0(a0)
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1458>
+               	jalr	ra <.Lpcrel_hi.9+0x1fbc>
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1464>
+               	jalr	ra <.Lpcrel_hi.9+0x1fc8>
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1470>
+               	jalr	ra <.Lpcrel_hi.9+0x1fd4>
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x147c>
+               	jalr	ra <.Lpcrel_hi.9+0x1fe0>
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1488>
+               	jalr	ra <.Lpcrel_hi.9+0x1fec>
                	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1494>
+               	jalr	ra <.Lpcrel_hi.9+0x1ff8>
                	mv	s6, a0
-               	addi	a0, s0, -0x4f0
+               	addi	a0, s0, -0x688
                	mv	a1, a0
                	sd	s5, 0x0(a1)
                	not	a1, s5
@@ -3081,14 +4515,14 @@ Disassembly of section .text:
                	addi	a2, a1, 0x1
                	addi	a1, a0, 0x10
                	sd	a2, 0x0(a1)
-               	addi	s7, s0, -0x520
-               	addi	a1, s0, -0x538
+               	addi	s7, s0, -0x6b8
+               	addi	a1, s0, -0x6d0
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x2f98 <.Lpcrel_hi.9+0x1544>
-               	bnez	a0, 0x2f6c <.Lpcrel_hi.9+0x1518>
+               	bltu	a1, a2, 0x4600 <.Lpcrel_hi.9+0x20a8>
+               	bnez	a0, 0x45d4 <.Lpcrel_hi.9+0x207c>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -3098,8 +4532,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2f4c <.Lpcrel_hi.9+0x14f8>
-               	j	0x2ff0 <.Lpcrel_hi.9+0x159c>
+               	bne	a5, t0, 0x45b4 <.Lpcrel_hi.9+0x205c>
+               	j	0x4658 <.Lpcrel_hi.9+0x2100>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -3109,9 +4543,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x2f78 <.Lpcrel_hi.9+0x1524>
-               	j	0x2ff0 <.Lpcrel_hi.9+0x159c>
-               	bnez	a0, 0x2fc8 <.Lpcrel_hi.9+0x1574>
+               	bne	a5, t0, 0x45e0 <.Lpcrel_hi.9+0x2088>
+               	j	0x4658 <.Lpcrel_hi.9+0x2100>
+               	bnez	a0, 0x4630 <.Lpcrel_hi.9+0x20d8>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x18
@@ -3121,8 +4555,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2fa8 <.Lpcrel_hi.9+0x1554>
-               	j	0x2ff0 <.Lpcrel_hi.9+0x159c>
+               	bne	a4, t0, 0x4610 <.Lpcrel_hi.9+0x20b8>
+               	j	0x4658 <.Lpcrel_hi.9+0x2100>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -3132,19 +4566,19 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2fd4 <.Lpcrel_hi.9+0x1580>
-               	addi	a1, s0, -0x538
+               	bne	a2, t0, 0x463c <.Lpcrel_hi.9+0x20e4>
+               	addi	a1, s0, -0x6d0
                	mv	a0, s7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x15a4>
-               	addi	s8, s0, -0x550
-               	addi	a0, s0, -0x580
+               	jalr	ra <.Lpcrel_hi.9+0x2108>
+               	addi	s8, s0, -0x6e8
+               	addi	a0, s0, -0x718
                	mv	a1, s7
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x3078 <.Lpcrel_hi.9+0x1624>
-               	bnez	a2, 0x304c <.Lpcrel_hi.9+0x15f8>
+               	bltu	a0, a1, 0x46e0 <.Lpcrel_hi.9+0x2188>
+               	bnez	a2, 0x46b4 <.Lpcrel_hi.9+0x215c>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -3154,8 +4588,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x302c <.Lpcrel_hi.9+0x15d8>
-               	j	0x30d0 <.Lpcrel_hi.9+0x167c>
+               	bne	a5, t0, 0x4694 <.Lpcrel_hi.9+0x213c>
+               	j	0x4738 <.Lpcrel_hi.9+0x21e0>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -3165,9 +4599,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x3058 <.Lpcrel_hi.9+0x1604>
-               	j	0x30d0 <.Lpcrel_hi.9+0x167c>
-               	bnez	a2, 0x30a8 <.Lpcrel_hi.9+0x1654>
+               	bne	a5, t0, 0x46c0 <.Lpcrel_hi.9+0x2168>
+               	j	0x4738 <.Lpcrel_hi.9+0x21e0>
+               	bnez	a2, 0x4710 <.Lpcrel_hi.9+0x21b8>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x30
@@ -3177,8 +4611,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x3088 <.Lpcrel_hi.9+0x1634>
-               	j	0x30d0 <.Lpcrel_hi.9+0x167c>
+               	bne	a4, t0, 0x46f0 <.Lpcrel_hi.9+0x2198>
+               	j	0x4738 <.Lpcrel_hi.9+0x21e0>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x30
@@ -3188,28 +4622,68 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x30b4 <.Lpcrel_hi.9+0x1660>
-               	addi	a1, s0, -0x580
+               	bne	a1, t0, 0x471c <.Lpcrel_hi.9+0x21c4>
+               	addi	a1, s0, -0x718
                	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1684>
-               	mv	a0, s8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	ld	s7, 0x0(a0)
-               	addi	a0, s8, 0x10
-               	ld	s8, 0x0(a0)
+               	jalr	ra <.Lpcrel_hi.9+0x21e8>
+               	addi	a0, s0, -0x730
+               	mv	a1, s8
+               	or	a2, a0, a1
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a0, a1, 0x47bc <.Lpcrel_hi.9+0x2264>
+               	bnez	a2, 0x4790 <.Lpcrel_hi.9+0x2238>
+               	addi	a3, a0, 0x18
+               	addi	a4, a1, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x4770 <.Lpcrel_hi.9+0x2218>
+               	j	0x4814 <.Lpcrel_hi.9+0x22bc>
+               	addi	a3, a0, 0x18
+               	addi	a4, a1, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x479c <.Lpcrel_hi.9+0x2244>
+               	j	0x4814 <.Lpcrel_hi.9+0x22bc>
+               	bnez	a2, 0x47ec <.Lpcrel_hi.9+0x2294>
+               	mv	a2, a0
+               	mv	a3, a1
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x47cc <.Lpcrel_hi.9+0x2274>
+               	j	0x4814 <.Lpcrel_hi.9+0x22bc>
+               	mv	a2, a0
+               	mv	a0, a1
+               	li	a1, 0x18
+               	lbu	a3, 0x0(a0)
+               	sb	a3, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x47f8 <.Lpcrel_hi.9+0x22a0>
+               	addi	a1, s0, -0x730
                	mv	a0, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x16a8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x16b4>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x16c0>
+               	jalr	ra <.Lpcrel_hi.9+0x22c4>
                	mv	s6, a0
-               	addi	a0, s0, -0x5b0
+               	addi	a0, s0, -0x760
                	mv	a1, a0
                	sd	s5, 0x0(a1)
                	addi	a1, s5, 0x1
@@ -3232,14 +4706,14 @@ Disassembly of section .text:
                	xor	a1, s5, t0
                	addi	a2, a0, 0x28
                	sd	a1, 0x0(a2)
-               	addi	s7, s0, -0x5e0
-               	addi	a1, s0, -0x610
+               	addi	s7, s0, -0x790
+               	addi	a1, s0, -0x7c0
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x31f4 <.Lpcrel_hi.9+0x17a0>
-               	bnez	a0, 0x31c8 <.Lpcrel_hi.9+0x1774>
+               	bltu	a1, a2, 0x48fc <.Lpcrel_hi.9+0x23a4>
+               	bnez	a0, 0x48d0 <.Lpcrel_hi.9+0x2378>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -3249,8 +4723,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x31a8 <.Lpcrel_hi.9+0x1754>
-               	j	0x324c <.Lpcrel_hi.9+0x17f8>
+               	bne	a5, t0, 0x48b0 <.Lpcrel_hi.9+0x2358>
+               	j	0x4954 <.Lpcrel_hi.9+0x23fc>
                	addi	a3, a1, 0x30
                	addi	a4, a2, 0x30
                	li	a5, 0x30
@@ -3260,9 +4734,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x31d4 <.Lpcrel_hi.9+0x1780>
-               	j	0x324c <.Lpcrel_hi.9+0x17f8>
-               	bnez	a0, 0x3224 <.Lpcrel_hi.9+0x17d0>
+               	bne	a5, t0, 0x48dc <.Lpcrel_hi.9+0x2384>
+               	j	0x4954 <.Lpcrel_hi.9+0x23fc>
+               	bnez	a0, 0x492c <.Lpcrel_hi.9+0x23d4>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x30
@@ -3272,8 +4746,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x3204 <.Lpcrel_hi.9+0x17b0>
-               	j	0x324c <.Lpcrel_hi.9+0x17f8>
+               	bne	a4, t0, 0x490c <.Lpcrel_hi.9+0x23b4>
+               	j	0x4954 <.Lpcrel_hi.9+0x23fc>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x30
@@ -3283,20 +4757,22 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x3230 <.Lpcrel_hi.9+0x17dc>
-               	addi	a1, s0, -0x610
+               	bne	a2, t0, 0x4938 <.Lpcrel_hi.9+0x23e0>
+               	addi	a1, s0, -0x7c0
                	mv	a0, s7
                	mv	a2, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1804>
-               	addi	s8, s0, -0x628
-               	addi	a0, s0, -0x658
+               	jalr	ra <.Lpcrel_hi.9+0x2408>
+               	addi	s8, s0, -0x7d8
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7f8
+               	add	a0, s0, t0
                	mv	a1, s7
                	or	a2, a0, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a0, a1, 0x32d8 <.Lpcrel_hi.9+0x1884>
-               	bnez	a2, 0x32ac <.Lpcrel_hi.9+0x1858>
+               	bltu	a0, a1, 0x49e8 <.Lpcrel_hi.9+0x2490>
+               	bnez	a2, 0x49bc <.Lpcrel_hi.9+0x2464>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -3306,8 +4782,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x328c <.Lpcrel_hi.9+0x1838>
-               	j	0x3330 <.Lpcrel_hi.9+0x18dc>
+               	bne	a5, t0, 0x499c <.Lpcrel_hi.9+0x2444>
+               	j	0x4a40 <.Lpcrel_hi.9+0x24e8>
                	addi	a3, a0, 0x30
                	addi	a4, a1, 0x30
                	li	a5, 0x30
@@ -3317,9 +4793,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x32b8 <.Lpcrel_hi.9+0x1864>
-               	j	0x3330 <.Lpcrel_hi.9+0x18dc>
-               	bnez	a2, 0x3308 <.Lpcrel_hi.9+0x18b4>
+               	bne	a5, t0, 0x49c8 <.Lpcrel_hi.9+0x2470>
+               	j	0x4a40 <.Lpcrel_hi.9+0x24e8>
+               	bnez	a2, 0x4a18 <.Lpcrel_hi.9+0x24c0>
                	mv	a2, a0
                	mv	a3, a1
                	li	a4, 0x30
@@ -3329,8 +4805,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x32e8 <.Lpcrel_hi.9+0x1894>
-               	j	0x3330 <.Lpcrel_hi.9+0x18dc>
+               	bne	a4, t0, 0x49f8 <.Lpcrel_hi.9+0x24a0>
+               	j	0x4a40 <.Lpcrel_hi.9+0x24e8>
                	mv	a2, a0
                	mv	a0, a1
                	li	a1, 0x30
@@ -3340,49 +4816,152 @@ Disassembly of section .text:
                	addi	a0, a0, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x3314 <.Lpcrel_hi.9+0x18c0>
-               	addi	a1, s0, -0x658
+               	bne	a1, t0, 0x4a24 <.Lpcrel_hi.9+0x24cc>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7f8
+               	add	a1, s0, t0
                	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x18e4>
+               	jalr	ra <.Lpcrel_hi.9+0x24f8>
                	mv	a0, s8
                	ld	a1, 0x0(a0)
                	addi	a0, s8, 0x8
                	ld	a2, 0x0(a0)
                	addi	a0, s8, 0x10
                	ld	a3, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7e0
+               	add	a0, s0, t0
                	add	a4, a1, s5
-               	xor	s7, a2, s5
-               	add	s5, a3, a1
+               	mv	a5, a0
+               	sd	a4, 0x0(a5)
+               	xor	a4, a2, s5
+               	addi	a2, a0, 0x8
+               	sd	a4, 0x0(a2)
+               	add	a2, a3, a1
+               	addi	a1, a0, 0x10
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7c8
+               	add	a1, s0, t0
+               	mv	a2, a0
+               	or	a0, a1, a2
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a1, a2, 0x4b1c <.Lpcrel_hi.9+0x25c4>
+               	bnez	a0, 0x4af0 <.Lpcrel_hi.9+0x2598>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x4ad0 <.Lpcrel_hi.9+0x2578>
+               	j	0x4b74 <.Lpcrel_hi.9+0x261c>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x4afc <.Lpcrel_hi.9+0x25a4>
+               	j	0x4b74 <.Lpcrel_hi.9+0x261c>
+               	bnez	a0, 0x4b4c <.Lpcrel_hi.9+0x25f4>
+               	mv	a0, a1
+               	mv	a3, a2
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x4b2c <.Lpcrel_hi.9+0x25d4>
+               	j	0x4b74 <.Lpcrel_hi.9+0x261c>
+               	mv	a0, a1
+               	mv	a1, a2
+               	li	a2, 0x18
+               	lbu	a3, 0x0(a1)
+               	sb	a3, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x4b58 <.Lpcrel_hi.9+0x2600>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7c8
+               	add	a1, s0, t0
                	mv	a0, s6
-               	mv	a1, a4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1918>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1924>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1930>
+               	jalr	ra <.Lpcrel_hi.9+0x262c>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x2910 <.Lpcrel_hi.9+0xebc>
+               	bltu	s4, t0, 0x3d10 <.Lpcrel_hi.9+0x17b8>
                	mv	a0, s3
-               	ld	s1, 0x6e8(sp)
-               	ld	s2, 0x6e0(sp)
-               	ld	s3, 0x6d8(sp)
-               	ld	s4, 0x6d0(sp)
-               	ld	s5, 0x6c8(sp)
-               	ld	s6, 0x6c0(sp)
-               	ld	s7, 0x6b8(sp)
-               	ld	s8, 0x6b0(sp)
-               	ld	s9, 0x6a8(sp)
-               	ld	s10, 0x6a0(sp)
-               	ld	s11, 0x698(sp)
-               	fld	fs0, 0x690(sp)
-               	fld	fs1, 0x688(sp)
-               	ld	ra, 0x6f8(sp)
-               	ld	s0, 0x6f0(sp)
-               	addi	sp, sp, 0x700
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x718
+               	add	t1, sp, t1
+               	ld	s1, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x720
+               	add	t1, sp, t1
+               	ld	s2, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x728
+               	add	t1, sp, t1
+               	ld	s3, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x730
+               	add	t1, sp, t1
+               	ld	s4, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x738
+               	add	t1, sp, t1
+               	ld	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x740
+               	add	t1, sp, t1
+               	ld	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x748
+               	add	t1, sp, t1
+               	ld	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x750
+               	add	t1, sp, t1
+               	ld	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x758
+               	add	t1, sp, t1
+               	ld	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x760
+               	add	t1, sp, t1
+               	ld	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x768
+               	add	t1, sp, t1
+               	ld	s11, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x770
+               	add	t1, sp, t1
+               	fld	fs0, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x708
+               	add	t1, sp, t1
+               	ld	ra, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x710
+               	add	t1, sp, t1
+               	ld	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x700
+               	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/call/call_ret_small.dis
+++ b/test/golden/riscv64-linux/call/call_ret_small.dis
@@ -316,205 +316,391 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_ret_small.fold8>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a2, a0
-               	sd	a1, -0x20(s0)
-               	addi	a1, s0, -0x20
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x18
+               	lw	a2, 0x0(a1)
+               	addi	a1, s0, -0x14
                	lw	a3, 0x0(a1)
-               	addi	a1, s0, -0x1c
-               	lw	s1, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold8+0x34>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold8+0x48>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a8 <corpus.cases.call.call_ret_small.fold8+0x3c>
+               	j	0x4dc <corpus.cases.call.call_ret_small.fold8+0x70>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a8 <corpus.cases.call.call_ret_small.fold8+0x3c>
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f4 <corpus.cases.call.call_ret_small.fold8+0x88>
+               	j	0x528 <corpus.cases.call.call_ret_small.fold8+0xbc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f4 <corpus.cases.call.call_ret_small.fold8+0x88>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold8f>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	fsd	fs0, 0x18(sp)
-               	mv	a1, a0
-               	fsw	fa0, -0x20(s0)
-               	fsw	fa1, -0x1c(s0)
-               	addi	a2, s0, -0x20
-               	flw	ft0, 0x0(a2)
-               	addi	a2, s0, -0x1c
-               	flw	fs0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold8f+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold8f+0x4c>
-               	fld	fs0, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	fsw	fa0, -0x18(s0)
+               	fsw	fa1, -0x14(s0)
+               	addi	a1, s0, -0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s0, -0x14
+               	flw	ft1, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x57c <corpus.cases.call.call_ret_small.fold8f+0x44>
+               	j	0x5b0 <corpus.cases.call.call_ret_small.fold8f+0x78>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x57c <corpus.cases.call.call_ret_small.fold8f+0x44>
+               	fmv.x.w	a1, ft1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5cc <corpus.cases.call.call_ret_small.fold8f+0x94>
+               	j	0x600 <corpus.cases.call.call_ret_small.fold8f+0xc8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5cc <corpus.cases.call.call_ret_small.fold8f+0x94>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold12>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lw	a2, 0x0(a1)
-               	addi	a1, s0, -0x2c
-               	lw	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	lw	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold12+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold12+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold12+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1c
+               	lw	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	lw	a4, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x658 <corpus.cases.call.call_ret_small.fold12+0x48>
+               	j	0x68c <corpus.cases.call.call_ret_small.fold12+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x658 <corpus.cases.call.call_ret_small.fold12+0x48>
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6a4 <corpus.cases.call.call_ret_small.fold12+0x94>
+               	j	0x6d8 <corpus.cases.call.call_ret_small.fold12+0xc8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6a4 <corpus.cases.call.call_ret_small.fold12+0x94>
+               	slli	a1, a4, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6f0 <corpus.cases.call.call_ret_small.fold12+0xe0>
+               	j	0x724 <corpus.cases.call.call_ret_small.fold12+0x114>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6f0 <corpus.cases.call.call_ret_small.fold12+0xe0>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold16>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a3, a0
-               	sd	a1, -0x28(s0)
-               	sd	a2, -0x20(s0)
-               	addi	a1, s0, -0x28
-               	ld	a2, 0x0(a1)
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
                	addi	a1, s0, -0x20
-               	ld	s1, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16+0x4c>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	ld	a2, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a3, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x76c <corpus.cases.call.call_ret_small.fold16+0x38>
+               	j	0x7a0 <corpus.cases.call.call_ret_small.fold16+0x6c>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x76c <corpus.cases.call.call_ret_small.fold16+0x38>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7b0 <corpus.cases.call.call_ret_small.fold16+0x7c>
+               	j	0x7e4 <corpus.cases.call.call_ret_small.fold16+0xb0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a4, a3, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7b0 <corpus.cases.call.call_ret_small.fold16+0x7c>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold16f>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	fsd	fs0, 0x18(sp)
-               	mv	a1, a0
-               	fsd	fa0, -0x28(s0)
-               	fsd	fa1, -0x20(s0)
-               	addi	a2, s0, -0x28
-               	fld	fa0, 0x0(a2)
-               	addi	a2, s0, -0x20
-               	fld	fs0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16f+0x34>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16f+0x48>
-               	fld	fs0, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	fsd	fa0, -0x20(s0)
+               	fsd	fa1, -0x18(s0)
+               	addi	a1, s0, -0x20
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	fld	ft1, 0x0(a1)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x830 <corpus.cases.call.call_ret_small.fold16f+0x3c>
+               	j	0x864 <corpus.cases.call.call_ret_small.fold16f+0x70>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x830 <corpus.cases.call.call_ret_small.fold16f+0x3c>
+               	fmv.x.d	a1, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x878 <corpus.cases.call.call_ret_small.fold16f+0x84>
+               	j	0x8ac <corpus.cases.call.call_ret_small.fold16f+0xb8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x878 <corpus.cases.call.call_ret_small.fold16f+0x84>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold16m>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	fsd	fs0, 0x18(sp)
-               	mv	a2, a0
-               	sd	a1, -0x28(s0)
-               	fsd	fa0, -0x20(s0)
-               	addi	a1, s0, -0x28
-               	ld	a3, 0x0(a1)
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	fsd	fa0, -0x18(s0)
                	addi	a1, s0, -0x20
-               	fld	fs0, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16m+0x38>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16m+0x4c>
-               	fld	fs0, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	ld	a2, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	fld	ft0, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8f4 <corpus.cases.call.call_ret_small.fold16m+0x38>
+               	j	0x928 <corpus.cases.call.call_ret_small.fold16m+0x6c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8f4 <corpus.cases.call.call_ret_small.fold16m+0x38>
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x93c <corpus.cases.call.call_ret_small.fold16m+0x80>
+               	j	0x970 <corpus.cases.call.call_ret_small.fold16m+0xb4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x93c <corpus.cases.call.call_ret_small.fold16m+0x80>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.fold16n>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a2, a0
-               	fsd	fa0, -0x28(s0)
-               	sd	a1, -0x20(s0)
-               	addi	a1, s0, -0x28
-               	fld	fa0, 0x0(a1)
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	fsd	fa0, -0x20(s0)
+               	sd	a1, -0x18(s0)
                	addi	a1, s0, -0x20
-               	ld	s1, 0x0(a1)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16n+0x34>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.fold16n+0x48>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a2, 0x0(a1)
+               	fmv.x.d	a1, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9bc <corpus.cases.call.call_ret_small.fold16n+0x3c>
+               	j	0x9f0 <corpus.cases.call.call_ret_small.fold16n+0x70>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9bc <corpus.cases.call.call_ret_small.fold16n+0x3c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa00 <corpus.cases.call.call_ret_small.fold16n+0x80>
+               	j	0xa34 <corpus.cases.call.call_ret_small.fold16n+0xb4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa00 <corpus.cases.call.call_ret_small.fold16n+0x80>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.call.call_ret_small.layout>:
@@ -522,253 +708,750 @@ Disassembly of section .text:
                	sd	ra, 0x8(sp)
                	sd	s0, 0x0(sp)
                	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa64 <corpus.cases.call.call_ret_small.layout+0x20>
+               	j	0xa9c <corpus.cases.call.call_ret_small.layout+0x58>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa64 <corpus.cases.call.call_ret_small.layout+0x20>
                	li	a1, 0x2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x30>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x5c>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x68>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x74>
                	li	a1, 0x8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x6c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0xc
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_ret_small.layout+0x80>
-               	mv	a1, a0
-               	mv	a0, a1
+               	li	a1, 0xc
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x8c>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x94>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0x98>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0xa8>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0xa4>
+               	li	a1, 0x10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_ret_small.layout+0xb0>
                	li	a1, 0x10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_ret_small.layout+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x10
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.layout+0xd0>
                	ld	ra, 0x8(sp)
                	ld	s0, 0x0(sp)
                	addi	sp, sp, 0x10
                	ret
 
 <corpus.cases.call.call_ret_small.regain>:
-               	addi	sp, sp, -0xd0
-               	sd	ra, 0xc8(sp)
-               	sd	s0, 0xc0(sp)
-               	addi	s0, sp, 0xd0
-               	sd	s1, 0xb8(sp)
-               	sd	s2, 0xb0(sp)
-               	sd	s3, 0xa8(sp)
-               	sd	s4, 0xa0(sp)
-               	sd	s5, 0x98(sp)
-               	sd	s6, 0x90(sp)
-               	sd	s7, 0x88(sp)
-               	sd	s8, 0x80(sp)
-               	fsd	fs0, 0x78(sp)
-               	fsd	fs1, 0x70(sp)
-               	fsd	fs2, 0x68(sp)
-               	fsd	fs3, 0x60(sp)
-               	fsd	fs4, 0x58(sp)
-               	sd	a0, -0x88(s0)
-               	sd	a1, -0x80(s0)
-               	fsd	fa0, -0x98(s0)
-               	fsd	fa1, -0x90(s0)
-               	sd	a2, -0xa8(s0)
-               	fsd	fa2, -0xa0(s0)
-               	sd	a3, -0xb8(s0)
-               	sd	a4, -0xb0(s0)
-               	sd	a5, -0xc0(s0)
-               	fsw	fa3, -0xc8(s0)
-               	fsw	fa4, -0xc4(s0)
-               	addi	a1, s0, -0x88
-               	ld	s1, 0x0(a1)
-               	addi	a1, s0, -0x80
-               	ld	s2, 0x0(a1)
-               	addi	a1, s0, -0x98
-               	fld	fs0, 0x0(a1)
-               	addi	a1, s0, -0x90
-               	fld	fs1, 0x0(a1)
-               	addi	a1, s0, -0xa8
-               	ld	s3, 0x0(a1)
-               	addi	a1, s0, -0xa0
-               	fld	fs2, 0x0(a1)
-               	addi	a1, s0, -0xb8
-               	lw	s4, 0x0(a1)
-               	addi	a1, s0, -0xb4
-               	lw	s5, 0x0(a1)
-               	addi	a1, s0, -0xb0
-               	lw	s6, 0x0(a1)
-               	addi	a1, s0, -0xc0
-               	lw	s7, 0x0(a1)
-               	addi	a1, s0, -0xbc
-               	lw	s8, 0x0(a1)
-               	addi	a1, s0, -0xc8
-               	flw	fs3, 0x0(a1)
-               	addi	a1, s0, -0xc4
-               	flw	fs4, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0xd8>
+               	addi	sp, sp, -0x150
+               	sd	ra, 0x148(sp)
+               	sd	s0, 0x140(sp)
+               	addi	s0, sp, 0x150
+               	sd	s1, 0x138(sp)
+               	sd	s2, 0x130(sp)
+               	sd	s3, 0x128(sp)
+               	sd	s4, 0x120(sp)
+               	sd	s5, 0x118(sp)
+               	sd	a0, -0x48(s0)
+               	sd	a1, -0x40(s0)
+               	fsd	fa0, -0x58(s0)
+               	fsd	fa1, -0x50(s0)
+               	sd	a2, -0x68(s0)
+               	fsd	fa2, -0x60(s0)
+               	sd	a3, -0x78(s0)
+               	sd	a4, -0x70(s0)
+               	sd	a5, -0x80(s0)
+               	fsw	fa3, -0x88(s0)
+               	fsw	fa4, -0x84(s0)
+               	addi	a0, s0, -0x98
+               	mv	a1, a0
+               	addi	a2, s0, -0x48
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0xbe0 <corpus.cases.call.call_ret_small.regain+0xc8>
+               	bnez	a3, 0xbb4 <corpus.cases.call.call_ret_small.regain+0x9c>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xb94 <corpus.cases.call.call_ret_small.regain+0x7c>
+               	j	0xc38 <corpus.cases.call.call_ret_small.regain+0x120>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xbc0 <corpus.cases.call.call_ret_small.regain+0xa8>
+               	j	0xc38 <corpus.cases.call.call_ret_small.regain+0x120>
+               	bnez	a3, 0xc10 <corpus.cases.call.call_ret_small.regain+0xf8>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xbf0 <corpus.cases.call.call_ret_small.regain+0xd8>
+               	j	0xc38 <corpus.cases.call.call_ret_small.regain+0x120>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x10
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0xc1c <corpus.cases.call.call_ret_small.regain+0x104>
+               	addi	s1, s0, -0xa8
                	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0xe4>
+               	addi	a2, s0, -0x58
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0xcb0 <corpus.cases.call.call_ret_small.regain+0x198>
+               	bnez	a3, 0xc84 <corpus.cases.call.call_ret_small.regain+0x16c>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xc64 <corpus.cases.call.call_ret_small.regain+0x14c>
+               	j	0xd08 <corpus.cases.call.call_ret_small.regain+0x1f0>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xc90 <corpus.cases.call.call_ret_small.regain+0x178>
+               	j	0xd08 <corpus.cases.call.call_ret_small.regain+0x1f0>
+               	bnez	a3, 0xce0 <corpus.cases.call.call_ret_small.regain+0x1c8>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xcc0 <corpus.cases.call.call_ret_small.regain+0x1a8>
+               	j	0xd08 <corpus.cases.call.call_ret_small.regain+0x1f0>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x10
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0xcec <corpus.cases.call.call_ret_small.regain+0x1d4>
+               	addi	s2, s0, -0xb8
                	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0xf0>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0xfc>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x108>
+               	addi	a2, s0, -0x68
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0xd80 <corpus.cases.call.call_ret_small.regain+0x268>
+               	bnez	a3, 0xd54 <corpus.cases.call.call_ret_small.regain+0x23c>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xd34 <corpus.cases.call.call_ret_small.regain+0x21c>
+               	j	0xdd8 <corpus.cases.call.call_ret_small.regain+0x2c0>
+               	addi	a4, a1, 0x10
+               	addi	a5, a2, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xd60 <corpus.cases.call.call_ret_small.regain+0x248>
+               	j	0xdd8 <corpus.cases.call.call_ret_small.regain+0x2c0>
+               	bnez	a3, 0xdb0 <corpus.cases.call.call_ret_small.regain+0x298>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xd90 <corpus.cases.call.call_ret_small.regain+0x278>
+               	j	0xdd8 <corpus.cases.call.call_ret_small.regain+0x2c0>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x10
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0xdbc <corpus.cases.call.call_ret_small.regain+0x2a4>
+               	addi	s3, s0, -0xc4
                	mv	a1, s3
+               	addi	a2, s0, -0x78
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0xe58 <corpus.cases.call.call_ret_small.regain+0x340>
+               	bnez	a3, 0xe2c <corpus.cases.call.call_ret_small.regain+0x314>
+               	addi	a4, a1, 0x8
+               	addi	a5, a2, 0x8
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	li	a6, 0x8
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xe0c <corpus.cases.call.call_ret_small.regain+0x2f4>
+               	j	0xeb8 <corpus.cases.call.call_ret_small.regain+0x3a0>
+               	addi	a4, a1, 0xc
+               	addi	a5, a2, 0xc
+               	li	a6, 0xc
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xe38 <corpus.cases.call.call_ret_small.regain+0x320>
+               	j	0xeb8 <corpus.cases.call.call_ret_small.regain+0x3a0>
+               	bnez	a3, 0xe90 <corpus.cases.call.call_ret_small.regain+0x378>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a5, 0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xe68 <corpus.cases.call.call_ret_small.regain+0x350>
+               	lw	a5, 0x0(a4)
+               	sw	a5, 0x0(a3)
+               	j	0xeb8 <corpus.cases.call.call_ret_small.regain+0x3a0>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0xc
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0xe9c <corpus.cases.call.call_ret_small.regain+0x384>
+               	addi	s4, s0, -0xcc
+               	lbu	a1, -0x80(s0)
+               	lbu	a2, -0x7f(s0)
+               	lbu	a3, -0x7e(s0)
+               	lbu	a4, -0x7d(s0)
+               	lbu	a5, -0x7c(s0)
+               	lbu	a6, -0x7b(s0)
+               	lbu	a7, -0x7a(s0)
+               	lbu	t5, -0x79(s0)
+               	sb	a1, 0x0(s4)
+               	sb	a2, 0x1(s4)
+               	sb	a3, 0x2(s4)
+               	sb	a4, 0x3(s4)
+               	sb	a5, 0x4(s4)
+               	sb	a6, 0x5(s4)
+               	sb	a7, 0x6(s4)
+               	sb	t5, 0x7(s4)
+               	addi	s5, s0, -0xd4
+               	lbu	a1, -0x88(s0)
+               	lbu	a2, -0x87(s0)
+               	lbu	a3, -0x86(s0)
+               	lbu	a4, -0x85(s0)
+               	lbu	a5, -0x84(s0)
+               	lbu	a6, -0x83(s0)
+               	lbu	a7, -0x82(s0)
+               	lbu	t5, -0x81(s0)
+               	sb	a1, 0x0(s5)
+               	sb	a2, 0x1(s5)
+               	sb	a3, 0x2(s5)
+               	sb	a4, 0x3(s5)
+               	sb	a5, 0x4(s5)
+               	sb	a6, 0x5(s5)
+               	sb	a7, 0x6(s5)
+               	sb	t5, 0x7(s5)
+               	addi	a1, s0, -0xe8
+               	mv	a2, a1
+               	mv	a3, a0
+               	or	a0, a2, a3
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a2, a3, 0xfb8 <corpus.cases.call.call_ret_small.regain+0x4a0>
+               	bnez	a0, 0xf8c <corpus.cases.call.call_ret_small.regain+0x474>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xf6c <corpus.cases.call.call_ret_small.regain+0x454>
+               	j	0x1010 <corpus.cases.call.call_ret_small.regain+0x4f8>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xf98 <corpus.cases.call.call_ret_small.regain+0x480>
+               	j	0x1010 <corpus.cases.call.call_ret_small.regain+0x4f8>
+               	bnez	a0, 0xfe8 <corpus.cases.call.call_ret_small.regain+0x4d0>
+               	mv	a0, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xfc8 <corpus.cases.call.call_ret_small.regain+0x4b0>
+               	j	0x1010 <corpus.cases.call.call_ret_small.regain+0x4f8>
+               	mv	a0, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0xff4 <corpus.cases.call.call_ret_small.regain+0x4dc>
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x114>
-               	fmv.d	fa0, fs2
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x528>
+               	addi	a1, s0, -0xf8
+               	mv	a2, a1
+               	mv	a3, s1
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x10c0 <corpus.cases.call.call_ret_small.regain+0x5a8>
+               	bnez	a4, 0x1094 <corpus.cases.call.call_ret_small.regain+0x57c>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1074 <corpus.cases.call.call_ret_small.regain+0x55c>
+               	j	0x1118 <corpus.cases.call.call_ret_small.regain+0x600>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x10a0 <corpus.cases.call.call_ret_small.regain+0x588>
+               	j	0x1118 <corpus.cases.call.call_ret_small.regain+0x600>
+               	bnez	a4, 0x10f0 <corpus.cases.call.call_ret_small.regain+0x5d8>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x10d0 <corpus.cases.call.call_ret_small.regain+0x5b8>
+               	j	0x1118 <corpus.cases.call.call_ret_small.regain+0x600>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x10fc <corpus.cases.call.call_ret_small.regain+0x5e4>
+               	fld	fa0, 0x0(a1)
+               	fld	fa1, 0x8(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x120>
-               	mv	a1, s4
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x608>
+               	addi	a1, s0, -0x108
+               	mv	a2, a1
+               	mv	a3, s2
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x11a0 <corpus.cases.call.call_ret_small.regain+0x688>
+               	bnez	a4, 0x1174 <corpus.cases.call.call_ret_small.regain+0x65c>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1154 <corpus.cases.call.call_ret_small.regain+0x63c>
+               	j	0x11f8 <corpus.cases.call.call_ret_small.regain+0x6e0>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1180 <corpus.cases.call.call_ret_small.regain+0x668>
+               	j	0x11f8 <corpus.cases.call.call_ret_small.regain+0x6e0>
+               	bnez	a4, 0x11d0 <corpus.cases.call.call_ret_small.regain+0x6b8>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x11b0 <corpus.cases.call.call_ret_small.regain+0x698>
+               	j	0x11f8 <corpus.cases.call.call_ret_small.regain+0x6e0>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x11dc <corpus.cases.call.call_ret_small.regain+0x6c4>
+               	ld	a2, 0x0(a1)
+               	fld	fa0, 0x8(a1)
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x12c>
-               	mv	a1, s5
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x6ec>
+               	addi	a1, s0, -0x114
+               	mv	a2, a1
+               	mv	a3, s3
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x128c <corpus.cases.call.call_ret_small.regain+0x774>
+               	bnez	a4, 0x1260 <corpus.cases.call.call_ret_small.regain+0x748>
+               	addi	a5, a2, 0x8
+               	addi	a6, a3, 0x8
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	li	a7, 0x8
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1240 <corpus.cases.call.call_ret_small.regain+0x728>
+               	j	0x12ec <corpus.cases.call.call_ret_small.regain+0x7d4>
+               	addi	a5, a2, 0xc
+               	addi	a6, a3, 0xc
+               	li	a7, 0xc
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x126c <corpus.cases.call.call_ret_small.regain+0x754>
+               	j	0x12ec <corpus.cases.call.call_ret_small.regain+0x7d4>
+               	bnez	a4, 0x12c4 <corpus.cases.call.call_ret_small.regain+0x7ac>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x129c <corpus.cases.call.call_ret_small.regain+0x784>
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	j	0x12ec <corpus.cases.call.call_ret_small.regain+0x7d4>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0xc
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x12d0 <corpus.cases.call.call_ret_small.regain+0x7b8>
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x120(s0)
+               	sb	a3, -0x11f(s0)
+               	sb	a4, -0x11e(s0)
+               	sb	a5, -0x11d(s0)
+               	sb	a6, -0x11c(s0)
+               	sb	a7, -0x11b(s0)
+               	sb	t5, -0x11a(s0)
+               	sb	t6, -0x119(s0)
+               	ld	a2, -0x120(s0)
+               	sd	zero, -0x128(s0)
+               	lbu	a3, 0x8(a1)
+               	lbu	a4, 0x9(a1)
+               	lbu	a5, 0xa(a1)
+               	lbu	a6, 0xb(a1)
+               	sb	a3, -0x128(s0)
+               	sb	a4, -0x127(s0)
+               	sb	a5, -0x126(s0)
+               	sb	a6, -0x125(s0)
+               	ld	a3, -0x128(s0)
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x138>
-               	mv	a1, s6
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x848>
+               	addi	a1, s0, -0x130
+               	lbu	a2, 0x0(s4)
+               	lbu	a3, 0x1(s4)
+               	lbu	a4, 0x2(s4)
+               	lbu	a5, 0x3(s4)
+               	lbu	a6, 0x4(s4)
+               	lbu	a7, 0x5(s4)
+               	lbu	t5, 0x6(s4)
+               	lbu	t6, 0x7(s4)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x138(s0)
+               	sb	a3, -0x137(s0)
+               	sb	a4, -0x136(s0)
+               	sb	a5, -0x135(s0)
+               	sb	a6, -0x134(s0)
+               	sb	a7, -0x133(s0)
+               	sb	t5, -0x132(s0)
+               	sb	t6, -0x131(s0)
+               	ld	a1, -0x138(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x144>
-               	mv	a1, s7
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x8d8>
+               	addi	a1, s0, -0x140
+               	lbu	a2, 0x0(s5)
+               	lbu	a3, 0x1(s5)
+               	lbu	a4, 0x2(s5)
+               	lbu	a5, 0x3(s5)
+               	lbu	a6, 0x4(s5)
+               	lbu	a7, 0x5(s5)
+               	lbu	t5, 0x6(s5)
+               	lbu	t6, 0x7(s5)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	flw	ft0, 0x0(a1)
+               	flw	ft1, 0x4(a1)
+               	fmv.s	fa0, ft0
+               	fmv.s	fa1, ft1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x150>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x15c>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x168>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x174>
-               	ld	s1, 0xb8(sp)
-               	ld	s2, 0xb0(sp)
-               	ld	s3, 0xa8(sp)
-               	ld	s4, 0xa0(sp)
-               	ld	s5, 0x98(sp)
-               	ld	s6, 0x90(sp)
-               	ld	s7, 0x88(sp)
-               	ld	s8, 0x80(sp)
-               	fld	fs0, 0x78(sp)
-               	fld	fs1, 0x70(sp)
-               	fld	fs2, 0x68(sp)
-               	fld	fs3, 0x60(sp)
-               	fld	fs4, 0x58(sp)
-               	ld	ra, 0xc8(sp)
-               	ld	s0, 0xc0(sp)
-               	addi	sp, sp, 0xd0
+               	jalr	ra <corpus.cases.call.call_ret_small.regain+0x934>
+               	ld	s1, 0x138(sp)
+               	ld	s2, 0x130(sp)
+               	ld	s3, 0x128(sp)
+               	ld	s4, 0x120(sp)
+               	ld	s5, 0x118(sp)
+               	ld	ra, 0x148(sp)
+               	ld	s0, 0x140(sp)
+               	addi	sp, sp, 0x150
                	ret
 
 <corpus.cases.call.call_ret_small.checksum>:
-               	addi	sp, sp, -0x1a0
-               	sd	ra, 0x198(sp)
-               	sd	s0, 0x190(sp)
-               	addi	s0, sp, 0x1a0
-               	sd	s1, 0x188(sp)
-               	sd	s2, 0x180(sp)
-               	sd	s3, 0x178(sp)
-               	sd	s4, 0x170(sp)
-               	sd	s5, 0x168(sp)
-               	sd	s6, 0x160(sp)
-               	sd	s7, 0x158(sp)
-               	sd	s8, 0x150(sp)
-               	sd	s9, 0x148(sp)
-               	sd	s10, 0x140(sp)
-               	sd	s11, 0x138(sp)
-               	fsd	fs0, 0x130(sp)
-               	fsd	fs1, 0x128(sp)
-               	fsd	fs2, 0x120(sp)
-               	fsd	fs3, 0x118(sp)
-               	fsd	fs4, 0x110(sp)
+               	addi	sp, sp, -0x310
+               	sd	ra, 0x308(sp)
+               	sd	s0, 0x300(sp)
+               	addi	s0, sp, 0x310
+               	sd	s1, 0x2f8(sp)
+               	sd	s2, 0x2f0(sp)
+               	sd	s3, 0x2e8(sp)
+               	sd	s4, 0x2e0(sp)
+               	sd	s5, 0x2d8(sp)
+               	sd	s6, 0x2d0(sp)
+               	sd	s7, 0x2c8(sp)
+               	sd	s8, 0x2c0(sp)
+               	sd	s9, 0x2b8(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x54>
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x60>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14e0 <corpus.cases.call.call_ret_small.checksum+0x68>
+               	j	0x1518 <corpus.cases.call.call_ret_small.checksum+0xa0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14e0 <corpus.cases.call.call_ret_small.checksum+0x68>
                	li	a1, 0x2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x6c>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xa4>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x78>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xb0>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x84>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xbc>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x90>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xc8>
                	li	a1, 0xc
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x9c>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xd4>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xa8>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xe0>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xb4>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xec>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xc0>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xf8>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0xcc>
-               	addi	s2, s0, -0x178
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x104>
+               	addi	s2, s0, -0x190
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0xb0c <corpus.cases.call.call_ret_small.checksum+0x108>
+               	bnez	a2, 0x15b8 <corpus.cases.call.call_ret_small.checksum+0x140>
                	mv	a2, a1
                	li	a3, 0x40
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xaf4 <corpus.cases.call.call_ret_small.checksum+0xf0>
-               	j	0xb28 <corpus.cases.call.call_ret_small.checksum+0x124>
+               	bne	a3, t0, 0x15a0 <corpus.cases.call.call_ret_small.checksum+0x128>
+               	j	0x15d4 <corpus.cases.call.call_ret_small.checksum+0x15c>
                	mv	a2, a1
                	li	a1, 0x40
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xb14 <corpus.cases.call.call_ret_small.checksum+0x110>
+               	bne	a1, t0, 0x15c0 <corpus.cases.call.call_ret_small.checksum+0x148>
                	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	a1, t0, 0xb38 <corpus.cases.call.call_ret_small.checksum+0x134>
-               	j	0xb9c <corpus.cases.call.call_ret_small.checksum+0x198>
+               	bltu	a1, t0, 0x15e4 <corpus.cases.call.call_ret_small.checksum+0x16c>
+               	j	0x1648 <corpus.cases.call.call_ret_small.checksum+0x1d0>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -793,114 +1476,188 @@ Disassembly of section .text:
                	sd	a2, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0x8
-               	bltu	a1, t0, 0xb38 <corpus.cases.call.call_ret_small.checksum+0x134>
+               	bltu	a1, t0, 0x15e4 <corpus.cases.call.call_ret_small.checksum+0x16c>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0xbb0 <corpus.cases.call.call_ret_small.checksum+0x1ac>
-               	j	0xd7c <.Lpcrel_hi.7+0x3c>
+               	bltu	s4, t0, 0x165c <corpus.cases.call.call_ret_small.checksum+0x1e4>
+               	j	0x19c8 <.Lpcrel_hi.7+0xb4>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
                	add	s5, a1, s1
-               	sext.w	a1, s5
+               	sext.w	a0, s5
+               	zext.b	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x1c4>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x200>
                	sext.w	a1, s5
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x1d0>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x218>
                	sext.w	a1, s5
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x1dc>
-               	sext.w	a1, s5
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x230>
+               	addi	a1, s0, -0x1e4
+               	sext.w	a2, s5
+               	mv	a3, a1
+               	sw	a2, 0x0(a3)
                	srli	a2, s5, 0x20
-               	sext.w	s6, a2
+               	sext.w	a3, a2
+               	addi	a2, a1, 0x4
+               	sw	a3, 0x0(a2)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x1f0(s0)
+               	sb	a3, -0x1ef(s0)
+               	sb	a4, -0x1ee(s0)
+               	sb	a5, -0x1ed(s0)
+               	sb	a6, -0x1ec(s0)
+               	sb	a7, -0x1eb(s0)
+               	sb	t5, -0x1ea(s0)
+               	sb	t6, -0x1e9(s0)
+               	ld	a1, -0x1f0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x1f0>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x1fc>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x29c>
+               	addi	a1, s0, -0x2b0
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a1, s5, t0
-               	fcvt.s.lu	ft0, a1
+               	and	a2, s5, t0
+               	fcvt.s.lu	ft0, a2
                	lui	t0, 0x41000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft1, ft0, ft10
+               	mv	a2, a1
+               	fsw	ft1, 0x0(a2)
                	li	t0, 0xff
-               	and	a1, s5, t0
-               	fcvt.s.lu	ft0, a1
+               	and	a2, s5, t0
+               	fcvt.s.lu	ft0, a2
                	lui	t0, 0x43000
                	fmv.w.x	ft10, t0
-               	fsub.s	fs0, ft0, ft10
-               	fmv.s	fa0, ft1
+               	fsub.s	ft1, ft0, ft10
+               	addi	a2, a1, 0x4
+               	fsw	ft1, 0x0(a2)
+               	flw	ft0, 0x0(a1)
+               	flw	ft1, 0x4(a1)
+               	fmv.s	fa0, ft0
+               	fmv.s	fa1, ft1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x23c>
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x248>
-               	sext.w	a1, s5
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x2fc>
+               	addi	a1, s0, -0x2bc
+               	sext.w	a2, s5
+               	mv	a3, a1
+               	sw	a2, 0x0(a3)
                	srli	a2, s5, 0x10
-               	sext.w	s6, a2
+               	sext.w	a3, a2
+               	addi	a2, a1, 0x4
+               	sw	a3, 0x0(a2)
                	srli	a2, s5, 0x20
-               	sext.w	s7, a2
+               	sext.w	a3, a2
+               	addi	a2, a1, 0x8
+               	sw	a3, 0x0(a2)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x2c8(s0)
+               	sb	a3, -0x2c7(s0)
+               	sb	a4, -0x2c6(s0)
+               	sb	a5, -0x2c5(s0)
+               	sb	a6, -0x2c4(s0)
+               	sb	a7, -0x2c3(s0)
+               	sb	t5, -0x2c2(s0)
+               	sb	t6, -0x2c1(s0)
+               	ld	a2, -0x2c8(s0)
+               	sd	zero, -0x2d0(s0)
+               	lbu	a3, 0x8(a1)
+               	lbu	a4, 0x9(a1)
+               	lbu	a5, 0xa(a1)
+               	lbu	a6, 0xb(a1)
+               	sb	a3, -0x2d0(s0)
+               	sb	a4, -0x2cf(s0)
+               	sb	a5, -0x2ce(s0)
+               	sb	a6, -0x2cd(s0)
+               	ld	a3, -0x2d0(s0)
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x264>
-               	mv	a1, s6
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x3a8>
+               	addi	a1, s0, -0x2e0
+               	mv	a2, a1
+               	sd	s5, 0x0(a2)
+               	not	a2, s5
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x270>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x27c>
-               	not	s6, s5
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x28c>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x298>
+               	jalr	ra <corpus.cases.call.call_ret_small.checksum+0x3d8>
+               	addi	a1, s0, -0x2f0
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	and	a1, s5, t0
-               	fcvt.d.lu	ft0, a1
+               	and	a2, s5, t0
+               	fcvt.d.lu	ft0, a2
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
+               	mv	a2, a1
+               	fsd	ft1, 0x0(a2)
                	lui	t0, 0x40
                	addiw	t0, t0, -0x1
-               	and	a1, s5, t0
-               	fcvt.d.lu	ft0, a1
+               	and	a2, s5, t0
+               	fcvt.d.lu	ft0, a2
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
+               	addi	a2, a1, 0x8
+               	fsd	ft1, 0x0(a2)
+               	fld	fa0, 0x0(a1)
+               	fld	fa1, 0x8(a1)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0xc>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x18>
+               	jalr	ra <.Lpcrel_hi.5+0x1c>
+               	addi	a1, s0, -0x300
                	li	t0, 0x3
-               	mul	a1, s5, t0
-               	addi	a2, a1, 0x1
+               	mul	a2, s5, t0
+               	addi	a3, a2, 0x1
+               	mv	a2, a1
+               	sd	a3, 0x0(a2)
                	lui	t0, 0x8
                	addiw	t0, t0, -0x1
-               	and	a1, s5, t0
-               	fcvt.d.lu	ft0, a1
+               	and	a2, s5, t0
+               	fcvt.d.lu	ft0, a2
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
+               	addi	a2, a1, 0x8
+               	fsd	ft1, 0x0(a2)
+               	ld	a2, 0x0(a1)
+               	fld	fa0, 0x8(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x10>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1c>
+               	jalr	ra <.Lpcrel_hi.6+0x20>
                	lui	t0, 0x2
                	addiw	t0, t0, -0x1
                	and	a1, s5, t0
@@ -909,68 +1666,98 @@ Disassembly of section .text:
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	xor	s6, s5, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x18>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x24>
+               	xor	a1, s5, t0
+               	fmv.x.d	a2, ft1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1940 <.Lpcrel_hi.7+0x2c>
+               	j	0x1974 <.Lpcrel_hi.7+0x60>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1940 <.Lpcrel_hi.7+0x2c>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1984 <.Lpcrel_hi.7+0x70>
+               	j	0x19b8 <.Lpcrel_hi.7+0xa4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1984 <.Lpcrel_hi.7+0x70>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x8
-               	bltu	s4, t0, 0xbb0 <corpus.cases.call.call_ret_small.checksum+0x1ac>
-               	addi	s4, s0, -0xd8
+               	bltu	s4, t0, 0x165c <corpus.cases.call.call_ret_small.checksum+0x1e4>
+               	addi	s4, s0, -0xa0
                	mv	a0, s4
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xdb0 <.Lpcrel_hi.7+0x70>
+               	bnez	a1, 0x19fc <.Lpcrel_hi.7+0xe8>
                	mv	a1, a0
                	li	a2, 0x48
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0xd98 <.Lpcrel_hi.7+0x58>
-               	j	0xdcc <.Lpcrel_hi.7+0x8c>
+               	bne	a2, t0, 0x19e4 <.Lpcrel_hi.7+0xd0>
+               	j	0x1a18 <.Lpcrel_hi.7+0x104>
                	mv	a1, a0
                	li	a0, 0x48
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xdb8 <.Lpcrel_hi.7+0x78>
-               	addi	s5, s0, -0x138
+               	bne	a0, t0, 0x1a04 <.Lpcrel_hi.7+0xf0>
+               	addi	s5, s0, -0x100
                	mv	a0, s5
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xe00 <.Lpcrel_hi.7+0xc0>
+               	bnez	a1, 0x1a4c <.Lpcrel_hi.7+0x138>
                	mv	a1, a0
                	li	a2, 0x60
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0xde8 <.Lpcrel_hi.7+0xa8>
-               	j	0xe1c <.Lpcrel_hi.7+0xdc>
+               	bne	a2, t0, 0x1a34 <.Lpcrel_hi.7+0x120>
+               	j	0x1a68 <.Lpcrel_hi.7+0x154>
                	mv	a1, a0
                	li	a0, 0x60
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xe08 <.Lpcrel_hi.7+0xc8>
+               	bne	a0, t0, 0x1a54 <.Lpcrel_hi.7+0x140>
                	li	a0, 0x0
                	li	t0, 0x6
-               	bltu	a0, t0, 0xe2c <.Lpcrel_hi.7+0xec>
-               	j	0x108c <.Lpcrel_hi.8+0xf8>
+               	bltu	a0, t0, 0x1a78 <.Lpcrel_hi.7+0x164>
+               	j	0x1cd8 <.Lpcrel_hi.8+0xf8>
                	slli	t0, a0, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	add	a1, a2, s1
-               	addi	a2, s0, -0x184
+               	addi	a2, s0, -0x13c
                	sext.w	a3, a1
                	mv	a4, a2
                	sw	a3, 0x0(a4)
@@ -990,8 +1777,8 @@ Disassembly of section .text:
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xef4 <.Lpcrel_hi.7+0x1b4>
-               	bnez	a2, 0xec8 <.Lpcrel_hi.7+0x188>
+               	bltu	a1, a3, 0x1b40 <.Lpcrel_hi.7+0x22c>
+               	bnez	a2, 0x1b14 <.Lpcrel_hi.7+0x200>
                	addi	a4, a1, 0x8
                	addi	a5, a3, 0x8
                	lw	a6, 0x0(a5)
@@ -1003,8 +1790,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xea8 <.Lpcrel_hi.7+0x168>
-               	j	0xf54 <.Lpcrel_hi.7+0x214>
+               	bne	a6, t0, 0x1af4 <.Lpcrel_hi.7+0x1e0>
+               	j	0x1ba0 <.Lpcrel_hi.7+0x28c>
                	addi	a4, a1, 0xc
                	addi	a5, a3, 0xc
                	li	a6, 0xc
@@ -1014,9 +1801,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xed4 <.Lpcrel_hi.7+0x194>
-               	j	0xf54 <.Lpcrel_hi.7+0x214>
-               	bnez	a2, 0xf2c <.Lpcrel_hi.7+0x1ec>
+               	bne	a6, t0, 0x1b20 <.Lpcrel_hi.7+0x20c>
+               	j	0x1ba0 <.Lpcrel_hi.7+0x28c>
+               	bnez	a2, 0x1b78 <.Lpcrel_hi.7+0x264>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x8
@@ -1026,10 +1813,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xf04 <.Lpcrel_hi.7+0x1c4>
+               	bne	a5, t0, 0x1b50 <.Lpcrel_hi.7+0x23c>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0xf54 <.Lpcrel_hi.7+0x214>
+               	j	0x1ba0 <.Lpcrel_hi.7+0x28c>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0xc
@@ -1039,14 +1826,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xf38 <.Lpcrel_hi.7+0x1f8>
+               	bne	a3, t0, 0x1b84 <.Lpcrel_hi.7+0x270>
                	slli	t0, a0, 0x3
                	add	a1, s2, t0
                	ld	a2, 0x0(a1)
                	li	t0, 0x3
                	mul	a1, a2, t0
                	add	a2, a1, s1
-               	addi	a1, s0, -0x198
+               	addi	a1, s0, -0x1a0
                	li	t0, 0x3
                	mul	a3, a2, t0
                	addi	a4, a3, 0x1
@@ -1071,8 +1858,8 @@ Disassembly of section .text:
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1028 <.Lpcrel_hi.8+0x94>
-               	bnez	a1, 0xffc <.Lpcrel_hi.8+0x68>
+               	bltu	a2, a3, 0x1c74 <.Lpcrel_hi.8+0x94>
+               	bnez	a1, 0x1c48 <.Lpcrel_hi.8+0x68>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -1082,8 +1869,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xfdc <.Lpcrel_hi.8+0x48>
-               	j	0x1080 <.Lpcrel_hi.8+0xec>
+               	bne	a6, t0, 0x1c28 <.Lpcrel_hi.8+0x48>
+               	j	0x1ccc <.Lpcrel_hi.8+0xec>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -1093,9 +1880,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1008 <.Lpcrel_hi.8+0x74>
-               	j	0x1080 <.Lpcrel_hi.8+0xec>
-               	bnez	a1, 0x1058 <.Lpcrel_hi.8+0xc4>
+               	bne	a6, t0, 0x1c54 <.Lpcrel_hi.8+0x74>
+               	j	0x1ccc <.Lpcrel_hi.8+0xec>
+               	bnez	a1, 0x1ca4 <.Lpcrel_hi.8+0xc4>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -1105,8 +1892,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1038 <.Lpcrel_hi.8+0xa4>
-               	j	0x1080 <.Lpcrel_hi.8+0xec>
+               	bne	a5, t0, 0x1c84 <.Lpcrel_hi.8+0xa4>
+               	j	0x1ccc <.Lpcrel_hi.8+0xec>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x10
@@ -1116,179 +1903,849 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1064 <.Lpcrel_hi.8+0xd0>
+               	bne	a3, t0, 0x1cb0 <.Lpcrel_hi.8+0xd0>
                	addi	a0, a0, 0x1
                	li	t0, 0x6
-               	bltu	a0, t0, 0xe2c <.Lpcrel_hi.7+0xec>
+               	bltu	a0, t0, 0x1a78 <.Lpcrel_hi.7+0x164>
                	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s6, t0, 0x109c <.Lpcrel_hi.8+0x108>
-               	j	0x112c <.Lpcrel_hi.8+0x198>
+               	bltu	s6, t0, 0x1ce8 <.Lpcrel_hi.8+0x108>
+               	j	0x1f4c <.Lpcrel_hi.8+0x36c>
                	li	t0, 0xc
                	mul	a0, s6, t0
                	add	a1, s4, a0
-               	mv	a0, a1
-               	lw	a2, 0x0(a0)
-               	addi	a0, a1, 0x4
-               	lw	s7, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	lw	s8, 0x0(a0)
-               	mv	a0, s3
+               	addi	a0, s0, -0x10c
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x1d74 <.Lpcrel_hi.8+0x194>
+               	bnez	a1, 0x1d48 <.Lpcrel_hi.8+0x168>
+               	addi	a4, a2, 0x8
+               	addi	a5, a3, 0x8
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	li	a6, 0x8
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1d28 <.Lpcrel_hi.8+0x148>
+               	j	0x1dd4 <.Lpcrel_hi.8+0x1f4>
+               	addi	a4, a2, 0xc
+               	addi	a5, a3, 0xc
+               	li	a6, 0xc
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1d54 <.Lpcrel_hi.8+0x174>
+               	j	0x1dd4 <.Lpcrel_hi.8+0x1f4>
+               	bnez	a1, 0x1dac <.Lpcrel_hi.8+0x1cc>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x1d84 <.Lpcrel_hi.8+0x1a4>
+               	lw	a5, 0x0(a4)
+               	sw	a5, 0x0(a1)
+               	j	0x1dd4 <.Lpcrel_hi.8+0x1f4>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0xc
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1db8 <.Lpcrel_hi.8+0x1d8>
+               	lbu	a1, 0x0(a0)
+               	lbu	a2, 0x1(a0)
+               	lbu	a3, 0x2(a0)
+               	lbu	a4, 0x3(a0)
+               	lbu	a5, 0x4(a0)
+               	lbu	a6, 0x5(a0)
+               	lbu	a7, 0x6(a0)
+               	lbu	t5, 0x7(a0)
+               	sb	a1, -0x118(s0)
+               	sb	a2, -0x117(s0)
+               	sb	a3, -0x116(s0)
+               	sb	a4, -0x115(s0)
+               	sb	a5, -0x114(s0)
+               	sb	a6, -0x113(s0)
+               	sb	a7, -0x112(s0)
+               	sb	t5, -0x111(s0)
+               	ld	a1, -0x118(s0)
+               	sd	zero, -0x120(s0)
+               	lbu	a2, 0x8(a0)
+               	lbu	a3, 0x9(a0)
+               	lbu	a4, 0xa(a0)
+               	lbu	a5, 0xb(a0)
+               	sb	a2, -0x120(s0)
+               	sb	a3, -0x11f(s0)
+               	sb	a4, -0x11e(s0)
+               	sb	a5, -0x11d(s0)
+               	ld	a2, -0x120(s0)
+               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x134>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x140>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x14c>
+               	jalr	ra <.Lpcrel_hi.8+0x264>
                	li	t0, 0x10
                	mul	a1, s6, t0
                	add	a2, s5, a1
+               	addi	a1, s0, -0x130
+               	mv	a3, a1
+               	mv	a4, a2
+               	or	a2, a3, a4
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x1ed0 <.Lpcrel_hi.8+0x2f0>
+               	bnez	a2, 0x1ea4 <.Lpcrel_hi.8+0x2c4>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1e84 <.Lpcrel_hi.8+0x2a4>
+               	j	0x1f28 <.Lpcrel_hi.8+0x348>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x1eb0 <.Lpcrel_hi.8+0x2d0>
+               	j	0x1f28 <.Lpcrel_hi.8+0x348>
+               	bnez	a2, 0x1f00 <.Lpcrel_hi.8+0x320>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x1ee0 <.Lpcrel_hi.8+0x300>
+               	j	0x1f28 <.Lpcrel_hi.8+0x348>
+               	mv	a2, a3
+               	mv	a3, a4
+               	li	a4, 0x10
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x1f0c <.Lpcrel_hi.8+0x32c>
+               	ld	a2, 0x0(a1)
+               	fld	fa0, 0x8(a1)
                	mv	a1, a2
-               	ld	a3, 0x0(a1)
-               	addi	a1, a2, 0x8
-               	fld	fs0, 0x0(a1)
-               	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x174>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x180>
+               	jalr	ra <.Lpcrel_hi.8+0x354>
                	addi	s6, s6, 0x1
                	mv	s3, a0
                	li	t0, 0x6
-               	bltu	s6, t0, 0x109c <.Lpcrel_hi.8+0x108>
+               	bltu	s6, t0, 0x1ce8 <.Lpcrel_hi.8+0x108>
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x113c <.Lpcrel_hi.8+0x1a8>
-               	j	0x12d0 <.Lpcrel_hi.11+0x12c>
+               	bltu	s4, t0, 0x1f5c <.Lpcrel_hi.8+0x37c>
+               	j	0x29b0 <.Lpcrel_hi.11+0x9b8>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
-               	add	s5, a1, s1
-               	not	s6, s5
+               	add	a0, a1, s1
+               	addi	a1, s0, -0x150
+               	mv	a2, a1
+               	sd	a0, 0x0(a2)
+               	not	a2, a0
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
+               	addi	a2, s0, -0x1b0
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	and	a0, s5, t0
-               	fcvt.d.lu	ft0, a0
+               	and	a3, a0, t0
+               	fcvt.d.lu	ft0, a3
 
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs0, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
+               	mv	a3, a2
+               	fsd	ft1, 0x0(a3)
                	lui	t0, 0x40
                	addiw	t0, t0, -0x1
-               	and	a0, s5, t0
-               	fcvt.d.lu	ft0, a0
+               	and	a3, a0, t0
+               	fcvt.d.lu	ft0, a3
 
 <.Lpcrel_hi.10>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs1, ft0, ft10
+               	fdiv.d	ft1, ft0, ft10
+               	addi	a3, a2, 0x8
+               	fsd	ft1, 0x0(a3)
+               	addi	a3, s0, -0x1c0
                	li	t0, 0x3
-               	mul	a0, s5, t0
-               	addi	s7, a0, 0x1
+               	mul	a4, a0, t0
+               	addi	a5, a4, 0x1
+               	mv	a4, a3
+               	sd	a5, 0x0(a4)
                	lui	t0, 0x8
                	addiw	t0, t0, -0x1
-               	and	a0, s5, t0
-               	fcvt.d.lu	ft0, a0
+               	and	a4, a0, t0
+               	fcvt.d.lu	ft0, a4
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fs2, ft0, ft10
-               	sext.w	s8, s5
-               	srli	a0, s5, 0x10
-               	sext.w	s9, a0
-               	srli	a0, s5, 0x20
-               	sext.w	s10, a0
-               	sext.w	s11, s5
-               	srli	a0, s5, 0x20
-               	sext.w	t2, a0
-               	sd	t2, -0x1a0(s0)
+               	fdiv.d	ft1, ft0, ft10
+               	addi	a4, a3, 0x8
+               	fsd	ft1, 0x0(a4)
+               	addi	a4, s0, -0x1cc
+               	sext.w	a5, a0
+               	mv	a6, a4
+               	sw	a5, 0x0(a6)
+               	srli	a5, a0, 0x10
+               	sext.w	a6, a5
+               	addi	a5, a4, 0x4
+               	sw	a6, 0x0(a5)
+               	srli	a5, a0, 0x20
+               	sext.w	a6, a5
+               	addi	a5, a4, 0x8
+               	sw	a6, 0x0(a5)
+               	addi	a5, s0, -0x1d4
+               	sext.w	a6, a0
+               	mv	a7, a5
+               	sw	a6, 0x0(a7)
+               	srli	a6, a0, 0x20
+               	sext.w	a7, a6
+               	addi	a6, a5, 0x4
+               	sw	a7, 0x0(a6)
+               	addi	a6, s0, -0x1dc
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	and	a0, s5, t0
-               	fcvt.s.lu	ft0, a0
+               	and	a7, a0, t0
+               	fcvt.s.lu	ft0, a7
                	lui	t0, 0x41000
                	fmv.w.x	ft10, t0
-               	fdiv.s	fs3, ft0, ft10
+               	fdiv.s	ft1, ft0, ft10
+               	mv	a7, a6
+               	fsw	ft1, 0x0(a7)
                	li	t0, 0xff
-               	and	a0, s5, t0
-               	fcvt.s.lu	ft0, a0
+               	and	a7, a0, t0
+               	fcvt.s.lu	ft0, a7
                	lui	t0, 0x43000
                	fmv.w.x	ft10, t0
-               	fsub.s	fs4, ft0, ft10
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x64>
+               	fsub.s	ft1, ft0, ft10
+               	addi	a0, a6, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x200
+               	mv	a7, a0
+               	mv	t5, a1
+               	or	a1, a7, t5
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a7, t5, 0x211c <.Lpcrel_hi.11+0x124>
+               	bnez	a1, 0x20f0 <.Lpcrel_hi.11+0xf8>
+               	addi	t6, a7, 0x10
+               	addi	s5, t5, 0x10
+               	li	s6, 0x10
+               	addi	t6, t6, -0x8
+               	addi	s5, s5, -0x8
+               	ld	s7, 0x0(s5)
+               	sd	s7, 0x0(t6)
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x20d0 <.Lpcrel_hi.11+0xd8>
+               	j	0x2174 <.Lpcrel_hi.11+0x17c>
+               	addi	t6, a7, 0x10
+               	addi	s5, t5, 0x10
+               	li	s6, 0x10
+               	addi	t6, t6, -0x1
+               	addi	s5, s5, -0x1
+               	lbu	s7, 0x0(s5)
+               	sb	s7, 0x0(t6)
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0x20fc <.Lpcrel_hi.11+0x104>
+               	j	0x2174 <.Lpcrel_hi.11+0x17c>
+               	bnez	a1, 0x214c <.Lpcrel_hi.11+0x154>
+               	mv	a1, a7
+               	mv	t6, t5
+               	li	s5, 0x10
+               	ld	s6, 0x0(t6)
+               	sd	s6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	t6, t6, 0x8
+               	addi	s5, s5, -0x8
+               	li	t0, 0x0
+               	bne	s5, t0, 0x212c <.Lpcrel_hi.11+0x134>
+               	j	0x2174 <.Lpcrel_hi.11+0x17c>
+               	mv	a1, a7
+               	mv	a7, t5
+               	li	t5, 0x10
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a7, a7, 0x1
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x2158 <.Lpcrel_hi.11+0x160>
+               	addi	s5, s0, -0x210
                	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x70>
+               	mv	a7, a2
+               	or	a2, a1, a7
+               	li	t0, 0x7
+               	and	a2, a2, t0
+               	bltu	a1, a7, 0x21ec <.Lpcrel_hi.11+0x1f4>
+               	bnez	a2, 0x21c0 <.Lpcrel_hi.11+0x1c8>
+               	addi	t5, a1, 0x10
+               	addi	t6, a7, 0x10
+               	li	s6, 0x10
+               	addi	t5, t5, -0x8
+               	addi	t6, t6, -0x8
+               	ld	s7, 0x0(t6)
+               	sd	s7, 0x0(t5)
+               	addi	s6, s6, -0x8
+               	li	t0, 0x0
+               	bne	s6, t0, 0x21a0 <.Lpcrel_hi.11+0x1a8>
+               	j	0x2244 <.Lpcrel_hi.11+0x24c>
+               	addi	t5, a1, 0x10
+               	addi	t6, a7, 0x10
+               	li	s6, 0x10
+               	addi	t5, t5, -0x1
+               	addi	t6, t6, -0x1
+               	lbu	s7, 0x0(t6)
+               	sb	s7, 0x0(t5)
+               	addi	s6, s6, -0x1
+               	li	t0, 0x0
+               	bne	s6, t0, 0x21cc <.Lpcrel_hi.11+0x1d4>
+               	j	0x2244 <.Lpcrel_hi.11+0x24c>
+               	bnez	a2, 0x221c <.Lpcrel_hi.11+0x224>
+               	mv	a2, a1
+               	mv	t5, a7
+               	li	t6, 0x10
+               	ld	s6, 0x0(t5)
+               	sd	s6, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	t5, t5, 0x8
+               	addi	t6, t6, -0x8
+               	li	t0, 0x0
+               	bne	t6, t0, 0x21fc <.Lpcrel_hi.11+0x204>
+               	j	0x2244 <.Lpcrel_hi.11+0x24c>
+               	mv	a2, a1
+               	mv	a1, a7
+               	li	a7, 0x10
+               	lbu	t5, 0x0(a1)
+               	sb	t5, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x2228 <.Lpcrel_hi.11+0x230>
+               	addi	s6, s0, -0x220
                	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x7c>
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x88>
-               	fmv.d	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x94>
+               	mv	a2, a3
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0x22bc <.Lpcrel_hi.11+0x2c4>
+               	bnez	a3, 0x2290 <.Lpcrel_hi.11+0x298>
+               	addi	a7, a1, 0x10
+               	addi	t5, a2, 0x10
+               	li	t6, 0x10
+               	addi	a7, a7, -0x8
+               	addi	t5, t5, -0x8
+               	ld	s7, 0x0(t5)
+               	sd	s7, 0x0(a7)
+               	addi	t6, t6, -0x8
+               	li	t0, 0x0
+               	bne	t6, t0, 0x2270 <.Lpcrel_hi.11+0x278>
+               	j	0x2314 <.Lpcrel_hi.11+0x31c>
+               	addi	a7, a1, 0x10
+               	addi	t5, a2, 0x10
+               	li	t6, 0x10
+               	addi	a7, a7, -0x1
+               	addi	t5, t5, -0x1
+               	lbu	s7, 0x0(t5)
+               	sb	s7, 0x0(a7)
+               	addi	t6, t6, -0x1
+               	li	t0, 0x0
+               	bne	t6, t0, 0x229c <.Lpcrel_hi.11+0x2a4>
+               	j	0x2314 <.Lpcrel_hi.11+0x31c>
+               	bnez	a3, 0x22ec <.Lpcrel_hi.11+0x2f4>
+               	mv	a3, a1
+               	mv	a7, a2
+               	li	t5, 0x10
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a7, a7, 0x8
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x22cc <.Lpcrel_hi.11+0x2d4>
+               	j	0x2314 <.Lpcrel_hi.11+0x31c>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0x10
+               	lbu	a7, 0x0(a1)
+               	sb	a7, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x22f8 <.Lpcrel_hi.11+0x300>
+               	addi	s7, s0, -0x22c
                	mv	a1, s7
+               	mv	a2, a4
+               	or	a3, a1, a2
+               	li	t0, 0x7
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0x2394 <.Lpcrel_hi.11+0x39c>
+               	bnez	a3, 0x2368 <.Lpcrel_hi.11+0x370>
+               	addi	a4, a1, 0x8
+               	addi	a7, a2, 0x8
+               	lw	t5, 0x0(a7)
+               	sw	t5, 0x0(a4)
+               	li	t5, 0x8
+               	addi	a4, a4, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a4)
+               	addi	t5, t5, -0x8
+               	li	t0, 0x0
+               	bne	t5, t0, 0x2348 <.Lpcrel_hi.11+0x350>
+               	j	0x23f4 <.Lpcrel_hi.11+0x3fc>
+               	addi	a4, a1, 0xc
+               	addi	a7, a2, 0xc
+               	li	t5, 0xc
+               	addi	a4, a4, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a4)
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0x2374 <.Lpcrel_hi.11+0x37c>
+               	j	0x23f4 <.Lpcrel_hi.11+0x3fc>
+               	bnez	a3, 0x23cc <.Lpcrel_hi.11+0x3d4>
+               	mv	a3, a1
+               	mv	a4, a2
+               	li	a7, 0x8
+               	ld	t5, 0x0(a4)
+               	sd	t5, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x23a4 <.Lpcrel_hi.11+0x3ac>
+               	lw	a7, 0x0(a4)
+               	sw	a7, 0x0(a3)
+               	j	0x23f4 <.Lpcrel_hi.11+0x3fc>
+               	mv	a3, a1
+               	mv	a1, a2
+               	li	a2, 0xc
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x23d8 <.Lpcrel_hi.11+0x3e0>
+               	addi	s8, s0, -0x234
+               	lbu	a1, 0x0(a5)
+               	lbu	a2, 0x1(a5)
+               	lbu	a3, 0x2(a5)
+               	lbu	a4, 0x3(a5)
+               	lbu	a7, 0x4(a5)
+               	lbu	t5, 0x5(a5)
+               	lbu	t6, 0x6(a5)
+               	lbu	s9, 0x7(a5)
+               	sb	a1, 0x0(s8)
+               	sb	a2, 0x1(s8)
+               	sb	a3, 0x2(s8)
+               	sb	a4, 0x3(s8)
+               	sb	a7, 0x4(s8)
+               	sb	t5, 0x5(s8)
+               	sb	t6, 0x6(s8)
+               	sb	s9, 0x7(s8)
+               	addi	s9, s0, -0x23c
+               	lbu	a1, 0x0(a6)
+               	lbu	a2, 0x1(a6)
+               	lbu	a3, 0x2(a6)
+               	lbu	a4, 0x3(a6)
+               	lbu	a5, 0x4(a6)
+               	lbu	a7, 0x5(a6)
+               	lbu	t5, 0x6(a6)
+               	lbu	t6, 0x7(a6)
+               	sb	a1, 0x0(s9)
+               	sb	a2, 0x1(s9)
+               	sb	a3, 0x2(s9)
+               	sb	a4, 0x3(s9)
+               	sb	a5, 0x4(s9)
+               	sb	a7, 0x5(s9)
+               	sb	t5, 0x6(s9)
+               	sb	t6, 0x7(s9)
+               	addi	a1, s0, -0x250
+               	mv	a2, a1
+               	mv	a3, a0
+               	or	a0, a2, a3
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a2, a3, 0x24f4 <.Lpcrel_hi.11+0x4fc>
+               	bnez	a0, 0x24c8 <.Lpcrel_hi.11+0x4d0>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x24a8 <.Lpcrel_hi.11+0x4b0>
+               	j	0x254c <.Lpcrel_hi.11+0x554>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x24d4 <.Lpcrel_hi.11+0x4dc>
+               	j	0x254c <.Lpcrel_hi.11+0x554>
+               	bnez	a0, 0x2524 <.Lpcrel_hi.11+0x52c>
+               	mv	a0, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x2504 <.Lpcrel_hi.11+0x50c>
+               	j	0x254c <.Lpcrel_hi.11+0x554>
+               	mv	a0, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x2530 <.Lpcrel_hi.11+0x538>
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xa0>
-               	fmv.d	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.11+0x584>
+               	addi	a1, s0, -0x260
+               	mv	a2, a1
+               	mv	a3, s5
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x25fc <.Lpcrel_hi.11+0x604>
+               	bnez	a4, 0x25d0 <.Lpcrel_hi.11+0x5d8>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x25b0 <.Lpcrel_hi.11+0x5b8>
+               	j	0x2654 <.Lpcrel_hi.11+0x65c>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x25dc <.Lpcrel_hi.11+0x5e4>
+               	j	0x2654 <.Lpcrel_hi.11+0x65c>
+               	bnez	a4, 0x262c <.Lpcrel_hi.11+0x634>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x260c <.Lpcrel_hi.11+0x614>
+               	j	0x2654 <.Lpcrel_hi.11+0x65c>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x2638 <.Lpcrel_hi.11+0x640>
+               	fld	fa0, 0x0(a1)
+               	fld	fa1, 0x8(a1)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xac>
-               	mv	a1, s8
+               	jalr	ra <.Lpcrel_hi.11+0x664>
+               	addi	a1, s0, -0x270
+               	mv	a2, a1
+               	mv	a3, s6
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x26dc <.Lpcrel_hi.11+0x6e4>
+               	bnez	a4, 0x26b0 <.Lpcrel_hi.11+0x6b8>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x2690 <.Lpcrel_hi.11+0x698>
+               	j	0x2734 <.Lpcrel_hi.11+0x73c>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x26bc <.Lpcrel_hi.11+0x6c4>
+               	j	0x2734 <.Lpcrel_hi.11+0x73c>
+               	bnez	a4, 0x270c <.Lpcrel_hi.11+0x714>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x26ec <.Lpcrel_hi.11+0x6f4>
+               	j	0x2734 <.Lpcrel_hi.11+0x73c>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x2718 <.Lpcrel_hi.11+0x720>
+               	ld	a2, 0x0(a1)
+               	fld	fa0, 0x8(a1)
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xb8>
-               	mv	a1, s9
+               	jalr	ra <.Lpcrel_hi.11+0x748>
+               	addi	a1, s0, -0x27c
+               	mv	a2, a1
+               	mv	a3, s7
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x27c8 <.Lpcrel_hi.11+0x7d0>
+               	bnez	a4, 0x279c <.Lpcrel_hi.11+0x7a4>
+               	addi	a5, a2, 0x8
+               	addi	a6, a3, 0x8
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	li	a7, 0x8
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x277c <.Lpcrel_hi.11+0x784>
+               	j	0x2828 <.Lpcrel_hi.11+0x830>
+               	addi	a5, a2, 0xc
+               	addi	a6, a3, 0xc
+               	li	a7, 0xc
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x27a8 <.Lpcrel_hi.11+0x7b0>
+               	j	0x2828 <.Lpcrel_hi.11+0x830>
+               	bnez	a4, 0x2800 <.Lpcrel_hi.11+0x808>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x27d8 <.Lpcrel_hi.11+0x7e0>
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	j	0x2828 <.Lpcrel_hi.11+0x830>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0xc
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x280c <.Lpcrel_hi.11+0x814>
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x288(s0)
+               	sb	a3, -0x287(s0)
+               	sb	a4, -0x286(s0)
+               	sb	a5, -0x285(s0)
+               	sb	a6, -0x284(s0)
+               	sb	a7, -0x283(s0)
+               	sb	t5, -0x282(s0)
+               	sb	t6, -0x281(s0)
+               	ld	a2, -0x288(s0)
+               	sd	zero, -0x290(s0)
+               	lbu	a3, 0x8(a1)
+               	lbu	a4, 0x9(a1)
+               	lbu	a5, 0xa(a1)
+               	lbu	a6, 0xb(a1)
+               	sb	a3, -0x290(s0)
+               	sb	a4, -0x28f(s0)
+               	sb	a5, -0x28e(s0)
+               	sb	a6, -0x28d(s0)
+               	ld	a3, -0x290(s0)
+               	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xc4>
-               	mv	a1, s10
+               	jalr	ra <.Lpcrel_hi.11+0x8a4>
+               	addi	a1, s0, -0x298
+               	lbu	a2, 0x0(s8)
+               	lbu	a3, 0x1(s8)
+               	lbu	a4, 0x2(s8)
+               	lbu	a5, 0x3(s8)
+               	lbu	a6, 0x4(s8)
+               	lbu	a7, 0x5(s8)
+               	lbu	t5, 0x6(s8)
+               	lbu	t6, 0x7(s8)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	lbu	a2, 0x0(a1)
+               	lbu	a3, 0x1(a1)
+               	lbu	a4, 0x2(a1)
+               	lbu	a5, 0x3(a1)
+               	lbu	a6, 0x4(a1)
+               	lbu	a7, 0x5(a1)
+               	lbu	t5, 0x6(a1)
+               	lbu	t6, 0x7(a1)
+               	sb	a2, -0x2a0(s0)
+               	sb	a3, -0x29f(s0)
+               	sb	a4, -0x29e(s0)
+               	sb	a5, -0x29d(s0)
+               	sb	a6, -0x29c(s0)
+               	sb	a7, -0x29b(s0)
+               	sb	t5, -0x29a(s0)
+               	sb	t6, -0x299(s0)
+               	ld	a1, -0x2a0(s0)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xd0>
-               	mv	a1, s11
+               	jalr	ra <.Lpcrel_hi.11+0x934>
+               	addi	a1, s0, -0x2a8
+               	lbu	a2, 0x0(s9)
+               	lbu	a3, 0x1(s9)
+               	lbu	a4, 0x2(s9)
+               	lbu	a5, 0x3(s9)
+               	lbu	a6, 0x4(s9)
+               	lbu	a7, 0x5(s9)
+               	lbu	t5, 0x6(s9)
+               	lbu	t6, 0x7(s9)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	flw	ft0, 0x0(a1)
+               	flw	ft1, 0x4(a1)
+               	fmv.s	fa0, ft0
+               	fmv.s	fa1, ft1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xdc>
-               	ld	t2, -0x1a0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xec>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0xf8>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x104>
+               	jalr	ra <.Lpcrel_hi.11+0x990>
                	mv	a1, a0
                	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x114>
+               	jalr	ra <.Lpcrel_hi.11+0x9a0>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x113c <.Lpcrel_hi.8+0x1a8>
+               	bltu	s4, t0, 0x1f5c <.Lpcrel_hi.8+0x37c>
                	mv	a0, s3
-               	ld	s1, 0x188(sp)
-               	ld	s2, 0x180(sp)
-               	ld	s3, 0x178(sp)
-               	ld	s4, 0x170(sp)
-               	ld	s5, 0x168(sp)
-               	ld	s6, 0x160(sp)
-               	ld	s7, 0x158(sp)
-               	ld	s8, 0x150(sp)
-               	ld	s9, 0x148(sp)
-               	ld	s10, 0x140(sp)
-               	ld	s11, 0x138(sp)
-               	fld	fs0, 0x130(sp)
-               	fld	fs1, 0x128(sp)
-               	fld	fs2, 0x120(sp)
-               	fld	fs3, 0x118(sp)
-               	fld	fs4, 0x110(sp)
-               	ld	ra, 0x198(sp)
-               	ld	s0, 0x190(sp)
-               	addi	sp, sp, 0x1a0
+               	ld	s1, 0x2f8(sp)
+               	ld	s2, 0x2f0(sp)
+               	ld	s3, 0x2e8(sp)
+               	ld	s4, 0x2e0(sp)
+               	ld	s5, 0x2d8(sp)
+               	ld	s6, 0x2d0(sp)
+               	ld	s7, 0x2c8(sp)
+               	ld	s8, 0x2c0(sp)
+               	ld	s9, 0x2b8(sp)
+               	ld	ra, 0x308(sp)
+               	ld	s0, 0x300(sp)
+               	addi	sp, sp, 0x310
                	ret

--- a/test/golden/riscv64-linux/call/call_variadic.dis
+++ b/test/golden/riscv64-linux/call/call_variadic.dis
@@ -26,55 +26,53 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.call.call_variadic.checksum>:
-               	addi	sp, sp, -0x150
-               	sd	ra, 0x148(sp)
-               	sd	s0, 0x140(sp)
-               	addi	s0, sp, 0x150
-               	sd	s1, 0x138(sp)
-               	sd	s2, 0x130(sp)
-               	sd	s3, 0x128(sp)
-               	sd	s4, 0x120(sp)
-               	sd	s5, 0x118(sp)
-               	sd	s6, 0x110(sp)
-               	sd	s7, 0x108(sp)
-               	sd	s8, 0x100(sp)
-               	sd	s9, 0xf8(sp)
-               	sd	s10, 0xf0(sp)
-               	sd	s11, 0xe8(sp)
-               	fsd	fs0, 0xe0(sp)
-               	fsd	fs1, 0xd8(sp)
-               	fsd	fs2, 0xd0(sp)
-               	fsd	fs3, 0xc8(sp)
-               	fsd	fs4, 0xc0(sp)
-               	fsd	fs5, 0xb8(sp)
-               	fsd	fs6, 0xb0(sp)
+               	addi	sp, sp, -0x140
+               	sd	ra, 0x138(sp)
+               	sd	s0, 0x130(sp)
+               	addi	s0, sp, 0x140
+               	sd	s1, 0x128(sp)
+               	sd	s2, 0x120(sp)
+               	sd	s3, 0x118(sp)
+               	sd	s4, 0x110(sp)
+               	sd	s5, 0x108(sp)
+               	sd	s6, 0x100(sp)
+               	sd	s7, 0xf8(sp)
+               	sd	s8, 0xf0(sp)
+               	sd	s9, 0xe8(sp)
+               	sd	s10, 0xe0(sp)
+               	sd	s11, 0xd8(sp)
+               	fsd	fs0, 0xd0(sp)
+               	fsd	fs1, 0xc8(sp)
+               	fsd	fs2, 0xc0(sp)
+               	fsd	fs3, 0xb8(sp)
+               	fsd	fs4, 0xb0(sp)
+               	fsd	fs5, 0xa8(sp)
+               	fsd	fs6, 0xa0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.checksum+0x5c>
                	addi	s2, s0, -0x100
-               	mv	a1, s2
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0xec <corpus.cases.call.call_variadic.checksum+0x98>
-               	mv	a2, a1
-               	li	a3, 0x60
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0xe4 <corpus.cases.call.call_variadic.checksum+0x90>
+               	mv	a1, a0
+               	li	a2, 0x60
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xd4 <corpus.cases.call.call_variadic.checksum+0x80>
-               	j	0x108 <corpus.cases.call.call_variadic.checksum+0xb4>
-               	mv	a2, a1
-               	li	a1, 0x60
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xcc <corpus.cases.call.call_variadic.checksum+0x78>
+               	j	0x100 <corpus.cases.call.call_variadic.checksum+0xac>
+               	mv	a1, a0
+               	li	a0, 0x60
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xf4 <corpus.cases.call.call_variadic.checksum+0xa0>
-               	li	a1, 0x0
+               	bne	a0, t0, 0xec <corpus.cases.call.call_variadic.checksum+0x98>
+               	li	a0, 0x0
                	li	t0, 0xc
-               	bltu	a1, t0, 0x118 <corpus.cases.call.call_variadic.checksum+0xc4>
-               	j	0x17c <corpus.cases.call.call_variadic.checksum+0x128>
+               	bltu	a0, t0, 0x110 <corpus.cases.call.call_variadic.checksum+0xbc>
+               	j	0x174 <corpus.cases.call.call_variadic.checksum+0x120>
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -83,7 +81,7 @@ Disassembly of section .text:
                	addi	t0, t0, -0x6a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd3
-               	mul	a2, a1, t0
+               	mul	a1, a0, t0
                	lui	t0, 0x1405
                	addiw	t0, t0, 0x7b8
                	slli	t0, t0, 0xc
@@ -92,28 +90,60 @@ Disassembly of section .text:
                	addi	t0, t0, 0x678
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x14f
-               	add	a3, a2, t0
-               	add	a2, a3, s1
-               	slli	t0, a1, 0x3
-               	add	a3, s2, t0
-               	sd	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	add	a2, a1, t0
+               	add	a1, a2, s1
+               	slli	t0, a0, 0x3
+               	add	a2, s2, t0
+               	sd	a1, 0x0(a2)
+               	addi	a0, a0, 0x1
                	li	t0, 0xc
-               	bltu	a1, t0, 0x118 <corpus.cases.call.call_variadic.checksum+0xc4>
+               	bltu	a0, t0, 0x110 <corpus.cases.call.call_variadic.checksum+0xbc>
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.checksum+0x12c>
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a4 <corpus.cases.call.call_variadic.checksum+0x150>
+               	j	0x1c0 <corpus.cases.call.call_variadic.checksum+0x16c>
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a0, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a4 <corpus.cases.call.call_variadic.checksum+0x150>
                	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.checksum+0x138>
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1d0 <corpus.cases.call.call_variadic.checksum+0x17c>
+               	j	0x1ec <corpus.cases.call.call_variadic.checksum+0x198>
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a0, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1d0 <corpus.cases.call.call_variadic.checksum+0x17c>
                	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.checksum+0x144>
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1fc <corpus.cases.call.call_variadic.checksum+0x1a8>
+               	j	0x218 <corpus.cases.call.call_variadic.checksum+0x1c4>
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a0, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1fc <corpus.cases.call.call_variadic.checksum+0x1a8>
                	mv	s3, a0
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1b4 <corpus.cases.call.call_variadic.checksum+0x160>
-               	j	0x72c <.Lpcrel_hi.2+0x498>
+               	bltu	s4, t0, 0x22c <corpus.cases.call.call_variadic.checksum+0x1d8>
+               	j	0xac8 <.Lpcrel_hi.2+0x7bc>
                	slli	t0, s4, 0x3
                	add	a0, s2, t0
                	ld	a1, 0x0(a0)
@@ -122,11 +152,11 @@ Disassembly of section .text:
                	sext.w	s7, s5
                	sext.w	s8, s5
                	srli	a0, s5, 0x7
-               	sext.w	s9, a0
+               	sext.w	a1, a0
                	srli	a0, s5, 0x3
-               	sext.w	s10, a0
+               	sext.w	s9, a0
                	srli	a0, s5, 0xb
-               	sext.w	s11, a0
+               	sext.w	s10, a0
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
                	and	a0, s5, t0
@@ -180,318 +210,519 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	fs6, ft0, ft10
                	li	t0, 0x3
-               	mul	t2, s5, t0
-               	sd	t2, -0x118(s0)
-               	zext.b	a1, s6
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x20>
-               	slli	a1, s7, 0x30
-               	srai	a1, a1, 0x30
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x30>
-               	slli	a1, s8, 0x20
-               	srli	a1, a1, 0x20
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x40>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x4c>
-               	zext.b	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x58>
-               	slli	a1, s10, 0x30
+               	mul	s11, s5, t0
+               	zext.b	a0, s6
+               	mv	a2, s3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x338 <.Lpcrel_hi.2+0x2c>
+               	j	0x36c <.Lpcrel_hi.2+0x60>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x338 <.Lpcrel_hi.2+0x2c>
+               	slli	a0, s7, 0x30
+               	srai	a0, a0, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x384 <.Lpcrel_hi.2+0x78>
+               	j	0x3b8 <.Lpcrel_hi.2+0xac>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x384 <.Lpcrel_hi.2+0x78>
+               	slli	a0, s8, 0x20
+               	srli	a0, a0, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3d0 <.Lpcrel_hi.2+0xc4>
+               	j	0x404 <.Lpcrel_hi.2+0xf8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3d0 <.Lpcrel_hi.2+0xc4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x414 <.Lpcrel_hi.2+0x108>
+               	j	0x448 <.Lpcrel_hi.2+0x13c>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, s5, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x414 <.Lpcrel_hi.2+0x108>
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <.Lpcrel_hi.2+0x150>
+               	j	0x490 <.Lpcrel_hi.2+0x184>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <.Lpcrel_hi.2+0x150>
+               	slli	a1, s9, 0x30
                	srli	a1, a1, 0x30
+               	mv	a0, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x68>
-               	sext.w	a1, s11
+               	jalr	ra <.Lpcrel_hi.2+0x190>
+               	sext.w	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x74>
-               	ld	t2, -0x118(s0)
-               	mv	a1, t2
+               	jalr	ra <.Lpcrel_hi.2+0x19c>
+               	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x84>
+               	jalr	ra <.Lpcrel_hi.2+0x1a8>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x90>
+               	jalr	ra <.Lpcrel_hi.2+0x1b4>
                	mv	a1, s2
                	ld	a2, 0x0(a1)
                	add	a1, a2, s5
                	addi	a2, s2, 0x8
-               	ld	s9, 0x0(a2)
+               	ld	a3, 0x0(a2)
                	addi	a2, s2, 0x10
-               	ld	s11, 0x0(a2)
+               	ld	a4, 0x0(a2)
                	addi	a2, s2, 0x18
                	ld	t2, 0x0(a2)
                	sd	t2, -0x120(s0)
                	addi	a2, s2, 0x20
                	ld	t2, 0x0(a2)
-               	sd	t2, -0x128(s0)
+               	sd	t2, -0x118(s0)
                	addi	a2, s2, 0x28
-               	ld	t2, 0x0(a2)
-               	sd	t2, -0x130(s0)
+               	ld	s10, 0x0(a2)
                	addi	a2, s2, 0x30
-               	ld	t2, 0x0(a2)
-               	sd	t2, -0x138(s0)
+               	ld	s11, 0x0(a2)
                	addi	a2, s2, 0x38
                	ld	t2, 0x0(a2)
-               	sd	t2, -0x140(s0)
+               	sd	t2, -0x128(s0)
                	addi	a2, s2, 0x40
                	ld	t2, 0x0(a2)
-               	sd	t2, -0x148(s0)
+               	sd	t2, -0x130(s0)
                	addi	a2, s2, 0x48
                	ld	t2, 0x0(a2)
-               	sd	t2, -0x150(s0)
+               	sd	t2, -0x138(s0)
                	addi	a2, s2, 0x50
                	ld	t2, 0x0(a2)
                	sd	t2, -0x108(s0)
                	addi	a2, s2, 0x58
                	ld	t2, 0x0(a2)
                	sd	t2, -0x110(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x120>
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x12c>
-               	mv	a1, s11
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x138>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x558 <.Lpcrel_hi.2+0x24c>
+               	j	0x58c <.Lpcrel_hi.2+0x280>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a5, a1, a6
+               	li	t0, 0xff
+               	and	a6, a5, t0
+               	xor	a5, a0, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x558 <.Lpcrel_hi.2+0x24c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x59c <.Lpcrel_hi.2+0x290>
+               	j	0x5d0 <.Lpcrel_hi.2+0x2c4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a5, a3, a2
+               	li	t0, 0xff
+               	and	a2, a5, t0
+               	xor	a5, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x59c <.Lpcrel_hi.2+0x290>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5e0 <.Lpcrel_hi.2+0x2d4>
+               	j	0x614 <.Lpcrel_hi.2+0x308>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5e0 <.Lpcrel_hi.2+0x2d4>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x624 <.Lpcrel_hi.2+0x318>
+               	j	0x65c <.Lpcrel_hi.2+0x350>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
                	ld	t2, -0x120(s0)
+               	srl	a3, t2, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x624 <.Lpcrel_hi.2+0x318>
+               	ld	t2, -0x118(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x148>
+               	jalr	ra <.Lpcrel_hi.2+0x358>
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.2+0x364>
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.2+0x370>
                	ld	t2, -0x128(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x158>
+               	jalr	ra <.Lpcrel_hi.2+0x380>
                	ld	t2, -0x130(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x168>
+               	jalr	ra <.Lpcrel_hi.2+0x390>
                	ld	t2, -0x138(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x178>
-               	ld	t2, -0x140(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x188>
-               	ld	t2, -0x148(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x198>
-               	ld	t2, -0x150(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1a8>
+               	jalr	ra <.Lpcrel_hi.2+0x3a0>
                	ld	t2, -0x108(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1b8>
+               	jalr	ra <.Lpcrel_hi.2+0x3b0>
                	ld	t2, -0x110(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1c8>
+               	jalr	ra <.Lpcrel_hi.2+0x3c0>
                	li	a1, 0xc
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1d4>
-               	fmv.s	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.2+0x3cc>
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6fc <.Lpcrel_hi.2+0x3f0>
+               	j	0x730 <.Lpcrel_hi.2+0x424>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6fc <.Lpcrel_hi.2+0x3f0>
+               	fmv.x.d	a1, fs4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x744 <.Lpcrel_hi.2+0x438>
+               	j	0x778 <.Lpcrel_hi.2+0x46c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x744 <.Lpcrel_hi.2+0x438>
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1e0>
-               	fmv.d	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.2+0x47c>
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1ec>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1f8>
-               	fmv.d	fa0, fs5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x204>
+               	jalr	ra <.Lpcrel_hi.2+0x488>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x210>
+               	jalr	ra <.Lpcrel_hi.2+0x494>
                	li	t0, 0x5
-               	mul	s9, s5, t0
-               	mv	a1, s5
+               	mul	s10, s5, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7c0 <.Lpcrel_hi.2+0x4b4>
+               	j	0x7f4 <.Lpcrel_hi.2+0x4e8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s5, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7c0 <.Lpcrel_hi.2+0x4b4>
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x224>
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x230>
+               	jalr	ra <.Lpcrel_hi.2+0x4f8>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x240>
-               	fmv.d	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.2+0x508>
+               	fmv.x.d	a1, fs4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x24c>
+               	jalr	ra <.Lpcrel_hi.2+0x514>
                	slli	a1, s7, 0x30
                	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x25c>
-               	mv	a1, s9
+               	jalr	ra <.Lpcrel_hi.2+0x524>
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x268>
+               	jalr	ra <.Lpcrel_hi.2+0x530>
                	li	a1, 0x6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x274>
+               	jalr	ra <.Lpcrel_hi.2+0x53c>
                	li	t0, 0x7
-               	mul	s9, s5, t0
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x288>
+               	mul	s10, s5, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x868 <.Lpcrel_hi.2+0x55c>
+               	j	0x89c <.Lpcrel_hi.2+0x590>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, s5, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x868 <.Lpcrel_hi.2+0x55c>
                	zext.b	a1, s6
                	add	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x29c>
+               	jalr	ra <.Lpcrel_hi.2+0x59c>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
                	add	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2b4>
-               	add	a1, s9, s5
+               	jalr	ra <.Lpcrel_hi.2+0x5b4>
+               	add	a1, s10, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2c0>
-               	slli	a1, s10, 0x30
+               	jalr	ra <.Lpcrel_hi.2+0x5c0>
+               	slli	a1, s9, 0x30
                	srli	a1, a1, 0x30
                	add	a2, a1, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2d8>
+               	jalr	ra <.Lpcrel_hi.2+0x5d8>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2e4>
+               	jalr	ra <.Lpcrel_hi.2+0x5e4>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2f0>
-               	fmv.s	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.2+0x5f0>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x2fc>
+               	jalr	ra <.Lpcrel_hi.2+0x608>
                	add	a1, s5, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x308>
-               	fmv.d	fa0, fs6
+               	jalr	ra <.Lpcrel_hi.2+0x614>
+               	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x314>
+               	jalr	ra <.Lpcrel_hi.2+0x620>
                	li	a1, 0x3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x320>
+               	jalr	ra <.Lpcrel_hi.2+0x62c>
                	zext.b	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x32c>
+               	jalr	ra <.Lpcrel_hi.2+0x638>
                	slli	a1, s7, 0x30
                	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x33c>
+               	jalr	ra <.Lpcrel_hi.2+0x648>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x34c>
+               	jalr	ra <.Lpcrel_hi.2+0x658>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x358>
+               	jalr	ra <.Lpcrel_hi.2+0x664>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x364>
+               	jalr	ra <.Lpcrel_hi.2+0x670>
                	zext.b	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x370>
+               	jalr	ra <.Lpcrel_hi.2+0x67c>
                	slli	a1, s7, 0x30
                	srai	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x380>
+               	jalr	ra <.Lpcrel_hi.2+0x68c>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x390>
+               	jalr	ra <.Lpcrel_hi.2+0x69c>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x39c>
+               	jalr	ra <.Lpcrel_hi.2+0x6a8>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3a8>
+               	jalr	ra <.Lpcrel_hi.2+0x6b4>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3b4>
-               	fmv.s	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.2+0x6c0>
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3c0>
-               	fmv.d	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.2+0x6d8>
+               	fmv.x.d	a1, fs4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3cc>
+               	jalr	ra <.Lpcrel_hi.2+0x6e4>
                	li	a1, 0x3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3d8>
+               	jalr	ra <.Lpcrel_hi.2+0x6f0>
                	li	t0, 0x7
                	mul	s7, s5, t0
                	li	t0, 0x3
-               	mul	s9, s5, t0
-               	mv	a1, s9
+               	mul	s10, s5, t0
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3f4>
+               	jalr	ra <.Lpcrel_hi.2+0x70c>
                	zext.b	a1, s6
-               	add	a2, a1, s9
+               	add	a2, a1, s10
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x408>
+               	jalr	ra <.Lpcrel_hi.2+0x720>
                	slli	a1, s8, 0x20
                	srli	a1, a1, 0x20
-               	add	a2, a1, s9
+               	add	a2, a1, s10
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x420>
-               	add	a1, s7, s9
+               	jalr	ra <.Lpcrel_hi.2+0x738>
+               	add	a1, s7, s10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x42c>
-               	slli	a1, s10, 0x30
+               	jalr	ra <.Lpcrel_hi.2+0x744>
+               	slli	a1, s9, 0x30
                	srli	a1, a1, 0x30
-               	add	a2, a1, s9
+               	add	a2, a1, s10
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x444>
+               	jalr	ra <.Lpcrel_hi.2+0x75c>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x450>
+               	jalr	ra <.Lpcrel_hi.2+0x768>
                	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x45c>
+               	jalr	ra <.Lpcrel_hi.2+0x774>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x468>
-               	fmv.s	fa0, fs3
+               	jalr	ra <.Lpcrel_hi.2+0x780>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x474>
+               	jalr	ra <.Lpcrel_hi.2+0x798>
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x480>
+               	jalr	ra <.Lpcrel_hi.2+0x7a4>
                	addi	s4, s4, 0x1
                	mv	s3, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x1b4 <corpus.cases.call.call_variadic.checksum+0x160>
+               	bltu	s4, t0, 0x22c <corpus.cases.call.call_variadic.checksum+0x1d8>
                	mv	a0, s3
-               	ld	s1, 0x138(sp)
-               	ld	s2, 0x130(sp)
-               	ld	s3, 0x128(sp)
-               	ld	s4, 0x120(sp)
-               	ld	s5, 0x118(sp)
-               	ld	s6, 0x110(sp)
-               	ld	s7, 0x108(sp)
-               	ld	s8, 0x100(sp)
-               	ld	s9, 0xf8(sp)
-               	ld	s10, 0xf0(sp)
-               	ld	s11, 0xe8(sp)
-               	fld	fs0, 0xe0(sp)
-               	fld	fs1, 0xd8(sp)
-               	fld	fs2, 0xd0(sp)
-               	fld	fs3, 0xc8(sp)
-               	fld	fs4, 0xc0(sp)
-               	fld	fs5, 0xb8(sp)
-               	fld	fs6, 0xb0(sp)
-               	ld	ra, 0x148(sp)
-               	ld	s0, 0x140(sp)
-               	addi	sp, sp, 0x150
+               	ld	s1, 0x128(sp)
+               	ld	s2, 0x120(sp)
+               	ld	s3, 0x118(sp)
+               	ld	s4, 0x110(sp)
+               	ld	s5, 0x108(sp)
+               	ld	s6, 0x100(sp)
+               	ld	s7, 0xf8(sp)
+               	ld	s8, 0xf0(sp)
+               	ld	s9, 0xe8(sp)
+               	ld	s10, 0xe0(sp)
+               	ld	s11, 0xd8(sp)
+               	fld	fs0, 0xd0(sp)
+               	fld	fs1, 0xc8(sp)
+               	fld	fs2, 0xc0(sp)
+               	fld	fs3, 0xb8(sp)
+               	fld	fs4, 0xb0(sp)
+               	fld	fs5, 0xa8(sp)
+               	fld	fs6, 0xa0(sp)
+               	ld	ra, 0x138(sp)
+               	ld	s0, 0x130(sp)
+               	addi	sp, sp, 0x140
                	ret
 
 <corpus.cases.call.call_variadic.fold_pack$pack>:
@@ -735,33 +966,30 @@ Disassembly of section .text:
                	fsd	fs0, 0x18(sp)
                	fsd	fs1, 0x10(sp)
                	fsd	fs2, 0x8(sp)
-               	mv	a1, a0
                	fmv.d	fs0, fa1
                	fmv.s	fs1, fa2
                	fmv.d	fs2, fa3
-               	mv	a0, a1
+               	fmv.x.w	a1, fa0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x30>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x38>
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs1
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs2
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x5c>
+               	fmv.x.d	a1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x6c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x68>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x80>
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32$f64$f32$f64+0x74>
                	fld	fs0, 0x18(sp)
                	fld	fs1, 0x10(sp)
                	fld	fs2, 0x8(sp)
@@ -789,40 +1017,29 @@ Disassembly of section .text:
                	mv	a0, a5
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x40>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x54>
-               	mv	a1, a0
-               	slli	a2, s1, 0x20
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
                	srli	a2, a2, 0x20
-               	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x70>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x58>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x68>
+               	fmv.x.d	a1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x74>
+               	slli	a1, s2, 0x30
+               	srai	a1, a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x84>
-               	mv	a1, a0
-               	slli	a2, s2, 0x30
-               	srai	a2, a2, 0x30
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0xa0>
-               	mv	a1, a0
-               	mv	a0, a1
                	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0xb4>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x90>
                	li	a1, 0x6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0xc8>
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$u32$f64$i16$u64+0x9c>
                	ld	s1, 0x28(sp)
                	ld	s2, 0x20(sp)
                	ld	s3, 0x18(sp)
@@ -915,27 +1132,21 @@ Disassembly of section .text:
                	mv	a1, s1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x50>
-               	mv	a1, a0
-               	add	a2, s2, s1
-               	mv	a0, a1
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x68>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x54>
+               	add	a1, s2, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x7c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x60>
+               	fmv.x.d	a1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x6c>
                	li	a1, 0x3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x90>
+               	jalr	ra <corpus.cases.call.call_variadic.bias_pack$pack$f32$u64$f64+0x78>
                	ld	s1, 0x18(sp)
                	ld	s2, 0x10(sp)
                	fld	fs0, 0x8(sp)
@@ -1030,15 +1241,18 @@ Disassembly of section .text:
                	fmv.d	fs1, fa1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd2_pack$pack$u64$f32$f64+0x20>
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fwd2_pack$pack$u64$f32$f64+0x2c>
-               	fmv.d	fa0, fs1
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd2_pack$pack$u64$f32$f64+0x38>
-               	li	a1, 0x3
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd2_pack$pack$u64$f32$f64+0x44>
+               	li	a1, 0x3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_variadic.fwd2_pack$pack$u64$f32$f64+0x50>
                	fld	fs0, 0x8(sp)
                	fld	fs1, 0x0(sp)
                	ld	ra, 0x18(sp)
@@ -1122,12 +1336,12 @@ Disassembly of section .text:
                	sd	ra, 0x8(sp)
                	sd	s0, 0x0(sp)
                	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	mv	a0, a1
+               	fmv.x.w	a1, fa0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32+0x18>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32+0x20>
                	li	a1, 0x1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$f32+0x2c>
@@ -1196,15 +1410,18 @@ Disassembly of section .text:
                	fmv.d	fs1, fa1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64+0x20>
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64+0x2c>
-               	fmv.d	fa0, fs1
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64+0x38>
-               	li	a1, 0x3
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64+0x44>
+               	li	a1, 0x3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.call.call_variadic.fwd_pack$pack$u64$f32$f64+0x50>
                	fld	fs0, 0x8(sp)
                	fld	fs1, 0x0(sp)
                	ld	ra, 0x18(sp)
@@ -1225,21 +1442,18 @@ Disassembly of section .text:
                	mv	a0, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x28>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x40>
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x4c>
                	li	a1, 0x3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x64>
+               	jalr	ra <corpus.cases.call.call_variadic.fold_pack$pack$u64$f32$f64+0x58>
                	fld	fs0, 0x8(sp)
                	fld	fs1, 0x0(sp)
                	ld	ra, 0x18(sp)

--- a/test/golden/riscv64-linux/cmp/branch_nest.dis
+++ b/test/golden/riscv64-linux/cmp/branch_nest.dis
@@ -3,124 +3,144 @@ cmp/branch_nest.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.branch_nest.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.branch_nest.checksum+0x24>
-               	sext.w	s2, s1
-               	mv	s1, a0
-               	li	s3, 0x0
+               	sext.w	a1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
                	li	t0, 0x14
-               	bltu	s3, t0, 0x44 <corpus.cases.cmp.branch_nest.checksum+0x44>
-               	j	0x1c0 <corpus.cases.cmp.branch_nest.checksum+0x1c0>
-               	addw	s4, s3, s2
+               	bltu	a2, t0, 0x34 <corpus.cases.cmp.branch_nest.checksum+0x34>
+               	j	0x230 <corpus.cases.cmp.branch_nest.checksum+0x230>
+               	addw	a3, a2, a1
                	li	t0, 0x4
-               	bltu	s4, t0, 0x160 <corpus.cases.cmp.branch_nest.checksum+0x160>
+               	bltu	a3, t0, 0x14c <corpus.cases.cmp.branch_nest.checksum+0x14c>
                	li	t0, 0x8
-               	bltu	s4, t0, 0x11c <corpus.cases.cmp.branch_nest.checksum+0x11c>
+               	bltu	a3, t0, 0x10c <corpus.cases.cmp.branch_nest.checksum+0x10c>
                	li	t0, 0xc
-               	bltu	s4, t0, 0xe0 <corpus.cases.cmp.branch_nest.checksum+0xe0>
+               	bltu	a3, t0, 0xd0 <corpus.cases.cmp.branch_nest.checksum+0xd0>
                	li	t0, 0x10
-               	bltu	s4, t0, 0xa0 <corpus.cases.cmp.branch_nest.checksum+0xa0>
+               	bltu	a3, t0, 0x90 <corpus.cases.cmp.branch_nest.checksum+0x90>
                	li	t0, 0x10
-               	beq	s4, t0, 0x98 <corpus.cases.cmp.branch_nest.checksum+0x98>
+               	beq	a3, t0, 0x88 <corpus.cases.cmp.branch_nest.checksum+0x88>
                	li	t0, 0x11
-               	beq	s4, t0, 0x90 <corpus.cases.cmp.branch_nest.checksum+0x90>
+               	beq	a3, t0, 0x80 <corpus.cases.cmp.branch_nest.checksum+0x80>
                	li	t0, 0x12
-               	beq	s4, t0, 0x88 <corpus.cases.cmp.branch_nest.checksum+0x88>
-               	li	a0, 0x1f7
+               	beq	a3, t0, 0x78 <corpus.cases.cmp.branch_nest.checksum+0x78>
+               	li	a4, 0x1f7
+               	j	0x7c <corpus.cases.cmp.branch_nest.checksum+0x7c>
+               	li	a4, 0x1f6
+               	j	0x84 <corpus.cases.cmp.branch_nest.checksum+0x84>
+               	li	a4, 0x1f5
                	j	0x8c <corpus.cases.cmp.branch_nest.checksum+0x8c>
-               	li	a0, 0x1f6
-               	j	0x94 <corpus.cases.cmp.branch_nest.checksum+0x94>
-               	li	a0, 0x1f5
-               	j	0x9c <corpus.cases.cmp.branch_nest.checksum+0x9c>
-               	li	a0, 0x1f4
-               	j	0xdc <corpus.cases.cmp.branch_nest.checksum+0xdc>
+               	li	a4, 0x1f4
+               	j	0xcc <corpus.cases.cmp.branch_nest.checksum+0xcc>
                	li	t0, 0xe
-               	bltu	s4, t0, 0xc0 <corpus.cases.cmp.branch_nest.checksum+0xc0>
+               	bltu	a3, t0, 0xb0 <corpus.cases.cmp.branch_nest.checksum+0xb0>
                	li	t0, 0xe
-               	beq	s4, t0, 0xb8 <corpus.cases.cmp.branch_nest.checksum+0xb8>
-               	li	a1, 0x193
-               	j	0xbc <corpus.cases.cmp.branch_nest.checksum+0xbc>
-               	li	a1, 0x192
-               	j	0xd8 <corpus.cases.cmp.branch_nest.checksum+0xd8>
+               	beq	a3, t0, 0xa8 <corpus.cases.cmp.branch_nest.checksum+0xa8>
+               	li	a5, 0x193
+               	j	0xac <corpus.cases.cmp.branch_nest.checksum+0xac>
+               	li	a5, 0x192
+               	j	0xc8 <corpus.cases.cmp.branch_nest.checksum+0xc8>
                	li	t0, 0xc
-               	beq	s4, t0, 0xd0 <corpus.cases.cmp.branch_nest.checksum+0xd0>
-               	li	a2, 0x191
-               	j	0xd4 <corpus.cases.cmp.branch_nest.checksum+0xd4>
-               	li	a2, 0x190
-               	mv	a1, a2
-               	mv	a0, a1
-               	j	0x118 <corpus.cases.cmp.branch_nest.checksum+0x118>
+               	beq	a3, t0, 0xc0 <corpus.cases.cmp.branch_nest.checksum+0xc0>
+               	li	a6, 0x191
+               	j	0xc4 <corpus.cases.cmp.branch_nest.checksum+0xc4>
+               	li	a6, 0x190
+               	mv	a5, a6
+               	mv	a4, a5
+               	j	0x108 <corpus.cases.cmp.branch_nest.checksum+0x108>
                	li	t0, 0x8
-               	beq	s4, t0, 0x110 <corpus.cases.cmp.branch_nest.checksum+0x110>
+               	beq	a3, t0, 0x100 <corpus.cases.cmp.branch_nest.checksum+0x100>
                	li	t0, 0x9
-               	beq	s4, t0, 0x108 <corpus.cases.cmp.branch_nest.checksum+0x108>
+               	beq	a3, t0, 0xf8 <corpus.cases.cmp.branch_nest.checksum+0xf8>
                	li	t0, 0xa
-               	beq	s4, t0, 0x100 <corpus.cases.cmp.branch_nest.checksum+0x100>
-               	li	a1, 0x12f
+               	beq	a3, t0, 0xf0 <corpus.cases.cmp.branch_nest.checksum+0xf0>
+               	li	a5, 0x12f
+               	j	0xf4 <corpus.cases.cmp.branch_nest.checksum+0xf4>
+               	li	a5, 0x12e
+               	j	0xfc <corpus.cases.cmp.branch_nest.checksum+0xfc>
+               	li	a5, 0x12d
                	j	0x104 <corpus.cases.cmp.branch_nest.checksum+0x104>
-               	li	a1, 0x12e
-               	j	0x10c <corpus.cases.cmp.branch_nest.checksum+0x10c>
-               	li	a1, 0x12d
-               	j	0x114 <corpus.cases.cmp.branch_nest.checksum+0x114>
-               	li	a1, 0x12c
-               	mv	a0, a1
-               	j	0x158 <corpus.cases.cmp.branch_nest.checksum+0x158>
+               	li	a5, 0x12c
+               	mv	a4, a5
+               	j	0x148 <corpus.cases.cmp.branch_nest.checksum+0x148>
                	li	t0, 0x6
-               	bltu	s4, t0, 0x13c <corpus.cases.cmp.branch_nest.checksum+0x13c>
+               	bltu	a3, t0, 0x12c <corpus.cases.cmp.branch_nest.checksum+0x12c>
                	li	t0, 0x6
-               	beq	s4, t0, 0x134 <corpus.cases.cmp.branch_nest.checksum+0x134>
-               	li	a1, 0xcb
-               	j	0x138 <corpus.cases.cmp.branch_nest.checksum+0x138>
-               	li	a1, 0xca
-               	j	0x154 <corpus.cases.cmp.branch_nest.checksum+0x154>
+               	beq	a3, t0, 0x124 <corpus.cases.cmp.branch_nest.checksum+0x124>
+               	li	a5, 0xcb
+               	j	0x128 <corpus.cases.cmp.branch_nest.checksum+0x128>
+               	li	a5, 0xca
+               	j	0x144 <corpus.cases.cmp.branch_nest.checksum+0x144>
                	li	t0, 0x4
-               	beq	s4, t0, 0x14c <corpus.cases.cmp.branch_nest.checksum+0x14c>
-               	li	a2, 0xc9
-               	j	0x150 <corpus.cases.cmp.branch_nest.checksum+0x150>
-               	li	a2, 0xc8
-               	mv	a1, a2
-               	mv	a0, a1
-               	mv	a1, a0
-               	j	0x198 <corpus.cases.cmp.branch_nest.checksum+0x198>
-               	li	t0, 0x0
-               	beq	s4, t0, 0x190 <corpus.cases.cmp.branch_nest.checksum+0x190>
-               	li	t0, 0x1
-               	beq	s4, t0, 0x188 <corpus.cases.cmp.branch_nest.checksum+0x188>
-               	li	t0, 0x2
-               	beq	s4, t0, 0x180 <corpus.cases.cmp.branch_nest.checksum+0x180>
-               	li	a0, 0x67
+               	beq	a3, t0, 0x13c <corpus.cases.cmp.branch_nest.checksum+0x13c>
+               	li	a6, 0xc9
+               	j	0x140 <corpus.cases.cmp.branch_nest.checksum+0x140>
+               	li	a6, 0xc8
+               	mv	a5, a6
+               	mv	a4, a5
                	j	0x184 <corpus.cases.cmp.branch_nest.checksum+0x184>
-               	li	a0, 0x66
-               	j	0x18c <corpus.cases.cmp.branch_nest.checksum+0x18c>
-               	li	a0, 0x65
-               	j	0x194 <corpus.cases.cmp.branch_nest.checksum+0x194>
-               	li	a0, 0x64
-               	mv	a1, a0
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.branch_nest.checksum+0x19c>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.branch_nest.checksum+0x1a8>
-               	addiw	s3, s3, 0x1
-               	mv	s1, a0
+               	li	t0, 0x0
+               	beq	a3, t0, 0x17c <corpus.cases.cmp.branch_nest.checksum+0x17c>
+               	li	t0, 0x1
+               	beq	a3, t0, 0x174 <corpus.cases.cmp.branch_nest.checksum+0x174>
+               	li	t0, 0x2
+               	beq	a3, t0, 0x16c <corpus.cases.cmp.branch_nest.checksum+0x16c>
+               	li	a5, 0x67
+               	j	0x170 <corpus.cases.cmp.branch_nest.checksum+0x170>
+               	li	a5, 0x66
+               	j	0x178 <corpus.cases.cmp.branch_nest.checksum+0x178>
+               	li	a5, 0x65
+               	j	0x180 <corpus.cases.cmp.branch_nest.checksum+0x180>
+               	li	a5, 0x64
+               	mv	a4, a5
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a4, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1a0 <corpus.cases.cmp.branch_nest.checksum+0x1a0>
+               	j	0x1d4 <corpus.cases.cmp.branch_nest.checksum+0x1d4>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1a0 <corpus.cases.cmp.branch_nest.checksum+0x1a0>
+               	slli	a5, a3, 0x20
+               	srli	a5, a5, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ec <corpus.cases.cmp.branch_nest.checksum+0x1ec>
+               	j	0x220 <corpus.cases.cmp.branch_nest.checksum+0x220>
+               	li	t0, 0x8
+               	mul	a6, a3, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ec <corpus.cases.cmp.branch_nest.checksum+0x1ec>
+               	addiw	a2, a2, 0x1
+               	mv	a0, a4
                	li	t0, 0x14
-               	bltu	s3, t0, 0x44 <corpus.cases.cmp.branch_nest.checksum+0x44>
-               	mv	a0, s1
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	bltu	a2, t0, 0x34 <corpus.cases.cmp.branch_nest.checksum+0x34>
                	ret

--- a/test/golden/riscv64-linux/cmp/cmp_i32.dis
+++ b/test/golden/riscv64-linux/cmp/cmp_i32.dis
@@ -3,235 +3,325 @@ cmp/cmp_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.cmp_i32.checksum>:
-               	addi	sp, sp, -0xc0
-               	sd	ra, 0xb8(sp)
-               	sd	s0, 0xb0(sp)
-               	addi	s0, sp, 0xc0
-               	sd	s1, 0xa8(sp)
-               	sd	s2, 0xa0(sp)
-               	sd	s3, 0x98(sp)
-               	sd	s4, 0x90(sp)
-               	sd	s5, 0x88(sp)
-               	sd	s6, 0x80(sp)
-               	sd	s7, 0x78(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x30>
-               	sext.w	s2, s1
-               	addi	s1, s0, -0x64
-               	addi	a1, s0, -0x80
-               	mv	a2, a1
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	sd	s1, 0x78(sp)
+               	sd	s2, 0x70(sp)
+               	sext.w	a1, a0
+               	addi	a0, s0, -0x3c
+               	addi	a2, s0, -0x58
+               	mv	a3, a2
+               	sw	zero, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	sw	zero, 0x0(a3)
+               	addi	a3, a2, 0x8
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0xc
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0xc
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x10
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x14
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x14
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x18
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	mv	a2, s1
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sw	t0, 0x0(a3)
+               	mv	a3, a0
+               	mv	a4, a2
+               	or	a2, a3, a4
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x128 <corpus.cases.cmp.cmp_i32.checksum+0x128>
-               	bnez	a1, 0xfc <corpus.cases.cmp.cmp_i32.checksum+0xfc>
-               	addi	a4, a2, 0x18
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x108 <corpus.cases.cmp.cmp_i32.checksum+0x108>
+               	bnez	a2, 0xdc <corpus.cases.cmp.cmp_i32.checksum+0xdc>
                	addi	a5, a3, 0x18
-               	lw	a6, 0x0(a5)
-               	sw	a6, 0x0(a4)
-               	li	a6, 0x18
-               	addi	a4, a4, -0x8
+               	addi	a6, a4, 0x18
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	li	a7, 0x18
                	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xbc <corpus.cases.cmp.cmp_i32.checksum+0xbc>
+               	j	0x168 <corpus.cases.cmp.cmp_i32.checksum+0x168>
+               	addi	a5, a3, 0x1c
+               	addi	a6, a4, 0x1c
+               	li	a7, 0x1c
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xe8 <corpus.cases.cmp.cmp_i32.checksum+0xe8>
+               	j	0x168 <corpus.cases.cmp.cmp_i32.checksum+0x168>
+               	bnez	a2, 0x140 <corpus.cases.cmp.cmp_i32.checksum+0x140>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x18
                	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdc <corpus.cases.cmp.cmp_i32.checksum+0xdc>
-               	j	0x188 <corpus.cases.cmp.cmp_i32.checksum+0x188>
-               	addi	a4, a2, 0x1c
-               	addi	a5, a3, 0x1c
-               	li	a6, 0x1c
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x108 <corpus.cases.cmp.cmp_i32.checksum+0x108>
-               	j	0x188 <corpus.cases.cmp.cmp_i32.checksum+0x188>
-               	bnez	a1, 0x160 <corpus.cases.cmp.cmp_i32.checksum+0x160>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x18
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x138 <corpus.cases.cmp.cmp_i32.checksum+0x138>
-               	lw	a5, 0x0(a4)
-               	sw	a5, 0x0(a1)
-               	j	0x188 <corpus.cases.cmp.cmp_i32.checksum+0x188>
-               	mv	a1, a2
+               	bne	a6, t0, 0x118 <corpus.cases.cmp.cmp_i32.checksum+0x118>
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a2)
+               	j	0x168 <corpus.cases.cmp.cmp_i32.checksum+0x168>
                	mv	a2, a3
-               	li	a3, 0x1c
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
+               	mv	a3, a4
+               	li	a4, 0x1c
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
                	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x16c <corpus.cases.cmp.cmp_i32.checksum+0x16c>
-               	addi	s3, s0, -0x9c
-               	addi	a1, s0, -0xb8
-               	mv	a2, a1
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x4
+               	bne	a4, t0, 0x14c <corpus.cases.cmp.cmp_i32.checksum+0x14c>
+               	addi	a2, s0, -0x74
+               	addi	a3, s0, -0x90
+               	mv	a4, a3
+               	sw	zero, 0x0(a4)
+               	addi	a4, a3, 0x4
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0xc
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x8
+               	sw	zero, 0x0(a4)
+               	addi	a4, a3, 0xc
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x10
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x14
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x14
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x18
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	mv	a2, s3
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sw	t0, 0x0(a4)
+               	mv	a4, a2
+               	mv	a5, a3
+               	or	a3, a4, a5
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x274 <corpus.cases.cmp.cmp_i32.checksum+0x274>
-               	bnez	a1, 0x248 <corpus.cases.cmp.cmp_i32.checksum+0x248>
-               	addi	a4, a2, 0x18
-               	addi	a5, a3, 0x18
-               	lw	a6, 0x0(a5)
-               	sw	a6, 0x0(a4)
-               	li	a6, 0x18
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	and	a3, a3, t0
+               	bltu	a4, a5, 0x254 <corpus.cases.cmp.cmp_i32.checksum+0x254>
+               	bnez	a3, 0x228 <corpus.cases.cmp.cmp_i32.checksum+0x228>
+               	addi	a6, a4, 0x18
+               	addi	a7, a5, 0x18
+               	lw	t5, 0x0(a7)
+               	sw	t5, 0x0(a6)
+               	li	t5, 0x18
                	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x228 <corpus.cases.cmp.cmp_i32.checksum+0x228>
-               	j	0x2d4 <corpus.cases.cmp.cmp_i32.checksum+0x2d4>
-               	addi	a4, a2, 0x1c
-               	addi	a5, a3, 0x1c
-               	li	a6, 0x1c
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
+               	bne	t5, t0, 0x208 <corpus.cases.cmp.cmp_i32.checksum+0x208>
+               	j	0x2b4 <corpus.cases.cmp.cmp_i32.checksum+0x2b4>
+               	addi	a6, a4, 0x1c
+               	addi	a7, a5, 0x1c
+               	li	t5, 0x1c
                	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x254 <corpus.cases.cmp.cmp_i32.checksum+0x254>
-               	j	0x2d4 <corpus.cases.cmp.cmp_i32.checksum+0x2d4>
-               	bnez	a1, 0x2ac <corpus.cases.cmp.cmp_i32.checksum+0x2ac>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x18
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
+               	bne	t5, t0, 0x234 <corpus.cases.cmp.cmp_i32.checksum+0x234>
+               	j	0x2b4 <corpus.cases.cmp.cmp_i32.checksum+0x2b4>
+               	bnez	a3, 0x28c <corpus.cases.cmp.cmp_i32.checksum+0x28c>
+               	mv	a3, a4
+               	mv	a6, a5
+               	li	a7, 0x18
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x284 <corpus.cases.cmp.cmp_i32.checksum+0x284>
-               	lw	a5, 0x0(a4)
-               	sw	a5, 0x0(a1)
-               	j	0x2d4 <corpus.cases.cmp.cmp_i32.checksum+0x2d4>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x1c
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	bne	a7, t0, 0x264 <corpus.cases.cmp.cmp_i32.checksum+0x264>
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a3)
+               	j	0x2b4 <corpus.cases.cmp.cmp_i32.checksum+0x2b4>
+               	mv	a3, a4
+               	mv	a4, a5
+               	li	a5, 0x1c
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2b8 <corpus.cases.cmp.cmp_i32.checksum+0x2b8>
-               	mv	s4, a0
-               	li	s5, 0x0
+               	bne	a5, t0, 0x298 <corpus.cases.cmp.cmp_i32.checksum+0x298>
+               	lui	a3, 0xfcbf3
+               	addiw	a3, a3, -0x632
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x484
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x222
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x325
+               	li	a4, 0x0
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2e8 <corpus.cases.cmp.cmp_i32.checksum+0x2e8>
-               	j	0x370 <corpus.cases.cmp.cmp_i32.checksum+0x370>
-               	slli	t0, s5, 0x2
-               	add	a0, s1, t0
-               	lw	a1, 0x0(a0)
-               	addw	s6, a1, s2
-               	slli	t0, s5, 0x2
-               	add	a0, s3, t0
-               	lw	s7, 0x0(a0)
-               	xor	a1, s6, s7
-               	seqz	a1, a1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x310>
-               	xor	a1, s6, s7
-               	snez	a1, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x320>
-               	slt	a1, s6, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x32c>
-               	slt	a1, s7, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x338>
-               	slt	a1, s7, s6
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x348>
-               	slt	a1, s6, s7
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i32.checksum+0x358>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a4, t0, 0x2e4 <corpus.cases.cmp.cmp_i32.checksum+0x2e4>
+               	j	0x4ec <corpus.cases.cmp.cmp_i32.checksum+0x4ec>
+               	slli	t0, a4, 0x2
+               	add	a5, a0, t0
+               	lw	a6, 0x0(a5)
+               	addw	a5, a6, a1
+               	slli	t0, a4, 0x2
+               	add	a6, a2, t0
+               	lw	a7, 0x0(a6)
+               	xor	a6, a5, a7
+               	seqz	a6, a6
+               	zext.b	t5, a6
+               	mv	a6, a3
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x320 <corpus.cases.cmp.cmp_i32.checksum+0x320>
+               	j	0x354 <corpus.cases.cmp.cmp_i32.checksum+0x354>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, t5, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x320 <corpus.cases.cmp.cmp_i32.checksum+0x320>
+               	xor	t5, a5, a7
+               	snez	t5, t5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x370 <corpus.cases.cmp.cmp_i32.checksum+0x370>
+               	j	0x3a4 <corpus.cases.cmp.cmp_i32.checksum+0x3a4>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x370 <corpus.cases.cmp.cmp_i32.checksum+0x370>
+               	slt	t5, a5, a7
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3bc <corpus.cases.cmp.cmp_i32.checksum+0x3bc>
+               	j	0x3f0 <corpus.cases.cmp.cmp_i32.checksum+0x3f0>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3bc <corpus.cases.cmp.cmp_i32.checksum+0x3bc>
+               	slt	t5, a7, a5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x408 <corpus.cases.cmp.cmp_i32.checksum+0x408>
+               	j	0x43c <corpus.cases.cmp.cmp_i32.checksum+0x43c>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x408 <corpus.cases.cmp.cmp_i32.checksum+0x408>
+               	slt	t5, a7, a5
+               	xori	t5, t5, 0x1
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x458 <corpus.cases.cmp.cmp_i32.checksum+0x458>
+               	j	0x48c <corpus.cases.cmp.cmp_i32.checksum+0x48c>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x458 <corpus.cases.cmp.cmp_i32.checksum+0x458>
+               	slt	t5, a5, a7
+               	xori	t5, t5, 0x1
+               	zext.b	a5, t5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4a8 <corpus.cases.cmp.cmp_i32.checksum+0x4a8>
+               	j	0x4dc <corpus.cases.cmp.cmp_i32.checksum+0x4dc>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4a8 <corpus.cases.cmp.cmp_i32.checksum+0x4a8>
+               	addi	a4, a4, 0x1
+               	mv	a3, a6
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2e8 <corpus.cases.cmp.cmp_i32.checksum+0x2e8>
-               	mv	a0, s4
-               	ld	s1, 0xa8(sp)
-               	ld	s2, 0xa0(sp)
-               	ld	s3, 0x98(sp)
-               	ld	s4, 0x90(sp)
-               	ld	s5, 0x88(sp)
-               	ld	s6, 0x80(sp)
-               	ld	s7, 0x78(sp)
-               	ld	ra, 0xb8(sp)
-               	ld	s0, 0xb0(sp)
-               	addi	sp, sp, 0xc0
+               	bltu	a4, t0, 0x2e4 <corpus.cases.cmp.cmp_i32.checksum+0x2e4>
+               	mv	a0, a3
+               	ld	s1, 0x78(sp)
+               	ld	s2, 0x70(sp)
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret

--- a/test/golden/riscv64-linux/cmp/cmp_i64.dis
+++ b/test/golden/riscv64-linux/cmp/cmp_i64.dis
@@ -3,232 +3,322 @@ cmp/cmp_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.cmp_i64.checksum>:
-               	addi	sp, sp, -0x130
-               	sd	ra, 0x128(sp)
-               	sd	s0, 0x120(sp)
-               	addi	s0, sp, 0x130
-               	sd	s1, 0x118(sp)
-               	sd	s2, 0x110(sp)
-               	sd	s3, 0x108(sp)
-               	sd	s4, 0x100(sp)
-               	sd	s5, 0xf8(sp)
-               	sd	s6, 0xf0(sp)
-               	sd	s7, 0xe8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x30>
-               	addi	s2, s0, -0x80
-               	addi	a1, s0, -0xb8
-               	mv	a2, a1
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	addi	sp, sp, -0x100
+               	sd	ra, 0xf8(sp)
+               	sd	s0, 0xf0(sp)
+               	addi	s0, sp, 0x100
+               	sd	s1, 0xe8(sp)
+               	sd	s2, 0xe0(sp)
+               	addi	a1, s0, -0x58
+               	addi	a2, s0, -0x90
+               	mv	a3, a2
+               	sd	zero, 0x0(a3)
+               	addi	a3, a2, 0x8
+               	sd	zero, 0x0(a3)
+               	addi	a3, a2, 0x10
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x18
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x20
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x20
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x28
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x28
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x30
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x30
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	mv	a2, s2
+               	sd	t0, 0x0(a3)
                	mv	a3, a1
-               	or	a1, a2, a3
+               	mv	a4, a2
+               	or	a2, a3, a4
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x128 <corpus.cases.cmp.cmp_i64.checksum+0x128>
-               	bnez	a1, 0xfc <corpus.cases.cmp.cmp_i64.checksum+0xfc>
-               	addi	a4, a2, 0x38
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x108 <corpus.cases.cmp.cmp_i64.checksum+0x108>
+               	bnez	a2, 0xdc <corpus.cases.cmp.cmp_i64.checksum+0xdc>
                	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x8
+               	addi	a6, a4, 0x38
+               	li	a7, 0x38
                	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xbc <corpus.cases.cmp.cmp_i64.checksum+0xbc>
+               	j	0x160 <corpus.cases.cmp.cmp_i64.checksum+0x160>
+               	addi	a5, a3, 0x38
+               	addi	a6, a4, 0x38
+               	li	a7, 0x38
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xe8 <corpus.cases.cmp.cmp_i64.checksum+0xe8>
+               	j	0x160 <corpus.cases.cmp.cmp_i64.checksum+0x160>
+               	bnez	a2, 0x138 <corpus.cases.cmp.cmp_i64.checksum+0x138>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x38
                	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdc <corpus.cases.cmp.cmp_i64.checksum+0xdc>
-               	j	0x180 <corpus.cases.cmp.cmp_i64.checksum+0x180>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x108 <corpus.cases.cmp.cmp_i64.checksum+0x108>
-               	j	0x180 <corpus.cases.cmp.cmp_i64.checksum+0x180>
-               	bnez	a1, 0x158 <corpus.cases.cmp.cmp_i64.checksum+0x158>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x38
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x138 <corpus.cases.cmp.cmp_i64.checksum+0x138>
-               	j	0x180 <corpus.cases.cmp.cmp_i64.checksum+0x180>
-               	mv	a1, a2
+               	bne	a6, t0, 0x118 <corpus.cases.cmp.cmp_i64.checksum+0x118>
+               	j	0x160 <corpus.cases.cmp.cmp_i64.checksum+0x160>
                	mv	a2, a3
-               	li	a3, 0x38
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
+               	mv	a3, a4
+               	li	a4, 0x38
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
                	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x164 <corpus.cases.cmp.cmp_i64.checksum+0x164>
-               	addi	s3, s0, -0xf0
-               	addi	a1, s0, -0x128
-               	mv	a2, a1
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
+               	bne	a4, t0, 0x144 <corpus.cases.cmp.cmp_i64.checksum+0x144>
+               	addi	a2, s0, -0xc8
+               	addi	a3, s0, -0x100
+               	mv	a4, a3
+               	sd	zero, 0x0(a4)
+               	addi	a4, a3, 0x8
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x10
+               	sd	zero, 0x0(a4)
+               	addi	a4, a3, 0x18
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x20
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x20
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x28
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x28
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x30
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x30
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	mv	a2, s3
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sd	t0, 0x0(a4)
+               	mv	a4, a2
+               	mv	a5, a3
+               	or	a3, a4, a5
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x270 <corpus.cases.cmp.cmp_i64.checksum+0x270>
-               	bnez	a1, 0x244 <corpus.cases.cmp.cmp_i64.checksum+0x244>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	and	a3, a3, t0
+               	bltu	a4, a5, 0x250 <corpus.cases.cmp.cmp_i64.checksum+0x250>
+               	bnez	a3, 0x224 <corpus.cases.cmp.cmp_i64.checksum+0x224>
+               	addi	a6, a4, 0x38
+               	addi	a7, a5, 0x38
+               	li	t5, 0x38
                	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x224 <corpus.cases.cmp.cmp_i64.checksum+0x224>
-               	j	0x2c8 <corpus.cases.cmp.cmp_i64.checksum+0x2c8>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
+               	bne	t5, t0, 0x204 <corpus.cases.cmp.cmp_i64.checksum+0x204>
+               	j	0x2a8 <corpus.cases.cmp.cmp_i64.checksum+0x2a8>
+               	addi	a6, a4, 0x38
+               	addi	a7, a5, 0x38
+               	li	t5, 0x38
                	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x250 <corpus.cases.cmp.cmp_i64.checksum+0x250>
-               	j	0x2c8 <corpus.cases.cmp.cmp_i64.checksum+0x2c8>
-               	bnez	a1, 0x2a0 <corpus.cases.cmp.cmp_i64.checksum+0x2a0>
-               	mv	a1, a2
-               	mv	a4, a3
+               	bne	t5, t0, 0x230 <corpus.cases.cmp.cmp_i64.checksum+0x230>
+               	j	0x2a8 <corpus.cases.cmp.cmp_i64.checksum+0x2a8>
+               	bnez	a3, 0x280 <corpus.cases.cmp.cmp_i64.checksum+0x280>
+               	mv	a3, a4
+               	mv	a6, a5
+               	li	a7, 0x38
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x260 <corpus.cases.cmp.cmp_i64.checksum+0x260>
+               	j	0x2a8 <corpus.cases.cmp.cmp_i64.checksum+0x2a8>
+               	mv	a3, a4
+               	mv	a4, a5
                	li	a5, 0x38
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x280 <corpus.cases.cmp.cmp_i64.checksum+0x280>
-               	j	0x2c8 <corpus.cases.cmp.cmp_i64.checksum+0x2c8>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x38
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x2ac <corpus.cases.cmp.cmp_i64.checksum+0x2ac>
-               	mv	s4, a0
-               	li	s5, 0x0
+               	bne	a5, t0, 0x28c <corpus.cases.cmp.cmp_i64.checksum+0x28c>
+               	lui	a3, 0xfcbf3
+               	addiw	a3, a3, -0x632
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x484
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x222
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x325
+               	li	a4, 0x0
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2dc <corpus.cases.cmp.cmp_i64.checksum+0x2dc>
-               	j	0x364 <corpus.cases.cmp.cmp_i64.checksum+0x364>
-               	slli	t0, s5, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	add	s6, a1, s1
-               	slli	t0, s5, 0x3
-               	add	a0, s3, t0
-               	ld	s7, 0x0(a0)
-               	xor	a1, s6, s7
-               	seqz	a1, a1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x304>
-               	xor	a1, s6, s7
-               	snez	a1, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x314>
-               	slt	a1, s6, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x320>
-               	slt	a1, s7, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x32c>
-               	slt	a1, s7, s6
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x33c>
-               	slt	a1, s6, s7
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_i64.checksum+0x34c>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a4, t0, 0x2d8 <corpus.cases.cmp.cmp_i64.checksum+0x2d8>
+               	j	0x4e0 <corpus.cases.cmp.cmp_i64.checksum+0x4e0>
+               	slli	t0, a4, 0x3
+               	add	a5, a1, t0
+               	ld	a6, 0x0(a5)
+               	add	a5, a6, a0
+               	slli	t0, a4, 0x3
+               	add	a6, a2, t0
+               	ld	a7, 0x0(a6)
+               	xor	a6, a5, a7
+               	seqz	a6, a6
+               	zext.b	t5, a6
+               	mv	a6, a3
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x314 <corpus.cases.cmp.cmp_i64.checksum+0x314>
+               	j	0x348 <corpus.cases.cmp.cmp_i64.checksum+0x348>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, t5, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x314 <corpus.cases.cmp.cmp_i64.checksum+0x314>
+               	xor	t5, a5, a7
+               	snez	t5, t5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x364 <corpus.cases.cmp.cmp_i64.checksum+0x364>
+               	j	0x398 <corpus.cases.cmp.cmp_i64.checksum+0x398>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x364 <corpus.cases.cmp.cmp_i64.checksum+0x364>
+               	slt	t5, a5, a7
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3b0 <corpus.cases.cmp.cmp_i64.checksum+0x3b0>
+               	j	0x3e4 <corpus.cases.cmp.cmp_i64.checksum+0x3e4>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3b0 <corpus.cases.cmp.cmp_i64.checksum+0x3b0>
+               	slt	t5, a7, a5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3fc <corpus.cases.cmp.cmp_i64.checksum+0x3fc>
+               	j	0x430 <corpus.cases.cmp.cmp_i64.checksum+0x430>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3fc <corpus.cases.cmp.cmp_i64.checksum+0x3fc>
+               	slt	t5, a7, a5
+               	xori	t5, t5, 0x1
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x44c <corpus.cases.cmp.cmp_i64.checksum+0x44c>
+               	j	0x480 <corpus.cases.cmp.cmp_i64.checksum+0x480>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x44c <corpus.cases.cmp.cmp_i64.checksum+0x44c>
+               	slt	t5, a5, a7
+               	xori	t5, t5, 0x1
+               	zext.b	a5, t5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x49c <corpus.cases.cmp.cmp_i64.checksum+0x49c>
+               	j	0x4d0 <corpus.cases.cmp.cmp_i64.checksum+0x4d0>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x49c <corpus.cases.cmp.cmp_i64.checksum+0x49c>
+               	addi	a4, a4, 0x1
+               	mv	a3, a6
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2dc <corpus.cases.cmp.cmp_i64.checksum+0x2dc>
-               	mv	a0, s4
-               	ld	s1, 0x118(sp)
-               	ld	s2, 0x110(sp)
-               	ld	s3, 0x108(sp)
-               	ld	s4, 0x100(sp)
-               	ld	s5, 0xf8(sp)
-               	ld	s6, 0xf0(sp)
-               	ld	s7, 0xe8(sp)
-               	ld	ra, 0x128(sp)
-               	ld	s0, 0x120(sp)
-               	addi	sp, sp, 0x130
+               	bltu	a4, t0, 0x2d8 <corpus.cases.cmp.cmp_i64.checksum+0x2d8>
+               	mv	a0, a3
+               	ld	s1, 0xe8(sp)
+               	ld	s2, 0xe0(sp)
+               	ld	ra, 0xf8(sp)
+               	ld	s0, 0xf0(sp)
+               	addi	sp, sp, 0x100
                	ret

--- a/test/golden/riscv64-linux/cmp/cmp_u32.dis
+++ b/test/golden/riscv64-linux/cmp/cmp_u32.dis
@@ -3,235 +3,325 @@ cmp/cmp_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.cmp_u32.checksum>:
-               	addi	sp, sp, -0xc0
-               	sd	ra, 0xb8(sp)
-               	sd	s0, 0xb0(sp)
-               	addi	s0, sp, 0xc0
-               	sd	s1, 0xa8(sp)
-               	sd	s2, 0xa0(sp)
-               	sd	s3, 0x98(sp)
-               	sd	s4, 0x90(sp)
-               	sd	s5, 0x88(sp)
-               	sd	s6, 0x80(sp)
-               	sd	s7, 0x78(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x30>
-               	sext.w	s2, s1
-               	addi	s1, s0, -0x64
-               	addi	a1, s0, -0x80
-               	mv	a2, a1
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	sd	s1, 0x78(sp)
+               	sd	s2, 0x70(sp)
+               	sext.w	a1, a0
+               	addi	a0, s0, -0x3c
+               	addi	a2, s0, -0x58
+               	mv	a3, a2
+               	sw	zero, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	sw	zero, 0x0(a3)
+               	addi	a3, a2, 0x8
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0xc
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0xc
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x10
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x14
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x14
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sw	t0, 0x0(a3)
+               	addi	a3, a2, 0x18
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	mv	a2, s1
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sw	t0, 0x0(a3)
+               	mv	a3, a0
+               	mv	a4, a2
+               	or	a2, a3, a4
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x128 <corpus.cases.cmp.cmp_u32.checksum+0x128>
-               	bnez	a1, 0xfc <corpus.cases.cmp.cmp_u32.checksum+0xfc>
-               	addi	a4, a2, 0x18
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x108 <corpus.cases.cmp.cmp_u32.checksum+0x108>
+               	bnez	a2, 0xdc <corpus.cases.cmp.cmp_u32.checksum+0xdc>
                	addi	a5, a3, 0x18
-               	lw	a6, 0x0(a5)
-               	sw	a6, 0x0(a4)
-               	li	a6, 0x18
-               	addi	a4, a4, -0x8
+               	addi	a6, a4, 0x18
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	li	a7, 0x18
                	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xbc <corpus.cases.cmp.cmp_u32.checksum+0xbc>
+               	j	0x168 <corpus.cases.cmp.cmp_u32.checksum+0x168>
+               	addi	a5, a3, 0x1c
+               	addi	a6, a4, 0x1c
+               	li	a7, 0x1c
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xe8 <corpus.cases.cmp.cmp_u32.checksum+0xe8>
+               	j	0x168 <corpus.cases.cmp.cmp_u32.checksum+0x168>
+               	bnez	a2, 0x140 <corpus.cases.cmp.cmp_u32.checksum+0x140>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x18
                	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdc <corpus.cases.cmp.cmp_u32.checksum+0xdc>
-               	j	0x188 <corpus.cases.cmp.cmp_u32.checksum+0x188>
-               	addi	a4, a2, 0x1c
-               	addi	a5, a3, 0x1c
-               	li	a6, 0x1c
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x108 <corpus.cases.cmp.cmp_u32.checksum+0x108>
-               	j	0x188 <corpus.cases.cmp.cmp_u32.checksum+0x188>
-               	bnez	a1, 0x160 <corpus.cases.cmp.cmp_u32.checksum+0x160>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x18
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x138 <corpus.cases.cmp.cmp_u32.checksum+0x138>
-               	lw	a5, 0x0(a4)
-               	sw	a5, 0x0(a1)
-               	j	0x188 <corpus.cases.cmp.cmp_u32.checksum+0x188>
-               	mv	a1, a2
+               	bne	a6, t0, 0x118 <corpus.cases.cmp.cmp_u32.checksum+0x118>
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a2)
+               	j	0x168 <corpus.cases.cmp.cmp_u32.checksum+0x168>
                	mv	a2, a3
-               	li	a3, 0x1c
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
+               	mv	a3, a4
+               	li	a4, 0x1c
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
                	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x16c <corpus.cases.cmp.cmp_u32.checksum+0x16c>
-               	addi	s3, s0, -0x9c
-               	addi	a1, s0, -0xb8
-               	mv	a2, a1
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x4
+               	bne	a4, t0, 0x14c <corpus.cases.cmp.cmp_u32.checksum+0x14c>
+               	addi	a2, s0, -0x74
+               	addi	a3, s0, -0x90
+               	mv	a4, a3
+               	sw	zero, 0x0(a4)
+               	addi	a4, a3, 0x4
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0xc
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x8
+               	sw	zero, 0x0(a4)
+               	addi	a4, a3, 0xc
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x10
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x14
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x14
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sw	t0, 0x0(a4)
+               	addi	a4, a3, 0x18
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a2)
-               	mv	a2, s3
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sw	t0, 0x0(a4)
+               	mv	a4, a2
+               	mv	a5, a3
+               	or	a3, a4, a5
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x274 <corpus.cases.cmp.cmp_u32.checksum+0x274>
-               	bnez	a1, 0x248 <corpus.cases.cmp.cmp_u32.checksum+0x248>
-               	addi	a4, a2, 0x18
-               	addi	a5, a3, 0x18
-               	lw	a6, 0x0(a5)
-               	sw	a6, 0x0(a4)
-               	li	a6, 0x18
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	and	a3, a3, t0
+               	bltu	a4, a5, 0x254 <corpus.cases.cmp.cmp_u32.checksum+0x254>
+               	bnez	a3, 0x228 <corpus.cases.cmp.cmp_u32.checksum+0x228>
+               	addi	a6, a4, 0x18
+               	addi	a7, a5, 0x18
+               	lw	t5, 0x0(a7)
+               	sw	t5, 0x0(a6)
+               	li	t5, 0x18
                	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x228 <corpus.cases.cmp.cmp_u32.checksum+0x228>
-               	j	0x2d4 <corpus.cases.cmp.cmp_u32.checksum+0x2d4>
-               	addi	a4, a2, 0x1c
-               	addi	a5, a3, 0x1c
-               	li	a6, 0x1c
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
+               	bne	t5, t0, 0x208 <corpus.cases.cmp.cmp_u32.checksum+0x208>
+               	j	0x2b4 <corpus.cases.cmp.cmp_u32.checksum+0x2b4>
+               	addi	a6, a4, 0x1c
+               	addi	a7, a5, 0x1c
+               	li	t5, 0x1c
                	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x254 <corpus.cases.cmp.cmp_u32.checksum+0x254>
-               	j	0x2d4 <corpus.cases.cmp.cmp_u32.checksum+0x2d4>
-               	bnez	a1, 0x2ac <corpus.cases.cmp.cmp_u32.checksum+0x2ac>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x18
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
+               	bne	t5, t0, 0x234 <corpus.cases.cmp.cmp_u32.checksum+0x234>
+               	j	0x2b4 <corpus.cases.cmp.cmp_u32.checksum+0x2b4>
+               	bnez	a3, 0x28c <corpus.cases.cmp.cmp_u32.checksum+0x28c>
+               	mv	a3, a4
+               	mv	a6, a5
+               	li	a7, 0x18
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x284 <corpus.cases.cmp.cmp_u32.checksum+0x284>
-               	lw	a5, 0x0(a4)
-               	sw	a5, 0x0(a1)
-               	j	0x2d4 <corpus.cases.cmp.cmp_u32.checksum+0x2d4>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x1c
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	bne	a7, t0, 0x264 <corpus.cases.cmp.cmp_u32.checksum+0x264>
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a3)
+               	j	0x2b4 <corpus.cases.cmp.cmp_u32.checksum+0x2b4>
+               	mv	a3, a4
+               	mv	a4, a5
+               	li	a5, 0x1c
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2b8 <corpus.cases.cmp.cmp_u32.checksum+0x2b8>
-               	mv	s4, a0
-               	li	s5, 0x0
+               	bne	a5, t0, 0x298 <corpus.cases.cmp.cmp_u32.checksum+0x298>
+               	lui	a3, 0xfcbf3
+               	addiw	a3, a3, -0x632
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x484
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x222
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x325
+               	li	a4, 0x0
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2e8 <corpus.cases.cmp.cmp_u32.checksum+0x2e8>
-               	j	0x370 <corpus.cases.cmp.cmp_u32.checksum+0x370>
-               	slli	t0, s5, 0x2
-               	add	a0, s1, t0
-               	lw	a1, 0x0(a0)
-               	addw	s6, a1, s2
-               	slli	t0, s5, 0x2
-               	add	a0, s3, t0
-               	lw	s7, 0x0(a0)
-               	xor	a1, s6, s7
-               	seqz	a1, a1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x310>
-               	xor	a1, s6, s7
-               	snez	a1, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x320>
-               	sltu	a1, s6, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x32c>
-               	sltu	a1, s7, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x338>
-               	sltu	a1, s7, s6
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x348>
-               	sltu	a1, s6, s7
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u32.checksum+0x358>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a4, t0, 0x2e4 <corpus.cases.cmp.cmp_u32.checksum+0x2e4>
+               	j	0x4ec <corpus.cases.cmp.cmp_u32.checksum+0x4ec>
+               	slli	t0, a4, 0x2
+               	add	a5, a0, t0
+               	lw	a6, 0x0(a5)
+               	addw	a5, a6, a1
+               	slli	t0, a4, 0x2
+               	add	a6, a2, t0
+               	lw	a7, 0x0(a6)
+               	xor	a6, a5, a7
+               	seqz	a6, a6
+               	zext.b	t5, a6
+               	mv	a6, a3
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x320 <corpus.cases.cmp.cmp_u32.checksum+0x320>
+               	j	0x354 <corpus.cases.cmp.cmp_u32.checksum+0x354>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, t5, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x320 <corpus.cases.cmp.cmp_u32.checksum+0x320>
+               	xor	t5, a5, a7
+               	snez	t5, t5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x370 <corpus.cases.cmp.cmp_u32.checksum+0x370>
+               	j	0x3a4 <corpus.cases.cmp.cmp_u32.checksum+0x3a4>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x370 <corpus.cases.cmp.cmp_u32.checksum+0x370>
+               	sltu	t5, a5, a7
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3bc <corpus.cases.cmp.cmp_u32.checksum+0x3bc>
+               	j	0x3f0 <corpus.cases.cmp.cmp_u32.checksum+0x3f0>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3bc <corpus.cases.cmp.cmp_u32.checksum+0x3bc>
+               	sltu	t5, a7, a5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x408 <corpus.cases.cmp.cmp_u32.checksum+0x408>
+               	j	0x43c <corpus.cases.cmp.cmp_u32.checksum+0x43c>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x408 <corpus.cases.cmp.cmp_u32.checksum+0x408>
+               	sltu	t5, a7, a5
+               	xori	t5, t5, 0x1
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x458 <corpus.cases.cmp.cmp_u32.checksum+0x458>
+               	j	0x48c <corpus.cases.cmp.cmp_u32.checksum+0x48c>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x458 <corpus.cases.cmp.cmp_u32.checksum+0x458>
+               	sltu	t5, a5, a7
+               	xori	t5, t5, 0x1
+               	zext.b	a5, t5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4a8 <corpus.cases.cmp.cmp_u32.checksum+0x4a8>
+               	j	0x4dc <corpus.cases.cmp.cmp_u32.checksum+0x4dc>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4a8 <corpus.cases.cmp.cmp_u32.checksum+0x4a8>
+               	addi	a4, a4, 0x1
+               	mv	a3, a6
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2e8 <corpus.cases.cmp.cmp_u32.checksum+0x2e8>
-               	mv	a0, s4
-               	ld	s1, 0xa8(sp)
-               	ld	s2, 0xa0(sp)
-               	ld	s3, 0x98(sp)
-               	ld	s4, 0x90(sp)
-               	ld	s5, 0x88(sp)
-               	ld	s6, 0x80(sp)
-               	ld	s7, 0x78(sp)
-               	ld	ra, 0xb8(sp)
-               	ld	s0, 0xb0(sp)
-               	addi	sp, sp, 0xc0
+               	bltu	a4, t0, 0x2e4 <corpus.cases.cmp.cmp_u32.checksum+0x2e4>
+               	mv	a0, a3
+               	ld	s1, 0x78(sp)
+               	ld	s2, 0x70(sp)
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret

--- a/test/golden/riscv64-linux/cmp/cmp_u64.dis
+++ b/test/golden/riscv64-linux/cmp/cmp_u64.dis
@@ -3,232 +3,322 @@ cmp/cmp_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.cmp_u64.checksum>:
-               	addi	sp, sp, -0x130
-               	sd	ra, 0x128(sp)
-               	sd	s0, 0x120(sp)
-               	addi	s0, sp, 0x130
-               	sd	s1, 0x118(sp)
-               	sd	s2, 0x110(sp)
-               	sd	s3, 0x108(sp)
-               	sd	s4, 0x100(sp)
-               	sd	s5, 0xf8(sp)
-               	sd	s6, 0xf0(sp)
-               	sd	s7, 0xe8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x30>
-               	addi	s2, s0, -0x80
-               	addi	a1, s0, -0xb8
-               	mv	a2, a1
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x10
+               	addi	sp, sp, -0x100
+               	sd	ra, 0xf8(sp)
+               	sd	s0, 0xf0(sp)
+               	addi	s0, sp, 0x100
+               	sd	s1, 0xe8(sp)
+               	sd	s2, 0xe0(sp)
+               	addi	a1, s0, -0x58
+               	addi	a2, s0, -0x90
+               	mv	a3, a2
+               	sd	zero, 0x0(a3)
+               	addi	a3, a2, 0x8
+               	sd	zero, 0x0(a3)
+               	addi	a3, a2, 0x10
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x18
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x20
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x20
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x28
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x28
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x30
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x30
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	mv	a2, s2
+               	sd	t0, 0x0(a3)
                	mv	a3, a1
-               	or	a1, a2, a3
+               	mv	a4, a2
+               	or	a2, a3, a4
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x128 <corpus.cases.cmp.cmp_u64.checksum+0x128>
-               	bnez	a1, 0xfc <corpus.cases.cmp.cmp_u64.checksum+0xfc>
-               	addi	a4, a2, 0x38
+               	and	a2, a2, t0
+               	bltu	a3, a4, 0x108 <corpus.cases.cmp.cmp_u64.checksum+0x108>
+               	bnez	a2, 0xdc <corpus.cases.cmp.cmp_u64.checksum+0xdc>
                	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x8
+               	addi	a6, a4, 0x38
+               	li	a7, 0x38
                	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0xbc <corpus.cases.cmp.cmp_u64.checksum+0xbc>
+               	j	0x160 <corpus.cases.cmp.cmp_u64.checksum+0x160>
+               	addi	a5, a3, 0x38
+               	addi	a6, a4, 0x38
+               	li	a7, 0x38
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0xe8 <corpus.cases.cmp.cmp_u64.checksum+0xe8>
+               	j	0x160 <corpus.cases.cmp.cmp_u64.checksum+0x160>
+               	bnez	a2, 0x138 <corpus.cases.cmp.cmp_u64.checksum+0x138>
+               	mv	a2, a3
+               	mv	a5, a4
+               	li	a6, 0x38
                	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	sd	a7, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdc <corpus.cases.cmp.cmp_u64.checksum+0xdc>
-               	j	0x180 <corpus.cases.cmp.cmp_u64.checksum+0x180>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
-               	addi	a6, a6, -0x1
-               	li	t0, 0x0
-               	bne	a6, t0, 0x108 <corpus.cases.cmp.cmp_u64.checksum+0x108>
-               	j	0x180 <corpus.cases.cmp.cmp_u64.checksum+0x180>
-               	bnez	a1, 0x158 <corpus.cases.cmp.cmp_u64.checksum+0x158>
-               	mv	a1, a2
-               	mv	a4, a3
-               	li	a5, 0x38
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
-               	li	t0, 0x0
-               	bne	a5, t0, 0x138 <corpus.cases.cmp.cmp_u64.checksum+0x138>
-               	j	0x180 <corpus.cases.cmp.cmp_u64.checksum+0x180>
-               	mv	a1, a2
+               	bne	a6, t0, 0x118 <corpus.cases.cmp.cmp_u64.checksum+0x118>
+               	j	0x160 <corpus.cases.cmp.cmp_u64.checksum+0x160>
                	mv	a2, a3
-               	li	a3, 0x38
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
+               	mv	a3, a4
+               	li	a4, 0x38
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a2)
                	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x164 <corpus.cases.cmp.cmp_u64.checksum+0x164>
-               	addi	s3, s0, -0xf0
-               	addi	a1, s0, -0x128
-               	mv	a2, a1
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
+               	bne	a4, t0, 0x144 <corpus.cases.cmp.cmp_u64.checksum+0x144>
+               	addi	a2, s0, -0xc8
+               	addi	a3, s0, -0x100
+               	mv	a4, a3
+               	sd	zero, 0x0(a4)
+               	addi	a4, a3, 0x8
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a1, 0x18
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x10
+               	sd	zero, 0x0(a4)
+               	addi	a4, a3, 0x18
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x20
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x20
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x28
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x28
                	li	t0, -0x1
-               	sd	t0, 0x0(a2)
-               	addi	a2, a1, 0x30
+               	sd	t0, 0x0(a4)
+               	addi	a4, a3, 0x30
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a2)
-               	mv	a2, s3
-               	mv	a3, a1
-               	or	a1, a2, a3
+               	sd	t0, 0x0(a4)
+               	mv	a4, a2
+               	mv	a5, a3
+               	or	a3, a4, a5
                	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x270 <corpus.cases.cmp.cmp_u64.checksum+0x270>
-               	bnez	a1, 0x244 <corpus.cases.cmp.cmp_u64.checksum+0x244>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x8
-               	addi	a5, a5, -0x8
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
+               	and	a3, a3, t0
+               	bltu	a4, a5, 0x250 <corpus.cases.cmp.cmp_u64.checksum+0x250>
+               	bnez	a3, 0x224 <corpus.cases.cmp.cmp_u64.checksum+0x224>
+               	addi	a6, a4, 0x38
+               	addi	a7, a5, 0x38
+               	li	t5, 0x38
                	addi	a6, a6, -0x8
+               	addi	a7, a7, -0x8
+               	ld	t6, 0x0(a7)
+               	sd	t6, 0x0(a6)
+               	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x224 <corpus.cases.cmp.cmp_u64.checksum+0x224>
-               	j	0x2c8 <corpus.cases.cmp.cmp_u64.checksum+0x2c8>
-               	addi	a4, a2, 0x38
-               	addi	a5, a3, 0x38
-               	li	a6, 0x38
-               	addi	a4, a4, -0x1
-               	addi	a5, a5, -0x1
-               	lbu	a7, 0x0(a5)
-               	sb	a7, 0x0(a4)
+               	bne	t5, t0, 0x204 <corpus.cases.cmp.cmp_u64.checksum+0x204>
+               	j	0x2a8 <corpus.cases.cmp.cmp_u64.checksum+0x2a8>
+               	addi	a6, a4, 0x38
+               	addi	a7, a5, 0x38
+               	li	t5, 0x38
                	addi	a6, a6, -0x1
+               	addi	a7, a7, -0x1
+               	lbu	t6, 0x0(a7)
+               	sb	t6, 0x0(a6)
+               	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x250 <corpus.cases.cmp.cmp_u64.checksum+0x250>
-               	j	0x2c8 <corpus.cases.cmp.cmp_u64.checksum+0x2c8>
-               	bnez	a1, 0x2a0 <corpus.cases.cmp.cmp_u64.checksum+0x2a0>
-               	mv	a1, a2
-               	mv	a4, a3
+               	bne	t5, t0, 0x230 <corpus.cases.cmp.cmp_u64.checksum+0x230>
+               	j	0x2a8 <corpus.cases.cmp.cmp_u64.checksum+0x2a8>
+               	bnez	a3, 0x280 <corpus.cases.cmp.cmp_u64.checksum+0x280>
+               	mv	a3, a4
+               	mv	a6, a5
+               	li	a7, 0x38
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x260 <corpus.cases.cmp.cmp_u64.checksum+0x260>
+               	j	0x2a8 <corpus.cases.cmp.cmp_u64.checksum+0x2a8>
+               	mv	a3, a4
+               	mv	a4, a5
                	li	a5, 0x38
-               	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, -0x8
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x280 <corpus.cases.cmp.cmp_u64.checksum+0x280>
-               	j	0x2c8 <corpus.cases.cmp.cmp_u64.checksum+0x2c8>
-               	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x38
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x2ac <corpus.cases.cmp.cmp_u64.checksum+0x2ac>
-               	mv	s4, a0
-               	li	s5, 0x0
+               	bne	a5, t0, 0x28c <corpus.cases.cmp.cmp_u64.checksum+0x28c>
+               	lui	a3, 0xfcbf3
+               	addiw	a3, a3, -0x632
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x484
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x222
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x325
+               	li	a4, 0x0
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2dc <corpus.cases.cmp.cmp_u64.checksum+0x2dc>
-               	j	0x364 <corpus.cases.cmp.cmp_u64.checksum+0x364>
-               	slli	t0, s5, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	add	s6, a1, s1
-               	slli	t0, s5, 0x3
-               	add	a0, s3, t0
-               	ld	s7, 0x0(a0)
-               	xor	a1, s6, s7
-               	seqz	a1, a1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x304>
-               	xor	a1, s6, s7
-               	snez	a1, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x314>
-               	sltu	a1, s6, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x320>
-               	sltu	a1, s7, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x32c>
-               	sltu	a1, s7, s6
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x33c>
-               	sltu	a1, s6, s7
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.cmp_u64.checksum+0x34c>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
+               	bltu	a4, t0, 0x2d8 <corpus.cases.cmp.cmp_u64.checksum+0x2d8>
+               	j	0x4e0 <corpus.cases.cmp.cmp_u64.checksum+0x4e0>
+               	slli	t0, a4, 0x3
+               	add	a5, a1, t0
+               	ld	a6, 0x0(a5)
+               	add	a5, a6, a0
+               	slli	t0, a4, 0x3
+               	add	a6, a2, t0
+               	ld	a7, 0x0(a6)
+               	xor	a6, a5, a7
+               	seqz	a6, a6
+               	zext.b	t5, a6
+               	mv	a6, a3
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x314 <corpus.cases.cmp.cmp_u64.checksum+0x314>
+               	j	0x348 <corpus.cases.cmp.cmp_u64.checksum+0x348>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, t5, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x314 <corpus.cases.cmp.cmp_u64.checksum+0x314>
+               	xor	t5, a5, a7
+               	snez	t5, t5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x364 <corpus.cases.cmp.cmp_u64.checksum+0x364>
+               	j	0x398 <corpus.cases.cmp.cmp_u64.checksum+0x398>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x364 <corpus.cases.cmp.cmp_u64.checksum+0x364>
+               	sltu	t5, a5, a7
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3b0 <corpus.cases.cmp.cmp_u64.checksum+0x3b0>
+               	j	0x3e4 <corpus.cases.cmp.cmp_u64.checksum+0x3e4>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3b0 <corpus.cases.cmp.cmp_u64.checksum+0x3b0>
+               	sltu	t5, a7, a5
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3fc <corpus.cases.cmp.cmp_u64.checksum+0x3fc>
+               	j	0x430 <corpus.cases.cmp.cmp_u64.checksum+0x430>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3fc <corpus.cases.cmp.cmp_u64.checksum+0x3fc>
+               	sltu	t5, a7, a5
+               	xori	t5, t5, 0x1
+               	zext.b	t6, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x44c <corpus.cases.cmp.cmp_u64.checksum+0x44c>
+               	j	0x480 <corpus.cases.cmp.cmp_u64.checksum+0x480>
+               	li	t0, 0x8
+               	mul	s1, t5, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a6, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s2, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x44c <corpus.cases.cmp.cmp_u64.checksum+0x44c>
+               	sltu	t5, a5, a7
+               	xori	t5, t5, 0x1
+               	zext.b	a5, t5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x49c <corpus.cases.cmp.cmp_u64.checksum+0x49c>
+               	j	0x4d0 <corpus.cases.cmp.cmp_u64.checksum+0x4d0>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x49c <corpus.cases.cmp.cmp_u64.checksum+0x49c>
+               	addi	a4, a4, 0x1
+               	mv	a3, a6
                	li	t0, 0x7
-               	bltu	s5, t0, 0x2dc <corpus.cases.cmp.cmp_u64.checksum+0x2dc>
-               	mv	a0, s4
-               	ld	s1, 0x118(sp)
-               	ld	s2, 0x110(sp)
-               	ld	s3, 0x108(sp)
-               	ld	s4, 0x100(sp)
-               	ld	s5, 0xf8(sp)
-               	ld	s6, 0xf0(sp)
-               	ld	s7, 0xe8(sp)
-               	ld	ra, 0x128(sp)
-               	ld	s0, 0x120(sp)
-               	addi	sp, sp, 0x130
+               	bltu	a4, t0, 0x2d8 <corpus.cases.cmp.cmp_u64.checksum+0x2d8>
+               	mv	a0, a3
+               	ld	s1, 0xe8(sp)
+               	ld	s2, 0xe0(sp)
+               	ld	ra, 0xf8(sp)
+               	ld	s0, 0xf0(sp)
+               	addi	sp, sp, 0x100
                	ret

--- a/test/golden/riscv64-linux/cmp/loop_shapes.dis
+++ b/test/golden/riscv64-linux/cmp/loop_shapes.dis
@@ -3,126 +3,200 @@ cmp/loop_shapes.o:
 Disassembly of section .text:
 
 <corpus.cases.cmp.loop_shapes.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	sd	s6, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0x2c>
-               	sext.w	s2, s1
-               	mv	s1, a0
-               	li	s3, 0x0
-               	mv	s4, s2
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
+               	mv	a3, a1
                	li	t0, 0x10
-               	bltu	s3, t0, 0x50 <corpus.cases.cmp.loop_shapes.checksum+0x50>
-               	j	0x80 <corpus.cases.cmp.loop_shapes.checksum+0x80>
+               	bltu	a2, t0, 0x4c <corpus.cases.cmp.loop_shapes.checksum+0x4c>
+               	j	0xc0 <corpus.cases.cmp.loop_shapes.checksum+0xc0>
                	li	t0, 0x3
-               	mulw	a0, s3, t0
-               	addw	a1, s4, a0
-               	addiw	s4, a1, 0x1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0x68>
-               	addiw	s3, s3, 0x1
-               	mv	s1, a0
+               	mulw	a4, a2, t0
+               	addw	a5, a3, a4
+               	addiw	a4, a5, 0x1
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a6, a0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x78 <corpus.cases.cmp.loop_shapes.checksum+0x78>
+               	j	0xac <corpus.cases.cmp.loop_shapes.checksum+0xac>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x78 <corpus.cases.cmp.loop_shapes.checksum+0x78>
+               	addiw	a2, a2, 0x1
+               	mv	a0, a6
+               	mv	a3, a4
                	li	t0, 0x10
-               	bltu	s3, t0, 0x50 <corpus.cases.cmp.loop_shapes.checksum+0x50>
+               	bltu	a2, t0, 0x4c <corpus.cases.cmp.loop_shapes.checksum+0x4c>
                	li	t1, 0x62
-               	addw	a0, t1, s2
-               	mv	s3, a0
+               	addw	a2, t1, a1
                	li	t1, 0x0
-               	bltu	t1, s3, 0x98 <corpus.cases.cmp.loop_shapes.checksum+0x98>
-               	j	0xb8 <corpus.cases.cmp.loop_shapes.checksum+0xb8>
-               	addiw	s3, s3, -0x7
-               	mv	a0, s1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0xa4>
-               	mv	s1, a0
-               	li	t1, 0x0
-               	bltu	t1, s3, 0x98 <corpus.cases.cmp.loop_shapes.checksum+0x98>
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0xc8 <corpus.cases.cmp.loop_shapes.checksum+0xc8>
+               	bltu	t1, a2, 0xd4 <corpus.cases.cmp.loop_shapes.checksum+0xd4>
+               	j	0x138 <corpus.cases.cmp.loop_shapes.checksum+0x138>
+               	addiw	a3, a2, -0x7
+               	slli	a4, a3, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a5, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0xf4 <corpus.cases.cmp.loop_shapes.checksum+0xf4>
                	j	0x128 <corpus.cases.cmp.loop_shapes.checksum+0x128>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0xf4 <corpus.cases.cmp.loop_shapes.checksum+0xf4>
+               	mv	a0, a5
+               	mv	a2, a3
+               	li	t1, 0x0
+               	bltu	t1, a2, 0xd4 <corpus.cases.cmp.loop_shapes.checksum+0xd4>
+               	li	a2, 0x0
                	li	t0, 0x6
-               	mulw	s4, s3, t0
-               	mv	s5, s1
-               	li	s6, 0x0
+               	bltu	a2, t0, 0x148 <corpus.cases.cmp.loop_shapes.checksum+0x148>
+               	j	0x1ec <corpus.cases.cmp.loop_shapes.checksum+0x1ec>
                	li	t0, 0x6
-               	bltu	s6, t0, 0xe4 <corpus.cases.cmp.loop_shapes.checksum+0xe4>
-               	j	0x118 <corpus.cases.cmp.loop_shapes.checksum+0x118>
+               	mulw	a3, a2, t0
+               	mv	a4, a0
+               	li	a5, 0x0
+               	li	t0, 0x6
+               	bltu	a5, t0, 0x164 <corpus.cases.cmp.loop_shapes.checksum+0x164>
+               	j	0x1dc <corpus.cases.cmp.loop_shapes.checksum+0x1dc>
                	li	t0, 0x3
-               	beq	s6, t0, 0x10c <corpus.cases.cmp.loop_shapes.checksum+0x10c>
-               	addw	a0, s4, s6
-               	addw	a1, a0, s2
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0xf8>
-               	addiw	s6, s6, 0x1
-               	mv	s5, a0
-               	j	0x110 <corpus.cases.cmp.loop_shapes.checksum+0x110>
-               	addiw	s6, s6, 0x1
+               	beq	a5, t0, 0x1d0 <corpus.cases.cmp.loop_shapes.checksum+0x1d0>
+               	addw	a6, a3, a5
+               	addw	a7, a6, a1
+               	slli	a6, a7, 0x20
+               	srli	a6, a6, 0x20
+               	mv	a7, a4
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x190 <corpus.cases.cmp.loop_shapes.checksum+0x190>
+               	j	0x1c4 <corpus.cases.cmp.loop_shapes.checksum+0x1c4>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x190 <corpus.cases.cmp.loop_shapes.checksum+0x190>
+               	addiw	a5, a5, 0x1
+               	mv	a4, a7
+               	j	0x1d4 <corpus.cases.cmp.loop_shapes.checksum+0x1d4>
+               	addiw	a5, a5, 0x1
                	li	t0, 0x6
-               	bltu	s6, t0, 0xe4 <corpus.cases.cmp.loop_shapes.checksum+0xe4>
-               	addiw	s3, s3, 0x1
-               	mv	s1, s5
+               	bltu	a5, t0, 0x164 <corpus.cases.cmp.loop_shapes.checksum+0x164>
+               	addiw	a2, a2, 0x1
+               	mv	a0, a4
                	li	t0, 0x6
-               	bltu	s3, t0, 0xc8 <corpus.cases.cmp.loop_shapes.checksum+0xc8>
+               	bltu	a2, t0, 0x148 <corpus.cases.cmp.loop_shapes.checksum+0x148>
                	li	t1, 0x9
-               	addw	s3, t1, s2
-               	mv	s4, s2
+               	addw	a2, t1, a1
+               	mv	a3, a1
                	lui	t0, 0xf4
                	addiw	t0, t0, 0x240
-               	bltu	s4, t0, 0x144 <corpus.cases.cmp.loop_shapes.checksum+0x144>
-               	j	0x16c <corpus.cases.cmp.loop_shapes.checksum+0x16c>
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0x14c>
-               	beq	s4, s3, 0x170 <corpus.cases.cmp.loop_shapes.checksum+0x170>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	bltu	a3, t0, 0x208 <corpus.cases.cmp.loop_shapes.checksum+0x208>
+               	j	0x270 <corpus.cases.cmp.loop_shapes.checksum+0x270>
+               	slli	a4, a3, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a5, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x224 <corpus.cases.cmp.loop_shapes.checksum+0x224>
+               	j	0x258 <corpus.cases.cmp.loop_shapes.checksum+0x258>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x224 <corpus.cases.cmp.loop_shapes.checksum+0x224>
+               	beq	a3, a2, 0x274 <corpus.cases.cmp.loop_shapes.checksum+0x274>
+               	addiw	a3, a3, 0x1
+               	mv	a0, a5
                	lui	t0, 0xf4
                	addiw	t0, t0, 0x240
-               	bltu	s4, t0, 0x144 <corpus.cases.cmp.loop_shapes.checksum+0x144>
-               	j	0x174 <corpus.cases.cmp.loop_shapes.checksum+0x174>
-               	mv	s1, a0
+               	bltu	a3, t0, 0x208 <corpus.cases.cmp.loop_shapes.checksum+0x208>
+               	j	0x278 <corpus.cases.cmp.loop_shapes.checksum+0x278>
+               	mv	a0, a5
                	li	t1, 0x1
-               	addw	a0, t1, s2
-               	mv	s2, a0
-               	li	s3, 0x1
-               	li	s4, 0x0
+               	addw	a2, t1, a1
+               	li	a1, 0x1
+               	li	a3, 0x0
                	li	t0, 0x14
-               	bltu	s4, t0, 0x194 <corpus.cases.cmp.loop_shapes.checksum+0x194>
-               	j	0x1c0 <corpus.cases.cmp.loop_shapes.checksum+0x1c0>
-               	addw	s5, s2, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.loop_shapes.checksum+0x1a0>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
-               	mv	s2, s3
-               	mv	s3, s5
+               	bltu	a3, t0, 0x294 <corpus.cases.cmp.loop_shapes.checksum+0x294>
+               	j	0x300 <corpus.cases.cmp.loop_shapes.checksum+0x300>
+               	addw	a4, a2, a1
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a6, a0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b4 <corpus.cases.cmp.loop_shapes.checksum+0x2b4>
+               	j	0x2e8 <corpus.cases.cmp.loop_shapes.checksum+0x2e8>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b4 <corpus.cases.cmp.loop_shapes.checksum+0x2b4>
+               	addiw	a3, a3, 0x1
+               	mv	a0, a6
+               	mv	a2, a1
+               	mv	a1, a4
                	li	t0, 0x14
-               	bltu	s4, t0, 0x194 <corpus.cases.cmp.loop_shapes.checksum+0x194>
-               	mv	a0, s1
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	s6, 0x0(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	bltu	a3, t0, 0x294 <corpus.cases.cmp.loop_shapes.checksum+0x294>
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/cmp/short_circuit.dis
+++ b/test/golden/riscv64-linux/cmp/short_circuit.dis
@@ -60,92 +60,186 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.cmp.short_circuit.fold_state>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	a1, a0
-
-<.Lpcrel_hi.8>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x10>
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc <corpus.cases.cmp.short_circuit.fold_state+0x18>
+               	j	0xf0 <.Lpcrel_hi.9>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc <corpus.cases.cmp.short_circuit.fold_state+0x18>
 
 <.Lpcrel_hi.9>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
+               	auipc	a1, 0x0
+               	mv	a1, a1
 
 <.Lpcrel_hi.10>:
-               	auipc	s2, 0x0
-               	mv	s2, s2
-               	mv	s3, a0
-               	li	s4, 0x0
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	li	a3, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x104 <.Lpcrel_hi.10+0x1c>
-               	j	0x144 <.Lpcrel_hi.10+0x5c>
-               	slli	t0, s4, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x2c>
-               	slli	t0, s4, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x44>
-               	addi	s4, s4, 0x1
-               	mv	s3, a0
+               	bltu	a3, t0, 0x110 <.Lpcrel_hi.10+0x18>
+               	j	0x1c4 <.Lpcrel_hi.10+0xcc>
+               	slli	t0, a3, 0x3
+               	add	a4, a1, t0
+               	ld	a5, 0x0(a4)
+               	mv	a4, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x130 <.Lpcrel_hi.10+0x38>
+               	j	0x164 <.Lpcrel_hi.10+0x6c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x130 <.Lpcrel_hi.10+0x38>
+               	slli	t0, a3, 0x3
+               	add	a5, a2, t0
+               	ld	a6, 0x0(a5)
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x180 <.Lpcrel_hi.10+0x88>
+               	j	0x1b4 <.Lpcrel_hi.10+0xbc>
+               	li	t0, 0x8
+               	mul	a7, a5, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x180 <.Lpcrel_hi.10+0x88>
+               	addi	a3, a3, 0x1
+               	mv	a0, a4
                	li	t0, 0x4
-               	bltu	s4, t0, 0x104 <.Lpcrel_hi.10+0x1c>
-               	mv	a0, s3
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	bltu	a3, t0, 0x110 <.Lpcrel_hi.10+0x18>
                	ret
 
 <corpus.cases.cmp.short_circuit.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.cmp.short_circuit.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	sext.w	s1, a0
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	sd	zero, 0x0(t0)
 
 <.Lpcrel_hi.12>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+
+<.Lpcrel_hi.13>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x20c <.Lpcrel_hi.13+0x18>
+               	j	0x230 <.Lpcrel_hi.14>
+               	slli	t0, a2, 0x3
+               	add	a3, a0, t0
+               	sd	zero, 0x0(a3)
+               	slli	t0, a2, 0x3
+               	add	a3, a1, t0
+               	sd	zero, 0x0(a3)
+               	addi	a2, a2, 0x1
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x20c <.Lpcrel_hi.13+0x18>
+
+<.Lpcrel_hi.14>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+               	addi	a1, a0, 0x1
+
+<.Lpcrel_hi.15>:
+               	auipc	t0, 0x0
+               	sd	a1, 0x0(t0)
+
+<.Lpcrel_hi.16>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+               	ld	a1, 0x0(a0)
+               	addi	a2, a1, 0x1
+               	sd	a2, 0x0(a0)
+
+<.Lpcrel_hi.17>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+
+<.Lpcrel_hi.18>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	sd	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <.Lpcrel_hi.18+0x3c>
+               	j	0x2d4 <.Lpcrel_hi.18+0x74>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x0
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <.Lpcrel_hi.18+0x3c>
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.18+0x74>
+
+<.Lpcrel_hi.19>:
+               	auipc	t0, 0x0
+               	sd	zero, 0x0(t0)
+
+<.Lpcrel_hi.20>:
                	auipc	a1, 0x0
                	mv	a1, a1
 
-<.Lpcrel_hi.13>:
+<.Lpcrel_hi.21>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	li	a3, 0x0
                	li	t0, 0x4
-               	bltu	a3, t0, 0x1c4 <.Lpcrel_hi.13+0x18>
-               	j	0x1e8 <.Lpcrel_hi.14>
+               	bltu	a3, t0, 0x304 <.Lpcrel_hi.21+0x18>
+               	j	0x328 <.Lpcrel_hi.22>
                	slli	t0, a3, 0x3
                	add	a4, a1, t0
                	sd	zero, 0x0(a4)
@@ -154,567 +248,409 @@ Disassembly of section .text:
                	sd	zero, 0x0(a4)
                	addi	a3, a3, 0x1
                	li	t0, 0x4
-               	bltu	a3, t0, 0x1c4 <.Lpcrel_hi.13+0x18>
+               	bltu	a3, t0, 0x304 <.Lpcrel_hi.21+0x18>
 
-<.Lpcrel_hi.14>:
+<.Lpcrel_hi.22>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	addi	a2, a1, 0x1
 
-<.Lpcrel_hi.15>:
+<.Lpcrel_hi.23>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
-
-<.Lpcrel_hi.16>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	ld	a2, 0x0(a1)
-               	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a1)
-
-<.Lpcrel_hi.17>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-
-<.Lpcrel_hi.18>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a1, 0x0(a2)
-               	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.18+0x10>
-
-<.Lpcrel_hi.19>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.19+0x8>
-
-<.Lpcrel_hi.20>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.21>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x264 <.Lpcrel_hi.21+0x1c>
-               	j	0x2a4 <.Lpcrel_hi.22>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x264 <.Lpcrel_hi.21+0x1c>
-
-<.Lpcrel_hi.22>:
-               	auipc	t0, 0x0
-               	sd	zero, 0x0(t0)
-
-<.Lpcrel_hi.23>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
 
 <.Lpcrel_hi.24>:
                	auipc	a1, 0x0
                	mv	a1, a1
-               	li	a2, 0x0
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x2cc <.Lpcrel_hi.24+0x18>
-               	j	0x2f0 <.Lpcrel_hi.25>
-               	slli	t0, a2, 0x3
-               	add	a3, a0, t0
-               	sd	zero, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	sd	zero, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x2cc <.Lpcrel_hi.24+0x18>
+               	ld	a2, 0x0(a1)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a1)
 
 <.Lpcrel_hi.25>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
+               	ld	a1, 0x0(t0)
 
 <.Lpcrel_hi.26>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a1, 0x0(a2)
+               	li	t1, 0x1
+               	xor	a1, t1, s1
 
 <.Lpcrel_hi.27>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+               	addi	a3, a2, 0x1
 
 <.Lpcrel_hi.28>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
+               	sd	a3, 0x0(t0)
 
 <.Lpcrel_hi.29>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	li	t1, 0x1
-               	xor	a0, t1, s2
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	ld	a3, 0x0(a2)
+               	addi	a4, a3, 0x1
+               	sd	a4, 0x0(a2)
 
 <.Lpcrel_hi.30>:
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+
+<.Lpcrel_hi.31>:
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	sd	a2, 0x0(a3)
+               	li	t0, 0x1
+               	zext.b	t1, a1
+               	zext.b	t0, t0
+               	xor	a2, t1, t0
+               	seqz	a2, a2
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3d0 <.Lpcrel_hi.31+0x34>
+               	j	0x404 <.Lpcrel_hi.31+0x68>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3d0 <.Lpcrel_hi.31+0x34>
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.31+0x68>
+
+<.Lpcrel_hi.32>:
+               	auipc	t0, 0x0
+               	sd	zero, 0x0(t0)
+
+<.Lpcrel_hi.33>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+
+<.Lpcrel_hi.34>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	li	a3, 0x0
+               	li	t0, 0x4
+               	bltu	a3, t0, 0x434 <.Lpcrel_hi.34+0x18>
+               	j	0x458 <.Lpcrel_hi.35>
+               	slli	t0, a3, 0x3
+               	add	a4, a1, t0
+               	sd	zero, 0x0(a4)
+               	slli	t0, a3, 0x3
+               	add	a4, a2, t0
+               	sd	zero, 0x0(a4)
+               	addi	a3, a3, 0x1
+               	li	t0, 0x4
+               	bltu	a3, t0, 0x434 <.Lpcrel_hi.34+0x18>
+
+<.Lpcrel_hi.35>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	addi	a2, a1, 0x1
 
-<.Lpcrel_hi.31>:
+<.Lpcrel_hi.36>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.32>:
+<.Lpcrel_hi.37>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	ld	a2, 0x0(a1)
                	addi	a3, a2, 0x1
                	sd	a3, 0x0(a1)
 
-<.Lpcrel_hi.33>:
+<.Lpcrel_hi.38>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
 
-<.Lpcrel_hi.34>:
+<.Lpcrel_hi.39>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a1, 0x0(a2)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4a4 <.Lpcrel_hi.39+0x1c>
+               	j	0x4dc <.Lpcrel_hi.39+0x54>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4a4 <.Lpcrel_hi.39+0x1c>
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.39+0x54>
+               	mv	s2, a0
+
+<.Lpcrel_hi.40>:
+               	auipc	t0, 0x0
+               	sd	zero, 0x0(t0)
+
+<.Lpcrel_hi.41>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+
+<.Lpcrel_hi.42>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x510 <.Lpcrel_hi.42+0x18>
+               	j	0x534 <.Lpcrel_hi.42+0x3c>
+               	slli	t0, a2, 0x3
+               	add	a3, a0, t0
+               	sd	zero, 0x0(a3)
+               	slli	t0, a2, 0x3
+               	add	a3, a1, t0
+               	sd	zero, 0x0(a3)
+               	addi	a2, a2, 0x1
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x510 <.Lpcrel_hi.42+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.42+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0x5b8 <.Lpcrel_hi.47+0x24>
+               	li	t1, 0x1
+               	xor	a0, t1, s1
+
+<.Lpcrel_hi.43>:
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+               	addi	a3, a2, 0x1
+
+<.Lpcrel_hi.44>:
+               	auipc	t0, 0x0
+               	sd	a3, 0x0(t0)
+
+<.Lpcrel_hi.45>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	ld	a3, 0x0(a2)
+               	addi	a4, a3, 0x1
+               	sd	a4, 0x0(a2)
+
+<.Lpcrel_hi.46>:
+               	auipc	t0, 0x0
+               	ld	a2, 0x0(t0)
+
+<.Lpcrel_hi.47>:
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	sd	a2, 0x0(a3)
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a2, t1, t0
+               	seqz	a2, a2
+               	j	0x5bc <.Lpcrel_hi.47+0x28>
+               	mv	a2, a1
+               	zext.b	a0, a2
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5d0 <.Lpcrel_hi.47+0x3c>
+               	j	0x604 <.Lpcrel_hi.47+0x70>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5d0 <.Lpcrel_hi.47+0x3c>
+               	mv	a0, s2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.47+0x74>
+               	mv	s2, a0
+
+<.Lpcrel_hi.48>:
+               	auipc	t0, 0x0
+               	sd	zero, 0x0(t0)
+
+<.Lpcrel_hi.49>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+
+<.Lpcrel_hi.50>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x63c <.Lpcrel_hi.50+0x18>
+               	j	0x660 <.Lpcrel_hi.50+0x3c>
+               	slli	t0, a2, 0x3
+               	add	a3, a0, t0
+               	sd	zero, 0x0(a3)
+               	slli	t0, a2, 0x3
+               	add	a3, a1, t0
+               	sd	zero, 0x0(a3)
+               	addi	a2, a2, 0x1
+               	li	t0, 0x4
+               	bltu	a2, t0, 0x63c <.Lpcrel_hi.50+0x18>
+               	li	a0, 0x0
+               	li	a1, 0x0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.50+0x44>
+               	li	t0, 0x1
+               	zext.b	t1, a0
+               	zext.b	t0, t0
+               	xor	a1, t1, t0
+               	seqz	a1, a1
+               	bnez	a1, 0x6cc <.Lpcrel_hi.55+0x14>
+
+<.Lpcrel_hi.51>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+               	addi	a2, a0, 0x1
+
+<.Lpcrel_hi.52>:
+               	auipc	t0, 0x0
+               	sd	a2, 0x0(t0)
+
+<.Lpcrel_hi.53>:
+               	auipc	a0, 0x0
+               	mv	a0, a0
+               	ld	a2, 0x0(a0)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a0)
+
+<.Lpcrel_hi.54>:
+               	auipc	t0, 0x0
+               	ld	a0, 0x0(t0)
+
+<.Lpcrel_hi.55>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a0, 0x0(a2)
+               	li	a0, 0x1
+               	j	0x6d0 <.Lpcrel_hi.55+0x18>
+               	mv	a0, a1
+               	bnez	a0, 0x6d8 <.Lpcrel_hi.56>
+               	j	0x778 <.Lpcrel_hi.65+0x1c>
+
+<.Lpcrel_hi.56>:
+               	auipc	t0, 0x0
+               	ld	a1, 0x0(t0)
+               	addi	a2, a1, 0x1
+
+<.Lpcrel_hi.57>:
+               	auipc	t0, 0x0
+               	sd	a2, 0x0(t0)
+
+<.Lpcrel_hi.58>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	ld	a2, 0x0(a1)
+               	addi	a3, a2, 0x1
+               	sd	a3, 0x0(a1)
+
+<.Lpcrel_hi.59>:
+               	auipc	t0, 0x0
+               	ld	a1, 0x0(t0)
+
+<.Lpcrel_hi.60>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	sd	a1, 0x0(a2)
                	li	t0, 0x1
-               	zext.b	t1, a0
+               	zext.b	t1, s1
                	zext.b	t0, t0
                	xor	a1, t1, t0
                	seqz	a1, a1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.34+0x24>
+               	bnez	a1, 0x770 <.Lpcrel_hi.65+0x14>
 
-<.Lpcrel_hi.35>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.35+0x8>
-
-<.Lpcrel_hi.36>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.37>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x3c4 <.Lpcrel_hi.37+0x1c>
-               	j	0x404 <.Lpcrel_hi.38>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.37+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.37+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x3c4 <.Lpcrel_hi.37+0x1c>
-
-<.Lpcrel_hi.38>:
-               	auipc	t0, 0x0
-               	sd	zero, 0x0(t0)
-
-<.Lpcrel_hi.39>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-
-<.Lpcrel_hi.40>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	li	a2, 0x0
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x42c <.Lpcrel_hi.40+0x18>
-               	j	0x450 <.Lpcrel_hi.41>
-               	slli	t0, a2, 0x3
-               	add	a3, a0, t0
-               	sd	zero, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	sd	zero, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x42c <.Lpcrel_hi.40+0x18>
-
-<.Lpcrel_hi.41>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a1, a0, 0x1
-
-<.Lpcrel_hi.42>:
-               	auipc	t0, 0x0
-               	sd	a1, 0x0(t0)
-
-<.Lpcrel_hi.43>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a1, 0x0(a0)
-               	addi	a2, a1, 0x1
-               	sd	a2, 0x0(a0)
-
-<.Lpcrel_hi.44>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.45>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	sd	a0, 0x0(a1)
-               	mv	a0, s4
-               	li	a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.45+0x14>
-
-<.Lpcrel_hi.46>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.46+0x8>
-
-<.Lpcrel_hi.47>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.48>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x4d0 <.Lpcrel_hi.48+0x1c>
-               	j	0x510 <.Lpcrel_hi.49>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.48+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.48+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x4d0 <.Lpcrel_hi.48+0x1c>
-
-<.Lpcrel_hi.49>:
-               	auipc	t0, 0x0
-               	sd	zero, 0x0(t0)
-
-<.Lpcrel_hi.50>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-
-<.Lpcrel_hi.51>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	li	a2, 0x0
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x538 <.Lpcrel_hi.51+0x18>
-               	j	0x55c <.Lpcrel_hi.51+0x3c>
-               	slli	t0, a2, 0x3
-               	add	a3, a0, t0
-               	sd	zero, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	sd	zero, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x538 <.Lpcrel_hi.51+0x18>
-               	li	a0, 0x0
-               	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.51+0x44>
-               	li	t0, 0x1
-               	zext.b	t1, a0
-               	zext.b	t0, t0
-               	xor	a1, t1, t0
-               	seqz	a1, a1
-               	bnez	a1, 0x5e0 <.Lpcrel_hi.56+0x24>
-               	li	t1, 0x1
-               	xor	a0, t1, s2
-
-<.Lpcrel_hi.52>:
+<.Lpcrel_hi.61>:
                	auipc	t0, 0x0
                	ld	a2, 0x0(t0)
                	addi	a3, a2, 0x1
 
-<.Lpcrel_hi.53>:
+<.Lpcrel_hi.62>:
                	auipc	t0, 0x0
                	sd	a3, 0x0(t0)
 
-<.Lpcrel_hi.54>:
+<.Lpcrel_hi.63>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	ld	a3, 0x0(a2)
                	addi	a4, a3, 0x1
                	sd	a4, 0x0(a2)
-
-<.Lpcrel_hi.55>:
-               	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-
-<.Lpcrel_hi.56>:
-               	auipc	a3, 0x0
-               	mv	a3, a3
-               	sd	a2, 0x0(a3)
-               	li	t0, 0x1
-               	zext.b	t1, a0
-               	zext.b	t0, t0
-               	xor	a2, t1, t0
-               	seqz	a2, a2
-               	j	0x5e4 <.Lpcrel_hi.56+0x28>
-               	mv	a2, a1
-               	mv	a0, s4
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.56+0x30>
-
-<.Lpcrel_hi.57>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.57+0x8>
-
-<.Lpcrel_hi.58>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.59>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x628 <.Lpcrel_hi.59+0x1c>
-               	j	0x668 <.Lpcrel_hi.60>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.59+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.59+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x628 <.Lpcrel_hi.59+0x1c>
-
-<.Lpcrel_hi.60>:
-               	auipc	t0, 0x0
-               	sd	zero, 0x0(t0)
-
-<.Lpcrel_hi.61>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-
-<.Lpcrel_hi.62>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	li	a2, 0x0
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x690 <.Lpcrel_hi.62+0x18>
-               	j	0x6b4 <.Lpcrel_hi.62+0x3c>
-               	slli	t0, a2, 0x3
-               	add	a3, a0, t0
-               	sd	zero, 0x0(a3)
-               	slli	t0, a2, 0x3
-               	add	a3, a1, t0
-               	sd	zero, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x4
-               	bltu	a2, t0, 0x690 <.Lpcrel_hi.62+0x18>
-               	li	a0, 0x0
-               	li	a1, 0x0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.62+0x44>
-               	li	t0, 0x1
-               	zext.b	t1, a0
-               	zext.b	t0, t0
-               	xor	a1, t1, t0
-               	seqz	a1, a1
-               	bnez	a1, 0x720 <.Lpcrel_hi.67+0x14>
-
-<.Lpcrel_hi.63>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a2, a0, 0x1
 
 <.Lpcrel_hi.64>:
                	auipc	t0, 0x0
-               	sd	a2, 0x0(t0)
+               	ld	a2, 0x0(t0)
 
 <.Lpcrel_hi.65>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a2, 0x0(a0)
-               	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a0)
-
-<.Lpcrel_hi.66>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.67>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a0, 0x0(a2)
-               	li	a0, 0x1
-               	j	0x724 <.Lpcrel_hi.67+0x18>
-               	mv	a0, a1
-               	bnez	a0, 0x730 <.Lpcrel_hi.68>
-               	mv	a1, a0
-               	j	0x7d0 <.Lpcrel_hi.77+0x1c>
-
-<.Lpcrel_hi.68>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a2, a0, 0x1
-
-<.Lpcrel_hi.69>:
-               	auipc	t0, 0x0
-               	sd	a2, 0x0(t0)
-
-<.Lpcrel_hi.70>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a2, 0x0(a0)
-               	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a0)
-
-<.Lpcrel_hi.71>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.72>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a0, 0x0(a2)
-               	li	t0, 0x1
-               	zext.b	t1, s2
-               	zext.b	t0, t0
-               	xor	a0, t1, t0
-               	seqz	a0, a0
-               	bnez	a0, 0x7c8 <.Lpcrel_hi.77+0x14>
-
-<.Lpcrel_hi.73>:
-               	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	addi	a3, a2, 0x1
-
-<.Lpcrel_hi.74>:
-               	auipc	t0, 0x0
-               	sd	a3, 0x0(t0)
-
-<.Lpcrel_hi.75>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	ld	a3, 0x0(a2)
-               	addi	a4, a3, 0x1
-               	sd	a4, 0x0(a2)
-
-<.Lpcrel_hi.76>:
-               	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-
-<.Lpcrel_hi.77>:
                	auipc	a3, 0x0
                	mv	a3, a3
                	sd	a2, 0x0(a3)
                	li	a2, 0x1
-               	j	0x7cc <.Lpcrel_hi.77+0x18>
-               	mv	a2, a0
-               	mv	a1, a2
-               	mv	a0, s4
+               	j	0x774 <.Lpcrel_hi.65+0x18>
+               	mv	a2, a1
+               	mv	a0, a2
+               	zext.b	a1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x78c <.Lpcrel_hi.65+0x30>
+               	j	0x7c0 <.Lpcrel_hi.65+0x64>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x78c <.Lpcrel_hi.65+0x30>
+               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.77+0x20>
+               	jalr	ra <.Lpcrel_hi.65+0x68>
+               	mv	s2, a0
 
-<.Lpcrel_hi.78>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.78+0x8>
-
-<.Lpcrel_hi.79>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.80>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x810 <.Lpcrel_hi.80+0x1c>
-               	j	0x850 <.Lpcrel_hi.81>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.80+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.80+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x810 <.Lpcrel_hi.80+0x1c>
-
-<.Lpcrel_hi.81>:
+<.Lpcrel_hi.66>:
                	auipc	t0, 0x0
                	sd	zero, 0x0(t0)
 
-<.Lpcrel_hi.82>:
+<.Lpcrel_hi.67>:
                	auipc	a0, 0x0
                	mv	a0, a0
 
-<.Lpcrel_hi.83>:
+<.Lpcrel_hi.68>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x878 <.Lpcrel_hi.83+0x18>
-               	j	0x89c <.Lpcrel_hi.83+0x3c>
+               	bltu	a2, t0, 0x7f8 <.Lpcrel_hi.68+0x18>
+               	j	0x81c <.Lpcrel_hi.68+0x3c>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -723,160 +659,143 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0x878 <.Lpcrel_hi.83+0x18>
+               	bltu	a2, t0, 0x7f8 <.Lpcrel_hi.68+0x18>
                	li	a0, 0x0
                	li	a1, 0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.83+0x44>
+               	jalr	ra <.Lpcrel_hi.68+0x44>
                	li	t0, 0x1
                	zext.b	t1, a0
                	zext.b	t0, t0
                	xor	a1, t1, t0
                	seqz	a1, a1
-               	bnez	a1, 0x908 <.Lpcrel_hi.88+0x14>
+               	bnez	a1, 0x888 <.Lpcrel_hi.73+0x14>
 
-<.Lpcrel_hi.84>:
+<.Lpcrel_hi.69>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	addi	a2, a0, 0x1
 
-<.Lpcrel_hi.85>:
+<.Lpcrel_hi.70>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.86>:
+<.Lpcrel_hi.71>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	ld	a2, 0x0(a0)
                	addi	a3, a2, 0x1
                	sd	a3, 0x0(a0)
 
-<.Lpcrel_hi.87>:
+<.Lpcrel_hi.72>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
 
-<.Lpcrel_hi.88>:
+<.Lpcrel_hi.73>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	sd	a0, 0x0(a2)
                	li	a0, 0x1
-               	j	0x90c <.Lpcrel_hi.88+0x18>
+               	j	0x88c <.Lpcrel_hi.73+0x18>
                	mv	a0, a1
-               	bnez	a0, 0x918 <.Lpcrel_hi.89>
-               	mv	a1, a0
-               	j	0x9b0 <.Lpcrel_hi.98+0x24>
+               	bnez	a0, 0x894 <.Lpcrel_hi.74>
+               	j	0x92c <.Lpcrel_hi.83+0x24>
 
-<.Lpcrel_hi.89>:
+<.Lpcrel_hi.74>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a2, a0, 0x1
+               	ld	a1, 0x0(t0)
+               	addi	a2, a1, 0x1
 
-<.Lpcrel_hi.90>:
+<.Lpcrel_hi.75>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.91>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a2, 0x0(a0)
+<.Lpcrel_hi.76>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	ld	a2, 0x0(a1)
                	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a0)
+               	sd	a3, 0x0(a1)
 
-<.Lpcrel_hi.92>:
+<.Lpcrel_hi.77>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
+               	ld	a1, 0x0(t0)
 
-<.Lpcrel_hi.93>:
+<.Lpcrel_hi.78>:
                	auipc	a2, 0x0
                	mv	a2, a2
-               	sd	a0, 0x0(a2)
+               	sd	a1, 0x0(a2)
                	li	t1, 0x1
-               	xor	a0, t1, s2
+               	xor	a1, t1, s1
 
-<.Lpcrel_hi.94>:
+<.Lpcrel_hi.79>:
                	auipc	t0, 0x0
                	ld	a2, 0x0(t0)
                	addi	a3, a2, 0x1
 
-<.Lpcrel_hi.95>:
+<.Lpcrel_hi.80>:
                	auipc	t0, 0x0
                	sd	a3, 0x0(t0)
 
-<.Lpcrel_hi.96>:
+<.Lpcrel_hi.81>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	ld	a3, 0x0(a2)
                	addi	a4, a3, 0x1
                	sd	a4, 0x0(a2)
 
-<.Lpcrel_hi.97>:
+<.Lpcrel_hi.82>:
                	auipc	t0, 0x0
                	ld	a2, 0x0(t0)
 
-<.Lpcrel_hi.98>:
+<.Lpcrel_hi.83>:
                	auipc	a3, 0x0
                	mv	a3, a3
                	sd	a2, 0x0(a3)
                	li	t0, 0x1
-               	zext.b	t1, a0
+               	zext.b	t1, a1
                	zext.b	t0, t0
                	xor	a2, t1, t0
                	seqz	a2, a2
-               	mv	a1, a2
-               	mv	a0, s4
+               	mv	a0, a2
+               	zext.b	a1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x940 <.Lpcrel_hi.83+0x38>
+               	j	0x974 <.Lpcrel_hi.83+0x6c>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x940 <.Lpcrel_hi.83+0x38>
+               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.98+0x28>
+               	jalr	ra <.Lpcrel_hi.83+0x70>
+               	mv	s2, a0
 
-<.Lpcrel_hi.99>:
-               	auipc	t0, 0x0
-               	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.99+0x8>
-
-<.Lpcrel_hi.100>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.101>:
-               	auipc	s3, 0x0
-               	mv	s3, s3
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x9f0 <.Lpcrel_hi.101+0x1c>
-               	j	0xa30 <.Lpcrel_hi.102>
-               	slli	t0, s5, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.101+0x2c>
-               	slli	t0, s5, 0x3
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.101+0x44>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x9f0 <.Lpcrel_hi.101+0x1c>
-
-<.Lpcrel_hi.102>:
+<.Lpcrel_hi.84>:
                	auipc	t0, 0x0
                	sd	zero, 0x0(t0)
 
-<.Lpcrel_hi.103>:
+<.Lpcrel_hi.85>:
                	auipc	a0, 0x0
                	mv	a0, a0
 
-<.Lpcrel_hi.104>:
+<.Lpcrel_hi.86>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.104+0x18>
-               	j	0xa7c <.Lpcrel_hi.104+0x3c>
+               	bltu	a2, t0, 0x9ac <.Lpcrel_hi.86+0x18>
+               	j	0x9d0 <.Lpcrel_hi.86+0x3c>
                	slli	t0, a2, 0x3
                	add	a3, a0, t0
                	sd	zero, 0x0(a3)
@@ -885,123 +804,101 @@ Disassembly of section .text:
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.104+0x18>
+               	bltu	a2, t0, 0x9ac <.Lpcrel_hi.86+0x18>
                	li	a0, 0x0
                	li	a1, 0x0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.104+0x44>
+               	jalr	ra <.Lpcrel_hi.86+0x44>
                	li	t0, 0x1
                	zext.b	t1, a0
                	zext.b	t0, t0
                	xor	a1, t1, t0
                	seqz	a1, a1
-               	bnez	a1, 0xaf8 <.Lpcrel_hi.109+0x24>
+               	bnez	a1, 0xa4c <.Lpcrel_hi.91+0x24>
 
-<.Lpcrel_hi.105>:
+<.Lpcrel_hi.87>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	addi	a2, a0, 0x1
 
-<.Lpcrel_hi.106>:
+<.Lpcrel_hi.88>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.107>:
+<.Lpcrel_hi.89>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	ld	a2, 0x0(a0)
                	addi	a3, a2, 0x1
                	sd	a3, 0x0(a0)
 
-<.Lpcrel_hi.108>:
+<.Lpcrel_hi.90>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
 
-<.Lpcrel_hi.109>:
+<.Lpcrel_hi.91>:
                	auipc	a2, 0x0
                	mv	a2, a2
                	sd	a0, 0x0(a2)
                	li	t0, 0x1
-               	zext.b	t1, s2
+               	zext.b	t1, s1
                	zext.b	t0, t0
                	xor	a0, t1, t0
                	seqz	a0, a0
-               	j	0xafc <.Lpcrel_hi.109+0x28>
+               	j	0xa50 <.Lpcrel_hi.91+0x28>
                	mv	a0, a1
-               	bnez	a0, 0xb08 <.Lpcrel_hi.110>
-               	mv	a1, a0
-               	j	0xb48 <.Lpcrel_hi.114+0x10>
+               	bnez	a0, 0xa58 <.Lpcrel_hi.92>
+               	j	0xa98 <.Lpcrel_hi.96+0x10>
 
-<.Lpcrel_hi.110>:
+<.Lpcrel_hi.92>:
                	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-               	addi	a2, a0, 0x1
+               	ld	a1, 0x0(t0)
+               	addi	a2, a1, 0x1
 
-<.Lpcrel_hi.111>:
+<.Lpcrel_hi.93>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.112>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	a2, 0x0(a0)
+<.Lpcrel_hi.94>:
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	ld	a2, 0x0(a1)
                	addi	a3, a2, 0x1
-               	sd	a3, 0x0(a0)
+               	sd	a3, 0x0(a1)
 
-<.Lpcrel_hi.113>:
-               	auipc	t0, 0x0
-               	ld	a0, 0x0(t0)
-
-<.Lpcrel_hi.114>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	sd	a0, 0x0(a2)
-               	li	a1, 0x1
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.114+0x14>
-
-<.Lpcrel_hi.115>:
+<.Lpcrel_hi.95>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.115+0x8>
 
-<.Lpcrel_hi.116>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-
-<.Lpcrel_hi.117>:
-               	auipc	s2, 0x0
-               	mv	s2, s2
-               	mv	s3, a0
-               	li	s4, 0x0
-               	li	t0, 0x4
-               	bltu	s4, t0, 0xb88 <.Lpcrel_hi.117+0x1c>
-               	j	0xbc8 <.Lpcrel_hi.117+0x5c>
-               	slli	t0, s4, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s3
+<.Lpcrel_hi.96>:
+               	auipc	a2, 0x0
+               	mv	a2, a2
+               	sd	a1, 0x0(a2)
+               	li	a0, 0x1
+               	zext.b	a1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaac <.Lpcrel_hi.96+0x24>
+               	j	0xae0 <.Lpcrel_hi.96+0x58>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaac <.Lpcrel_hi.96+0x24>
+               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.117+0x2c>
-               	slli	t0, s4, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.117+0x44>
-               	addi	s4, s4, 0x1
-               	mv	s3, a0
-               	li	t0, 0x4
-               	bltu	s4, t0, 0xb88 <.Lpcrel_hi.117+0x1c>
-               	mv	a0, s3
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <.Lpcrel_hi.96+0x5c>
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/comptime/ct_runtime_agree.dis
+++ b/test/golden/riscv64-linux/comptime/ct_runtime_agree.dis
@@ -29,112 +29,181 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
-               	addi	sp, sp, -0xb0
-               	sd	ra, 0xa8(sp)
-               	sd	s0, 0xa0(sp)
-               	addi	s0, sp, 0xb0
-               	sd	s1, 0x98(sp)
-               	sd	s2, 0x90(sp)
-               	sd	s3, 0x88(sp)
-               	sd	s4, 0x80(sp)
-               	sd	s5, 0x78(sp)
-               	sd	s6, 0x70(sp)
-               	sd	s7, 0x68(sp)
-               	sd	s8, 0x60(sp)
-               	sd	s9, 0x58(sp)
-               	fsd	fs0, 0x50(sp)
-               	fsd	fs1, 0x48(sp)
-               	fsd	fs2, 0x40(sp)
-               	fsd	fs3, 0x38(sp)
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	sd	s1, 0x78(sp)
+               	sd	s2, 0x70(sp)
+               	sd	s3, 0x68(sp)
+               	sd	s4, 0x60(sp)
+               	sd	s5, 0x58(sp)
+               	sd	s6, 0x50(sp)
+               	fsd	fs0, 0x48(sp)
+               	fsd	fs1, 0x40(sp)
+               	fsd	fs2, 0x38(sp)
+               	fsd	fs3, 0x30(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x48>
-               	mv	a1, a0
                	lui	t1, 0x12345
                	addiw	t1, t1, 0x678
-               	add	s2, t1, s1
+               	add	a0, t1, s1
                	li	t0, 0x3
-               	mul	a2, s2, t0
-               	addi	s3, a2, 0x7
-               	slli	a2, s3, 0xd
+               	mul	a1, a0, t0
+               	addi	a2, a1, 0x7
+               	slli	a1, a2, 0xd
                	lui	t0, 0xf0f
                	addiw	t0, t0, 0xf1
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xf1
-               	xor	s4, a2, t0
-               	srli	a2, s4, 0x7
-               	xor	s5, s4, a2
+               	xor	a3, a1, t0
+               	srli	a1, a3, 0x7
+               	xor	s2, a3, a1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	and	s6, s5, t0
+               	and	s3, s2, t0
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	s7, s6, t0
-               	srli	s8, s7, 0x11
-               	add	s9, s8, s6
-               	mv	a0, a1
-               	lui	a1, 0x12345
-               	addiw	a1, a1, 0x678
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0xc4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0xd8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	lui	a1, 0x369d0
-               	addiw	a1, a1, 0x36f
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0xf0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x104>
-               	mv	a1, a0
-               	mv	a0, a1
-               	lui	a1, 0x6dcaf
-               	addiw	a1, a1, 0x62f
+               	mul	s4, s3, t0
+               	srli	s5, s4, 0x11
+               	add	s6, s5, s3
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
                	slli	a1, a1, 0xc
-               	addi	a1, a1, -0xf1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x124>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x138>
-               	mv	a1, a0
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x130 <corpus.cases.comptime.ct_runtime_agree.checksum+0xd0>
+               	j	0x16c <corpus.cases.comptime.ct_runtime_agree.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	lui	t1, 0x12345
+               	addiw	t1, t1, 0x678
+               	srl	a6, t1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x130 <corpus.cases.comptime.ct_runtime_agree.checksum+0xd0>
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x17c <corpus.cases.comptime.ct_runtime_agree.checksum+0x11c>
+               	j	0x1b0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x150>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x17c <corpus.cases.comptime.ct_runtime_agree.checksum+0x11c>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1c0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x160>
+               	j	0x1fc <corpus.cases.comptime.ct_runtime_agree.checksum+0x19c>
+               	li	t0, 0x8
+               	mul	a4, a0, t0
+               	lui	t1, 0x369d0
+               	addiw	t1, t1, 0x36f
+               	srl	a5, t1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1c0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x160>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x20c <corpus.cases.comptime.ct_runtime_agree.checksum+0x1ac>
+               	j	0x240 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1e0>
+               	li	t0, 0x8
+               	mul	a4, a0, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x20c <corpus.cases.comptime.ct_runtime_agree.checksum+0x1ac>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x250 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1f0>
+               	j	0x294 <corpus.cases.comptime.ct_runtime_agree.checksum+0x234>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x6dcaf
+               	addiw	t1, t1, 0x62f
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0xf1
+               	srl	a4, t1, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x250 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1f0>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2a4 <corpus.cases.comptime.ct_runtime_agree.checksum+0x244>
+               	j	0x2d8 <corpus.cases.comptime.ct_runtime_agree.checksum+0x278>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a4, a3, a2
+               	li	t0, 0xff
+               	and	a2, a4, t0
+               	xor	a4, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2a4 <corpus.cases.comptime.ct_runtime_agree.checksum+0x244>
                	mv	a0, a1
                	lui	a1, 0x6d116
                	addiw	a1, a1, 0x3c3
                	slli	a1, a1, 0xc
                	addi	a1, a1, -0x52f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x158>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x28c>
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x16c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x298>
                	lui	a1, 0x163c3
                	addiw	a1, a1, -0x52f
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x184>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x2a8>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x198>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x2b4>
                	lui	a1, 0xdbe
                	addiw	a1, a1, -0xc1
                	slli	a1, a1, 0xc
@@ -144,39 +213,28 @@ Disassembly of section .text:
                	slli	a1, a1, 0xc
                	addi	a1, a1, 0x381
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x1c8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s7
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x2dc>
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x1dc>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x2e8>
                	lui	a1, 0x6defa
                	addiw	a1, a1, -0xa0
                	slli	a1, a1, 0xc
                	addi	a1, a1, 0x5e
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x1fc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s8
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x300>
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x210>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x30c>
                	lui	a1, 0x6df10
                	addiw	a1, a1, 0x323
                	slli	a1, a1, 0xc
                	addi	a1, a1, -0x4d1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x230>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s9
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x324>
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x244>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.comptime.ct_runtime_agree.checksum+0x330>
                	fcvt.d.lu	ft0, s1
 
 <.Lpcrel_hi.0>:
@@ -205,58 +263,58 @@ Disassembly of section .text:
                	fdiv.d	fs2, fs1, ft10
                	fmul.d	ft0, fs2, fs2
                	fadd.d	fs3, ft0, fs0
-               	mv	a0, a1
-
-<.Lpcrel_hi.5>:
-               	auipc	t0, 0x0
-               	fld	fa0, 0x0(t0)
+               	lui	a1, 0x3fd5
+               	addiw	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x555
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.4+0x34>
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.6>:
-               	auipc	t0, 0x0
-               	fld	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.4+0x40>
+               	lui	a1, 0x3fd5
+               	addiw	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x555
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x550
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs1
+               	jalr	ra <.Lpcrel_hi.4+0x68>
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.7>:
-               	auipc	t0, 0x0
-               	fld	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.4+0x74>
+               	lui	a1, 0x3fd3
+               	addiw	a1, a1, 0x64e
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, -0x6ca
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x4d9
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x360
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.4+0x9c>
+               	fmv.x.d	a1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.8>:
-               	auipc	t0, 0x0
-               	fld	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.4+0xa8>
+               	lui	a1, 0x3fdb
+               	addiw	a1, a1, 0x35d
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x537
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x3e5
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, -0x451
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs3
+               	jalr	ra <.Lpcrel_hi.4+0xd0>
+               	fmv.x.d	a1, fs3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x1c>
-               	mv	a1, a0
+               	jalr	ra <.Lpcrel_hi.4+0xdc>
                	fcvt.s.lu	ft0, s1
                	lui	t0, 0x3f800
                	fmv.w.x	ft11, t0
@@ -271,343 +329,409 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fsub.s	fs1, ft0, ft10
 
-<.Lpcrel_hi.9>:
+<.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	flw	ft10, 0x0(t0)
                	fdiv.s	fs2, fs1, ft10
                	fmul.s	ft0, fs2, fs2
                	fadd.s	fs3, ft0, fs0
-               	mv	a0, a1
-
-<.Lpcrel_hi.10>:
-               	auipc	t0, 0x0
-               	flw	fa0, 0x0(t0)
+               	lui	t0, 0x3eaab
+               	addiw	t0, t0, -0x555
+               	sext.w	a1, t0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.5+0x2c>
+               	fmv.x.w	a1, fs0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.11>:
-               	auipc	t0, 0x0
-               	flw	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.5+0x44>
+               	lui	t0, 0x3eaab
+               	addiw	t0, t0, -0x550
+               	sext.w	a1, t0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs1
+               	jalr	ra <.Lpcrel_hi.5+0x64>
+               	fmv.x.w	a1, fs1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.12>:
-               	auipc	t0, 0x0
-               	flw	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.5+0x7c>
+               	lui	t0, 0x3e9b2
+               	addiw	t0, t0, 0x6ce
+               	sext.w	a1, t0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.5+0x9c>
+               	fmv.x.w	a1, fs2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
-
-<.Lpcrel_hi.13>:
-               	auipc	t0, 0x0
-               	flw	fa0, 0x0(t0)
+               	jalr	ra <.Lpcrel_hi.5+0xb4>
+               	lui	t0, 0x3ed9b
+               	addiw	t0, t0, -0x153
+               	sext.w	a1, t0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs3
+               	jalr	ra <.Lpcrel_hi.5+0xd4>
+               	fmv.x.w	a1, fs3
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x1c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0xec>
                	lui	a1, 0x9e
                	addiw	a1, a1, 0x378
                	slli	a1, a1, 0xc
                	addi	a1, a1, -0x64f
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0x104>
                	lui	a1, 0x145
                	addiw	a1, a1, -0x6ef
                	slli	a1, a1, 0xc
                	addi	a1, a1, 0x4a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x5c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0x11c>
                	lui	a1, 0x517
                	addiw	a1, a1, 0x154
                	slli	a1, a1, 0xc
                	addi	a1, a1, 0x775
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x7c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0x134>
                	lui	a1, 0xc52
                	addiw	a1, a1, 0x556
                	slli	a1, a1, 0xc
                	addi	a1, a1, 0x62a
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x9c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0x14c>
                	lui	a1, 0x1f7b
                	addiw	a1, a1, -0x1d2
                	slli	a1, a1, 0xc
                	addi	a1, a1, -0x5bb
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0xbc>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <.Lpcrel_hi.5+0x164>
                	lui	a1, 0x3995
                	addiw	a1, a1, 0x443
                	slli	a1, a1, 0xc
                	addi	a1, a1, -0x736
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0xdc>
-               	addi	s2, s0, -0xa8
-               	mv	a1, s2
+               	jalr	ra <.Lpcrel_hi.5+0x17c>
+               	addi	a1, s0, -0x90
+               	mv	a2, a1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x590 <.Lpcrel_hi.13+0x118>
-               	mv	a2, a1
-               	li	a3, 0x30
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a3, a2, t0
+               	bnez	a3, 0x69c <.Lpcrel_hi.5+0x1b8>
+               	mv	a3, a2
+               	li	a4, 0x30
+               	sd	zero, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x578 <.Lpcrel_hi.13+0x100>
-               	j	0x5ac <.Lpcrel_hi.13+0x134>
-               	mv	a2, a1
-               	li	a1, 0x30
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a4, t0, 0x684 <.Lpcrel_hi.5+0x1a0>
+               	j	0x6b8 <.Lpcrel_hi.5+0x1d4>
+               	mv	a3, a2
+               	li	a2, 0x30
+               	sb	zero, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x598 <.Lpcrel_hi.13+0x120>
+               	bne	a2, t0, 0x6a4 <.Lpcrel_hi.5+0x1c0>
                	li	t1, 0x1
-               	add	a1, t1, s1
-               	mv	a2, s2
-               	sd	a1, 0x0(a2)
+               	add	a2, t1, s1
+               	mv	a3, a1
+               	sd	a2, 0x0(a3)
                	li	t1, 0x3
-               	add	a1, t1, s1
-               	addi	a2, s2, 0x8
-               	sd	a1, 0x0(a2)
+               	add	a2, t1, s1
+               	addi	a3, a1, 0x8
+               	sd	a2, 0x0(a3)
                	li	t1, 0x7
-               	add	a1, t1, s1
-               	addi	a2, s2, 0x10
-               	sd	a1, 0x0(a2)
+               	add	a2, t1, s1
+               	addi	a3, a1, 0x10
+               	sd	a2, 0x0(a3)
                	li	t1, 0xf
-               	add	a1, t1, s1
-               	addi	a2, s2, 0x18
-               	sd	a1, 0x0(a2)
+               	add	a2, t1, s1
+               	addi	a3, a1, 0x18
+               	sd	a2, 0x0(a3)
                	li	t1, 0x1f
-               	add	a1, t1, s1
-               	addi	a2, s2, 0x20
-               	sd	a1, 0x0(a2)
+               	add	a2, t1, s1
+               	addi	a3, a1, 0x20
+               	sd	a2, 0x0(a3)
                	li	t1, 0x3f
-               	add	a1, t1, s1
-               	addi	a2, s2, 0x28
-               	sd	a1, 0x0(a2)
-               	mv	s3, a0
-               	li	s4, 0x0
-               	li	s5, 0x0
+               	add	a2, t1, s1
+               	addi	a3, a1, 0x28
+               	sd	a2, 0x0(a3)
+               	li	a2, 0x0
+               	li	a3, 0x0
                	li	t0, 0x6
-               	bltu	s5, t0, 0x624 <.Lpcrel_hi.13+0x1ac>
-               	j	0x668 <.Lpcrel_hi.13+0x1f0>
-               	slli	t0, s5, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
+               	bltu	a3, t0, 0x72c <.Lpcrel_hi.5+0x248>
+               	j	0x7ac <.Lpcrel_hi.5+0x2c8>
+               	slli	t0, a3, 0x3
+               	add	a4, a1, t0
+               	ld	a5, 0x0(a4)
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	a0, a1, t0
-               	xor	s4, s4, a0
-               	mv	a0, s3
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x1d8>
-               	addi	s5, s5, 0x1
-               	mv	s3, a0
+               	mul	a4, a5, t0
+               	xor	a5, a2, a4
+               	mv	a4, a0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x764 <.Lpcrel_hi.5+0x280>
+               	j	0x798 <.Lpcrel_hi.5+0x2b4>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x764 <.Lpcrel_hi.5+0x280>
+               	addi	a3, a3, 0x1
+               	mv	a0, a4
+               	mv	a2, a5
                	li	t0, 0x6
-               	bltu	s5, t0, 0x624 <.Lpcrel_hi.13+0x1ac>
-               	mv	a0, s3
-               	li	a1, 0xb
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x1f8>
-               	mv	s2, a0
-               	bltu	s9, s7, 0x698 <.Lpcrel_hi.13+0x220>
-               	mv	a0, s2
-               	li	a1, 0x16
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x210>
-               	mv	s3, a0
-               	j	0x6ac <.Lpcrel_hi.13+0x234>
-               	mv	a0, s2
-               	li	a1, 0xb
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x228>
-               	mv	s3, a0
-               	mv	a0, s3
-               	li	a1, 0x21
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x23c>
-               	mv	s2, a0
+               	bltu	a3, t0, 0x72c <.Lpcrel_hi.5+0x248>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7bc <.Lpcrel_hi.5+0x2d8>
+               	j	0x7f4 <.Lpcrel_hi.5+0x310>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0xb
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7bc <.Lpcrel_hi.5+0x2d8>
+               	bltu	s6, s4, 0x848 <.Lpcrel_hi.5+0x364>
+               	mv	a1, a0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x80c <.Lpcrel_hi.5+0x328>
+               	j	0x844 <.Lpcrel_hi.5+0x360>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	li	t1, 0x16
+               	srl	a4, t1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x80c <.Lpcrel_hi.5+0x328>
+               	j	0x894 <.Lpcrel_hi.5+0x3b0>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x858 <.Lpcrel_hi.5+0x374>
+               	j	0x890 <.Lpcrel_hi.5+0x3ac>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	li	t1, 0xb
+               	srl	a4, t1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x858 <.Lpcrel_hi.5+0x374>
+               	mv	a1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8a4 <.Lpcrel_hi.5+0x3c0>
+               	j	0x8dc <.Lpcrel_hi.5+0x3f8>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	li	t1, 0x21
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8a4 <.Lpcrel_hi.5+0x3c0>
                	lui	t1, 0x10
                	addiw	t1, t1, -0x1
-               	bltu	t1, s6, 0x6e4 <.Lpcrel_hi.13+0x26c>
-               	mv	a0, s2
-               	li	a1, 0x2c
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x25c>
-               	mv	s3, a0
-               	j	0x6f8 <.Lpcrel_hi.13+0x280>
-               	mv	a0, s2
-               	li	a1, 0x21
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x274>
-               	mv	s3, a0
+               	bltu	t1, s3, 0x938 <.Lpcrel_hi.5+0x454>
+               	mv	a0, a1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x8fc <.Lpcrel_hi.5+0x418>
+               	j	0x934 <.Lpcrel_hi.5+0x450>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	li	t1, 0x2c
+               	srl	a4, t1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x8fc <.Lpcrel_hi.5+0x418>
+               	j	0x984 <.Lpcrel_hi.5+0x4a0>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x948 <.Lpcrel_hi.5+0x464>
+               	j	0x980 <.Lpcrel_hi.5+0x49c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	li	t1, 0x21
+               	srl	a4, t1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x948 <.Lpcrel_hi.5+0x464>
+               	mv	a0, a1
                	sext.w	s2, s1
                	li	t1, 0x1
                	addw	s1, t1, s2
-               	srli	a0, s9, 0x1d
-               	xor	a1, s9, a0
-               	lui	t0, 0x10000
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1b3
-               	mul	a2, a1, t0
-               	mv	a0, s3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x2ac>
-               	li	t0, 0x0
-               	zext.b	t1, s2
-               	zext.b	t0, t0
-               	beq	t1, t0, 0x770 <.Lpcrel_hi.13+0x2f8>
-               	li	t0, 0x1
-               	zext.b	t1, s2
-               	zext.b	t0, t0
-               	beq	t1, t0, 0x754 <.Lpcrel_hi.13+0x2dc>
-               	li	a1, 0x0
-               	j	0x76c <.Lpcrel_hi.13+0x2f4>
-               	slli	a2, s9, 0x11
-               	srli	a3, s9, 0x2f
-               	or	a4, a2, a3
-               	lui	t0, 0x3
-               	addiw	t0, t0, 0x39
-               	add	a1, a4, t0
-               	j	0x788 <.Lpcrel_hi.13+0x310>
-               	srli	a2, s9, 0x1d
-               	xor	a3, s9, a2
-               	lui	t0, 0x10000
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1b3
-               	mul	a1, a3, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x310>
-               	slli	a1, s9, 0x11
-               	srli	a2, s9, 0x2f
-               	or	a3, a1, a2
-               	lui	t0, 0x3
-               	addiw	t0, t0, 0x39
-               	add	a1, a3, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x330>
-               	li	t0, 0x0
-               	zext.b	t1, s1
-               	zext.b	t0, t0
-               	beq	t1, t0, 0x7f4 <.Lpcrel_hi.13+0x37c>
-               	li	t0, 0x1
-               	zext.b	t1, s1
-               	zext.b	t0, t0
-               	beq	t1, t0, 0x7d8 <.Lpcrel_hi.13+0x360>
-               	li	a1, 0x0
-               	j	0x7f0 <.Lpcrel_hi.13+0x378>
-               	slli	a2, s9, 0x11
-               	srli	a3, s9, 0x2f
-               	or	a4, a2, a3
-               	lui	t0, 0x3
-               	addiw	t0, t0, 0x39
-               	add	a1, a4, t0
-               	j	0x80c <.Lpcrel_hi.13+0x394>
-               	srli	a2, s9, 0x1d
-               	xor	a3, s9, a2
-               	lui	t0, 0x10000
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1b3
-               	mul	a1, a3, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x394>
                	srli	a1, s6, 0x1d
                	xor	a2, s6, a1
                	lui	t0, 0x10000
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1b3
                	mul	a1, a2, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x3b4>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9b8 <.Lpcrel_hi.5+0x4d4>
+               	j	0x9ec <.Lpcrel_hi.5+0x508>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9b8 <.Lpcrel_hi.5+0x4d4>
                	li	t0, 0x0
                	zext.b	t1, s2
                	zext.b	t0, t0
-               	beq	t1, t0, 0x878 <.Lpcrel_hi.13+0x400>
+               	beq	t1, t0, 0xa30 <.Lpcrel_hi.5+0x54c>
                	li	t0, 0x1
                	zext.b	t1, s2
                	zext.b	t0, t0
-               	beq	t1, t0, 0x85c <.Lpcrel_hi.13+0x3e4>
+               	beq	t1, t0, 0xa14 <.Lpcrel_hi.5+0x530>
                	li	a1, 0x0
-               	j	0x874 <.Lpcrel_hi.13+0x3fc>
+               	j	0xa2c <.Lpcrel_hi.5+0x548>
                	slli	a2, s6, 0x11
                	srli	a3, s6, 0x2f
                	or	a4, a2, a3
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
                	add	a1, a4, t0
-               	j	0x890 <.Lpcrel_hi.13+0x418>
+               	j	0xa48 <.Lpcrel_hi.5+0x564>
                	srli	a2, s6, 0x1d
                	xor	a3, s6, a2
                	lui	t0, 0x10000
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1b3
                	mul	a1, a3, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x418>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.5+0x574>
+               	j	0xa8c <.Lpcrel_hi.5+0x5a8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa58 <.Lpcrel_hi.5+0x574>
                	slli	a1, s6, 0x11
                	srli	a2, s6, 0x2f
                	or	a3, a1, a2
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
                	add	a1, a3, t0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x438>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xab4 <.Lpcrel_hi.5+0x5d0>
+               	j	0xae8 <.Lpcrel_hi.5+0x604>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xab4 <.Lpcrel_hi.5+0x5d0>
                	li	t0, 0x0
                	zext.b	t1, s1
                	zext.b	t0, t0
-               	beq	t1, t0, 0x8fc <.Lpcrel_hi.13+0x484>
+               	beq	t1, t0, 0xb2c <.Lpcrel_hi.5+0x648>
                	li	t0, 0x1
                	zext.b	t1, s1
                	zext.b	t0, t0
-               	beq	t1, t0, 0x8e0 <.Lpcrel_hi.13+0x468>
+               	beq	t1, t0, 0xb10 <.Lpcrel_hi.5+0x62c>
                	li	a1, 0x0
-               	j	0x8f8 <.Lpcrel_hi.13+0x480>
+               	j	0xb28 <.Lpcrel_hi.5+0x644>
                	slli	a2, s6, 0x11
                	srli	a3, s6, 0x2f
                	or	a4, a2, a3
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
                	add	a1, a4, t0
-               	j	0x914 <.Lpcrel_hi.13+0x49c>
+               	j	0xb44 <.Lpcrel_hi.5+0x660>
                	srli	a2, s6, 0x1d
                	xor	a3, s6, a2
                	lui	t0, 0x10000
@@ -615,23 +739,86 @@ Disassembly of section .text:
                	addi	t0, t0, 0x1b3
                	mul	a1, a3, t0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x49c>
-               	ld	s1, 0x98(sp)
-               	ld	s2, 0x90(sp)
-               	ld	s3, 0x88(sp)
-               	ld	s4, 0x80(sp)
-               	ld	s5, 0x78(sp)
-               	ld	s6, 0x70(sp)
-               	ld	s7, 0x68(sp)
-               	ld	s8, 0x60(sp)
-               	ld	s9, 0x58(sp)
-               	fld	fs0, 0x50(sp)
-               	fld	fs1, 0x48(sp)
-               	fld	fs2, 0x40(sp)
-               	fld	fs3, 0x38(sp)
-               	ld	ra, 0xa8(sp)
-               	ld	s0, 0xa0(sp)
-               	addi	sp, sp, 0xb0
+               	jalr	ra <.Lpcrel_hi.5+0x660>
+               	srli	a1, s3, 0x1d
+               	xor	a2, s3, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a2, t0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.5+0x680>
+               	li	t0, 0x0
+               	zext.b	t1, s2
+               	zext.b	t0, t0
+               	beq	t1, t0, 0xbb0 <.Lpcrel_hi.5+0x6cc>
+               	li	t0, 0x1
+               	zext.b	t1, s2
+               	zext.b	t0, t0
+               	beq	t1, t0, 0xb94 <.Lpcrel_hi.5+0x6b0>
+               	li	a1, 0x0
+               	j	0xbac <.Lpcrel_hi.5+0x6c8>
+               	slli	a2, s3, 0x11
+               	srli	a3, s3, 0x2f
+               	or	a4, a2, a3
+               	lui	t0, 0x3
+               	addiw	t0, t0, 0x39
+               	add	a1, a4, t0
+               	j	0xbc8 <.Lpcrel_hi.5+0x6e4>
+               	srli	a2, s3, 0x1d
+               	xor	a3, s3, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.5+0x6e4>
+               	slli	a1, s3, 0x11
+               	srli	a2, s3, 0x2f
+               	or	a3, a1, a2
+               	lui	t0, 0x3
+               	addiw	t0, t0, 0x39
+               	add	a1, a3, t0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.5+0x704>
+               	li	t0, 0x0
+               	zext.b	t1, s1
+               	zext.b	t0, t0
+               	beq	t1, t0, 0xc34 <.Lpcrel_hi.5+0x750>
+               	li	t0, 0x1
+               	zext.b	t1, s1
+               	zext.b	t0, t0
+               	beq	t1, t0, 0xc18 <.Lpcrel_hi.5+0x734>
+               	li	a1, 0x0
+               	j	0xc30 <.Lpcrel_hi.5+0x74c>
+               	slli	a2, s3, 0x11
+               	srli	a3, s3, 0x2f
+               	or	a4, a2, a3
+               	lui	t0, 0x3
+               	addiw	t0, t0, 0x39
+               	add	a1, a4, t0
+               	j	0xc4c <.Lpcrel_hi.5+0x768>
+               	srli	a2, s3, 0x1d
+               	xor	a3, s3, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.5+0x768>
+               	ld	s1, 0x78(sp)
+               	ld	s2, 0x70(sp)
+               	ld	s3, 0x68(sp)
+               	ld	s4, 0x60(sp)
+               	ld	s5, 0x58(sp)
+               	ld	s6, 0x50(sp)
+               	fld	fs0, 0x48(sp)
+               	fld	fs1, 0x40(sp)
+               	fld	fs2, 0x38(sp)
+               	fld	fs3, 0x30(sp)
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret
 
 <corpus.cases.comptime.ct_runtime_agree.apply$0>:

--- a/test/golden/riscv64-linux/convert/bitcast.dis
+++ b/test/golden/riscv64-linux/convert/bitcast.dis
@@ -3,38 +3,78 @@ convert/bitcast.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.bitcast.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	fsd	fs0, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x20>
-               	mv	a1, a0
-               	sext.w	a2, s1
+               	sext.w	a1, a0
                	lui	t0, 0xc0491
                	addiw	t0, t0, -0x25
-               	xor	a3, a2, t0
-               	fmv.w.x	fs0, a3
-               	fmv.x.w	s2, fs0
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x4c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x60>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x74>
-               	mv	a1, a0
+               	xor	a2, a1, t0
+               	fmv.w.x	ft0, a2
+               	fmv.x.w	a1, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x50 <corpus.cases.convert.bitcast.checksum+0x50>
+               	j	0x84 <corpus.cases.convert.bitcast.checksum+0x84>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x50 <corpus.cases.convert.bitcast.checksum+0x50>
+               	fmv.x.w	a3, ft0
+               	slli	a4, a3, 0x20
+               	srli	a4, a4, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa0 <corpus.cases.convert.bitcast.checksum+0xa0>
+               	j	0xd4 <corpus.cases.convert.bitcast.checksum+0xd4>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa0 <corpus.cases.convert.bitcast.checksum+0xa0>
+               	slli	a3, a1, 0x20
+               	srli	a3, a3, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xec <corpus.cases.convert.bitcast.checksum+0xec>
+               	j	0x120 <corpus.cases.convert.bitcast.checksum+0x120>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xec <corpus.cases.convert.bitcast.checksum+0xec>
                	lui	t0, 0x4009
                	addiw	t0, t0, 0x220
                	slli	t0, t0, 0xc
@@ -43,60 +83,147 @@ Disassembly of section .text:
                	addi	t0, t0, 0x443
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x2e8
-               	xor	a2, s1, t0
-               	fmv.d.x	fs0, a2
-               	fmv.x.d	s1, fs0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0xb4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0xc8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0xdc>
-               	mv	a1, a0
+               	xor	a1, a0, t0
+               	fmv.d.x	ft0, a1
+               	fmv.x.d	a0, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.convert.bitcast.checksum+0x15c>
+               	j	0x190 <corpus.cases.convert.bitcast.checksum+0x190>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.convert.bitcast.checksum+0x15c>
+               	fmv.x.d	a1, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a4 <corpus.cases.convert.bitcast.checksum+0x1a4>
+               	j	0x1d8 <corpus.cases.convert.bitcast.checksum+0x1d8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a4 <corpus.cases.convert.bitcast.checksum+0x1a4>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1e8 <corpus.cases.convert.bitcast.checksum+0x1e8>
+               	j	0x21c <corpus.cases.convert.bitcast.checksum+0x21c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1e8 <corpus.cases.convert.bitcast.checksum+0x1e8>
                	lui	t0, 0x40491
                	addiw	t0, t0, -0x25
-               	sext.w	a2, t0
-               	fmv.w.x	fs0, a2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x100>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x114>
-               	mv	a1, a0
-               	lui	a2, 0x4006
-               	addiw	a2, a2, -0x40f
-               	slli	a2, a2, 0xc
-               	addi	a2, a2, -0x575
-               	slli	a2, a2, 0xc
-               	addi	a2, a2, 0x145
-               	slli	a2, a2, 0xc
-               	addi	a2, a2, 0x769
-               	fmv.d.x	fs0, a2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x14c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.bitcast.checksum+0x160>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	fld	fs0, 0x8(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	sext.w	a0, t0
+               	fmv.w.x	ft0, a0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.convert.bitcast.checksum+0x244>
+               	j	0x278 <corpus.cases.convert.bitcast.checksum+0x278>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.convert.bitcast.checksum+0x244>
+               	fmv.x.w	a0, ft0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x294 <corpus.cases.convert.bitcast.checksum+0x294>
+               	j	0x2c8 <corpus.cases.convert.bitcast.checksum+0x2c8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x294 <corpus.cases.convert.bitcast.checksum+0x294>
+               	lui	a0, 0x4006
+               	addiw	a0, a0, -0x40f
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, -0x575
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x145
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x769
+               	fmv.d.x	ft0, a0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2fc <corpus.cases.convert.bitcast.checksum+0x2fc>
+               	j	0x330 <corpus.cases.convert.bitcast.checksum+0x330>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2fc <corpus.cases.convert.bitcast.checksum+0x2fc>
+               	fmv.x.d	a0, ft0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x344 <corpus.cases.convert.bitcast.checksum+0x344>
+               	j	0x378 <corpus.cases.convert.bitcast.checksum+0x378>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x344 <corpus.cases.convert.bitcast.checksum+0x344>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/convert/ext_sign.dis
+++ b/test/golden/riscv64-linux/convert/ext_sign.dis
@@ -3,136 +3,316 @@ convert/ext_sign.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.ext_sign.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x30>
-               	mv	a1, a0
-               	sext.w	a2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t0, 0x80
-               	or	s2, a2, t0
-               	not	s3, s2
-               	sext.w	a2, s1
+               	or	a2, a1, t0
+               	not	a1, a2
+               	sext.w	a3, a0
                	lui	t0, 0x8
-               	or	s4, a2, t0
-               	not	s5, s4
-               	sext.w	a2, s1
+               	or	a4, a3, t0
+               	not	a3, a4
+               	sext.w	a5, a0
                	lui	t0, 0x80000
-               	or	s1, a2, t0
-               	not	s6, s1
-               	slli	a2, s2, 0x38
-               	srai	a2, a2, 0x38
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x7c>
-               	mv	a1, a0
-               	slli	a2, s3, 0x38
-               	srai	a2, a2, 0x38
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x98>
-               	mv	a1, a0
-               	slli	a2, s2, 0x38
-               	srai	a2, a2, 0x38
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0xb4>
-               	mv	a1, a0
-               	slli	a2, s3, 0x38
-               	srai	a2, a2, 0x38
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0xd0>
-               	mv	a1, a0
-               	slli	s7, s2, 0x38
-               	srai	s7, s7, 0x38
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0xec>
-               	mv	a1, a0
-               	slli	s2, s3, 0x38
-               	srai	s2, s2, 0x38
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x108>
-               	mv	a1, a0
-               	slli	a2, s4, 0x30
+               	or	a0, a5, t0
+               	not	a5, a0
+               	slli	a6, a2, 0x38
+               	srai	a6, a6, 0x38
+               	slli	a7, a6, 0x30
+               	srai	a7, a7, 0x30
+               	lui	a6, 0xfcbf3
+               	addiw	a6, a6, -0x632
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x484
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x222
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x325
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x84 <corpus.cases.convert.ext_sign.checksum+0x84>
+               	j	0xb8 <corpus.cases.convert.ext_sign.checksum+0xb8>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x84 <corpus.cases.convert.ext_sign.checksum+0x84>
+               	slli	a7, a1, 0x38
+               	srai	a7, a7, 0x38
+               	slli	t5, a7, 0x30
+               	srai	t5, t5, 0x30
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.convert.ext_sign.checksum+0xd8>
+               	j	0x10c <corpus.cases.convert.ext_sign.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.convert.ext_sign.checksum+0xd8>
+               	slli	a7, a2, 0x38
+               	srai	a7, a7, 0x38
+               	sext.w	t5, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x128 <corpus.cases.convert.ext_sign.checksum+0x128>
+               	j	0x15c <corpus.cases.convert.ext_sign.checksum+0x15c>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x128 <corpus.cases.convert.ext_sign.checksum+0x128>
+               	slli	a7, a1, 0x38
+               	srai	a7, a7, 0x38
+               	sext.w	t5, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x178 <corpus.cases.convert.ext_sign.checksum+0x178>
+               	j	0x1ac <corpus.cases.convert.ext_sign.checksum+0x1ac>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x178 <corpus.cases.convert.ext_sign.checksum+0x178>
+               	slli	a7, a2, 0x38
+               	srai	a7, a7, 0x38
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x1c4 <corpus.cases.convert.ext_sign.checksum+0x1c4>
+               	j	0x1f8 <corpus.cases.convert.ext_sign.checksum+0x1f8>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x1c4 <corpus.cases.convert.ext_sign.checksum+0x1c4>
+               	slli	a7, a1, 0x38
+               	srai	a7, a7, 0x38
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x210 <corpus.cases.convert.ext_sign.checksum+0x210>
+               	j	0x244 <corpus.cases.convert.ext_sign.checksum+0x244>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x210 <corpus.cases.convert.ext_sign.checksum+0x210>
+               	slli	a7, a4, 0x30
+               	srai	a7, a7, 0x30
+               	sext.w	t5, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x260 <corpus.cases.convert.ext_sign.checksum+0x260>
+               	j	0x294 <corpus.cases.convert.ext_sign.checksum+0x294>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x260 <corpus.cases.convert.ext_sign.checksum+0x260>
+               	slli	a7, a3, 0x30
+               	srai	a7, a7, 0x30
+               	sext.w	t5, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b0 <corpus.cases.convert.ext_sign.checksum+0x2b0>
+               	j	0x2e4 <corpus.cases.convert.ext_sign.checksum+0x2e4>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b0 <corpus.cases.convert.ext_sign.checksum+0x2b0>
+               	slli	a7, a4, 0x30
+               	srai	a7, a7, 0x30
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x2fc <corpus.cases.convert.ext_sign.checksum+0x2fc>
+               	j	0x330 <corpus.cases.convert.ext_sign.checksum+0x330>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x2fc <corpus.cases.convert.ext_sign.checksum+0x2fc>
+               	slli	a7, a3, 0x30
+               	srai	a7, a7, 0x30
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x348 <corpus.cases.convert.ext_sign.checksum+0x348>
+               	j	0x37c <corpus.cases.convert.ext_sign.checksum+0x37c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x348 <corpus.cases.convert.ext_sign.checksum+0x348>
+               	sext.w	a7, a0
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x390 <corpus.cases.convert.ext_sign.checksum+0x390>
+               	j	0x3c4 <corpus.cases.convert.ext_sign.checksum+0x3c4>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x390 <corpus.cases.convert.ext_sign.checksum+0x390>
+               	sext.w	a7, a5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3d8 <corpus.cases.convert.ext_sign.checksum+0x3d8>
+               	j	0x40c <corpus.cases.convert.ext_sign.checksum+0x40c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3d8 <corpus.cases.convert.ext_sign.checksum+0x3d8>
+               	slli	a7, a2, 0x38
+               	srai	a7, a7, 0x38
+               	slli	a2, a4, 0x30
                	srai	a2, a2, 0x30
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x124>
-               	mv	a1, a0
-               	slli	a2, s5, 0x30
-               	srai	a2, a2, 0x30
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x140>
-               	mv	a1, a0
-               	slli	s3, s4, 0x30
-               	srai	s3, s3, 0x30
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x15c>
-               	mv	a1, a0
-               	slli	s4, s5, 0x30
-               	srai	s4, s4, 0x30
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x178>
-               	mv	a1, a0
-               	sext.w	s5, s1
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x190>
-               	mv	a1, a0
-               	sext.w	s1, s6
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x1a8>
-               	mv	a1, a0
-               	add	a2, s7, s3
-               	add	a3, a2, s5
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x1c4>
-               	mv	a1, a0
-               	add	a2, s2, s4
-               	add	a3, a2, s1
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_sign.checksum+0x1e0>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	add	a4, a7, a2
+               	sext.w	a2, a0
+               	add	a0, a4, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x438 <corpus.cases.convert.ext_sign.checksum+0x438>
+               	j	0x46c <corpus.cases.convert.ext_sign.checksum+0x46c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a7, a0, a4
+               	li	t0, 0xff
+               	and	a4, a7, t0
+               	xor	a7, a6, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x438 <corpus.cases.convert.ext_sign.checksum+0x438>
+               	slli	a0, a1, 0x38
+               	srai	a0, a0, 0x38
+               	slli	a1, a3, 0x30
+               	srai	a1, a1, 0x30
+               	add	a2, a0, a1
+               	sext.w	a0, a5
+               	add	a1, a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x498 <corpus.cases.convert.ext_sign.checksum+0x498>
+               	j	0x4cc <corpus.cases.convert.ext_sign.checksum+0x4cc>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a6, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x498 <corpus.cases.convert.ext_sign.checksum+0x498>
+               	mv	a0, a6
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/convert/ext_zero.dis
+++ b/test/golden/riscv64-linux/convert/ext_zero.dis
@@ -3,136 +3,320 @@ convert/ext_zero.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.ext_zero.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x30>
-               	mv	a1, a0
-               	sext.w	a2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t0, 0x80
-               	or	s2, a2, t0
+               	or	a2, a1, t0
                	li	t1, 0xff
-               	subw	s3, t1, s2
-               	sext.w	a2, s1
+               	subw	a1, t1, a2
+               	sext.w	a3, a0
                	lui	t0, 0x8
-               	or	s4, a2, t0
+               	or	a4, a3, t0
                	lui	t1, 0x10
                	addiw	t1, t1, -0x1
-               	subw	s5, t1, s4
-               	sext.w	a2, s1
+               	subw	a3, t1, a4
+               	sext.w	a5, a0
                	lui	t0, 0x80000
-               	or	s1, a2, t0
+               	or	a0, a5, t0
                	li	t1, -0x1
-               	subw	s6, t1, s1
-               	zext.b	a2, s2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x88>
-               	mv	a1, a0
-               	zext.b	a2, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0xa0>
-               	mv	a1, a0
-               	zext.b	a2, s2
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0xb8>
-               	mv	a1, a0
-               	zext.b	a2, s3
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0xd0>
-               	mv	a1, a0
-               	zext.b	s7, s2
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0xe8>
-               	mv	a1, a0
-               	zext.b	s2, s3
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x100>
-               	mv	a1, a0
-               	slli	a2, s4, 0x30
+               	subw	a5, t1, a0
+               	zext.b	a6, a2
+               	slli	a7, a6, 0x30
+               	srli	a7, a7, 0x30
+               	lui	a6, 0xfcbf3
+               	addiw	a6, a6, -0x632
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x484
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x222
+               	slli	a6, a6, 0xc
+               	addi	a6, a6, 0x325
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x90 <corpus.cases.convert.ext_zero.checksum+0x90>
+               	j	0xc4 <corpus.cases.convert.ext_zero.checksum+0xc4>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x90 <corpus.cases.convert.ext_zero.checksum+0x90>
+               	zext.b	a7, a1
+               	slli	t5, a7, 0x30
+               	srli	t5, t5, 0x30
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xe0 <corpus.cases.convert.ext_zero.checksum+0xe0>
+               	j	0x114 <corpus.cases.convert.ext_zero.checksum+0x114>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xe0 <corpus.cases.convert.ext_zero.checksum+0xe0>
+               	zext.b	a7, a2
+               	slli	t5, a7, 0x20
+               	srli	t5, t5, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x130 <corpus.cases.convert.ext_zero.checksum+0x130>
+               	j	0x164 <corpus.cases.convert.ext_zero.checksum+0x164>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x130 <corpus.cases.convert.ext_zero.checksum+0x130>
+               	zext.b	a7, a1
+               	slli	t5, a7, 0x20
+               	srli	t5, t5, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x180 <corpus.cases.convert.ext_zero.checksum+0x180>
+               	j	0x1b4 <corpus.cases.convert.ext_zero.checksum+0x1b4>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x180 <corpus.cases.convert.ext_zero.checksum+0x180>
+               	zext.b	a7, a2
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x1c8 <corpus.cases.convert.ext_zero.checksum+0x1c8>
+               	j	0x1fc <corpus.cases.convert.ext_zero.checksum+0x1fc>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x1c8 <corpus.cases.convert.ext_zero.checksum+0x1c8>
+               	zext.b	a7, a1
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x210 <corpus.cases.convert.ext_zero.checksum+0x210>
+               	j	0x244 <corpus.cases.convert.ext_zero.checksum+0x244>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x210 <corpus.cases.convert.ext_zero.checksum+0x210>
+               	slli	a7, a4, 0x30
+               	srli	a7, a7, 0x30
+               	slli	t5, a7, 0x20
+               	srli	t5, t5, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x264 <corpus.cases.convert.ext_zero.checksum+0x264>
+               	j	0x298 <corpus.cases.convert.ext_zero.checksum+0x298>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x264 <corpus.cases.convert.ext_zero.checksum+0x264>
+               	slli	a7, a3, 0x30
+               	srli	a7, a7, 0x30
+               	slli	t5, a7, 0x20
+               	srli	t5, t5, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b8 <corpus.cases.convert.ext_zero.checksum+0x2b8>
+               	j	0x2ec <corpus.cases.convert.ext_zero.checksum+0x2ec>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, t5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2b8 <corpus.cases.convert.ext_zero.checksum+0x2b8>
+               	slli	a7, a4, 0x30
+               	srli	a7, a7, 0x30
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x304 <corpus.cases.convert.ext_zero.checksum+0x304>
+               	j	0x338 <corpus.cases.convert.ext_zero.checksum+0x338>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x304 <corpus.cases.convert.ext_zero.checksum+0x304>
+               	slli	a7, a3, 0x30
+               	srli	a7, a7, 0x30
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x350 <corpus.cases.convert.ext_zero.checksum+0x350>
+               	j	0x384 <corpus.cases.convert.ext_zero.checksum+0x384>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x350 <corpus.cases.convert.ext_zero.checksum+0x350>
+               	slli	a7, a0, 0x20
+               	srli	a7, a7, 0x20
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x39c <corpus.cases.convert.ext_zero.checksum+0x39c>
+               	j	0x3d0 <corpus.cases.convert.ext_zero.checksum+0x3d0>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x39c <corpus.cases.convert.ext_zero.checksum+0x39c>
+               	slli	a7, a5, 0x20
+               	srli	a7, a7, 0x20
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3e8 <corpus.cases.convert.ext_zero.checksum+0x3e8>
+               	j	0x41c <corpus.cases.convert.ext_zero.checksum+0x41c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x3e8 <corpus.cases.convert.ext_zero.checksum+0x3e8>
+               	zext.b	a7, a2
+               	slli	a2, a4, 0x30
                	srli	a2, a2, 0x30
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x11c>
-               	mv	a1, a0
-               	slli	a2, s5, 0x30
-               	srli	a2, a2, 0x30
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x138>
-               	mv	a1, a0
-               	slli	s3, s4, 0x30
-               	srli	s3, s3, 0x30
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x154>
-               	mv	a1, a0
-               	slli	s4, s5, 0x30
-               	srli	s4, s4, 0x30
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x170>
-               	mv	a1, a0
-               	slli	s5, s1, 0x20
-               	srli	s5, s5, 0x20
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x18c>
-               	mv	a1, a0
-               	slli	s1, s6, 0x20
-               	srli	s1, s1, 0x20
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x1a8>
-               	mv	a1, a0
-               	add	a2, s7, s3
-               	add	a3, a2, s5
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x1c4>
-               	mv	a1, a0
-               	add	a2, s2, s4
-               	add	a3, a2, s1
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.ext_zero.checksum+0x1e0>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	add	a4, a7, a2
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	add	a0, a4, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x448 <corpus.cases.convert.ext_zero.checksum+0x448>
+               	j	0x47c <corpus.cases.convert.ext_zero.checksum+0x47c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a7, a0, a4
+               	li	t0, 0xff
+               	and	a4, a7, t0
+               	xor	a7, a6, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x448 <corpus.cases.convert.ext_zero.checksum+0x448>
+               	zext.b	a0, a1
+               	slli	a1, a3, 0x30
+               	srli	a1, a1, 0x30
+               	add	a2, a0, a1
+               	slli	a0, a5, 0x20
+               	srli	a0, a0, 0x20
+               	add	a1, a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4a8 <corpus.cases.convert.ext_zero.checksum+0x4a8>
+               	j	0x4dc <corpus.cases.convert.ext_zero.checksum+0x4dc>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a6, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4a8 <corpus.cases.convert.ext_zero.checksum+0x4a8>
+               	mv	a0, a6
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/convert/f2f.dis
+++ b/test/golden/riscv64-linux/convert/f2f.dis
@@ -3,99 +3,229 @@ convert/f2f.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.f2f.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	fsd	fs0, 0x20(sp)
-               	fsd	fs1, 0x18(sp)
-               	fsd	fs2, 0x10(sp)
-               	fsd	fs3, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2f.checksum+0x28>
-               	mv	a1, a0
-               	fcvt.d.lu	fs0, s1
-               	fcvt.s.lu	fs1, s1
+               	fcvt.d.lu	ft0, a0
+               	fcvt.s.lu	ft1, a0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	fa0, ft11, fs0
-               	fcvt.s.d	fs2, fa0
-               	fcvt.d.s	fs3, fs2
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x18>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x2c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x40>
-               	mv	a1, a0
+               	fadd.d	ft2, ft11, ft0
+               	fcvt.s.d	ft3, ft2
+               	fcvt.d.s	ft4, ft3
+               	fmv.x.d	a0, ft2
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x50 <.Lpcrel_hi.0+0x48>
+               	j	0x84 <.Lpcrel_hi.0+0x7c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x50 <.Lpcrel_hi.0+0x48>
+               	fmv.x.w	a0, ft3
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa0 <.Lpcrel_hi.0+0x98>
+               	j	0xd4 <.Lpcrel_hi.0+0xcc>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa0 <.Lpcrel_hi.0+0x98>
+               	fmv.x.d	a0, ft4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xe8 <.Lpcrel_hi.0+0xe0>
+               	j	0x11c <.Lpcrel_hi.1>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xe8 <.Lpcrel_hi.0+0xe0>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	fa0, ft11, fs0
-               	fcvt.s.d	fs2, fa0
-               	fcvt.d.s	fs3, fs2
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x18>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x40>
-               	mv	a1, a0
+               	fadd.d	ft2, ft11, ft0
+               	fcvt.s.d	ft3, ft2
+               	fcvt.d.s	ft4, ft3
+               	fmv.x.d	a0, ft2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x144 <.Lpcrel_hi.1+0x28>
+               	j	0x178 <.Lpcrel_hi.1+0x5c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x144 <.Lpcrel_hi.1+0x28>
+               	fmv.x.w	a0, ft3
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x194 <.Lpcrel_hi.1+0x78>
+               	j	0x1c8 <.Lpcrel_hi.1+0xac>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x194 <.Lpcrel_hi.1+0x78>
+               	fmv.x.d	a0, ft4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1dc <.Lpcrel_hi.1+0xc0>
+               	j	0x210 <.Lpcrel_hi.2>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1dc <.Lpcrel_hi.1+0xc0>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	fa0, ft11, fs0
-               	fcvt.s.d	fs0, fa0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x14>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x28>
-               	mv	a1, a0
+               	fadd.d	ft2, ft11, ft0
+               	fcvt.s.d	ft0, ft2
+               	fmv.x.d	a0, ft2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x234 <.Lpcrel_hi.2+0x24>
+               	j	0x268 <.Lpcrel_hi.2+0x58>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x234 <.Lpcrel_hi.2+0x24>
+               	fmv.x.w	a0, ft0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x284 <.Lpcrel_hi.2+0x74>
+               	j	0x2b8 <.Lpcrel_hi.3>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x284 <.Lpcrel_hi.2+0x74>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs1
-               	fcvt.d.s	fs0, ft0
+               	fadd.s	ft0, ft11, ft1
+               	fcvt.d.s	ft1, ft0
+               	fmv.x.w	a0, ft0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2e4 <.Lpcrel_hi.3+0x2c>
+               	j	0x318 <.Lpcrel_hi.3+0x60>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2e4 <.Lpcrel_hi.3+0x2c>
+               	fmv.x.d	a0, ft1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x32c <.Lpcrel_hi.3+0x74>
+               	j	0x360 <.Lpcrel_hi.3+0xa8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x32c <.Lpcrel_hi.3+0x74>
                	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x18>
-               	mv	a1, a0
-               	mv	a0, a1
-               	fmv.d	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2c>
-               	ld	s1, 0x28(sp)
-               	fld	fs0, 0x20(sp)
-               	fld	fs1, 0x18(sp)
-               	fld	fs2, 0x10(sp)
-               	fld	fs3, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
                	ret

--- a/test/golden/riscv64-linux/convert/f2i.dis
+++ b/test/golden/riscv64-linux/convert/f2i.dis
@@ -3,115 +3,314 @@ convert/f2i.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.f2i.fold_pos>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	fsd	fs0, 0x8(sp)
-               	fsd	fs1, 0x0(sp)
-               	mv	a1, a0
-               	fmv.s	fs0, fa0
-               	fmv.d	fs1, fa1
-               	fcvt.wu.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x30>
-               	mv	a1, a0
-               	fcvt.wu.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x48>
-               	mv	a1, a0
-               	fcvt.wu.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x60>
-               	mv	a1, a0
-               	fcvt.lu.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x78>
-               	mv	a1, a0
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x90>
-               	mv	a1, a0
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0xa8>
-               	mv	a1, a0
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0xc0>
-               	mv	a1, a0
-               	fcvt.l.s	a2, fs0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0xd8>
-               	mv	a1, a0
-               	fcvt.wu.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0xf0>
-               	mv	a1, a0
-               	fcvt.wu.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x108>
-               	mv	a1, a0
-               	fcvt.wu.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x120>
-               	mv	a1, a0
-               	fcvt.lu.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x138>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x150>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x168>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x180>
-               	mv	a1, a0
-               	fcvt.l.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_pos+0x198>
-               	fld	fs0, 0x8(sp)
-               	fld	fs1, 0x0(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	fcvt.wu.s	a1, fa0, rtz
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x18 <corpus.cases.convert.f2i.fold_pos+0x18>
+               	j	0x4c <corpus.cases.convert.f2i.fold_pos+0x4c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x18 <corpus.cases.convert.f2i.fold_pos+0x18>
+               	fcvt.wu.s	a1, fa0, rtz
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x68 <corpus.cases.convert.f2i.fold_pos+0x68>
+               	j	0x9c <corpus.cases.convert.f2i.fold_pos+0x9c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x68 <corpus.cases.convert.f2i.fold_pos+0x68>
+               	fcvt.wu.s	a1, fa0, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb8 <corpus.cases.convert.f2i.fold_pos+0xb8>
+               	j	0xec <corpus.cases.convert.f2i.fold_pos+0xec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb8 <corpus.cases.convert.f2i.fold_pos+0xb8>
+               	fcvt.lu.s	a1, fa0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x100 <corpus.cases.convert.f2i.fold_pos+0x100>
+               	j	0x134 <corpus.cases.convert.f2i.fold_pos+0x134>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x100 <corpus.cases.convert.f2i.fold_pos+0x100>
+               	fcvt.w.s	a1, fa0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x150 <corpus.cases.convert.f2i.fold_pos+0x150>
+               	j	0x184 <corpus.cases.convert.f2i.fold_pos+0x184>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x150 <corpus.cases.convert.f2i.fold_pos+0x150>
+               	fcvt.w.s	a1, fa0, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a0 <corpus.cases.convert.f2i.fold_pos+0x1a0>
+               	j	0x1d4 <corpus.cases.convert.f2i.fold_pos+0x1d4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a0 <corpus.cases.convert.f2i.fold_pos+0x1a0>
+               	fcvt.w.s	a1, fa0, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <corpus.cases.convert.f2i.fold_pos+0x1ec>
+               	j	0x220 <corpus.cases.convert.f2i.fold_pos+0x220>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <corpus.cases.convert.f2i.fold_pos+0x1ec>
+               	fcvt.l.s	a1, fa0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x234 <corpus.cases.convert.f2i.fold_pos+0x234>
+               	j	0x268 <corpus.cases.convert.f2i.fold_pos+0x268>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x234 <corpus.cases.convert.f2i.fold_pos+0x234>
+               	fcvt.wu.d	a1, fa1, rtz
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x280 <corpus.cases.convert.f2i.fold_pos+0x280>
+               	j	0x2b4 <corpus.cases.convert.f2i.fold_pos+0x2b4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x280 <corpus.cases.convert.f2i.fold_pos+0x280>
+               	fcvt.wu.d	a1, fa1, rtz
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2d0 <corpus.cases.convert.f2i.fold_pos+0x2d0>
+               	j	0x304 <corpus.cases.convert.f2i.fold_pos+0x304>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2d0 <corpus.cases.convert.f2i.fold_pos+0x2d0>
+               	fcvt.wu.d	a1, fa1, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x320 <corpus.cases.convert.f2i.fold_pos+0x320>
+               	j	0x354 <corpus.cases.convert.f2i.fold_pos+0x354>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x320 <corpus.cases.convert.f2i.fold_pos+0x320>
+               	fcvt.lu.d	a1, fa1, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x368 <corpus.cases.convert.f2i.fold_pos+0x368>
+               	j	0x39c <corpus.cases.convert.f2i.fold_pos+0x39c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x368 <corpus.cases.convert.f2i.fold_pos+0x368>
+               	fcvt.w.d	a1, fa1, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <corpus.cases.convert.f2i.fold_pos+0x3b8>
+               	j	0x3ec <corpus.cases.convert.f2i.fold_pos+0x3ec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <corpus.cases.convert.f2i.fold_pos+0x3b8>
+               	fcvt.w.d	a1, fa1, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x408 <corpus.cases.convert.f2i.fold_pos+0x408>
+               	j	0x43c <corpus.cases.convert.f2i.fold_pos+0x43c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x408 <corpus.cases.convert.f2i.fold_pos+0x408>
+               	fcvt.w.d	a1, fa1, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x454 <corpus.cases.convert.f2i.fold_pos+0x454>
+               	j	0x488 <corpus.cases.convert.f2i.fold_pos+0x488>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x454 <corpus.cases.convert.f2i.fold_pos+0x454>
+               	fcvt.l.d	a1, fa1, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.convert.f2i.fold_pos+0x49c>
+               	j	0x4d0 <corpus.cases.convert.f2i.fold_pos+0x4d0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x49c <corpus.cases.convert.f2i.fold_pos+0x49c>
                	ret
 
 <corpus.cases.convert.f2i.fold_neg>:
@@ -121,56 +320,48 @@ Disassembly of section .text:
                	addi	s0, sp, 0x20
                	fsd	fs0, 0x8(sp)
                	fsd	fs1, 0x0(sp)
-               	mv	a1, a0
                	fmv.s	fs0, fa0
                	fmv.d	fs1, fa1
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
+               	fcvt.w.s	a1, fs0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
                	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x30>
-               	mv	a1, a0
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
+               	fcvt.w.s	a1, fs0, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
                	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x48>
-               	mv	a1, a0
-               	fcvt.w.s	a2, fs0, rtz
-               	mv	a0, a1
+               	fcvt.w.s	a1, fs0, rtz
+               	sext.w	a2, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x60>
-               	mv	a1, a0
-               	fcvt.l.s	a2, fs0, rtz
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x5c>
+               	fcvt.l.s	a1, fs0, rtz
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x68>
+               	fcvt.w.d	a1, fs1, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x78>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x80>
+               	fcvt.w.d	a1, fs1, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x90>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0x98>
+               	fcvt.w.d	a1, fs1, rtz
+               	sext.w	a2, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0xa8>
-               	mv	a1, a0
-               	fcvt.w.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0xac>
+               	fcvt.l.d	a1, fs1, rtz
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0xc0>
-               	mv	a1, a0
-               	fcvt.l.d	a2, fs1, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0xd8>
+               	jalr	ra <corpus.cases.convert.f2i.fold_neg+0xb8>
                	fld	fs0, 0x8(sp)
                	fld	fs1, 0x0(sp)
                	ld	ra, 0x18(sp)
@@ -179,76 +370,340 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.convert.f2i.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	fsd	fs0, 0x20(sp)
-               	fsd	fs1, 0x18(sp)
-               	fsd	fs2, 0x10(sp)
-               	fsd	fs3, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2i.checksum+0x28>
-               	fcvt.s.lu	fs0, s1
-               	fcvt.d.lu	fs1, s1
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	fsd	fs0, 0x18(sp)
+               	fsd	fs1, 0x10(sp)
+               	fsd	fs2, 0x8(sp)
+               	fsd	fs3, 0x0(sp)
+               	fcvt.s.lu	fs0, a0
+               	fcvt.d.lu	fs1, a0
                	lui	t0, 0x42230
                	fmv.w.x	ft11, t0
-               	fadd.s	fs2, ft11, fs0
+               	fadd.s	ft0, ft11, fs0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	fs3, ft11, fs1
-               	fcvt.wu.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x10>
-               	fcvt.wu.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x1c>
-               	fcvt.wu.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x28>
-               	fcvt.lu.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x34>
-               	fcvt.w.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x40>
-               	fcvt.w.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x4c>
-               	fcvt.w.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x58>
-               	fcvt.l.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x64>
-               	fcvt.wu.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x70>
-               	fcvt.wu.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x7c>
-               	fcvt.wu.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x88>
-               	fcvt.lu.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x94>
-               	fcvt.w.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0xa0>
-               	fcvt.w.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0xac>
-               	fcvt.w.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0xb8>
-               	fcvt.l.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0xc4>
+               	fadd.d	ft1, ft11, fs1
+               	fcvt.wu.s	a0, ft0, rtz
+               	zext.b	a1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x624 <.Lpcrel_hi.0+0x44>
+               	j	0x658 <.Lpcrel_hi.0+0x78>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x624 <.Lpcrel_hi.0+0x44>
+               	fcvt.wu.s	a1, ft0, rtz
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x674 <.Lpcrel_hi.0+0x94>
+               	j	0x6a8 <.Lpcrel_hi.0+0xc8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x674 <.Lpcrel_hi.0+0x94>
+               	fcvt.wu.s	a1, ft0, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6c4 <.Lpcrel_hi.0+0xe4>
+               	j	0x6f8 <.Lpcrel_hi.0+0x118>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6c4 <.Lpcrel_hi.0+0xe4>
+               	fcvt.lu.s	a1, ft0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x70c <.Lpcrel_hi.0+0x12c>
+               	j	0x740 <.Lpcrel_hi.0+0x160>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x70c <.Lpcrel_hi.0+0x12c>
+               	fcvt.w.s	a1, ft0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x75c <.Lpcrel_hi.0+0x17c>
+               	j	0x790 <.Lpcrel_hi.0+0x1b0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x75c <.Lpcrel_hi.0+0x17c>
+               	fcvt.w.s	a1, ft0, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7ac <.Lpcrel_hi.0+0x1cc>
+               	j	0x7e0 <.Lpcrel_hi.0+0x200>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7ac <.Lpcrel_hi.0+0x1cc>
+               	fcvt.w.s	a1, ft0, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7f8 <.Lpcrel_hi.0+0x218>
+               	j	0x82c <.Lpcrel_hi.0+0x24c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7f8 <.Lpcrel_hi.0+0x218>
+               	fcvt.l.s	a1, ft0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x840 <.Lpcrel_hi.0+0x260>
+               	j	0x874 <.Lpcrel_hi.0+0x294>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x840 <.Lpcrel_hi.0+0x260>
+               	fcvt.wu.d	a1, ft1, rtz
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x88c <.Lpcrel_hi.0+0x2ac>
+               	j	0x8c0 <.Lpcrel_hi.0+0x2e0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x88c <.Lpcrel_hi.0+0x2ac>
+               	fcvt.wu.d	a1, ft1, rtz
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8dc <.Lpcrel_hi.0+0x2fc>
+               	j	0x910 <.Lpcrel_hi.0+0x330>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8dc <.Lpcrel_hi.0+0x2fc>
+               	fcvt.wu.d	a1, ft1, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x92c <.Lpcrel_hi.0+0x34c>
+               	j	0x960 <.Lpcrel_hi.0+0x380>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x92c <.Lpcrel_hi.0+0x34c>
+               	fcvt.lu.d	a1, ft1, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x974 <.Lpcrel_hi.0+0x394>
+               	j	0x9a8 <.Lpcrel_hi.0+0x3c8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x974 <.Lpcrel_hi.0+0x394>
+               	fcvt.w.d	a1, ft1, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x9c4 <.Lpcrel_hi.0+0x3e4>
+               	j	0x9f8 <.Lpcrel_hi.0+0x418>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x9c4 <.Lpcrel_hi.0+0x3e4>
+               	fcvt.w.d	a1, ft1, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa14 <.Lpcrel_hi.0+0x434>
+               	j	0xa48 <.Lpcrel_hi.0+0x468>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa14 <.Lpcrel_hi.0+0x434>
+               	fcvt.w.d	a1, ft1, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa60 <.Lpcrel_hi.0+0x480>
+               	j	0xa94 <.Lpcrel_hi.0+0x4b4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa60 <.Lpcrel_hi.0+0x480>
+               	fcvt.l.d	a1, ft1, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xaa8 <.Lpcrel_hi.0+0x4c8>
+               	j	0xadc <.Lpcrel_hi.0+0x4fc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xaa8 <.Lpcrel_hi.0+0x4c8>
                	lui	t0, 0x42230
                	fmv.w.x	ft11, t0
                	fneg.s	ft0, ft11
@@ -259,66 +714,94 @@ Disassembly of section .text:
                	fld	ft11, 0x0(t0)
                	fsub.d	fs3, ft11, fs1
                	fcvt.w.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x10>
-               	fcvt.w.s	a1, fs2, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.1+0x1c>
                	fcvt.w.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x28>
-               	fcvt.l.s	a1, fs2, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	mv	a1, a2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.1+0x34>
-               	fcvt.w.d	a1, fs3, rtz
+               	fcvt.w.s	a1, fs2, rtz
+               	sext.w	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x40>
-               	fcvt.w.d	a1, fs3, rtz
+               	jalr	ra <.Lpcrel_hi.1+0x48>
+               	fcvt.l.s	a1, fs2, rtz
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x4c>
+               	jalr	ra <.Lpcrel_hi.1+0x54>
                	fcvt.w.d	a1, fs3, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x58>
+               	jalr	ra <.Lpcrel_hi.1+0x6c>
+               	fcvt.w.d	a1, fs3, rtz
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0x84>
+               	fcvt.w.d	a1, fs3, rtz
+               	sext.w	a2, a1
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0x98>
                	fcvt.l.d	a1, fs3, rtz
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x64>
+               	jalr	ra <.Lpcrel_hi.1+0xa4>
                	lui	t0, 0x42fe0
                	fmv.w.x	ft11, t0
                	fadd.s	ft0, ft11, fs0
                	fcvt.w.s	a1, ft0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7c>
+               	jalr	ra <.Lpcrel_hi.1+0xc8>
                	lui	t0, 0x437f0
                	fmv.w.x	ft11, t0
                	fadd.s	ft0, ft11, fs0
                	fcvt.wu.s	a1, ft0, rtz
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x94>
+               	jalr	ra <.Lpcrel_hi.1+0xe8>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fadd.d	fs0, ft11, fs1
                	fcvt.wu.d	a1, fs0, rtz
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x10>
+               	jalr	ra <.Lpcrel_hi.2+0x18>
                	fcvt.w.d	a1, fs0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1c>
+               	jalr	ra <.Lpcrel_hi.2+0x30>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fsub.d	ft0, ft11, fs1
                	fcvt.w.d	a1, ft0, rtz
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x10>
-               	ld	s1, 0x28(sp)
-               	fld	fs0, 0x20(sp)
-               	fld	fs1, 0x18(sp)
-               	fld	fs2, 0x10(sp)
-               	fld	fs3, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <.Lpcrel_hi.3+0x1c>
+               	fld	fs0, 0x18(sp)
+               	fld	fs1, 0x10(sp)
+               	fld	fs2, 0x8(sp)
+               	fld	fs3, 0x0(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/convert/f2u_high.dis
+++ b/test/golden/riscv64-linux/convert/f2u_high.dis
@@ -3,236 +3,572 @@ convert/f2u_high.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.f2u_high.f32_u32>:
-               	addi	sp, sp, -0x10
-               	sd	ra, 0x8(sp)
-               	sd	s0, 0x0(sp)
-               	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	fcvt.wu.s	a2, fa0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2u_high.f32_u32+0x20>
-               	ld	ra, 0x8(sp)
-               	ld	s0, 0x0(sp)
-               	addi	sp, sp, 0x10
+               	fcvt.wu.s	a1, fa0, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c <corpus.cases.convert.f2u_high.f32_u32+0x1c>
+               	j	0x50 <corpus.cases.convert.f2u_high.f32_u32+0x50>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1c <corpus.cases.convert.f2u_high.f32_u32+0x1c>
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u32>:
-               	addi	sp, sp, -0x10
-               	sd	ra, 0x8(sp)
-               	sd	s0, 0x0(sp)
-               	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	fcvt.wu.d	a2, fa0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2u_high.f64_u32+0x20>
-               	ld	ra, 0x8(sp)
-               	ld	s0, 0x0(sp)
-               	addi	sp, sp, 0x10
+               	fcvt.wu.d	a1, fa0, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x70 <corpus.cases.convert.f2u_high.f64_u32+0x1c>
+               	j	0xa4 <corpus.cases.convert.f2u_high.f64_u32+0x50>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x70 <corpus.cases.convert.f2u_high.f64_u32+0x1c>
                	ret
 
 <corpus.cases.convert.f2u_high.f32_u64>:
-               	addi	sp, sp, -0x10
-               	sd	ra, 0x8(sp)
-               	sd	s0, 0x0(sp)
-               	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	fcvt.lu.s	a2, fa0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2u_high.f32_u64+0x20>
-               	ld	ra, 0x8(sp)
-               	ld	s0, 0x0(sp)
-               	addi	sp, sp, 0x10
+               	fcvt.lu.s	a1, fa0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc <corpus.cases.convert.f2u_high.f32_u64+0x14>
+               	j	0xf0 <corpus.cases.convert.f2u_high.f32_u64+0x48>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc <corpus.cases.convert.f2u_high.f32_u64+0x14>
                	ret
 
 <corpus.cases.convert.f2u_high.f64_u64>:
-               	addi	sp, sp, -0x10
-               	sd	ra, 0x8(sp)
-               	sd	s0, 0x0(sp)
-               	addi	s0, sp, 0x10
-               	mv	a1, a0
-               	fcvt.lu.d	a2, fa0, rtz
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2u_high.f64_u64+0x20>
-               	ld	ra, 0x8(sp)
-               	ld	s0, 0x0(sp)
-               	addi	sp, sp, 0x10
+               	fcvt.lu.d	a1, fa0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x108 <corpus.cases.convert.f2u_high.f64_u64+0x14>
+               	j	0x13c <corpus.cases.convert.f2u_high.f64_u64+0x48>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x108 <corpus.cases.convert.f2u_high.f64_u64+0x14>
                	ret
 
 <corpus.cases.convert.f2u_high.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	fsd	fs0, 0x10(sp)
-               	fsd	fs1, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.f2u_high.checksum+0x20>
-               	fcvt.s.lu	fs0, s1
-               	fcvt.d.lu	fs1, s1
+               	fcvt.s.lu	ft0, a0
+               	fcvt.d.lu	ft1, a0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.wu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x10>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.wu.s	a0, ft2, rtz
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x190 <.Lpcrel_hi.0+0x48>
+               	j	0x1c4 <.Lpcrel_hi.0+0x7c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x190 <.Lpcrel_hi.0+0x48>
                	lui	t0, 0x4f000
                	fmv.w.x	ft11, t0
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.wu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x28>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.wu.s	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <.Lpcrel_hi.0+0xa4>
+               	j	0x220 <.Lpcrel_hi.1>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <.Lpcrel_hi.0+0xa4>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.wu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x10>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.wu.s	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x248 <.Lpcrel_hi.1+0x28>
+               	j	0x27c <.Lpcrel_hi.1+0x5c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x248 <.Lpcrel_hi.1+0x28>
                	lui	t0, 0x4f400
                	fmv.w.x	ft11, t0
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.wu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x28>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.wu.s	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2a4 <.Lpcrel_hi.1+0x84>
+               	j	0x2d8 <.Lpcrel_hi.2>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2a4 <.Lpcrel_hi.1+0x84>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.wu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x10>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.wu.s	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x300 <.Lpcrel_hi.2+0x28>
+               	j	0x334 <.Lpcrel_hi.3>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x300 <.Lpcrel_hi.2+0x28>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
-               	fcvt.wu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x10>
+               	fadd.d	ft2, ft11, ft1
+               	fcvt.wu.d	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x35c <.Lpcrel_hi.3+0x28>
+               	j	0x390 <.Lpcrel_hi.4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x35c <.Lpcrel_hi.3+0x28>
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
-               	fcvt.wu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.4+0x10>
+               	fadd.d	ft2, ft11, ft1
+               	fcvt.wu.d	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <.Lpcrel_hi.4+0x28>
+               	j	0x3ec <.Lpcrel_hi.5>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <.Lpcrel_hi.4+0x28>
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
-               	fcvt.wu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x10>
+               	fadd.d	ft2, ft11, ft1
+               	fcvt.wu.d	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x414 <.Lpcrel_hi.5+0x28>
+               	j	0x448 <.Lpcrel_hi.6>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x414 <.Lpcrel_hi.5+0x28>
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
-               	fcvt.wu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x10>
+               	fadd.d	ft2, ft11, ft1
+               	fcvt.wu.d	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x470 <.Lpcrel_hi.6+0x28>
+               	j	0x4a4 <.Lpcrel_hi.7>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x470 <.Lpcrel_hi.6+0x28>
 
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
-               	fcvt.wu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x10>
+               	fadd.d	ft2, ft11, ft1
+               	fcvt.wu.d	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4cc <.Lpcrel_hi.7+0x28>
+               	j	0x500 <.Lpcrel_hi.7+0x5c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4cc <.Lpcrel_hi.7+0x28>
                	lui	t0, 0x5e800
                	fmv.w.x	ft11, t0
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.lu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x28>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.lu.s	a1, ft2, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x520 <.Lpcrel_hi.7+0x7c>
+               	j	0x554 <.Lpcrel_hi.7+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x520 <.Lpcrel_hi.7+0x7c>
                	lui	t0, 0x5f000
                	fmv.w.x	ft11, t0
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.lu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x40>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.lu.s	a1, ft2, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x574 <.Lpcrel_hi.7+0xd0>
+               	j	0x5a8 <.Lpcrel_hi.8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x574 <.Lpcrel_hi.7+0xd0>
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.lu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x10>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.lu.s	a1, ft2, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5c8 <.Lpcrel_hi.8+0x20>
+               	j	0x5fc <.Lpcrel_hi.8+0x54>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5c8 <.Lpcrel_hi.8+0x20>
                	lui	t0, 0x5f400
                	fmv.w.x	ft11, t0
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.lu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x28>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.lu.s	a1, ft2, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x61c <.Lpcrel_hi.8+0x74>
+               	j	0x650 <.Lpcrel_hi.9>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x61c <.Lpcrel_hi.8+0x74>
 
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fadd.s	ft0, ft11, fs0
-               	fcvt.lu.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x10>
+               	fadd.s	ft2, ft11, ft0
+               	fcvt.lu.s	a1, ft2, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x670 <.Lpcrel_hi.9+0x20>
+               	j	0x6a4 <.Lpcrel_hi.10>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x670 <.Lpcrel_hi.9+0x20>
 
 <.Lpcrel_hi.10>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
+               	fadd.d	ft0, ft11, ft1
                	fcvt.lu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x10>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6c4 <.Lpcrel_hi.10+0x20>
+               	j	0x6f8 <.Lpcrel_hi.11>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6c4 <.Lpcrel_hi.10+0x20>
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
+               	fadd.d	ft0, ft11, ft1
                	fcvt.lu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x10>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x718 <.Lpcrel_hi.11+0x20>
+               	j	0x74c <.Lpcrel_hi.12>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x718 <.Lpcrel_hi.11+0x20>
 
 <.Lpcrel_hi.12>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
+               	fadd.d	ft0, ft11, ft1
                	fcvt.lu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x10>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x76c <.Lpcrel_hi.12+0x20>
+               	j	0x7a0 <.Lpcrel_hi.13>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x76c <.Lpcrel_hi.12+0x20>
 
 <.Lpcrel_hi.13>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
+               	fadd.d	ft0, ft11, ft1
                	fcvt.lu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x10>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c0 <.Lpcrel_hi.13+0x20>
+               	j	0x7f4 <.Lpcrel_hi.14>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c0 <.Lpcrel_hi.13+0x20>
 
 <.Lpcrel_hi.14>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fadd.d	ft0, ft11, fs1
+               	fadd.d	ft0, ft11, ft1
                	fcvt.lu.d	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x10>
-               	ld	s1, 0x18(sp)
-               	fld	fs0, 0x10(sp)
-               	fld	fs1, 0x8(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x814 <.Lpcrel_hi.14+0x20>
+               	j	0x848 <.Lpcrel_hi.14+0x54>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x814 <.Lpcrel_hi.14+0x20>
                	ret

--- a/test/golden/riscv64-linux/convert/i2f.dis
+++ b/test/golden/riscv64-linux/convert/i2f.dis
@@ -3,262 +3,748 @@ convert/i2f.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.i2f.fold_from>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	sd	s8, 0x0(sp)
-               	mv	t5, a0
-               	mv	s1, a1
-               	mv	s2, a2
-               	mv	s3, a3
-               	mv	s4, a4
-               	mv	s5, a5
-               	mv	s6, a6
-               	mv	s7, a7
-               	ld	s8, 0x0(s0)
-               	zext.b	t0, s1
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
+               	ld	t5, 0x0(s0)
+               	zext.b	t0, a1
                	fcvt.s.wu	ft0, t0
-               	mv	a0, t5
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x64>
-               	mv	a1, a0
-               	zext.b	t0, s1
-               	fcvt.d.wu	fa0, t0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x7c>
-               	mv	a1, a0
-               	slli	t0, s2, 0x30
+               	fmv.x.w	t6, ft0
+               	slli	s1, t6, 0x20
+               	srli	s1, s1, 0x20
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x44 <corpus.cases.convert.i2f.fold_from+0x44>
+               	j	0x78 <corpus.cases.convert.i2f.fold_from+0x78>
+               	li	t0, 0x8
+               	mul	s2, t6, t0
+               	srl	s3, s1, s2
+               	li	t0, 0xff
+               	and	s2, s3, t0
+               	xor	s3, a0, s2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s3, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x44 <corpus.cases.convert.i2f.fold_from+0x44>
+               	zext.b	t0, a1
+               	fcvt.d.wu	ft0, t0
+               	fmv.x.d	a1, ft0
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x94 <corpus.cases.convert.i2f.fold_from+0x94>
+               	j	0xc8 <corpus.cases.convert.i2f.fold_from+0xc8>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a1, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a0, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x94 <corpus.cases.convert.i2f.fold_from+0x94>
+               	slli	t0, a2, 0x30
                	srli	t0, t0, 0x30
                	fcvt.s.wu	ft0, t0
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x9c>
-               	mv	a1, a0
-               	slli	t0, s2, 0x30
+               	fmv.x.w	a1, ft0
+               	slli	t6, a1, 0x20
+               	srli	t6, t6, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.convert.i2f.fold_from+0xf0>
+               	j	0x124 <corpus.cases.convert.i2f.fold_from+0x124>
+               	li	t0, 0x8
+               	mul	s1, a1, t0
+               	srl	s2, t6, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a0, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s2, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.convert.i2f.fold_from+0xf0>
+               	slli	t0, a2, 0x30
                	srli	t0, t0, 0x30
-               	fcvt.d.wu	fa0, t0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0xb8>
-               	mv	a1, a0
-               	fcvt.s.wu	ft0, s3
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0xd0>
-               	mv	a1, a0
-               	fcvt.d.wu	fa0, s3
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0xe4>
-               	mv	a1, a0
-               	fcvt.s.lu	ft0, s4
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0xfc>
-               	mv	a1, a0
-               	fcvt.d.lu	fa0, s4
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x110>
-               	mv	a1, a0
-               	slli	t0, s5, 0x38
+               	fcvt.d.wu	ft0, t0
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x144 <corpus.cases.convert.i2f.fold_from+0x144>
+               	j	0x178 <corpus.cases.convert.i2f.fold_from+0x178>
+               	li	t0, 0x8
+               	mul	t6, a2, t0
+               	srl	s1, a1, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a0, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s1, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x144 <corpus.cases.convert.i2f.fold_from+0x144>
+               	fcvt.s.wu	ft0, a3
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x198 <corpus.cases.convert.i2f.fold_from+0x198>
+               	j	0x1cc <corpus.cases.convert.i2f.fold_from+0x1cc>
+               	li	t0, 0x8
+               	mul	t6, a1, t0
+               	srl	s1, a2, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a0, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s1, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x198 <corpus.cases.convert.i2f.fold_from+0x198>
+               	fcvt.d.wu	ft0, a3
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1e4 <corpus.cases.convert.i2f.fold_from+0x1e4>
+               	j	0x218 <corpus.cases.convert.i2f.fold_from+0x218>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	t6, a1, a3
+               	li	t0, 0xff
+               	and	a3, t6, t0
+               	xor	t6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, t6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1e4 <corpus.cases.convert.i2f.fold_from+0x1e4>
+               	fcvt.s.lu	ft0, a4
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x238 <corpus.cases.convert.i2f.fold_from+0x238>
+               	j	0x26c <corpus.cases.convert.i2f.fold_from+0x26c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	t6, a2, a3
+               	li	t0, 0xff
+               	and	a3, t6, t0
+               	xor	t6, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, t6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x238 <corpus.cases.convert.i2f.fold_from+0x238>
+               	fcvt.d.lu	ft0, a4
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x284 <corpus.cases.convert.i2f.fold_from+0x284>
+               	j	0x2b8 <corpus.cases.convert.i2f.fold_from+0x2b8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x284 <corpus.cases.convert.i2f.fold_from+0x284>
+               	slli	t0, a5, 0x38
                	srai	t0, t0, 0x38
                	fcvt.s.w	ft0, t0
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x130>
-               	mv	a1, a0
-               	slli	t0, s5, 0x38
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <corpus.cases.convert.i2f.fold_from+0x2e0>
+               	j	0x314 <corpus.cases.convert.i2f.fold_from+0x314>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <corpus.cases.convert.i2f.fold_from+0x2e0>
+               	slli	t0, a5, 0x38
                	srai	t0, t0, 0x38
-               	fcvt.d.w	fa0, t0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x14c>
-               	mv	a1, a0
-               	slli	t0, s6, 0x30
+               	fcvt.d.w	ft0, t0
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <corpus.cases.convert.i2f.fold_from+0x334>
+               	j	0x368 <corpus.cases.convert.i2f.fold_from+0x368>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x334 <corpus.cases.convert.i2f.fold_from+0x334>
+               	slli	t0, a6, 0x30
                	srai	t0, t0, 0x30
                	fcvt.s.w	ft0, t0
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x16c>
-               	mv	a1, a0
-               	slli	t0, s6, 0x30
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x390 <corpus.cases.convert.i2f.fold_from+0x390>
+               	j	0x3c4 <corpus.cases.convert.i2f.fold_from+0x3c4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x390 <corpus.cases.convert.i2f.fold_from+0x390>
+               	slli	t0, a6, 0x30
                	srai	t0, t0, 0x30
-               	fcvt.d.w	fa0, t0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x188>
-               	mv	a1, a0
-               	fcvt.s.w	ft0, s7
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x1a0>
-               	mv	a1, a0
-               	fcvt.d.w	fa0, s7
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x1b4>
-               	mv	a1, a0
-               	fcvt.s.l	ft0, s8
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x1cc>
-               	mv	a1, a0
-               	fcvt.d.l	fa0, s8
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.fold_from+0x1e0>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	s8, 0x0(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	fcvt.d.w	ft0, t0
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3e4 <corpus.cases.convert.i2f.fold_from+0x3e4>
+               	j	0x418 <corpus.cases.convert.i2f.fold_from+0x418>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3e4 <corpus.cases.convert.i2f.fold_from+0x3e4>
+               	fcvt.s.w	ft0, a7
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x438 <corpus.cases.convert.i2f.fold_from+0x438>
+               	j	0x46c <corpus.cases.convert.i2f.fold_from+0x46c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x438 <corpus.cases.convert.i2f.fold_from+0x438>
+               	fcvt.d.w	ft0, a7
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x484 <corpus.cases.convert.i2f.fold_from+0x484>
+               	j	0x4b8 <corpus.cases.convert.i2f.fold_from+0x4b8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x484 <corpus.cases.convert.i2f.fold_from+0x484>
+               	fcvt.s.l	ft0, t5
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d8 <corpus.cases.convert.i2f.fold_from+0x4d8>
+               	j	0x50c <corpus.cases.convert.i2f.fold_from+0x50c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d8 <corpus.cases.convert.i2f.fold_from+0x4d8>
+               	fcvt.d.l	ft0, t5
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x524 <corpus.cases.convert.i2f.fold_from+0x524>
+               	j	0x558 <corpus.cases.convert.i2f.fold_from+0x558>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x524 <corpus.cases.convert.i2f.fold_from+0x524>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.convert.i2f.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x28>
-               	sext.w	a1, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	sext.w	a1, a0
                	li	t0, 0x80
-               	or	s2, a1, t0
-               	sext.w	a1, s1
+               	or	a2, a1, t0
+               	sext.w	a1, a0
                	lui	t0, 0x8
-               	or	s3, a1, t0
-               	sext.w	a1, s1
+               	or	a3, a1, t0
+               	sext.w	a1, a0
                	lui	t0, 0x80000
-               	or	s4, a1, t0
+               	or	a4, a1, t0
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	or	s5, s1, t0
-               	zext.b	t0, s2
+               	or	a1, a0, t0
+               	zext.b	t0, a2
                	fcvt.s.wu	ft0, t0
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x74>
-               	zext.b	t0, s2
-               	fcvt.d.wu	fa0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x84>
-               	slli	t0, s3, 0x30
+               	fmv.x.w	a5, ft0
+               	slli	a6, a5, 0x20
+               	srli	a6, a6, 0x20
+               	lui	a5, 0xfcbf3
+               	addiw	a5, a5, -0x632
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x484
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x222
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x325
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x608 <corpus.cases.convert.i2f.checksum+0x94>
+               	j	0x63c <corpus.cases.convert.i2f.checksum+0xc8>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x608 <corpus.cases.convert.i2f.checksum+0x94>
+               	zext.b	t0, a2
+               	fcvt.d.wu	ft0, t0
+               	fmv.x.d	a6, ft0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x658 <corpus.cases.convert.i2f.checksum+0xe4>
+               	j	0x68c <corpus.cases.convert.i2f.checksum+0x118>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x658 <corpus.cases.convert.i2f.checksum+0xe4>
+               	slli	t0, a3, 0x30
                	srli	t0, t0, 0x30
                	fcvt.s.wu	ft0, t0
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x9c>
-               	slli	t0, s3, 0x30
+               	fmv.x.w	a6, ft0
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x6b4 <corpus.cases.convert.i2f.checksum+0x140>
+               	j	0x6e8 <corpus.cases.convert.i2f.checksum+0x174>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x6b4 <corpus.cases.convert.i2f.checksum+0x140>
+               	slli	t0, a3, 0x30
                	srli	t0, t0, 0x30
-               	fcvt.d.wu	fa0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0xb0>
-               	fcvt.s.wu	ft0, s4
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0xc0>
-               	fcvt.d.wu	fa0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0xcc>
-               	fcvt.s.lu	ft0, s5
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0xdc>
-               	fcvt.d.lu	fa0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0xe8>
-               	slli	t0, s2, 0x38
+               	fcvt.d.wu	ft0, t0
+               	fmv.x.d	a6, ft0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x708 <corpus.cases.convert.i2f.checksum+0x194>
+               	j	0x73c <corpus.cases.convert.i2f.checksum+0x1c8>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x708 <corpus.cases.convert.i2f.checksum+0x194>
+               	fcvt.s.wu	ft0, a4
+               	fmv.x.w	a6, ft0
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x75c <corpus.cases.convert.i2f.checksum+0x1e8>
+               	j	0x790 <corpus.cases.convert.i2f.checksum+0x21c>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x75c <corpus.cases.convert.i2f.checksum+0x1e8>
+               	fcvt.d.wu	ft0, a4
+               	fmv.x.d	a6, ft0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x7a8 <corpus.cases.convert.i2f.checksum+0x234>
+               	j	0x7dc <corpus.cases.convert.i2f.checksum+0x268>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x7a8 <corpus.cases.convert.i2f.checksum+0x234>
+               	fcvt.s.lu	ft0, a1
+               	fmv.x.w	a6, ft0
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x7fc <corpus.cases.convert.i2f.checksum+0x288>
+               	j	0x830 <corpus.cases.convert.i2f.checksum+0x2bc>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x7fc <corpus.cases.convert.i2f.checksum+0x288>
+               	fcvt.d.lu	ft0, a1
+               	fmv.x.d	a6, ft0
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x848 <corpus.cases.convert.i2f.checksum+0x2d4>
+               	j	0x87c <corpus.cases.convert.i2f.checksum+0x308>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x848 <corpus.cases.convert.i2f.checksum+0x2d4>
+               	slli	t0, a2, 0x38
                	srai	t0, t0, 0x38
                	fcvt.s.w	ft0, t0
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x100>
-               	slli	t0, s2, 0x38
+               	fmv.x.w	a6, ft0
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x8a4 <corpus.cases.convert.i2f.checksum+0x330>
+               	j	0x8d8 <corpus.cases.convert.i2f.checksum+0x364>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x8a4 <corpus.cases.convert.i2f.checksum+0x330>
+               	slli	t0, a2, 0x38
                	srai	t0, t0, 0x38
-               	fcvt.d.w	fa0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x114>
-               	slli	t0, s3, 0x30
+               	fcvt.d.w	ft0, t0
+               	fmv.x.d	a2, ft0
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x8f8 <corpus.cases.convert.i2f.checksum+0x384>
+               	j	0x92c <corpus.cases.convert.i2f.checksum+0x3b8>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a2, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x8f8 <corpus.cases.convert.i2f.checksum+0x384>
+               	slli	t0, a3, 0x30
                	srai	t0, t0, 0x30
                	fcvt.s.w	ft0, t0
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x12c>
-               	slli	t0, s3, 0x30
+               	fmv.x.w	a2, ft0
+               	slli	a6, a2, 0x20
+               	srli	a6, a6, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x954 <corpus.cases.convert.i2f.checksum+0x3e0>
+               	j	0x988 <corpus.cases.convert.i2f.checksum+0x414>
+               	li	t0, 0x8
+               	mul	a7, a2, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x954 <corpus.cases.convert.i2f.checksum+0x3e0>
+               	slli	t0, a3, 0x30
                	srai	t0, t0, 0x30
-               	fcvt.d.w	fa0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x140>
-               	fcvt.s.w	ft0, s4
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x150>
-               	fcvt.d.w	fa0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x15c>
-               	fcvt.s.l	ft0, s5
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x16c>
-               	fcvt.d.l	fa0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x178>
+               	fcvt.d.w	ft0, t0
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9a8 <corpus.cases.convert.i2f.checksum+0x434>
+               	j	0x9dc <corpus.cases.convert.i2f.checksum+0x468>
+               	li	t0, 0x8
+               	mul	a6, a3, t0
+               	srl	a7, a2, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a5, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a7, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9a8 <corpus.cases.convert.i2f.checksum+0x434>
+               	fcvt.s.w	ft0, a4
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9fc <corpus.cases.convert.i2f.checksum+0x488>
+               	j	0xa30 <corpus.cases.convert.i2f.checksum+0x4bc>
+               	li	t0, 0x8
+               	mul	a6, a2, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a5, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9fc <corpus.cases.convert.i2f.checksum+0x488>
+               	fcvt.d.w	ft0, a4
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa48 <corpus.cases.convert.i2f.checksum+0x4d4>
+               	j	0xa7c <corpus.cases.convert.i2f.checksum+0x508>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a6, a2, a4
+               	li	t0, 0xff
+               	and	a4, a6, t0
+               	xor	a6, a5, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa48 <corpus.cases.convert.i2f.checksum+0x4d4>
+               	fcvt.s.l	ft0, a1
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa9c <corpus.cases.convert.i2f.checksum+0x528>
+               	j	0xad0 <corpus.cases.convert.i2f.checksum+0x55c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a6, a3, a4
+               	li	t0, 0xff
+               	and	a4, a6, t0
+               	xor	a6, a5, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa9c <corpus.cases.convert.i2f.checksum+0x528>
+               	fcvt.d.l	ft0, a1
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xae8 <corpus.cases.convert.i2f.checksum+0x574>
+               	j	0xb1c <corpus.cases.convert.i2f.checksum+0x5a8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a5, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xae8 <corpus.cases.convert.i2f.checksum+0x574>
                	li	t0, 0x1
-               	or	s2, s1, t0
+               	or	s1, a0, t0
                	li	t1, 0x0
-               	sub	s1, t1, s2
-               	fcvt.s.lu	ft0, s2
-               	fmv.s	fa0, ft0
+               	sub	s2, t1, s1
+               	fcvt.s.lu	ft0, s1
+               	fmv.x.w	a0, ft0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	mv	a0, a5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x198>
-               	fcvt.d.lu	fa0, s2
+               	jalr	ra <corpus.cases.convert.i2f.checksum+0x5cc>
+               	fcvt.d.lu	ft0, s1
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x1a4>
-               	fcvt.s.l	ft0, s1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.convert.i2f.checksum+0x5dc>
+               	fcvt.s.l	ft0, s2
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x1b4>
-               	fcvt.d.l	fa0, s1
+               	jalr	ra <corpus.cases.convert.i2f.checksum+0x5f8>
+               	fcvt.d.l	ft0, s2
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.i2f.checksum+0x1c0>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <corpus.cases.convert.i2f.checksum+0x608>
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/convert/trunc.dis
+++ b/test/golden/riscv64-linux/convert/trunc.dis
@@ -3,20 +3,11 @@ convert/trunc.o:
 Disassembly of section .text:
 
 <corpus.cases.convert.trunc.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	sd	s6, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x2c>
-               	mv	a1, a0
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
                	lui	t0, 0x1234
                	addiw	t0, t0, 0x568
                	slli	t0, t0, 0xc
@@ -25,80 +16,190 @@ Disassembly of section .text:
                	addi	t0, t0, -0x432
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x110
-               	xor	a2, s1, t0
+               	xor	a1, a0, t0
                	li	t0, 0x1
-               	or	a3, a2, t0
-               	sext.w	s1, a3
-               	sext.w	s2, a3
-               	sext.w	s3, a3
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x78>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x8c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0xa0>
-               	mv	a1, a0
+               	or	a0, a1, t0
+               	sext.w	a1, a0
+               	sext.w	a2, a0
+               	sext.w	a3, a0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	lui	a4, 0xfcbf3
+               	addiw	a4, a4, -0x632
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x484
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x222
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x325
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x84 <corpus.cases.convert.trunc.checksum+0x84>
+               	j	0xb8 <corpus.cases.convert.trunc.checksum+0xb8>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a0, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x84 <corpus.cases.convert.trunc.checksum+0x84>
+               	slli	a0, a2, 0x30
+               	srli	a0, a0, 0x30
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xd0 <corpus.cases.convert.trunc.checksum+0xd0>
+               	j	0x104 <corpus.cases.convert.trunc.checksum+0x104>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a0, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xd0 <corpus.cases.convert.trunc.checksum+0xd0>
+               	zext.b	a0, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x118 <corpus.cases.convert.trunc.checksum+0x118>
+               	j	0x14c <corpus.cases.convert.trunc.checksum+0x14c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a0, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x118 <corpus.cases.convert.trunc.checksum+0x118>
                	lui	t0, 0x55555
                	addiw	t0, t0, 0x555
-               	xor	a2, s1, t0
-               	sext.w	s4, a2
-               	sext.w	s5, a2
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0xc8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0xdc>
-               	mv	a1, a0
+               	xor	a0, a1, t0
+               	sext.w	a5, a0
+               	sext.w	a6, a0
+               	slli	a0, a5, 0x30
+               	srli	a0, a0, 0x30
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x178 <corpus.cases.convert.trunc.checksum+0x178>
+               	j	0x1ac <corpus.cases.convert.trunc.checksum+0x1ac>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a0, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a4, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x178 <corpus.cases.convert.trunc.checksum+0x178>
+               	zext.b	a0, a6
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x1c0 <corpus.cases.convert.trunc.checksum+0x1c0>
+               	j	0x1f4 <corpus.cases.convert.trunc.checksum+0x1f4>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a0, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a4, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x1c0 <corpus.cases.convert.trunc.checksum+0x1c0>
                	lui	t0, 0x5
                	addiw	t0, t0, 0x555
-               	xor	a2, s2, t0
-               	sext.w	s6, a2
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x100>
-               	mv	a1, a0
-               	slli	a2, s1, 0x20
-               	srli	a2, a2, 0x20
-               	slli	a3, s2, 0x30
-               	srli	a3, a3, 0x30
-               	add	a4, a2, a3
-               	zext.b	a2, s3
-               	add	a3, a4, a2
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x130>
-               	mv	a1, a0
-               	slli	a2, s4, 0x30
-               	srli	a2, a2, 0x30
-               	zext.b	a3, s5
-               	add	a4, a2, a3
-               	zext.b	a2, s6
-               	add	a3, a4, a2
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.convert.trunc.checksum+0x15c>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	s6, 0x0(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	xor	a0, a2, t0
+               	sext.w	a7, a0
+               	zext.b	a0, a7
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x218 <corpus.cases.convert.trunc.checksum+0x218>
+               	j	0x24c <corpus.cases.convert.trunc.checksum+0x24c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a0, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a4, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x218 <corpus.cases.convert.trunc.checksum+0x218>
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	add	a2, a0, a1
+               	zext.b	a0, a3
+               	add	a1, a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x278 <corpus.cases.convert.trunc.checksum+0x278>
+               	j	0x2ac <corpus.cases.convert.trunc.checksum+0x2ac>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x278 <corpus.cases.convert.trunc.checksum+0x278>
+               	slli	a0, a5, 0x30
+               	srli	a0, a0, 0x30
+               	zext.b	a1, a6
+               	add	a2, a0, a1
+               	zext.b	a0, a7
+               	add	a1, a2, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2d4 <corpus.cases.convert.trunc.checksum+0x2d4>
+               	j	0x308 <corpus.cases.convert.trunc.checksum+0x308>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2d4 <corpus.cases.convert.trunc.checksum+0x2d4>
+               	mv	a0, a4
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/float/arith_f32.dis
+++ b/test/golden/riscv64-linux/float/arith_f32.dis
@@ -9,31 +9,53 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.arith_f32.fold32>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.s	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x54 <corpus.cases.float.arith_f32.fold32+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.fold32+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x78 <corpus.cases.float.arith_f32.fold32+0x68>
+               	fmv.x.w	a0, fa0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a0, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.float.arith_f32.fold32+0x30>
+               	j	0x74 <corpus.cases.float.arith_f32.fold32+0x64>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.float.arith_f32.fold32+0x30>
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.fold32+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x88 <corpus.cases.float.arith_f32.fold32+0x78>
+               	j	0xc8 <corpus.cases.float.arith_f32.fold32+0xb8>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x100
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x88 <corpus.cases.float.arith_f32.fold32+0x78>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.arith_f32.checksum>:
@@ -44,18 +66,13 @@ Disassembly of section .text:
                	sd	s1, 0x38(sp)
                	sd	s2, 0x30(sp)
                	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	fsd	fs0, 0x18(sp)
-               	fsd	fs1, 0x10(sp)
-               	fsd	fs2, 0x8(sp)
-               	fsd	fs3, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x34>
-               	mv	s2, a0
-               	sext.w	s3, s1
+               	fsd	fs0, 0x20(sp)
+               	fsd	fs1, 0x18(sp)
+               	fsd	fs2, 0x10(sp)
+               	fsd	fs3, 0x8(sp)
+               	sext.w	s1, a0
                	lui	t1, 0x3f800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs0, a0
                	lui	t0, 0x3fc00
                	fmv.w.x	ft11, t0
@@ -64,114 +81,77 @@ Disassembly of section .text:
                	fmv.w.x	ft11, t0
                	fmul.s	fs2, ft11, fs0
                	fadd.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x108 <corpus.cases.float.arith_f32.checksum+0x90>
-               	mv	a0, s2
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x80>
-               	mv	s1, a0
-               	j	0x11c <corpus.cases.float.arith_f32.checksum+0xa4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x98>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x7c>
                	fsub.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x144 <corpus.cases.float.arith_f32.checksum+0xcc>
-               	mv	a0, s1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x8c>
+               	fsub.s	ft0, fs2, fs1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x9c>
+               	fmul.s	ft0, fs1, fs2
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xac>
+               	fdiv.s	ft0, fs1, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.float.arith_f32.checksum+0xbc>
-               	mv	s2, a0
-               	j	0x158 <corpus.cases.float.arith_f32.checksum+0xe0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xd4>
-               	mv	s2, a0
-               	fsub.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x180 <corpus.cases.float.arith_f32.checksum+0x108>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xf8>
-               	mv	s1, a0
-               	j	0x194 <corpus.cases.float.arith_f32.checksum+0x11c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x110>
-               	mv	s1, a0
-               	fmul.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1bc <corpus.cases.float.arith_f32.checksum+0x144>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x134>
-               	mv	s2, a0
-               	j	0x1d0 <corpus.cases.float.arith_f32.checksum+0x158>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x14c>
-               	mv	s2, a0
-               	fdiv.s	ft0, fs1, fs2
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x164>
                	fdiv.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x174>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xcc>
                	fneg.s	ft0, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x184>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xdc>
                	fmv.w.x	ft11, zero
                	fsub.s	fs2, ft11, fs1
                	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x198>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0xf0>
                	fsub.s	ft0, fs1, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1a8>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x100>
                	fadd.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1b8>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x110>
                	lui	t0, 0x40400
                	fmv.w.x	ft11, t0
                	fmul.s	fs1, ft11, fs0
                	fdiv.s	fs2, fs0, fs1
                	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1d4>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x12c>
                	fmul.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1e4>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x13c>
                	fsub.s	ft0, fs0, fs2
                	fsub.s	ft1, ft0, fs2
                	fsub.s	ft0, ft1, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1fc>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x154>
                	lui	t0, 0x42440
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs0, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x214>
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x16c>
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
@@ -214,158 +194,113 @@ Disassembly of section .text:
                	jalr	ra <.Lpcrel_hi.1+0x70>
                	fmv.w.x	ft11, zero
                	fmul.s	ft0, ft11, fs0
-               	mv	s1, a0
+               	mv	s2, a0
                	fmv.d	fs1, ft0
-               	li	s2, 0x0
+               	li	s3, 0x0
                	li	t0, 0x18
-               	bltu	s2, t0, 0x344 <.Lpcrel_hi.1+0x98>
-               	j	0x3a0 <.Lpcrel_hi.1+0xf4>
+               	bltu	s3, t0, 0x2f4 <.Lpcrel_hi.1+0x98>
+               	j	0x324 <.Lpcrel_hi.1+0xc8>
                	fadd.s	ft0, fs1, fs2
                	lui	t0, 0x3fc00
                	fmv.w.x	ft10, t0
-               	fmul.s	fs3, ft0, ft10
-               	feq.s	a0, fs3, fs3
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x378 <.Lpcrel_hi.1+0xcc>
-               	mv	a0, s1
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xbc>
-               	mv	s4, a0
-               	j	0x38c <.Lpcrel_hi.1+0xe0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xd4>
-               	mv	s4, a0
-               	addiw	s2, s2, 0x1
-               	mv	s1, s4
-               	fmv.d	fs1, fs3
-               	li	t0, 0x18
-               	bltu	s2, t0, 0x344 <.Lpcrel_hi.1+0x98>
-               	lui	t1, 0x7f800
-               	addiw	t1, t1, -0x1
-               	addw	a0, t1, s3
-               	fmv.w.x	fs1, a0
-               	feq.s	a0, fs1, fs1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3d4 <.Lpcrel_hi.1+0x128>
-               	mv	a0, s1
+               	fmul.s	fs1, ft0, ft10
+               	mv	a0, s2
                	fmv.s	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x118>
+               	jalr	ra <.Lpcrel_hi.1+0xb0>
+               	addiw	s3, s3, 0x1
                	mv	s2, a0
-               	j	0x3e8 <.Lpcrel_hi.1+0x13c>
-               	mv	a0, s1
-               	li	a1, -0x1
+               	li	t0, 0x18
+               	bltu	s3, t0, 0x2f4 <.Lpcrel_hi.1+0x98>
+               	lui	t1, 0x7f800
+               	addiw	t1, t1, -0x1
+               	addw	a0, t1, s1
+               	fmv.w.x	fs1, a0
+               	mv	a0, s2
+               	fmv.s	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x130>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0xe0>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs1, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x418 <.Lpcrel_hi.1+0x16c>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x15c>
-               	mv	s1, a0
-               	j	0x42c <.Lpcrel_hi.1+0x180>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x174>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0xf8>
                	fadd.s	ft0, fs1, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x454 <.Lpcrel_hi.1+0x1a8>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x198>
-               	mv	s2, a0
-               	j	0x468 <.Lpcrel_hi.1+0x1bc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1b0>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x108>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	fs2, fs1, ft10
-               	mv	a0, s2
                	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1d0>
+               	jalr	ra <.Lpcrel_hi.1+0x120>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1e4>
+               	jalr	ra <.Lpcrel_hi.1+0x134>
                	fmul.s	ft0, fs1, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1f4>
+               	jalr	ra <.Lpcrel_hi.1+0x144>
                	fsub.s	ft0, fs1, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x204>
+               	jalr	ra <.Lpcrel_hi.1+0x154>
                	lui	t1, 0x800
-               	addw	a1, t1, s3
+               	addw	a1, t1, s1
                	fmv.w.x	fs1, a1
                	li	t1, 0x1
-               	addw	a1, t1, s3
+               	addw	a1, t1, s1
                	fmv.w.x	fs2, a1
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs1, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x234>
+               	jalr	ra <.Lpcrel_hi.1+0x184>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs1, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x24c>
+               	jalr	ra <.Lpcrel_hi.1+0x19c>
                	fsub.s	ft0, fs1, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x25c>
+               	jalr	ra <.Lpcrel_hi.1+0x1ac>
                	fmul.s	ft0, fs1, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x26c>
+               	jalr	ra <.Lpcrel_hi.1+0x1bc>
                	fadd.s	ft0, fs2, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x27c>
+               	jalr	ra <.Lpcrel_hi.1+0x1cc>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x294>
+               	jalr	ra <.Lpcrel_hi.1+0x1e4>
                	lui	t0, 0x3f400
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2ac>
+               	jalr	ra <.Lpcrel_hi.1+0x1fc>
                	lui	t0, 0x4b800
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2c4>
+               	jalr	ra <.Lpcrel_hi.1+0x214>
                	fdiv.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2d4>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x224>
                	lui	t0, 0x40b00
                	fmv.w.x	ft11, t0
                	fmul.s	fs1, ft11, fs0
@@ -373,355 +308,311 @@ Disassembly of section .text:
                	fmv.w.x	ft11, t0
                	fmul.s	fs2, ft11, fs0
                	fmv.w.x	ft10, zero
-               	feq.s	a0, fs2, ft10
-               	bnez	a0, 0x5d8 <.Lpcrel_hi.1+0x32c>
+               	feq.s	a1, fs2, ft10
+               	bnez	a1, 0x4d4 <.Lpcrel_hi.1+0x278>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs1, ft10
-               	feq.s	a1, fs1, ft0
-               	bnez	a1, 0x5c8 <.Lpcrel_hi.1+0x31c>
-               	j	0x5d4 <.Lpcrel_hi.1+0x328>
+               	feq.s	a2, fs1, ft0
+               	bnez	a2, 0x4c4 <.Lpcrel_hi.1+0x268>
+               	j	0x4d0 <.Lpcrel_hi.1+0x274>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, fs1, ft10
-               	xori	a1, a1, 0x1
-               	j	0x5dc <.Lpcrel_hi.1+0x330>
-               	mv	a1, a0
-               	bnez	a1, 0x68c <.Lpcrel_hi.1+0x3e0>
+               	feq.s	a2, fs1, ft10
+               	xori	a2, a2, 0x1
+               	j	0x4d8 <.Lpcrel_hi.1+0x27c>
+               	mv	a2, a1
+               	bnez	a2, 0x588 <.Lpcrel_hi.1+0x32c>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, fs1, ft10
-               	bnez	a0, 0x5f4 <.Lpcrel_hi.1+0x348>
+               	flt.s	a1, fs1, ft10
+               	bnez	a1, 0x4f0 <.Lpcrel_hi.1+0x294>
                	fmv.d	ft0, fs1
-               	j	0x5fc <.Lpcrel_hi.1+0x350>
+               	j	0x4f8 <.Lpcrel_hi.1+0x29c>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
                	fmv.w.x	ft10, zero
-               	flt.s	a1, fs2, ft10
-               	bnez	a1, 0x610 <.Lpcrel_hi.1+0x364>
+               	flt.s	a2, fs2, ft10
+               	bnez	a2, 0x50c <.Lpcrel_hi.1+0x2b0>
                	fmv.d	ft1, fs2
-               	j	0x618 <.Lpcrel_hi.1+0x36c>
+               	j	0x514 <.Lpcrel_hi.1+0x2b8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.s	a1, ft3, ft2
-               	bnez	a1, 0x67c <.Lpcrel_hi.1+0x3d0>
+               	fle.s	a2, ft3, ft2
+               	bnez	a2, 0x578 <.Lpcrel_hi.1+0x31c>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.s	a1, ft1, ft5
-               	bnez	a1, 0x654 <.Lpcrel_hi.1+0x3a8>
-               	bnez	a0, 0x64c <.Lpcrel_hi.1+0x3a0>
+               	fle.s	a2, ft1, ft5
+               	bnez	a2, 0x550 <.Lpcrel_hi.1+0x2f4>
+               	bnez	a1, 0x548 <.Lpcrel_hi.1+0x2ec>
                	fmv.d	ft6, ft4
-               	j	0x650 <.Lpcrel_hi.1+0x3a4>
+               	j	0x54c <.Lpcrel_hi.1+0x2f0>
                	fneg.s	ft6, ft4
-               	j	0x6a0 <.Lpcrel_hi.1+0x3f4>
-               	fle.s	a1, ft5, ft4
-               	bnez	a1, 0x664 <.Lpcrel_hi.1+0x3b8>
+               	j	0x59c <.Lpcrel_hi.1+0x340>
+               	fle.s	a2, ft5, ft4
+               	bnez	a2, 0x560 <.Lpcrel_hi.1+0x304>
                	fmv.d	ft7, ft4
-               	j	0x668 <.Lpcrel_hi.1+0x3bc>
+               	j	0x564 <.Lpcrel_hi.1+0x308>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0x638 <.Lpcrel_hi.1+0x38c>
+               	j	0x534 <.Lpcrel_hi.1+0x2d8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft3, ft3, ft10
-               	j	0x628 <.Lpcrel_hi.1+0x37c>
+               	j	0x524 <.Lpcrel_hi.1+0x2c8>
                	fdiv.s	ft0, fs1, fs2
-               	fcvt.l.s	a0, ft0, rtz
-               	fcvt.s.l	ft0, a0
+               	fcvt.l.s	a1, ft0, rtz
+               	fcvt.s.l	ft0, a1
                	fmul.s	ft1, ft0, fs2
                	fsub.s	ft6, fs1, ft1
-               	feq.s	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x6c4 <.Lpcrel_hi.1+0x418>
-               	mv	a0, s1
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x408>
-               	mv	s2, a0
-               	j	0x6d8 <.Lpcrel_hi.1+0x42c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x420>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x344>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
                	fmv.w.x	ft10, zero
-               	feq.s	a0, fs2, ft10
-               	bnez	a0, 0x714 <.Lpcrel_hi.1+0x468>
+               	feq.s	a1, fs2, ft10
+               	bnez	a1, 0x5e4 <.Lpcrel_hi.1+0x388>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
-               	feq.s	a1, ft0, ft1
-               	bnez	a1, 0x704 <.Lpcrel_hi.1+0x458>
-               	j	0x710 <.Lpcrel_hi.1+0x464>
+               	feq.s	a2, ft0, ft1
+               	bnez	a2, 0x5d4 <.Lpcrel_hi.1+0x378>
+               	j	0x5e0 <.Lpcrel_hi.1+0x384>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0x718 <.Lpcrel_hi.1+0x46c>
-               	mv	a1, a0
-               	bnez	a1, 0x7c8 <.Lpcrel_hi.1+0x51c>
+               	feq.s	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x5e8 <.Lpcrel_hi.1+0x38c>
+               	mv	a2, a1
+               	bnez	a2, 0x698 <.Lpcrel_hi.1+0x43c>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, ft0, ft10
-               	bnez	a0, 0x730 <.Lpcrel_hi.1+0x484>
+               	flt.s	a1, ft0, ft10
+               	bnez	a1, 0x600 <.Lpcrel_hi.1+0x3a4>
                	fmv.d	ft1, ft0
-               	j	0x738 <.Lpcrel_hi.1+0x48c>
+               	j	0x608 <.Lpcrel_hi.1+0x3ac>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	fmv.w.x	ft10, zero
-               	flt.s	a1, fs2, ft10
-               	bnez	a1, 0x74c <.Lpcrel_hi.1+0x4a0>
+               	flt.s	a2, fs2, ft10
+               	bnez	a2, 0x61c <.Lpcrel_hi.1+0x3c0>
                	fmv.d	ft2, fs2
-               	j	0x754 <.Lpcrel_hi.1+0x4a8>
+               	j	0x624 <.Lpcrel_hi.1+0x3c8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, fs2
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.s	a1, ft4, ft3
-               	bnez	a1, 0x7b8 <.Lpcrel_hi.1+0x50c>
+               	fle.s	a2, ft4, ft3
+               	bnez	a2, 0x688 <.Lpcrel_hi.1+0x42c>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.s	a1, ft2, ft6
-               	bnez	a1, 0x790 <.Lpcrel_hi.1+0x4e4>
-               	bnez	a0, 0x788 <.Lpcrel_hi.1+0x4dc>
+               	fle.s	a2, ft2, ft6
+               	bnez	a2, 0x660 <.Lpcrel_hi.1+0x404>
+               	bnez	a1, 0x658 <.Lpcrel_hi.1+0x3fc>
                	fmv.d	ft7, ft5
-               	j	0x78c <.Lpcrel_hi.1+0x4e0>
+               	j	0x65c <.Lpcrel_hi.1+0x400>
                	fneg.s	ft7, ft5
-               	j	0x7dc <.Lpcrel_hi.1+0x530>
-               	fle.s	a1, ft6, ft5
-               	bnez	a1, 0x7a0 <.Lpcrel_hi.1+0x4f4>
+               	j	0x6ac <.Lpcrel_hi.1+0x450>
+               	fle.s	a2, ft6, ft5
+               	bnez	a2, 0x670 <.Lpcrel_hi.1+0x414>
                	fmv.d	fa0, ft5
-               	j	0x7a4 <.Lpcrel_hi.1+0x4f8>
+               	j	0x674 <.Lpcrel_hi.1+0x418>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x774 <.Lpcrel_hi.1+0x4c8>
+               	j	0x644 <.Lpcrel_hi.1+0x3e8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0x764 <.Lpcrel_hi.1+0x4b8>
+               	j	0x634 <.Lpcrel_hi.1+0x3d8>
                	fdiv.s	ft1, ft0, fs2
-               	fcvt.l.s	a0, ft1, rtz
-               	fcvt.s.l	ft1, a0
+               	fcvt.l.s	a1, ft1, rtz
+               	fcvt.s.l	ft1, a1
                	fmul.s	ft2, ft1, fs2
                	fsub.s	ft7, ft0, ft2
-               	feq.s	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x800 <.Lpcrel_hi.1+0x554>
-               	mv	a0, s2
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x544>
-               	mv	s1, a0
-               	j	0x814 <.Lpcrel_hi.1+0x568>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x55c>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x454>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
                	fmv.w.x	ft10, zero
-               	feq.s	a0, ft0, ft10
-               	bnez	a0, 0x850 <.Lpcrel_hi.1+0x5a4>
+               	feq.s	a1, ft0, ft10
+               	bnez	a1, 0x6f4 <.Lpcrel_hi.1+0x498>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, fs1, ft10
-               	feq.s	a1, fs1, ft1
-               	bnez	a1, 0x840 <.Lpcrel_hi.1+0x594>
-               	j	0x84c <.Lpcrel_hi.1+0x5a0>
+               	feq.s	a2, fs1, ft1
+               	bnez	a2, 0x6e4 <.Lpcrel_hi.1+0x488>
+               	j	0x6f0 <.Lpcrel_hi.1+0x494>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, fs1, ft10
-               	xori	a1, a1, 0x1
-               	j	0x854 <.Lpcrel_hi.1+0x5a8>
-               	mv	a1, a0
-               	bnez	a1, 0x904 <.Lpcrel_hi.1+0x658>
+               	feq.s	a2, fs1, ft10
+               	xori	a2, a2, 0x1
+               	j	0x6f8 <.Lpcrel_hi.1+0x49c>
+               	mv	a2, a1
+               	bnez	a2, 0x7a8 <.Lpcrel_hi.1+0x54c>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, fs1, ft10
-               	bnez	a0, 0x86c <.Lpcrel_hi.1+0x5c0>
+               	flt.s	a1, fs1, ft10
+               	bnez	a1, 0x710 <.Lpcrel_hi.1+0x4b4>
                	fmv.d	ft1, fs1
-               	j	0x874 <.Lpcrel_hi.1+0x5c8>
+               	j	0x718 <.Lpcrel_hi.1+0x4bc>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs1
                	fmv.w.x	ft10, zero
-               	flt.s	a1, ft0, ft10
-               	bnez	a1, 0x888 <.Lpcrel_hi.1+0x5dc>
+               	flt.s	a2, ft0, ft10
+               	bnez	a2, 0x72c <.Lpcrel_hi.1+0x4d0>
                	fmv.d	ft2, ft0
-               	j	0x890 <.Lpcrel_hi.1+0x5e4>
+               	j	0x734 <.Lpcrel_hi.1+0x4d8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, ft0
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.s	a1, ft4, ft3
-               	bnez	a1, 0x8f4 <.Lpcrel_hi.1+0x648>
+               	fle.s	a2, ft4, ft3
+               	bnez	a2, 0x798 <.Lpcrel_hi.1+0x53c>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.s	a1, ft2, ft6
-               	bnez	a1, 0x8cc <.Lpcrel_hi.1+0x620>
-               	bnez	a0, 0x8c4 <.Lpcrel_hi.1+0x618>
+               	fle.s	a2, ft2, ft6
+               	bnez	a2, 0x770 <.Lpcrel_hi.1+0x514>
+               	bnez	a1, 0x768 <.Lpcrel_hi.1+0x50c>
                	fmv.d	ft7, ft5
-               	j	0x8c8 <.Lpcrel_hi.1+0x61c>
+               	j	0x76c <.Lpcrel_hi.1+0x510>
                	fneg.s	ft7, ft5
-               	j	0x918 <.Lpcrel_hi.1+0x66c>
-               	fle.s	a1, ft6, ft5
-               	bnez	a1, 0x8dc <.Lpcrel_hi.1+0x630>
+               	j	0x7bc <.Lpcrel_hi.1+0x560>
+               	fle.s	a2, ft6, ft5
+               	bnez	a2, 0x780 <.Lpcrel_hi.1+0x524>
                	fmv.d	fa0, ft5
-               	j	0x8e0 <.Lpcrel_hi.1+0x634>
+               	j	0x784 <.Lpcrel_hi.1+0x528>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x8b0 <.Lpcrel_hi.1+0x604>
+               	j	0x754 <.Lpcrel_hi.1+0x4f8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0x8a0 <.Lpcrel_hi.1+0x5f4>
+               	j	0x744 <.Lpcrel_hi.1+0x4e8>
                	fdiv.s	ft1, fs1, ft0
-               	fcvt.l.s	a0, ft1, rtz
-               	fcvt.s.l	ft1, a0
+               	fcvt.l.s	a1, ft1, rtz
+               	fcvt.s.l	ft1, a1
                	fmul.s	ft2, ft1, ft0
                	fsub.s	ft7, fs1, ft2
-               	feq.s	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x93c <.Lpcrel_hi.1+0x690>
-               	mv	a0, s1
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x680>
-               	mv	s2, a0
-               	j	0x950 <.Lpcrel_hi.1+0x6a4>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x698>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x564>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	fmv.w.x	ft10, zero
-               	feq.s	a0, ft1, ft10
-               	bnez	a0, 0x994 <.Lpcrel_hi.1+0x6e8>
+               	feq.s	a1, ft1, ft10
+               	bnez	a1, 0x80c <.Lpcrel_hi.1+0x5b0>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft2, ft0, ft10
-               	feq.s	a1, ft0, ft2
-               	bnez	a1, 0x984 <.Lpcrel_hi.1+0x6d8>
-               	j	0x990 <.Lpcrel_hi.1+0x6e4>
+               	feq.s	a2, ft0, ft2
+               	bnez	a2, 0x7fc <.Lpcrel_hi.1+0x5a0>
+               	j	0x808 <.Lpcrel_hi.1+0x5ac>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0x998 <.Lpcrel_hi.1+0x6ec>
-               	mv	a1, a0
-               	bnez	a1, 0xa48 <.Lpcrel_hi.1+0x79c>
+               	feq.s	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x810 <.Lpcrel_hi.1+0x5b4>
+               	mv	a2, a1
+               	bnez	a2, 0x8c0 <.Lpcrel_hi.1+0x664>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, ft0, ft10
-               	bnez	a0, 0x9b0 <.Lpcrel_hi.1+0x704>
+               	flt.s	a1, ft0, ft10
+               	bnez	a1, 0x828 <.Lpcrel_hi.1+0x5cc>
                	fmv.d	ft2, ft0
-               	j	0x9b8 <.Lpcrel_hi.1+0x70c>
+               	j	0x830 <.Lpcrel_hi.1+0x5d4>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, ft0
                	fmv.w.x	ft10, zero
-               	flt.s	a1, ft1, ft10
-               	bnez	a1, 0x9cc <.Lpcrel_hi.1+0x720>
+               	flt.s	a2, ft1, ft10
+               	bnez	a2, 0x844 <.Lpcrel_hi.1+0x5e8>
                	fmv.d	ft3, ft1
-               	j	0x9d4 <.Lpcrel_hi.1+0x728>
+               	j	0x84c <.Lpcrel_hi.1+0x5f0>
                	fmv.w.x	ft11, zero
                	fsub.s	ft3, ft11, ft1
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft4, ft2, ft10
                	fmv.d	ft5, ft3
-               	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xa38 <.Lpcrel_hi.1+0x78c>
+               	fle.s	a2, ft5, ft4
+               	bnez	a2, 0x8b0 <.Lpcrel_hi.1+0x654>
                	fmv.d	ft6, ft2
                	fmv.d	ft7, ft5
-               	fle.s	a1, ft3, ft7
-               	bnez	a1, 0xa10 <.Lpcrel_hi.1+0x764>
-               	bnez	a0, 0xa08 <.Lpcrel_hi.1+0x75c>
+               	fle.s	a2, ft3, ft7
+               	bnez	a2, 0x888 <.Lpcrel_hi.1+0x62c>
+               	bnez	a1, 0x880 <.Lpcrel_hi.1+0x624>
                	fmv.d	fa0, ft6
-               	j	0xa0c <.Lpcrel_hi.1+0x760>
+               	j	0x884 <.Lpcrel_hi.1+0x628>
                	fneg.s	fa0, ft6
-               	j	0xa5c <.Lpcrel_hi.1+0x7b0>
-               	fle.s	a1, ft7, ft6
-               	bnez	a1, 0xa20 <.Lpcrel_hi.1+0x774>
+               	j	0x8d4 <.Lpcrel_hi.1+0x678>
+               	fle.s	a2, ft7, ft6
+               	bnez	a2, 0x898 <.Lpcrel_hi.1+0x63c>
                	fmv.d	fa1, ft6
-               	j	0xa24 <.Lpcrel_hi.1+0x778>
+               	j	0x89c <.Lpcrel_hi.1+0x640>
                	fsub.s	fa1, ft6, ft7
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft7, ft7, ft10
                	fmv.d	ft6, fa1
-               	j	0x9f4 <.Lpcrel_hi.1+0x748>
+               	j	0x86c <.Lpcrel_hi.1+0x610>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft5, ft5, ft10
-               	j	0x9e4 <.Lpcrel_hi.1+0x738>
+               	j	0x85c <.Lpcrel_hi.1+0x600>
                	fdiv.s	ft2, ft0, ft1
-               	fcvt.l.s	a0, ft2, rtz
-               	fcvt.s.l	ft2, a0
+               	fcvt.l.s	a1, ft2, rtz
+               	fcvt.s.l	ft2, a1
                	fmul.s	ft3, ft2, ft1
                	fsub.s	fa0, ft0, ft3
-               	feq.s	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa7c <.Lpcrel_hi.1+0x7d0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7c0>
-               	mv	s1, a0
-               	j	0xa90 <.Lpcrel_hi.1+0x7e4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7d8>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x678>
                	lui	t0, 0x40e00
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fmv.w.x	ft10, zero
-               	feq.s	a0, ft11, ft10
-               	bnez	a0, 0xad8 <.Lpcrel_hi.1+0x82c>
+               	feq.s	a1, ft11, ft10
+               	bnez	a1, 0x924 <.Lpcrel_hi.1+0x6c8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
-               	feq.s	a1, ft0, ft1
-               	bnez	a1, 0xac8 <.Lpcrel_hi.1+0x81c>
-               	j	0xad4 <.Lpcrel_hi.1+0x828>
+               	feq.s	a2, ft0, ft1
+               	bnez	a2, 0x914 <.Lpcrel_hi.1+0x6b8>
+               	j	0x920 <.Lpcrel_hi.1+0x6c4>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0xadc <.Lpcrel_hi.1+0x830>
-               	mv	a1, a0
-               	bnez	a1, 0xba0 <.Lpcrel_hi.1+0x8f4>
+               	feq.s	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x928 <.Lpcrel_hi.1+0x6cc>
+               	mv	a2, a1
+               	bnez	a2, 0x9ec <.Lpcrel_hi.1+0x790>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, ft0, ft10
-               	bnez	a0, 0xaf4 <.Lpcrel_hi.1+0x848>
+               	flt.s	a1, ft0, ft10
+               	bnez	a1, 0x940 <.Lpcrel_hi.1+0x6e4>
                	fmv.d	ft1, ft0
-               	j	0xafc <.Lpcrel_hi.1+0x850>
+               	j	0x948 <.Lpcrel_hi.1+0x6ec>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fmv.w.x	ft10, zero
-               	flt.s	a1, ft11, ft10
-               	bnez	a1, 0xb1c <.Lpcrel_hi.1+0x870>
+               	flt.s	a2, ft11, ft10
+               	bnez	a2, 0x968 <.Lpcrel_hi.1+0x70c>
                	lui	t0, 0x3f000
                	fmv.w.x	ft2, t0
-               	j	0xb2c <.Lpcrel_hi.1+0x880>
+               	j	0x978 <.Lpcrel_hi.1+0x71c>
                	fmv.w.x	ft11, zero
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
@@ -730,297 +621,251 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.s	a1, ft4, ft3
-               	bnez	a1, 0xb90 <.Lpcrel_hi.1+0x8e4>
+               	fle.s	a2, ft4, ft3
+               	bnez	a2, 0x9dc <.Lpcrel_hi.1+0x780>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.s	a1, ft2, ft6
-               	bnez	a1, 0xb68 <.Lpcrel_hi.1+0x8bc>
-               	bnez	a0, 0xb60 <.Lpcrel_hi.1+0x8b4>
+               	fle.s	a2, ft2, ft6
+               	bnez	a2, 0x9b4 <.Lpcrel_hi.1+0x758>
+               	bnez	a1, 0x9ac <.Lpcrel_hi.1+0x750>
                	fmv.d	ft7, ft5
-               	j	0xb64 <.Lpcrel_hi.1+0x8b8>
+               	j	0x9b0 <.Lpcrel_hi.1+0x754>
                	fneg.s	ft7, ft5
-               	j	0xbc4 <.Lpcrel_hi.1+0x918>
-               	fle.s	a1, ft6, ft5
-               	bnez	a1, 0xb78 <.Lpcrel_hi.1+0x8cc>
+               	j	0xa10 <.Lpcrel_hi.1+0x7b4>
+               	fle.s	a2, ft6, ft5
+               	bnez	a2, 0x9c4 <.Lpcrel_hi.1+0x768>
                	fmv.d	fa0, ft5
-               	j	0xb7c <.Lpcrel_hi.1+0x8d0>
+               	j	0x9c8 <.Lpcrel_hi.1+0x76c>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xb4c <.Lpcrel_hi.1+0x8a0>
+               	j	0x998 <.Lpcrel_hi.1+0x73c>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0xb3c <.Lpcrel_hi.1+0x890>
+               	j	0x988 <.Lpcrel_hi.1+0x72c>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft1, ft0, ft10
-               	fcvt.l.s	a0, ft1, rtz
-               	fcvt.s.l	ft1, a0
+               	fcvt.l.s	a1, ft1, rtz
+               	fcvt.s.l	ft1, a1
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft2, ft1, ft10
                	fsub.s	ft7, ft0, ft2
-               	feq.s	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xbe8 <.Lpcrel_hi.1+0x93c>
-               	mv	a0, s1
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x92c>
-               	mv	s2, a0
-               	j	0xbfc <.Lpcrel_hi.1+0x950>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x944>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x7b8>
                	fmv.w.x	ft10, zero
-               	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xc30 <.Lpcrel_hi.1+0x984>
+               	feq.s	a1, fs2, ft10
+               	bnez	a1, 0xa50 <.Lpcrel_hi.1+0x7f4>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs0, ft10
-               	feq.s	a1, fs0, ft0
-               	bnez	a1, 0xc20 <.Lpcrel_hi.1+0x974>
-               	j	0xc2c <.Lpcrel_hi.1+0x980>
+               	feq.s	a2, fs0, ft0
+               	bnez	a2, 0xa40 <.Lpcrel_hi.1+0x7e4>
+               	j	0xa4c <.Lpcrel_hi.1+0x7f0>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, fs0, ft10
-               	xori	a1, a1, 0x1
-               	j	0xc34 <.Lpcrel_hi.1+0x988>
-               	mv	a1, a0
-               	bnez	a1, 0xce4 <.Lpcrel_hi.1+0xa38>
+               	feq.s	a2, fs0, ft10
+               	xori	a2, a2, 0x1
+               	j	0xa54 <.Lpcrel_hi.1+0x7f8>
+               	mv	a2, a1
+               	bnez	a2, 0xb04 <.Lpcrel_hi.1+0x8a8>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, fs0, ft10
-               	bnez	a0, 0xc4c <.Lpcrel_hi.1+0x9a0>
+               	flt.s	a1, fs0, ft10
+               	bnez	a1, 0xa6c <.Lpcrel_hi.1+0x810>
                	fmv.d	ft0, fs0
-               	j	0xc54 <.Lpcrel_hi.1+0x9a8>
+               	j	0xa74 <.Lpcrel_hi.1+0x818>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs0
                	fmv.w.x	ft10, zero
-               	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xc68 <.Lpcrel_hi.1+0x9bc>
+               	flt.s	a2, fs2, ft10
+               	bnez	a2, 0xa88 <.Lpcrel_hi.1+0x82c>
                	fmv.d	ft1, fs2
-               	j	0xc70 <.Lpcrel_hi.1+0x9c4>
+               	j	0xa90 <.Lpcrel_hi.1+0x834>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.s	a1, ft3, ft2
-               	bnez	a1, 0xcd4 <.Lpcrel_hi.1+0xa28>
+               	fle.s	a2, ft3, ft2
+               	bnez	a2, 0xaf4 <.Lpcrel_hi.1+0x898>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.s	a1, ft1, ft5
-               	bnez	a1, 0xcac <.Lpcrel_hi.1+0xa00>
-               	bnez	a0, 0xca4 <.Lpcrel_hi.1+0x9f8>
+               	fle.s	a2, ft1, ft5
+               	bnez	a2, 0xacc <.Lpcrel_hi.1+0x870>
+               	bnez	a1, 0xac4 <.Lpcrel_hi.1+0x868>
                	fmv.d	ft6, ft4
-               	j	0xca8 <.Lpcrel_hi.1+0x9fc>
+               	j	0xac8 <.Lpcrel_hi.1+0x86c>
                	fneg.s	ft6, ft4
-               	j	0xcf8 <.Lpcrel_hi.1+0xa4c>
-               	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xcbc <.Lpcrel_hi.1+0xa10>
+               	j	0xb18 <.Lpcrel_hi.1+0x8bc>
+               	fle.s	a2, ft5, ft4
+               	bnez	a2, 0xadc <.Lpcrel_hi.1+0x880>
                	fmv.d	ft7, ft4
-               	j	0xcc0 <.Lpcrel_hi.1+0xa14>
+               	j	0xae0 <.Lpcrel_hi.1+0x884>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xc90 <.Lpcrel_hi.1+0x9e4>
+               	j	0xab0 <.Lpcrel_hi.1+0x854>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft3, ft3, ft10
-               	j	0xc80 <.Lpcrel_hi.1+0x9d4>
+               	j	0xaa0 <.Lpcrel_hi.1+0x844>
                	fdiv.s	ft0, fs0, fs2
-               	fcvt.l.s	a0, ft0, rtz
-               	fcvt.s.l	ft0, a0
+               	fcvt.l.s	a1, ft0, rtz
+               	fcvt.s.l	ft0, a1
                	fmul.s	ft1, ft0, fs2
                	fsub.s	ft6, fs0, ft1
-               	feq.s	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xd1c <.Lpcrel_hi.1+0xa70>
-               	mv	a0, s2
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa60>
-               	mv	s1, a0
-               	j	0xd30 <.Lpcrel_hi.1+0xa84>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa78>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x8c0>
                	fmv.w.x	ft10, zero
-               	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xd64 <.Lpcrel_hi.1+0xab8>
+               	feq.s	a1, fs2, ft10
+               	bnez	a1, 0xb58 <.Lpcrel_hi.1+0x8fc>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
-               	feq.s	a1, fs2, ft0
-               	bnez	a1, 0xd54 <.Lpcrel_hi.1+0xaa8>
-               	j	0xd60 <.Lpcrel_hi.1+0xab4>
+               	feq.s	a2, fs2, ft0
+               	bnez	a2, 0xb48 <.Lpcrel_hi.1+0x8ec>
+               	j	0xb54 <.Lpcrel_hi.1+0x8f8>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, fs2, ft10
-               	xori	a1, a1, 0x1
-               	j	0xd68 <.Lpcrel_hi.1+0xabc>
-               	mv	a1, a0
-               	bnez	a1, 0xe18 <.Lpcrel_hi.1+0xb6c>
+               	feq.s	a2, fs2, ft10
+               	xori	a2, a2, 0x1
+               	j	0xb5c <.Lpcrel_hi.1+0x900>
+               	mv	a2, a1
+               	bnez	a2, 0xc0c <.Lpcrel_hi.1+0x9b0>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, fs2, ft10
-               	bnez	a0, 0xd80 <.Lpcrel_hi.1+0xad4>
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0xb74 <.Lpcrel_hi.1+0x918>
                	fmv.d	ft0, fs2
-               	j	0xd88 <.Lpcrel_hi.1+0xadc>
+               	j	0xb7c <.Lpcrel_hi.1+0x920>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
                	fmv.w.x	ft10, zero
-               	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xd9c <.Lpcrel_hi.1+0xaf0>
+               	flt.s	a2, fs2, ft10
+               	bnez	a2, 0xb90 <.Lpcrel_hi.1+0x934>
                	fmv.d	ft1, fs2
-               	j	0xda4 <.Lpcrel_hi.1+0xaf8>
+               	j	0xb98 <.Lpcrel_hi.1+0x93c>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.s	a1, ft3, ft2
-               	bnez	a1, 0xe08 <.Lpcrel_hi.1+0xb5c>
+               	fle.s	a2, ft3, ft2
+               	bnez	a2, 0xbfc <.Lpcrel_hi.1+0x9a0>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.s	a1, ft1, ft5
-               	bnez	a1, 0xde0 <.Lpcrel_hi.1+0xb34>
-               	bnez	a0, 0xdd8 <.Lpcrel_hi.1+0xb2c>
+               	fle.s	a2, ft1, ft5
+               	bnez	a2, 0xbd4 <.Lpcrel_hi.1+0x978>
+               	bnez	a1, 0xbcc <.Lpcrel_hi.1+0x970>
                	fmv.d	ft6, ft4
-               	j	0xddc <.Lpcrel_hi.1+0xb30>
+               	j	0xbd0 <.Lpcrel_hi.1+0x974>
                	fneg.s	ft6, ft4
-               	j	0xe2c <.Lpcrel_hi.1+0xb80>
-               	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xdf0 <.Lpcrel_hi.1+0xb44>
+               	j	0xc20 <.Lpcrel_hi.1+0x9c4>
+               	fle.s	a2, ft5, ft4
+               	bnez	a2, 0xbe4 <.Lpcrel_hi.1+0x988>
                	fmv.d	ft7, ft4
-               	j	0xdf4 <.Lpcrel_hi.1+0xb48>
+               	j	0xbe8 <.Lpcrel_hi.1+0x98c>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xdc4 <.Lpcrel_hi.1+0xb18>
+               	j	0xbb8 <.Lpcrel_hi.1+0x95c>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft3, ft3, ft10
-               	j	0xdb4 <.Lpcrel_hi.1+0xb08>
+               	j	0xba8 <.Lpcrel_hi.1+0x94c>
                	fdiv.s	ft0, fs2, fs2
-               	fcvt.l.s	a0, ft0, rtz
-               	fcvt.s.l	ft0, a0
+               	fcvt.l.s	a1, ft0, rtz
+               	fcvt.s.l	ft0, a1
                	fmul.s	ft1, ft0, fs2
                	fsub.s	ft6, fs2, ft1
-               	feq.s	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xe50 <.Lpcrel_hi.1+0xba4>
-               	mv	a0, s1
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xb94>
-               	mv	s2, a0
-               	j	0xe64 <.Lpcrel_hi.1+0xbb8>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xbac>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x9c8>
                	lui	t0, 0x49800
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
                	fmv.w.x	ft10, zero
-               	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xea4 <.Lpcrel_hi.1+0xbf8>
+               	feq.s	a1, fs2, ft10
+               	bnez	a1, 0xc6c <.Lpcrel_hi.1+0xa10>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
-               	feq.s	a1, ft0, ft1
-               	bnez	a1, 0xe94 <.Lpcrel_hi.1+0xbe8>
-               	j	0xea0 <.Lpcrel_hi.1+0xbf4>
+               	feq.s	a2, ft0, ft1
+               	bnez	a2, 0xc5c <.Lpcrel_hi.1+0xa00>
+               	j	0xc68 <.Lpcrel_hi.1+0xa0c>
                	fmv.w.x	ft10, zero
-               	feq.s	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0xea8 <.Lpcrel_hi.1+0xbfc>
-               	mv	a1, a0
-               	bnez	a1, 0xf58 <.Lpcrel_hi.1+0xcac>
+               	feq.s	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0xc70 <.Lpcrel_hi.1+0xa14>
+               	mv	a2, a1
+               	bnez	a2, 0xd20 <.Lpcrel_hi.1+0xac4>
                	fmv.w.x	ft10, zero
-               	flt.s	a0, ft0, ft10
-               	bnez	a0, 0xec0 <.Lpcrel_hi.1+0xc14>
+               	flt.s	a1, ft0, ft10
+               	bnez	a1, 0xc88 <.Lpcrel_hi.1+0xa2c>
                	fmv.d	ft1, ft0
-               	j	0xec8 <.Lpcrel_hi.1+0xc1c>
+               	j	0xc90 <.Lpcrel_hi.1+0xa34>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	fmv.w.x	ft10, zero
-               	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xedc <.Lpcrel_hi.1+0xc30>
+               	flt.s	a2, fs2, ft10
+               	bnez	a2, 0xca4 <.Lpcrel_hi.1+0xa48>
                	fmv.d	ft2, fs2
-               	j	0xee4 <.Lpcrel_hi.1+0xc38>
+               	j	0xcac <.Lpcrel_hi.1+0xa50>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, fs2
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.s	a1, ft4, ft3
-               	bnez	a1, 0xf48 <.Lpcrel_hi.1+0xc9c>
+               	fle.s	a2, ft4, ft3
+               	bnez	a2, 0xd10 <.Lpcrel_hi.1+0xab4>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.s	a1, ft2, ft6
-               	bnez	a1, 0xf20 <.Lpcrel_hi.1+0xc74>
-               	bnez	a0, 0xf18 <.Lpcrel_hi.1+0xc6c>
+               	fle.s	a2, ft2, ft6
+               	bnez	a2, 0xce8 <.Lpcrel_hi.1+0xa8c>
+               	bnez	a1, 0xce0 <.Lpcrel_hi.1+0xa84>
                	fmv.d	ft7, ft5
-               	j	0xf1c <.Lpcrel_hi.1+0xc70>
+               	j	0xce4 <.Lpcrel_hi.1+0xa88>
                	fneg.s	ft7, ft5
-               	j	0xf6c <.Lpcrel_hi.1+0xcc0>
-               	fle.s	a1, ft6, ft5
-               	bnez	a1, 0xf30 <.Lpcrel_hi.1+0xc84>
+               	j	0xd34 <.Lpcrel_hi.1+0xad8>
+               	fle.s	a2, ft6, ft5
+               	bnez	a2, 0xcf8 <.Lpcrel_hi.1+0xa9c>
                	fmv.d	fa0, ft5
-               	j	0xf34 <.Lpcrel_hi.1+0xc88>
+               	j	0xcfc <.Lpcrel_hi.1+0xaa0>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xf04 <.Lpcrel_hi.1+0xc58>
+               	j	0xccc <.Lpcrel_hi.1+0xa70>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0xef4 <.Lpcrel_hi.1+0xc48>
+               	j	0xcbc <.Lpcrel_hi.1+0xa60>
                	fdiv.s	ft1, ft0, fs2
-               	fcvt.l.s	a0, ft1, rtz
-               	fcvt.s.l	ft1, a0
+               	fcvt.l.s	a1, ft1, rtz
+               	fcvt.s.l	ft1, a1
                	fmul.s	ft2, ft1, fs2
                	fsub.s	ft7, ft0, ft2
-               	feq.s	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xf90 <.Lpcrel_hi.1+0xce4>
-               	mv	a0, s2
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xcd4>
-               	mv	s1, a0
-               	j	0xfa4 <.Lpcrel_hi.1+0xcf8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xcec>
-               	mv	s1, a0
-               	mv	a0, s1
+               	jalr	ra <.Lpcrel_hi.1+0xadc>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	fld	fs0, 0x18(sp)
-               	fld	fs1, 0x10(sp)
-               	fld	fs2, 0x8(sp)
-               	fld	fs3, 0x0(sp)
+               	fld	fs0, 0x20(sp)
+               	fld	fs1, 0x18(sp)
+               	fld	fs2, 0x10(sp)
+               	fld	fs3, 0x8(sp)
                	ld	ra, 0x48(sp)
                	ld	s0, 0x40(sp)
                	addi	sp, sp, 0x50

--- a/test/golden/riscv64-linux/float/arith_f64.dis
+++ b/test/golden/riscv64-linux/float/arith_f64.dis
@@ -8,31 +8,50 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.arith_f64.fold64>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x50 <corpus.cases.float.arith_f64.fold64+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f64.fold64+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x70 <corpus.cases.float.arith_f64.fold64+0x64>
+               	fmv.x.d	a0, fa0
+               	mv	a2, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.float.arith_f64.fold64+0x28>
+               	j	0x68 <corpus.cases.float.arith_f64.fold64+0x5c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.float.arith_f64.fold64+0x28>
+               	mv	a0, a2
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f64.fold64+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x80 <corpus.cases.float.arith_f64.fold64+0x74>
+               	j	0xb8 <corpus.cases.float.arith_f64.fold64+0xac>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	li	t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x80 <corpus.cases.float.arith_f64.fold64+0x74>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.arith_f64.checksum>:
@@ -43,15 +62,11 @@ Disassembly of section .text:
                	sd	s1, 0x38(sp)
                	sd	s2, 0x30(sp)
                	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	fsd	fs0, 0x18(sp)
-               	fsd	fs1, 0x10(sp)
-               	fsd	fs2, 0x8(sp)
-               	fsd	fs3, 0x0(sp)
+               	fsd	fs0, 0x20(sp)
+               	fsd	fs1, 0x18(sp)
+               	fsd	fs2, 0x10(sp)
+               	fsd	fs3, 0x8(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f64.checksum+0x34>
-               	mv	s2, a0
                	lui	t1, 0x3ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -69,82 +84,45 @@ Disassembly of section .text:
                	fld	ft11, 0x0(t0)
                	fmul.d	fs2, ft11, fs0
                	fadd.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x108 <.Lpcrel_hi.1+0x30>
-               	mv	a0, s2
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x20>
-               	mv	s3, a0
-               	j	0x11c <.Lpcrel_hi.1+0x44>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x38>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.1+0x30>
                	fsub.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x140 <.Lpcrel_hi.1+0x68>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x58>
-               	mv	s2, a0
-               	j	0x154 <.Lpcrel_hi.1+0x7c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x70>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x3c>
                	fsub.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x178 <.Lpcrel_hi.1+0xa0>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x90>
-               	mv	s3, a0
-               	j	0x18c <.Lpcrel_hi.1+0xb4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa8>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.1+0x48>
                	fmul.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1b0 <.Lpcrel_hi.1+0xd8>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xc8>
-               	mv	s2, a0
-               	j	0x1c4 <.Lpcrel_hi.1+0xec>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xe0>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x54>
                	fdiv.d	fa0, fs1, fs2
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xf4>
+               	jalr	ra <.Lpcrel_hi.1+0x60>
                	fdiv.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x100>
+               	jalr	ra <.Lpcrel_hi.1+0x6c>
                	fneg.d	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x10c>
+               	jalr	ra <.Lpcrel_hi.1+0x78>
                	fmv.d.x	ft11, zero
                	fsub.d	fs2, ft11, fs1
                	fmv.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x120>
+               	jalr	ra <.Lpcrel_hi.1+0x8c>
                	fsub.d	fa0, fs1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x12c>
+               	jalr	ra <.Lpcrel_hi.1+0x98>
                	fadd.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x138>
+               	jalr	ra <.Lpcrel_hi.1+0xa4>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
@@ -211,33 +189,22 @@ Disassembly of section .text:
                	fmv.d	fs1, ft0
                	li	s3, 0x0
                	li	t0, 0x18
-               	bltu	s3, t0, 0x300 <.Lpcrel_hi.6+0x70>
-               	j	0x35c <.Lpcrel_hi.7+0x58>
+               	bltu	s3, t0, 0x2a8 <.Lpcrel_hi.6+0x70>
+               	j	0x2d8 <.Lpcrel_hi.7+0x2c>
                	fadd.d	ft0, fs1, fs2
 
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fmul.d	fs3, ft0, ft10
-               	feq.d	a0, fs3, fs3
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x334 <.Lpcrel_hi.7+0x30>
+               	fmul.d	fs1, ft0, ft10
                	mv	a0, s2
-               	fmv.d	fa0, fs3
+               	fmv.d	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x20>
-               	mv	s4, a0
-               	j	0x348 <.Lpcrel_hi.7+0x44>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x38>
-               	mv	s4, a0
+               	jalr	ra <.Lpcrel_hi.7+0x14>
                	addi	s3, s3, 0x1
-               	mv	s2, s4
-               	fmv.d	fs1, fs3
+               	mv	s2, a0
                	li	t0, 0x18
-               	bltu	s3, t0, 0x300 <.Lpcrel_hi.6+0x70>
+               	bltu	s3, t0, 0x2a8 <.Lpcrel_hi.6+0x70>
                	lui	t1, 0x7ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -245,71 +212,38 @@ Disassembly of section .text:
                	addi	t1, t1, -0x1
                	add	a0, t1, s1
                	fmv.d.x	fs1, a0
-               	feq.d	a0, fs1, fs1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x39c <.Lpcrel_hi.7+0x98>
                	mv	a0, s2
                	fmv.d	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x88>
-               	mv	s3, a0
-               	j	0x3b0 <.Lpcrel_hi.8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0xa0>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.7+0x50>
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	fa0, fs1, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3dc <.Lpcrel_hi.8+0x2c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x1c>
-               	mv	s2, a0
-               	j	0x3f0 <.Lpcrel_hi.8+0x40>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.8+0xc>
                	fadd.d	fa0, fs1, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x414 <.Lpcrel_hi.8+0x64>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x54>
-               	mv	s3, a0
-               	j	0x428 <.Lpcrel_hi.9>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x6c>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.8+0x18>
 
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fs2, fs1, ft10
-               	mv	a0, s3
                	fmv.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x14>
+               	jalr	ra <.Lpcrel_hi.9+0x10>
                	fmv.d.x	ft11, zero
                	fsub.d	fa0, ft11, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x24>
+               	jalr	ra <.Lpcrel_hi.9+0x20>
                	fmul.d	fa0, fs1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x30>
+               	jalr	ra <.Lpcrel_hi.9+0x2c>
                	fsub.d	fa0, fs1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x3c>
+               	jalr	ra <.Lpcrel_hi.9+0x38>
                	lui	t1, 0x10000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -365,7 +299,6 @@ Disassembly of section .text:
                	fdiv.d	fa0, fs2, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.14+0x18>
-               	mv	s1, a0
 
 <.Lpcrel_hi.15>:
                	auipc	t0, 0x0
@@ -377,34 +310,34 @@ Disassembly of section .text:
                	fld	ft11, 0x0(t0)
                	fmul.d	fs2, ft11, fs0
                	fmv.d.x	ft10, zero
-               	feq.d	a0, fs2, ft10
-               	bnez	a0, 0x570 <.Lpcrel_hi.17+0x28>
+               	feq.d	a1, fs2, ft10
+               	bnez	a1, 0x464 <.Lpcrel_hi.17+0x28>
 
 <.Lpcrel_hi.17>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs1, ft10
-               	feq.d	a1, fs1, ft0
-               	bnez	a1, 0x560 <.Lpcrel_hi.17+0x18>
-               	j	0x56c <.Lpcrel_hi.17+0x24>
+               	feq.d	a2, fs1, ft0
+               	bnez	a2, 0x454 <.Lpcrel_hi.17+0x18>
+               	j	0x460 <.Lpcrel_hi.17+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, fs1, ft10
-               	xori	a1, a1, 0x1
-               	j	0x574 <.Lpcrel_hi.17+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0x624 <.Lpcrel_hi.20+0x10>
+               	feq.d	a2, fs1, ft10
+               	xori	a2, a2, 0x1
+               	j	0x468 <.Lpcrel_hi.17+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0x518 <.Lpcrel_hi.20+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, fs1, ft10
-               	bnez	a0, 0x58c <.Lpcrel_hi.17+0x44>
+               	flt.d	a1, fs1, ft10
+               	bnez	a1, 0x480 <.Lpcrel_hi.17+0x44>
                	fmv.d	ft0, fs1
-               	j	0x594 <.Lpcrel_hi.17+0x4c>
+               	j	0x488 <.Lpcrel_hi.17+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs1
                	fmv.d.x	ft10, zero
-               	flt.d	a1, fs2, ft10
-               	bnez	a1, 0x5a8 <.Lpcrel_hi.17+0x60>
+               	flt.d	a2, fs2, ft10
+               	bnez	a2, 0x49c <.Lpcrel_hi.17+0x60>
                	fmv.d	ft1, fs2
-               	j	0x5b0 <.Lpcrel_hi.18>
+               	j	0x4a4 <.Lpcrel_hi.18>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
 
@@ -413,21 +346,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.d	a1, ft3, ft2
-               	bnez	a1, 0x614 <.Lpcrel_hi.20>
+               	fle.d	a2, ft3, ft2
+               	bnez	a2, 0x508 <.Lpcrel_hi.20>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.d	a1, ft1, ft5
-               	bnez	a1, 0x5ec <.Lpcrel_hi.18+0x3c>
-               	bnez	a0, 0x5e4 <.Lpcrel_hi.18+0x34>
+               	fle.d	a2, ft1, ft5
+               	bnez	a2, 0x4e0 <.Lpcrel_hi.18+0x3c>
+               	bnez	a1, 0x4d8 <.Lpcrel_hi.18+0x34>
                	fmv.d	ft6, ft4
-               	j	0x5e8 <.Lpcrel_hi.18+0x38>
+               	j	0x4dc <.Lpcrel_hi.18+0x38>
                	fneg.d	ft6, ft4
-               	j	0x638 <.Lpcrel_hi.20+0x24>
-               	fle.d	a1, ft5, ft4
-               	bnez	a1, 0x5fc <.Lpcrel_hi.18+0x4c>
+               	j	0x52c <.Lpcrel_hi.20+0x24>
+               	fle.d	a2, ft5, ft4
+               	bnez	a2, 0x4f0 <.Lpcrel_hi.18+0x4c>
                	fmv.d	ft7, ft4
-               	j	0x600 <.Lpcrel_hi.19>
+               	j	0x4f4 <.Lpcrel_hi.19>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.19>:
@@ -435,63 +368,52 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0x5d0 <.Lpcrel_hi.18+0x20>
+               	j	0x4c4 <.Lpcrel_hi.18+0x20>
 
 <.Lpcrel_hi.20>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0x5c0 <.Lpcrel_hi.18+0x10>
+               	j	0x4b4 <.Lpcrel_hi.18+0x10>
                	fdiv.d	ft0, fs1, fs2
-               	fcvt.l.d	a0, ft0, rtz
-               	fcvt.d.l	ft0, a0
+               	fcvt.l.d	a1, ft0, rtz
+               	fcvt.d.l	ft0, a1
                	fmul.d	ft1, ft0, fs2
                	fsub.d	ft6, fs1, ft1
-               	feq.d	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x65c <.Lpcrel_hi.20+0x48>
-               	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x38>
-               	mv	s2, a0
-               	j	0x670 <.Lpcrel_hi.20+0x5c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x50>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.20+0x28>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs1
                	fmv.d.x	ft10, zero
-               	feq.d	a0, fs2, ft10
-               	bnez	a0, 0x6ac <.Lpcrel_hi.21+0x28>
+               	feq.d	a1, fs2, ft10
+               	bnez	a1, 0x574 <.Lpcrel_hi.21+0x28>
 
 <.Lpcrel_hi.21>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
-               	feq.d	a1, ft0, ft1
-               	bnez	a1, 0x69c <.Lpcrel_hi.21+0x18>
-               	j	0x6a8 <.Lpcrel_hi.21+0x24>
+               	feq.d	a2, ft0, ft1
+               	bnez	a2, 0x564 <.Lpcrel_hi.21+0x18>
+               	j	0x570 <.Lpcrel_hi.21+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0x6b0 <.Lpcrel_hi.21+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0x760 <.Lpcrel_hi.24+0x10>
+               	feq.d	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x578 <.Lpcrel_hi.21+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0x628 <.Lpcrel_hi.24+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, ft0, ft10
-               	bnez	a0, 0x6c8 <.Lpcrel_hi.21+0x44>
+               	flt.d	a1, ft0, ft10
+               	bnez	a1, 0x590 <.Lpcrel_hi.21+0x44>
                	fmv.d	ft1, ft0
-               	j	0x6d0 <.Lpcrel_hi.21+0x4c>
+               	j	0x598 <.Lpcrel_hi.21+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
                	fmv.d.x	ft10, zero
-               	flt.d	a1, fs2, ft10
-               	bnez	a1, 0x6e4 <.Lpcrel_hi.21+0x60>
+               	flt.d	a2, fs2, ft10
+               	bnez	a2, 0x5ac <.Lpcrel_hi.21+0x60>
                	fmv.d	ft2, fs2
-               	j	0x6ec <.Lpcrel_hi.22>
+               	j	0x5b4 <.Lpcrel_hi.22>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, fs2
 
@@ -500,21 +422,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.d	a1, ft4, ft3
-               	bnez	a1, 0x750 <.Lpcrel_hi.24>
+               	fle.d	a2, ft4, ft3
+               	bnez	a2, 0x618 <.Lpcrel_hi.24>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.d	a1, ft2, ft6
-               	bnez	a1, 0x728 <.Lpcrel_hi.22+0x3c>
-               	bnez	a0, 0x720 <.Lpcrel_hi.22+0x34>
+               	fle.d	a2, ft2, ft6
+               	bnez	a2, 0x5f0 <.Lpcrel_hi.22+0x3c>
+               	bnez	a1, 0x5e8 <.Lpcrel_hi.22+0x34>
                	fmv.d	ft7, ft5
-               	j	0x724 <.Lpcrel_hi.22+0x38>
+               	j	0x5ec <.Lpcrel_hi.22+0x38>
                	fneg.d	ft7, ft5
-               	j	0x774 <.Lpcrel_hi.24+0x24>
-               	fle.d	a1, ft6, ft5
-               	bnez	a1, 0x738 <.Lpcrel_hi.22+0x4c>
+               	j	0x63c <.Lpcrel_hi.24+0x24>
+               	fle.d	a2, ft6, ft5
+               	bnez	a2, 0x600 <.Lpcrel_hi.22+0x4c>
                	fmv.d	fa0, ft5
-               	j	0x73c <.Lpcrel_hi.23>
+               	j	0x604 <.Lpcrel_hi.23>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.23>:
@@ -522,63 +444,52 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x70c <.Lpcrel_hi.22+0x20>
+               	j	0x5d4 <.Lpcrel_hi.22+0x20>
 
 <.Lpcrel_hi.24>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0x6fc <.Lpcrel_hi.22+0x10>
+               	j	0x5c4 <.Lpcrel_hi.22+0x10>
                	fdiv.d	ft1, ft0, fs2
-               	fcvt.l.d	a0, ft1, rtz
-               	fcvt.d.l	ft1, a0
+               	fcvt.l.d	a1, ft1, rtz
+               	fcvt.d.l	ft1, a1
                	fmul.d	ft2, ft1, fs2
                	fsub.d	ft7, ft0, ft2
-               	feq.d	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x798 <.Lpcrel_hi.24+0x48>
-               	mv	a0, s2
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x38>
-               	mv	s1, a0
-               	j	0x7ac <.Lpcrel_hi.24+0x5c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.24+0x50>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.24+0x28>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs2
                	fmv.d.x	ft10, zero
-               	feq.d	a0, ft0, ft10
-               	bnez	a0, 0x7e8 <.Lpcrel_hi.25+0x28>
+               	feq.d	a1, ft0, ft10
+               	bnez	a1, 0x684 <.Lpcrel_hi.25+0x28>
 
 <.Lpcrel_hi.25>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, fs1, ft10
-               	feq.d	a1, fs1, ft1
-               	bnez	a1, 0x7d8 <.Lpcrel_hi.25+0x18>
-               	j	0x7e4 <.Lpcrel_hi.25+0x24>
+               	feq.d	a2, fs1, ft1
+               	bnez	a2, 0x674 <.Lpcrel_hi.25+0x18>
+               	j	0x680 <.Lpcrel_hi.25+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, fs1, ft10
-               	xori	a1, a1, 0x1
-               	j	0x7ec <.Lpcrel_hi.25+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0x89c <.Lpcrel_hi.28+0x10>
+               	feq.d	a2, fs1, ft10
+               	xori	a2, a2, 0x1
+               	j	0x688 <.Lpcrel_hi.25+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0x738 <.Lpcrel_hi.28+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, fs1, ft10
-               	bnez	a0, 0x804 <.Lpcrel_hi.25+0x44>
+               	flt.d	a1, fs1, ft10
+               	bnez	a1, 0x6a0 <.Lpcrel_hi.25+0x44>
                	fmv.d	ft1, fs1
-               	j	0x80c <.Lpcrel_hi.25+0x4c>
+               	j	0x6a8 <.Lpcrel_hi.25+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs1
                	fmv.d.x	ft10, zero
-               	flt.d	a1, ft0, ft10
-               	bnez	a1, 0x820 <.Lpcrel_hi.25+0x60>
+               	flt.d	a2, ft0, ft10
+               	bnez	a2, 0x6bc <.Lpcrel_hi.25+0x60>
                	fmv.d	ft2, ft0
-               	j	0x828 <.Lpcrel_hi.26>
+               	j	0x6c4 <.Lpcrel_hi.26>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, ft0
 
@@ -587,21 +498,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.d	a1, ft4, ft3
-               	bnez	a1, 0x88c <.Lpcrel_hi.28>
+               	fle.d	a2, ft4, ft3
+               	bnez	a2, 0x728 <.Lpcrel_hi.28>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.d	a1, ft2, ft6
-               	bnez	a1, 0x864 <.Lpcrel_hi.26+0x3c>
-               	bnez	a0, 0x85c <.Lpcrel_hi.26+0x34>
+               	fle.d	a2, ft2, ft6
+               	bnez	a2, 0x700 <.Lpcrel_hi.26+0x3c>
+               	bnez	a1, 0x6f8 <.Lpcrel_hi.26+0x34>
                	fmv.d	ft7, ft5
-               	j	0x860 <.Lpcrel_hi.26+0x38>
+               	j	0x6fc <.Lpcrel_hi.26+0x38>
                	fneg.d	ft7, ft5
-               	j	0x8b0 <.Lpcrel_hi.28+0x24>
-               	fle.d	a1, ft6, ft5
-               	bnez	a1, 0x874 <.Lpcrel_hi.26+0x4c>
+               	j	0x74c <.Lpcrel_hi.28+0x24>
+               	fle.d	a2, ft6, ft5
+               	bnez	a2, 0x710 <.Lpcrel_hi.26+0x4c>
                	fmv.d	fa0, ft5
-               	j	0x878 <.Lpcrel_hi.27>
+               	j	0x714 <.Lpcrel_hi.27>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.27>:
@@ -609,65 +520,54 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x848 <.Lpcrel_hi.26+0x20>
+               	j	0x6e4 <.Lpcrel_hi.26+0x20>
 
 <.Lpcrel_hi.28>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0x838 <.Lpcrel_hi.26+0x10>
+               	j	0x6d4 <.Lpcrel_hi.26+0x10>
                	fdiv.d	ft1, fs1, ft0
-               	fcvt.l.d	a0, ft1, rtz
-               	fcvt.d.l	ft1, a0
+               	fcvt.l.d	a1, ft1, rtz
+               	fcvt.d.l	ft1, a1
                	fmul.d	ft2, ft1, ft0
                	fsub.d	ft7, fs1, ft2
-               	feq.d	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8d4 <.Lpcrel_hi.28+0x48>
-               	mv	a0, s1
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.28+0x38>
-               	mv	s2, a0
-               	j	0x8e8 <.Lpcrel_hi.28+0x5c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.28+0x50>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.28+0x28>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs1
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
                	fmv.d.x	ft10, zero
-               	feq.d	a0, ft1, ft10
-               	bnez	a0, 0x92c <.Lpcrel_hi.29+0x28>
+               	feq.d	a1, ft1, ft10
+               	bnez	a1, 0x79c <.Lpcrel_hi.29+0x28>
 
 <.Lpcrel_hi.29>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft2, ft0, ft10
-               	feq.d	a1, ft0, ft2
-               	bnez	a1, 0x91c <.Lpcrel_hi.29+0x18>
-               	j	0x928 <.Lpcrel_hi.29+0x24>
+               	feq.d	a2, ft0, ft2
+               	bnez	a2, 0x78c <.Lpcrel_hi.29+0x18>
+               	j	0x798 <.Lpcrel_hi.29+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0x930 <.Lpcrel_hi.29+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0x9e0 <.Lpcrel_hi.32+0x10>
+               	feq.d	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x7a0 <.Lpcrel_hi.29+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0x850 <.Lpcrel_hi.32+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, ft0, ft10
-               	bnez	a0, 0x948 <.Lpcrel_hi.29+0x44>
+               	flt.d	a1, ft0, ft10
+               	bnez	a1, 0x7b8 <.Lpcrel_hi.29+0x44>
                	fmv.d	ft2, ft0
-               	j	0x950 <.Lpcrel_hi.29+0x4c>
+               	j	0x7c0 <.Lpcrel_hi.29+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, ft0
                	fmv.d.x	ft10, zero
-               	flt.d	a1, ft1, ft10
-               	bnez	a1, 0x964 <.Lpcrel_hi.29+0x60>
+               	flt.d	a2, ft1, ft10
+               	bnez	a2, 0x7d4 <.Lpcrel_hi.29+0x60>
                	fmv.d	ft3, ft1
-               	j	0x96c <.Lpcrel_hi.30>
+               	j	0x7dc <.Lpcrel_hi.30>
                	fmv.d.x	ft11, zero
                	fsub.d	ft3, ft11, ft1
 
@@ -676,21 +576,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft4, ft2, ft10
                	fmv.d	ft5, ft3
-               	fle.d	a1, ft5, ft4
-               	bnez	a1, 0x9d0 <.Lpcrel_hi.32>
+               	fle.d	a2, ft5, ft4
+               	bnez	a2, 0x840 <.Lpcrel_hi.32>
                	fmv.d	ft6, ft2
                	fmv.d	ft7, ft5
-               	fle.d	a1, ft3, ft7
-               	bnez	a1, 0x9a8 <.Lpcrel_hi.30+0x3c>
-               	bnez	a0, 0x9a0 <.Lpcrel_hi.30+0x34>
+               	fle.d	a2, ft3, ft7
+               	bnez	a2, 0x818 <.Lpcrel_hi.30+0x3c>
+               	bnez	a1, 0x810 <.Lpcrel_hi.30+0x34>
                	fmv.d	fa0, ft6
-               	j	0x9a4 <.Lpcrel_hi.30+0x38>
+               	j	0x814 <.Lpcrel_hi.30+0x38>
                	fneg.d	fa0, ft6
-               	j	0x9f4 <.Lpcrel_hi.32+0x24>
-               	fle.d	a1, ft7, ft6
-               	bnez	a1, 0x9b8 <.Lpcrel_hi.30+0x4c>
+               	j	0x864 <.Lpcrel_hi.32+0x24>
+               	fle.d	a2, ft7, ft6
+               	bnez	a2, 0x828 <.Lpcrel_hi.30+0x4c>
                	fmv.d	fa1, ft6
-               	j	0x9bc <.Lpcrel_hi.31>
+               	j	0x82c <.Lpcrel_hi.31>
                	fsub.d	fa1, ft6, ft7
 
 <.Lpcrel_hi.31>:
@@ -698,31 +598,20 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft7, ft7, ft10
                	fmv.d	ft6, fa1
-               	j	0x98c <.Lpcrel_hi.30+0x20>
+               	j	0x7fc <.Lpcrel_hi.30+0x20>
 
 <.Lpcrel_hi.32>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft5, ft5, ft10
-               	j	0x97c <.Lpcrel_hi.30+0x10>
+               	j	0x7ec <.Lpcrel_hi.30+0x10>
                	fdiv.d	ft2, ft0, ft1
-               	fcvt.l.d	a0, ft2, rtz
-               	fcvt.d.l	ft2, a0
+               	fcvt.l.d	a1, ft2, rtz
+               	fcvt.d.l	ft2, a1
                	fmul.d	ft3, ft2, ft1
                	fsub.d	fa0, ft0, ft3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa14 <.Lpcrel_hi.32+0x44>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x34>
-               	mv	s1, a0
-               	j	0xa28 <.Lpcrel_hi.33>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.32+0x4c>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.32+0x24>
 
 <.Lpcrel_hi.33>:
                	auipc	t0, 0x0
@@ -733,18 +622,18 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
-               	feq.d	a0, ft0, ft1
-               	bnez	a0, 0xa4c <.Lpcrel_hi.34+0x18>
-               	j	0xa58 <.Lpcrel_hi.34+0x24>
+               	feq.d	a1, ft0, ft1
+               	bnez	a1, 0x890 <.Lpcrel_hi.34+0x18>
+               	j	0x89c <.Lpcrel_hi.34+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a0, ft0, ft10
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xaf8 <.Lpcrel_hi.40>
+               	feq.d	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	bnez	a1, 0x93c <.Lpcrel_hi.40>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, ft0, ft10
-               	bnez	a0, 0xa70 <.Lpcrel_hi.34+0x3c>
+               	flt.d	a1, ft0, ft10
+               	bnez	a1, 0x8b4 <.Lpcrel_hi.34+0x3c>
                	fmv.d	ft1, ft0
-               	j	0xa78 <.Lpcrel_hi.35>
+               	j	0x8bc <.Lpcrel_hi.35>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
 
@@ -756,25 +645,25 @@ Disassembly of section .text:
 <.Lpcrel_hi.36>:
                	auipc	t0, 0x0
                	fld	ft3, 0x0(t0)
-               	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xae8 <.Lpcrel_hi.39>
+               	fle.d	a2, ft3, ft2
+               	bnez	a2, 0x92c <.Lpcrel_hi.39>
                	fmv.d	ft4, ft1
                	fmv.d	ft5, ft3
 
 <.Lpcrel_hi.37>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fle.d	a1, ft11, ft5
-               	bnez	a1, 0xac0 <.Lpcrel_hi.37+0x24>
-               	bnez	a0, 0xab8 <.Lpcrel_hi.37+0x1c>
+               	fle.d	a2, ft11, ft5
+               	bnez	a2, 0x904 <.Lpcrel_hi.37+0x24>
+               	bnez	a1, 0x8fc <.Lpcrel_hi.37+0x1c>
                	fmv.d	ft6, ft4
-               	j	0xabc <.Lpcrel_hi.37+0x20>
+               	j	0x900 <.Lpcrel_hi.37+0x20>
                	fneg.d	ft6, ft4
-               	j	0xb1c <.Lpcrel_hi.41+0x10>
-               	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xad0 <.Lpcrel_hi.37+0x34>
+               	j	0x960 <.Lpcrel_hi.41+0x10>
+               	fle.d	a2, ft5, ft4
+               	bnez	a2, 0x914 <.Lpcrel_hi.37+0x34>
                	fmv.d	ft7, ft4
-               	j	0xad4 <.Lpcrel_hi.38>
+               	j	0x918 <.Lpcrel_hi.38>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.38>:
@@ -782,69 +671,58 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xa9c <.Lpcrel_hi.37>
+               	j	0x8e0 <.Lpcrel_hi.37>
 
 <.Lpcrel_hi.39>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xa8c <.Lpcrel_hi.36+0x8>
+               	j	0x8d0 <.Lpcrel_hi.36+0x8>
 
 <.Lpcrel_hi.40>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft1, ft0, ft10
-               	fcvt.l.d	a0, ft1, rtz
-               	fcvt.d.l	ft1, a0
+               	fcvt.l.d	a1, ft1, rtz
+               	fcvt.d.l	ft1, a1
 
 <.Lpcrel_hi.41>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft2, ft1, ft10
                	fsub.d	ft6, ft0, ft2
-               	feq.d	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb40 <.Lpcrel_hi.41+0x34>
-               	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.41+0x24>
-               	mv	s2, a0
-               	j	0xb54 <.Lpcrel_hi.41+0x48>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.41+0x3c>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.41+0x14>
                	fmv.d.x	ft10, zero
-               	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xb88 <.Lpcrel_hi.42+0x28>
+               	feq.d	a1, fs2, ft10
+               	bnez	a1, 0x9a0 <.Lpcrel_hi.42+0x28>
 
 <.Lpcrel_hi.42>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs0, ft10
-               	feq.d	a1, fs0, ft0
-               	bnez	a1, 0xb78 <.Lpcrel_hi.42+0x18>
-               	j	0xb84 <.Lpcrel_hi.42+0x24>
+               	feq.d	a2, fs0, ft0
+               	bnez	a2, 0x990 <.Lpcrel_hi.42+0x18>
+               	j	0x99c <.Lpcrel_hi.42+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, fs0, ft10
-               	xori	a1, a1, 0x1
-               	j	0xb8c <.Lpcrel_hi.42+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0xc3c <.Lpcrel_hi.45+0x10>
+               	feq.d	a2, fs0, ft10
+               	xori	a2, a2, 0x1
+               	j	0x9a4 <.Lpcrel_hi.42+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0xa54 <.Lpcrel_hi.45+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, fs0, ft10
-               	bnez	a0, 0xba4 <.Lpcrel_hi.42+0x44>
+               	flt.d	a1, fs0, ft10
+               	bnez	a1, 0x9bc <.Lpcrel_hi.42+0x44>
                	fmv.d	ft0, fs0
-               	j	0xbac <.Lpcrel_hi.42+0x4c>
+               	j	0x9c4 <.Lpcrel_hi.42+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs0
                	fmv.d.x	ft10, zero
-               	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xbc0 <.Lpcrel_hi.42+0x60>
+               	flt.d	a2, fs2, ft10
+               	bnez	a2, 0x9d8 <.Lpcrel_hi.42+0x60>
                	fmv.d	ft1, fs2
-               	j	0xbc8 <.Lpcrel_hi.43>
+               	j	0x9e0 <.Lpcrel_hi.43>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
 
@@ -853,21 +731,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xc2c <.Lpcrel_hi.45>
+               	fle.d	a2, ft3, ft2
+               	bnez	a2, 0xa44 <.Lpcrel_hi.45>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.d	a1, ft1, ft5
-               	bnez	a1, 0xc04 <.Lpcrel_hi.43+0x3c>
-               	bnez	a0, 0xbfc <.Lpcrel_hi.43+0x34>
+               	fle.d	a2, ft1, ft5
+               	bnez	a2, 0xa1c <.Lpcrel_hi.43+0x3c>
+               	bnez	a1, 0xa14 <.Lpcrel_hi.43+0x34>
                	fmv.d	ft6, ft4
-               	j	0xc00 <.Lpcrel_hi.43+0x38>
+               	j	0xa18 <.Lpcrel_hi.43+0x38>
                	fneg.d	ft6, ft4
-               	j	0xc50 <.Lpcrel_hi.45+0x24>
-               	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xc14 <.Lpcrel_hi.43+0x4c>
+               	j	0xa68 <.Lpcrel_hi.45+0x24>
+               	fle.d	a2, ft5, ft4
+               	bnez	a2, 0xa2c <.Lpcrel_hi.43+0x4c>
                	fmv.d	ft7, ft4
-               	j	0xc18 <.Lpcrel_hi.44>
+               	j	0xa30 <.Lpcrel_hi.44>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.44>:
@@ -875,61 +753,50 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xbe8 <.Lpcrel_hi.43+0x20>
+               	j	0xa00 <.Lpcrel_hi.43+0x20>
 
 <.Lpcrel_hi.45>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xbd8 <.Lpcrel_hi.43+0x10>
+               	j	0x9f0 <.Lpcrel_hi.43+0x10>
                	fdiv.d	ft0, fs0, fs2
-               	fcvt.l.d	a0, ft0, rtz
-               	fcvt.d.l	ft0, a0
+               	fcvt.l.d	a1, ft0, rtz
+               	fcvt.d.l	ft0, a1
                	fmul.d	ft1, ft0, fs2
                	fsub.d	ft6, fs0, ft1
-               	feq.d	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xc74 <.Lpcrel_hi.45+0x48>
-               	mv	a0, s2
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.45+0x38>
-               	mv	s1, a0
-               	j	0xc88 <.Lpcrel_hi.45+0x5c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.45+0x50>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.45+0x28>
                	fmv.d.x	ft10, zero
-               	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xcbc <.Lpcrel_hi.46+0x28>
+               	feq.d	a1, fs2, ft10
+               	bnez	a1, 0xaa8 <.Lpcrel_hi.46+0x28>
 
 <.Lpcrel_hi.46>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs2, ft10
-               	feq.d	a1, fs2, ft0
-               	bnez	a1, 0xcac <.Lpcrel_hi.46+0x18>
-               	j	0xcb8 <.Lpcrel_hi.46+0x24>
+               	feq.d	a2, fs2, ft0
+               	bnez	a2, 0xa98 <.Lpcrel_hi.46+0x18>
+               	j	0xaa4 <.Lpcrel_hi.46+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, fs2, ft10
-               	xori	a1, a1, 0x1
-               	j	0xcc0 <.Lpcrel_hi.46+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0xd70 <.Lpcrel_hi.49+0x10>
+               	feq.d	a2, fs2, ft10
+               	xori	a2, a2, 0x1
+               	j	0xaac <.Lpcrel_hi.46+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0xb5c <.Lpcrel_hi.49+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, fs2, ft10
-               	bnez	a0, 0xcd8 <.Lpcrel_hi.46+0x44>
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0xac4 <.Lpcrel_hi.46+0x44>
                	fmv.d	ft0, fs2
-               	j	0xce0 <.Lpcrel_hi.46+0x4c>
+               	j	0xacc <.Lpcrel_hi.46+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs2
                	fmv.d.x	ft10, zero
-               	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xcf4 <.Lpcrel_hi.46+0x60>
+               	flt.d	a2, fs2, ft10
+               	bnez	a2, 0xae0 <.Lpcrel_hi.46+0x60>
                	fmv.d	ft1, fs2
-               	j	0xcfc <.Lpcrel_hi.47>
+               	j	0xae8 <.Lpcrel_hi.47>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
 
@@ -938,21 +805,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
-               	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xd60 <.Lpcrel_hi.49>
+               	fle.d	a2, ft3, ft2
+               	bnez	a2, 0xb4c <.Lpcrel_hi.49>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
-               	fle.d	a1, ft1, ft5
-               	bnez	a1, 0xd38 <.Lpcrel_hi.47+0x3c>
-               	bnez	a0, 0xd30 <.Lpcrel_hi.47+0x34>
+               	fle.d	a2, ft1, ft5
+               	bnez	a2, 0xb24 <.Lpcrel_hi.47+0x3c>
+               	bnez	a1, 0xb1c <.Lpcrel_hi.47+0x34>
                	fmv.d	ft6, ft4
-               	j	0xd34 <.Lpcrel_hi.47+0x38>
+               	j	0xb20 <.Lpcrel_hi.47+0x38>
                	fneg.d	ft6, ft4
-               	j	0xd84 <.Lpcrel_hi.49+0x24>
-               	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xd48 <.Lpcrel_hi.47+0x4c>
+               	j	0xb70 <.Lpcrel_hi.49+0x24>
+               	fle.d	a2, ft5, ft4
+               	bnez	a2, 0xb34 <.Lpcrel_hi.47+0x4c>
                	fmv.d	ft7, ft4
-               	j	0xd4c <.Lpcrel_hi.48>
+               	j	0xb38 <.Lpcrel_hi.48>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.48>:
@@ -960,66 +827,55 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xd1c <.Lpcrel_hi.47+0x20>
+               	j	0xb08 <.Lpcrel_hi.47+0x20>
 
 <.Lpcrel_hi.49>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xd0c <.Lpcrel_hi.47+0x10>
+               	j	0xaf8 <.Lpcrel_hi.47+0x10>
                	fdiv.d	ft0, fs2, fs2
-               	fcvt.l.d	a0, ft0, rtz
-               	fcvt.d.l	ft0, a0
+               	fcvt.l.d	a1, ft0, rtz
+               	fcvt.d.l	ft0, a1
                	fmul.d	ft1, ft0, fs2
                	fsub.d	ft6, fs2, ft1
-               	feq.d	a0, ft6, ft6
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xda8 <.Lpcrel_hi.49+0x48>
-               	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.49+0x38>
-               	mv	s2, a0
-               	j	0xdbc <.Lpcrel_hi.50>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.49+0x50>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.49+0x28>
 
 <.Lpcrel_hi.50>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fmul.d	ft0, ft11, fs0
                	fmv.d.x	ft10, zero
-               	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xdfc <.Lpcrel_hi.51+0x28>
+               	feq.d	a1, fs2, ft10
+               	bnez	a1, 0xbbc <.Lpcrel_hi.51+0x28>
 
 <.Lpcrel_hi.51>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
-               	feq.d	a1, ft0, ft1
-               	bnez	a1, 0xdec <.Lpcrel_hi.51+0x18>
-               	j	0xdf8 <.Lpcrel_hi.51+0x24>
+               	feq.d	a2, ft0, ft1
+               	bnez	a2, 0xbac <.Lpcrel_hi.51+0x18>
+               	j	0xbb8 <.Lpcrel_hi.51+0x24>
                	fmv.d.x	ft10, zero
-               	feq.d	a1, ft0, ft10
-               	xori	a1, a1, 0x1
-               	j	0xe00 <.Lpcrel_hi.51+0x2c>
-               	mv	a1, a0
-               	bnez	a1, 0xeb0 <.Lpcrel_hi.54+0x10>
+               	feq.d	a2, ft0, ft10
+               	xori	a2, a2, 0x1
+               	j	0xbc0 <.Lpcrel_hi.51+0x2c>
+               	mv	a2, a1
+               	bnez	a2, 0xc70 <.Lpcrel_hi.54+0x10>
                	fmv.d.x	ft10, zero
-               	flt.d	a0, ft0, ft10
-               	bnez	a0, 0xe18 <.Lpcrel_hi.51+0x44>
+               	flt.d	a1, ft0, ft10
+               	bnez	a1, 0xbd8 <.Lpcrel_hi.51+0x44>
                	fmv.d	ft1, ft0
-               	j	0xe20 <.Lpcrel_hi.51+0x4c>
+               	j	0xbe0 <.Lpcrel_hi.51+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
                	fmv.d.x	ft10, zero
-               	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xe34 <.Lpcrel_hi.51+0x60>
+               	flt.d	a2, fs2, ft10
+               	bnez	a2, 0xbf4 <.Lpcrel_hi.51+0x60>
                	fmv.d	ft2, fs2
-               	j	0xe3c <.Lpcrel_hi.52>
+               	j	0xbfc <.Lpcrel_hi.52>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, fs2
 
@@ -1028,21 +884,21 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
-               	fle.d	a1, ft4, ft3
-               	bnez	a1, 0xea0 <.Lpcrel_hi.54>
+               	fle.d	a2, ft4, ft3
+               	bnez	a2, 0xc60 <.Lpcrel_hi.54>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
-               	fle.d	a1, ft2, ft6
-               	bnez	a1, 0xe78 <.Lpcrel_hi.52+0x3c>
-               	bnez	a0, 0xe70 <.Lpcrel_hi.52+0x34>
+               	fle.d	a2, ft2, ft6
+               	bnez	a2, 0xc38 <.Lpcrel_hi.52+0x3c>
+               	bnez	a1, 0xc30 <.Lpcrel_hi.52+0x34>
                	fmv.d	ft7, ft5
-               	j	0xe74 <.Lpcrel_hi.52+0x38>
+               	j	0xc34 <.Lpcrel_hi.52+0x38>
                	fneg.d	ft7, ft5
-               	j	0xec4 <.Lpcrel_hi.54+0x24>
-               	fle.d	a1, ft6, ft5
-               	bnez	a1, 0xe88 <.Lpcrel_hi.52+0x4c>
+               	j	0xc84 <.Lpcrel_hi.54+0x24>
+               	fle.d	a2, ft6, ft5
+               	bnez	a2, 0xc48 <.Lpcrel_hi.52+0x4c>
                	fmv.d	fa0, ft5
-               	j	0xe8c <.Lpcrel_hi.53>
+               	j	0xc4c <.Lpcrel_hi.53>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.53>:
@@ -1050,41 +906,28 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xe5c <.Lpcrel_hi.52+0x20>
+               	j	0xc1c <.Lpcrel_hi.52+0x20>
 
 <.Lpcrel_hi.54>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0xe4c <.Lpcrel_hi.52+0x10>
+               	j	0xc0c <.Lpcrel_hi.52+0x10>
                	fdiv.d	ft1, ft0, fs2
-               	fcvt.l.d	a0, ft1, rtz
-               	fcvt.d.l	ft1, a0
+               	fcvt.l.d	a1, ft1, rtz
+               	fcvt.d.l	ft1, a1
                	fmul.d	ft2, ft1, fs2
                	fsub.d	ft7, ft0, ft2
-               	feq.d	a0, ft7, ft7
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xee8 <.Lpcrel_hi.54+0x48>
-               	mv	a0, s2
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.54+0x38>
-               	mv	s1, a0
-               	j	0xefc <.Lpcrel_hi.54+0x5c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.54+0x50>
-               	mv	s1, a0
-               	mv	a0, s1
+               	jalr	ra <.Lpcrel_hi.54+0x28>
                	ld	s1, 0x38(sp)
                	ld	s2, 0x30(sp)
                	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	fld	fs0, 0x18(sp)
-               	fld	fs1, 0x10(sp)
-               	fld	fs2, 0x8(sp)
-               	fld	fs3, 0x0(sp)
+               	fld	fs0, 0x20(sp)
+               	fld	fs1, 0x18(sp)
+               	fld	fs2, 0x10(sp)
+               	fld	fs3, 0x8(sp)
                	ld	ra, 0x48(sp)
                	ld	s0, 0x40(sp)
                	addi	sp, sp, 0x50

--- a/test/golden/riscv64-linux/float/cmp_f32.dis
+++ b/test/golden/riscv64-linux/float/cmp_f32.dis
@@ -3,381 +3,575 @@ float/cmp_f32.o:
 Disassembly of section .text:
 
 <corpus.cases.float.cmp_f32.fold32>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.s	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x44 <corpus.cases.float.cmp_f32.fold32+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.fold32+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x68 <corpus.cases.float.cmp_f32.fold32+0x68>
+               	fmv.x.w	a0, fa0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a0, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x30 <corpus.cases.float.cmp_f32.fold32+0x30>
+               	j	0x64 <corpus.cases.float.cmp_f32.fold32+0x64>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x30 <corpus.cases.float.cmp_f32.fold32+0x30>
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.fold32+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x78 <corpus.cases.float.cmp_f32.fold32+0x78>
+               	j	0xb8 <corpus.cases.float.cmp_f32.fold32+0xb8>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x100
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x78 <corpus.cases.float.cmp_f32.fold32+0x78>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.cmp_f32.checksum>:
-               	addi	sp, sp, -0x90
-               	sd	ra, 0x88(sp)
-               	sd	s0, 0x80(sp)
-               	addi	s0, sp, 0x90
-               	sd	s1, 0x78(sp)
-               	sd	s2, 0x70(sp)
-               	sd	s3, 0x68(sp)
-               	sd	s4, 0x60(sp)
-               	sd	s5, 0x58(sp)
-               	sd	s6, 0x50(sp)
-               	sd	s7, 0x48(sp)
-               	fsd	fs0, 0x40(sp)
-               	fsd	fs1, 0x38(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x38>
-               	sext.w	a1, s1
-               	addi	s1, s0, -0x88
-               	mv	a2, s1
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	sd	s1, 0x38(sp)
+               	fsd	fs0, 0x30(sp)
+               	sext.w	a1, a0
+               	addi	s1, s0, -0x50
+               	mv	a0, s1
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0xe0 <corpus.cases.float.cmp_f32.checksum+0x78>
-               	mv	a3, a2
-               	li	a4, 0x30
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a2, a0, t0
+               	bnez	a2, 0x110 <corpus.cases.float.cmp_f32.checksum+0x50>
+               	mv	a2, a0
+               	li	a3, 0x30
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0xc8 <corpus.cases.float.cmp_f32.checksum+0x60>
-               	j	0xfc <corpus.cases.float.cmp_f32.checksum+0x94>
-               	mv	a3, a2
-               	li	a2, 0x30
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a3, t0, 0xf8 <corpus.cases.float.cmp_f32.checksum+0x38>
+               	j	0x12c <corpus.cases.float.cmp_f32.checksum+0x6c>
+               	mv	a2, a0
+               	li	a0, 0x30
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xe8 <corpus.cases.float.cmp_f32.checksum+0x80>
+               	bne	a0, t0, 0x118 <corpus.cases.float.cmp_f32.checksum+0x58>
                	lui	t1, 0xff800
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	mv	a2, s1
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	mv	a0, s1
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0xbf800
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x4
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x4
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x80800
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x8
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x8
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x80000
                	addiw	t1, t1, 0x1
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0xc
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0xc
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x80000
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x10
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x10
+               	fsw	ft0, 0x0(a0)
                	fmv.w.x	ft0, a1
-               	addi	a2, s1, 0x14
-               	fsw	ft0, 0x0(a2)
+               	addi	a0, s1, 0x14
+               	fsw	ft0, 0x0(a0)
                	li	t1, 0x1
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x18
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x18
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x3f800
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x1c
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x1c
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7f800
                	addiw	t1, t1, -0x1
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x20
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x20
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7f800
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x24
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x24
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7fc00
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a2, s1, 0x28
-               	fsw	ft0, 0x0(a2)
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x28
+               	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7f800
                	addiw	t1, t1, 0x1
-               	addw	a2, t1, a1
-               	fmv.w.x	ft0, a2
-               	addi	a1, s1, 0x2c
-               	fsw	ft0, 0x0(a1)
-               	mv	s2, a0
-               	li	s3, 0x0
-               	li	t0, 0xc
-               	bltu	s3, t0, 0x204 <corpus.cases.float.cmp_f32.checksum+0x19c>
-               	j	0x3d4 <corpus.cases.float.cmp_f32.checksum+0x36c>
-               	slli	a0, s3, 0x20
-               	srli	a0, a0, 0x20
-               	slli	t0, a0, 0x2
-               	add	s4, s1, t0
-               	mv	s5, s2
-               	li	s6, 0x0
-               	li	t0, 0xc
-               	bltu	s6, t0, 0x228 <corpus.cases.float.cmp_f32.checksum+0x1c0>
-               	j	0x3c4 <corpus.cases.float.cmp_f32.checksum+0x35c>
-               	flw	fs0, 0x0(s4)
-               	slli	a0, s6, 0x20
-               	srli	a0, a0, 0x20
-               	slli	t0, a0, 0x2
-               	add	a1, s1, t0
-               	flw	fs1, 0x0(a1)
-               	feq.s	a1, fs0, fs1
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x1e0>
-               	feq.s	a1, fs0, fs1
-               	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x1f0>
-               	flt.s	s7, fs0, fs1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x200>
-               	fle.s	a1, fs0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x20c>
-               	flt.s	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x218>
-               	fle.s	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x224>
-               	bnez	s7, 0x2a0 <corpus.cases.float.cmp_f32.checksum+0x238>
+               	addw	a0, t1, a1
+               	fmv.w.x	ft0, a0
+               	addi	a0, s1, 0x2c
+               	fsw	ft0, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	li	a1, 0x0
-               	j	0x2a4 <corpus.cases.float.cmp_f32.checksum+0x23c>
-               	li	a1, 0x1
-               	fle.s	a2, fs0, fs1
-               	bnez	a2, 0x2b4 <corpus.cases.float.cmp_f32.checksum+0x24c>
-               	mv	a2, a1
-               	j	0x2b8 <corpus.cases.float.cmp_f32.checksum+0x250>
-               	addiw	a2, a1, 0x2
-               	flt.s	a1, fs1, fs0
-               	bnez	a1, 0x2c8 <corpus.cases.float.cmp_f32.checksum+0x260>
-               	mv	a1, a2
-               	j	0x2cc <corpus.cases.float.cmp_f32.checksum+0x264>
-               	addiw	a1, a2, 0x4
-               	fle.s	a2, fs1, fs0
-               	bnez	a2, 0x2dc <corpus.cases.float.cmp_f32.checksum+0x274>
-               	mv	a2, a1
-               	j	0x2e0 <corpus.cases.float.cmp_f32.checksum+0x278>
-               	addiw	a2, a1, 0x8
-               	feq.s	a1, fs0, fs1
-               	bnez	a1, 0x2f0 <corpus.cases.float.cmp_f32.checksum+0x288>
-               	mv	a1, a2
-               	j	0x2f4 <corpus.cases.float.cmp_f32.checksum+0x28c>
-               	addiw	a1, a2, 0x10
-               	feq.s	a2, fs0, fs1
-               	xori	a2, a2, 0x1
-               	bnez	a2, 0x308 <corpus.cases.float.cmp_f32.checksum+0x2a0>
-               	mv	a2, a1
-               	j	0x30c <corpus.cases.float.cmp_f32.checksum+0x2a4>
-               	addiw	a2, a1, 0x20
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x2a8>
-               	flt.s	a1, fs0, fs1
-               	bnez	a1, 0x324 <corpus.cases.float.cmp_f32.checksum+0x2bc>
-               	j	0x328 <corpus.cases.float.cmp_f32.checksum+0x2c0>
-               	flt.s	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x2c0>
-               	flt.s	a1, fs0, fs1
-               	bnez	a1, 0x340 <corpus.cases.float.cmp_f32.checksum+0x2d8>
-               	flt.s	a2, fs1, fs0
-               	j	0x344 <corpus.cases.float.cmp_f32.checksum+0x2dc>
-               	mv	a2, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x2e0>
-               	flt.s	a1, fs0, fs1
-               	li	t0, 0x1
-               	zext.b	t1, a1
-               	zext.b	t0, t0
-               	xor	a2, t1, t0
-               	snez	a2, a2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x304>
-               	feq.s	a1, fs0, fs0
-               	bnez	a1, 0x380 <corpus.cases.float.cmp_f32.checksum+0x318>
-               	j	0x384 <corpus.cases.float.cmp_f32.checksum+0x31c>
-               	feq.s	a1, fs1, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x31c>
-               	feq.s	a1, fs0, fs0
-               	xori	a1, a1, 0x1
-               	bnez	a1, 0x3a4 <corpus.cases.float.cmp_f32.checksum+0x33c>
-               	feq.s	a2, fs1, fs1
-               	xori	a2, a2, 0x1
-               	j	0x3a8 <corpus.cases.float.cmp_f32.checksum+0x340>
-               	mv	a2, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x344>
-               	addiw	s6, s6, 0x1
-               	mv	s5, a0
                	li	t0, 0xc
-               	bltu	s6, t0, 0x228 <corpus.cases.float.cmp_f32.checksum+0x1c0>
-               	addiw	s3, s3, 0x1
-               	mv	s2, s5
-               	li	t0, 0xc
-               	bltu	s3, t0, 0x204 <corpus.cases.float.cmp_f32.checksum+0x19c>
-               	mv	a0, s1
-               	flw	ft0, 0x0(a0)
-               	flw	ft1, 0x0(a0)
-               	fmv.d	fs0, ft1
-               	li	a0, 0x1
-               	li	t0, 0xc
-               	bltu	a0, t0, 0x3f4 <corpus.cases.float.cmp_f32.checksum+0x38c>
-               	j	0x478 <corpus.cases.float.cmp_f32.checksum+0x410>
-               	slli	a1, a0, 0x20
-               	srli	a1, a1, 0x20
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	flw	ft1, 0x0(a2)
-               	flt.s	a1, ft1, ft0
-               	bnez	a1, 0x418 <corpus.cases.float.cmp_f32.checksum+0x3b0>
-               	fmv.d	ft1, ft0
-               	j	0x42c <corpus.cases.float.cmp_f32.checksum+0x3c4>
-               	slli	a1, a0, 0x20
-               	srli	a1, a1, 0x20
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	flw	ft1, 0x0(a2)
-               	slli	a1, a0, 0x20
-               	srli	a1, a1, 0x20
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	flw	ft2, 0x0(a2)
-               	flt.s	a1, fs0, ft2
-               	bnez	a1, 0x450 <corpus.cases.float.cmp_f32.checksum+0x3e8>
-               	fmv.d	ft2, fs0
-               	j	0x464 <corpus.cases.float.cmp_f32.checksum+0x3fc>
-               	slli	a1, a0, 0x20
-               	srli	a1, a1, 0x20
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	flw	ft2, 0x0(a2)
-               	addiw	a0, a0, 0x1
-               	fmv.d	ft0, ft1
-               	fmv.d	fs0, ft2
-               	li	t0, 0xc
-               	bltu	a0, t0, 0x3f4 <corpus.cases.float.cmp_f32.checksum+0x38c>
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x49c <corpus.cases.float.cmp_f32.checksum+0x434>
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x424>
-               	mv	s3, a0
-               	j	0x4b0 <corpus.cases.float.cmp_f32.checksum+0x448>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x43c>
-               	mv	s3, a0
-               	feq.s	a0, fs0, fs0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4d4 <corpus.cases.float.cmp_f32.checksum+0x46c>
-               	mv	a0, s3
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x45c>
-               	mv	s2, a0
-               	j	0x4e8 <corpus.cases.float.cmp_f32.checksum+0x480>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x474>
-               	mv	s2, a0
-               	li	a1, 0x0
-               	li	a0, 0x0
-               	li	t0, 0xc
-               	bltu	a0, t0, 0x4fc <corpus.cases.float.cmp_f32.checksum+0x494>
-               	j	0x5a0 <corpus.cases.float.cmp_f32.checksum+0x538>
-               	slli	a2, a0, 0x20
+               	bltu	a1, t0, 0x250 <corpus.cases.float.cmp_f32.checksum+0x190>
+               	j	0x710 <corpus.cases.float.cmp_f32.checksum+0x650>
+               	slli	a2, a1, 0x20
                	srli	a2, a2, 0x20
                	slli	t0, a2, 0x2
                	add	a3, s1, t0
-               	mv	a2, a1
+               	mv	a2, a0
                	li	a4, 0x0
                	li	t0, 0xc
-               	bltu	a4, t0, 0x520 <corpus.cases.float.cmp_f32.checksum+0x4b8>
-               	j	0x590 <corpus.cases.float.cmp_f32.checksum+0x528>
+               	bltu	a4, t0, 0x274 <corpus.cases.float.cmp_f32.checksum+0x1b4>
+               	j	0x700 <corpus.cases.float.cmp_f32.checksum+0x640>
                	flw	ft0, 0x0(a3)
                	slli	a5, a4, 0x20
                	srli	a5, a5, 0x20
                	slli	t0, a5, 0x2
                	add	a6, s1, t0
                	flw	ft1, 0x0(a6)
-               	flt.s	a5, ft0, ft1
-               	zext.b	a7, a5
-               	addw	a5, a2, a7
-               	flw	ft0, 0x0(a3)
-               	flw	ft1, 0x0(a6)
-               	fle.s	a7, ft0, ft1
-               	zext.b	t5, a7
-               	addw	a7, a5, t5
-               	flw	ft0, 0x0(a3)
-               	flw	ft1, 0x0(a6)
                	feq.s	a5, ft0, ft1
-               	zext.b	t5, a5
-               	addw	a5, a7, t5
-               	flw	ft0, 0x0(a3)
-               	flw	ft1, 0x0(a6)
+               	zext.b	a6, a5
+               	mv	a5, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2a8 <corpus.cases.float.cmp_f32.checksum+0x1e8>
+               	j	0x2dc <corpus.cases.float.cmp_f32.checksum+0x21c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x2a8 <corpus.cases.float.cmp_f32.checksum+0x1e8>
                	feq.s	a6, ft0, ft1
                	xori	a6, a6, 0x1
                	zext.b	a7, a6
-               	addw	a2, a5, a7
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2f8 <corpus.cases.float.cmp_f32.checksum+0x238>
+               	j	0x32c <corpus.cases.float.cmp_f32.checksum+0x26c>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2f8 <corpus.cases.float.cmp_f32.checksum+0x238>
+               	flt.s	a6, ft0, ft1
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x344 <corpus.cases.float.cmp_f32.checksum+0x284>
+               	j	0x378 <corpus.cases.float.cmp_f32.checksum+0x2b8>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x344 <corpus.cases.float.cmp_f32.checksum+0x284>
+               	fle.s	a6, ft0, ft1
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x390 <corpus.cases.float.cmp_f32.checksum+0x2d0>
+               	j	0x3c4 <corpus.cases.float.cmp_f32.checksum+0x304>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x390 <corpus.cases.float.cmp_f32.checksum+0x2d0>
+               	flt.s	a6, ft1, ft0
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3dc <corpus.cases.float.cmp_f32.checksum+0x31c>
+               	j	0x410 <corpus.cases.float.cmp_f32.checksum+0x350>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3dc <corpus.cases.float.cmp_f32.checksum+0x31c>
+               	fle.s	a6, ft1, ft0
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x428 <corpus.cases.float.cmp_f32.checksum+0x368>
+               	j	0x45c <corpus.cases.float.cmp_f32.checksum+0x39c>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x428 <corpus.cases.float.cmp_f32.checksum+0x368>
+               	flt.s	a6, ft0, ft1
+               	bnez	a6, 0x46c <corpus.cases.float.cmp_f32.checksum+0x3ac>
+               	li	a6, 0x0
+               	j	0x470 <corpus.cases.float.cmp_f32.checksum+0x3b0>
+               	li	a6, 0x1
+               	fle.s	a7, ft0, ft1
+               	bnez	a7, 0x480 <corpus.cases.float.cmp_f32.checksum+0x3c0>
+               	mv	a7, a6
+               	j	0x484 <corpus.cases.float.cmp_f32.checksum+0x3c4>
+               	addiw	a7, a6, 0x2
+               	flt.s	a6, ft1, ft0
+               	bnez	a6, 0x494 <corpus.cases.float.cmp_f32.checksum+0x3d4>
+               	mv	a6, a7
+               	j	0x498 <corpus.cases.float.cmp_f32.checksum+0x3d8>
+               	addiw	a6, a7, 0x4
+               	fle.s	a7, ft1, ft0
+               	bnez	a7, 0x4a8 <corpus.cases.float.cmp_f32.checksum+0x3e8>
+               	mv	a7, a6
+               	j	0x4ac <corpus.cases.float.cmp_f32.checksum+0x3ec>
+               	addiw	a7, a6, 0x8
+               	feq.s	a6, ft0, ft1
+               	bnez	a6, 0x4bc <corpus.cases.float.cmp_f32.checksum+0x3fc>
+               	mv	a6, a7
+               	j	0x4c0 <corpus.cases.float.cmp_f32.checksum+0x400>
+               	addiw	a6, a7, 0x10
+               	feq.s	a7, ft0, ft1
+               	xori	a7, a7, 0x1
+               	bnez	a7, 0x4d4 <corpus.cases.float.cmp_f32.checksum+0x414>
+               	mv	a7, a6
+               	j	0x4d8 <corpus.cases.float.cmp_f32.checksum+0x418>
+               	addiw	a7, a6, 0x20
+               	zext.b	a6, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4ec <corpus.cases.float.cmp_f32.checksum+0x42c>
+               	j	0x520 <corpus.cases.float.cmp_f32.checksum+0x460>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x4ec <corpus.cases.float.cmp_f32.checksum+0x42c>
+               	flt.s	a6, ft0, ft1
+               	bnez	a6, 0x52c <corpus.cases.float.cmp_f32.checksum+0x46c>
+               	j	0x530 <corpus.cases.float.cmp_f32.checksum+0x470>
+               	flt.s	a6, ft1, ft0
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x544 <corpus.cases.float.cmp_f32.checksum+0x484>
+               	j	0x578 <corpus.cases.float.cmp_f32.checksum+0x4b8>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x544 <corpus.cases.float.cmp_f32.checksum+0x484>
+               	flt.s	a6, ft0, ft1
+               	bnez	a6, 0x588 <corpus.cases.float.cmp_f32.checksum+0x4c8>
+               	flt.s	a7, ft1, ft0
+               	j	0x58c <corpus.cases.float.cmp_f32.checksum+0x4cc>
+               	mv	a7, a6
+               	zext.b	a6, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x5a0 <corpus.cases.float.cmp_f32.checksum+0x4e0>
+               	j	0x5d4 <corpus.cases.float.cmp_f32.checksum+0x514>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x5a0 <corpus.cases.float.cmp_f32.checksum+0x4e0>
+               	flt.s	a6, ft0, ft1
+               	li	t0, 0x1
+               	zext.b	t1, a6
+               	zext.b	t0, t0
+               	xor	a7, t1, t0
+               	snez	a7, a7
+               	zext.b	a6, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x600 <corpus.cases.float.cmp_f32.checksum+0x540>
+               	j	0x634 <corpus.cases.float.cmp_f32.checksum+0x574>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x600 <corpus.cases.float.cmp_f32.checksum+0x540>
+               	feq.s	a6, ft0, ft0
+               	bnez	a6, 0x640 <corpus.cases.float.cmp_f32.checksum+0x580>
+               	j	0x644 <corpus.cases.float.cmp_f32.checksum+0x584>
+               	feq.s	a6, ft1, ft1
+               	zext.b	a7, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x658 <corpus.cases.float.cmp_f32.checksum+0x598>
+               	j	0x68c <corpus.cases.float.cmp_f32.checksum+0x5cc>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a7, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x658 <corpus.cases.float.cmp_f32.checksum+0x598>
+               	feq.s	a6, ft0, ft0
+               	xori	a6, a6, 0x1
+               	bnez	a6, 0x6a4 <corpus.cases.float.cmp_f32.checksum+0x5e4>
+               	feq.s	a7, ft1, ft1
+               	xori	a7, a7, 0x1
+               	j	0x6a8 <corpus.cases.float.cmp_f32.checksum+0x5e8>
+               	mv	a7, a6
+               	zext.b	a6, a7
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6bc <corpus.cases.float.cmp_f32.checksum+0x5fc>
+               	j	0x6f0 <corpus.cases.float.cmp_f32.checksum+0x630>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6bc <corpus.cases.float.cmp_f32.checksum+0x5fc>
                	addiw	a4, a4, 0x1
+               	mv	a2, a5
                	li	t0, 0xc
-               	bltu	a4, t0, 0x520 <corpus.cases.float.cmp_f32.checksum+0x4b8>
-               	addiw	a0, a0, 0x1
-               	mv	a1, a2
+               	bltu	a4, t0, 0x274 <corpus.cases.float.cmp_f32.checksum+0x1b4>
+               	addiw	a1, a1, 0x1
+               	mv	a0, a2
                	li	t0, 0xc
-               	bltu	a0, t0, 0x4fc <corpus.cases.float.cmp_f32.checksum+0x494>
-               	mv	a0, s2
+               	bltu	a1, t0, 0x250 <corpus.cases.float.cmp_f32.checksum+0x190>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	flw	ft1, 0x0(a1)
+               	fmv.d	fs0, ft1
+               	li	a1, 0x1
+               	li	t0, 0xc
+               	bltu	a1, t0, 0x730 <corpus.cases.float.cmp_f32.checksum+0x670>
+               	j	0x7b4 <corpus.cases.float.cmp_f32.checksum+0x6f4>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	slli	t0, a2, 0x2
+               	add	a3, s1, t0
+               	flw	ft1, 0x0(a3)
+               	flt.s	a2, ft1, ft0
+               	bnez	a2, 0x754 <corpus.cases.float.cmp_f32.checksum+0x694>
+               	fmv.d	ft1, ft0
+               	j	0x768 <corpus.cases.float.cmp_f32.checksum+0x6a8>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	slli	t0, a2, 0x2
+               	add	a3, s1, t0
+               	flw	ft1, 0x0(a3)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	slli	t0, a2, 0x2
+               	add	a3, s1, t0
+               	flw	ft2, 0x0(a3)
+               	flt.s	a2, fs0, ft2
+               	bnez	a2, 0x78c <corpus.cases.float.cmp_f32.checksum+0x6cc>
+               	fmv.d	ft2, fs0
+               	j	0x7a0 <corpus.cases.float.cmp_f32.checksum+0x6e0>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	slli	t0, a2, 0x2
+               	add	a3, s1, t0
+               	flw	ft2, 0x0(a3)
+               	addiw	a1, a1, 0x1
+               	fmv.d	ft0, ft1
+               	fmv.d	fs0, ft2
+               	li	t0, 0xc
+               	bltu	a1, t0, 0x730 <corpus.cases.float.cmp_f32.checksum+0x670>
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x53c>
-               	ld	s1, 0x78(sp)
-               	ld	s2, 0x70(sp)
-               	ld	s3, 0x68(sp)
-               	ld	s4, 0x60(sp)
-               	ld	s5, 0x58(sp)
-               	ld	s6, 0x50(sp)
-               	ld	s7, 0x48(sp)
-               	fld	fs0, 0x40(sp)
-               	fld	fs1, 0x38(sp)
-               	ld	ra, 0x88(sp)
-               	ld	s0, 0x80(sp)
-               	addi	sp, sp, 0x90
+               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x6f8>
+               	fmv.s	fa0, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.cmp_f32.checksum+0x704>
+               	li	a1, 0x0
+               	li	a2, 0x0
+               	li	t0, 0xc
+               	bltu	a2, t0, 0x7e0 <corpus.cases.float.cmp_f32.checksum+0x720>
+               	j	0x884 <corpus.cases.float.cmp_f32.checksum+0x7c4>
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	slli	t0, a3, 0x2
+               	add	a4, s1, t0
+               	mv	a3, a1
+               	li	a5, 0x0
+               	li	t0, 0xc
+               	bltu	a5, t0, 0x804 <corpus.cases.float.cmp_f32.checksum+0x744>
+               	j	0x874 <corpus.cases.float.cmp_f32.checksum+0x7b4>
+               	flw	ft0, 0x0(a4)
+               	slli	a6, a5, 0x20
+               	srli	a6, a6, 0x20
+               	slli	t0, a6, 0x2
+               	add	a7, s1, t0
+               	flw	ft1, 0x0(a7)
+               	flt.s	a6, ft0, ft1
+               	zext.b	t5, a6
+               	addw	a6, a3, t5
+               	flw	ft0, 0x0(a4)
+               	flw	ft1, 0x0(a7)
+               	fle.s	t5, ft0, ft1
+               	zext.b	t6, t5
+               	addw	t5, a6, t6
+               	flw	ft0, 0x0(a4)
+               	flw	ft1, 0x0(a7)
+               	feq.s	a6, ft0, ft1
+               	zext.b	t6, a6
+               	addw	a6, t5, t6
+               	flw	ft0, 0x0(a4)
+               	flw	ft1, 0x0(a7)
+               	feq.s	a7, ft0, ft1
+               	xori	a7, a7, 0x1
+               	zext.b	t5, a7
+               	addw	a3, a6, t5
+               	addiw	a5, a5, 0x1
+               	li	t0, 0xc
+               	bltu	a5, t0, 0x804 <corpus.cases.float.cmp_f32.checksum+0x744>
+               	addiw	a2, a2, 0x1
+               	mv	a1, a3
+               	li	t0, 0xc
+               	bltu	a2, t0, 0x7e0 <corpus.cases.float.cmp_f32.checksum+0x720>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x89c <corpus.cases.float.cmp_f32.checksum+0x7dc>
+               	j	0x8d0 <corpus.cases.float.cmp_f32.checksum+0x810>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x89c <corpus.cases.float.cmp_f32.checksum+0x7dc>
+               	ld	s1, 0x38(sp)
+               	fld	fs0, 0x30(sp)
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret

--- a/test/golden/riscv64-linux/float/cmp_f64.dis
+++ b/test/golden/riscv64-linux/float/cmp_f64.dis
@@ -3,31 +3,50 @@ float/cmp_f64.o:
 Disassembly of section .text:
 
 <corpus.cases.float.cmp_f64.fold64>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x44 <corpus.cases.float.cmp_f64.fold64+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.fold64+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x64 <corpus.cases.float.cmp_f64.fold64+0x64>
+               	fmv.x.d	a0, fa0
+               	mv	a2, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x28 <corpus.cases.float.cmp_f64.fold64+0x28>
+               	j	0x5c <corpus.cases.float.cmp_f64.fold64+0x5c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x28 <corpus.cases.float.cmp_f64.fold64+0x28>
+               	mv	a0, a2
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.fold64+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x74 <corpus.cases.float.cmp_f64.fold64+0x74>
+               	j	0xac <corpus.cases.float.cmp_f64.fold64+0xac>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	li	t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x74 <corpus.cases.float.cmp_f64.fold64+0x74>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.cmp_f64.checksum>:
@@ -42,448 +61,661 @@ Disassembly of section .text:
                	sd	s5, 0xa8(sp)
                	sd	s6, 0xa0(sp)
                	sd	s7, 0x98(sp)
-               	sd	s8, 0x90(sp)
-               	fsd	fs0, 0x88(sp)
-               	fsd	fs1, 0x80(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x3c>
-               	sext.w	s2, s1
-               	addi	s3, s0, -0xc0
-               	mv	a1, s3
+               	fsd	fs0, 0x90(sp)
+               	fsd	fs1, 0x88(sp)
+               	sext.w	s1, a0
+               	addi	s2, s0, -0xd8
+               	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0xe4 <corpus.cases.float.cmp_f64.checksum+0x7c>
+               	bnez	a2, 0x120 <corpus.cases.float.cmp_f64.checksum+0x6c>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xcc <corpus.cases.float.cmp_f64.checksum+0x64>
-               	j	0x100 <corpus.cases.float.cmp_f64.checksum+0x98>
+               	bne	a3, t0, 0x108 <corpus.cases.float.cmp_f64.checksum+0x54>
+               	j	0x13c <corpus.cases.float.cmp_f64.checksum+0x88>
                	mv	a2, a1
                	li	a1, 0x60
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xec <corpus.cases.float.cmp_f64.checksum+0x84>
+               	bne	a1, t0, 0x128 <corpus.cases.float.cmp_f64.checksum+0x74>
                	lui	t1, 0xf0000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	mv	a1, s3
+               	mv	a1, s2
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfbff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x8
+               	addi	a1, s2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xf8010
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x10
+               	addi	a1, s2, 0x10
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x1
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x18
+               	addi	a1, s2, 0x18
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	fsd	ft0, 0x0(a1)
-               	fmv.d.x	ft0, s1
-               	addi	a1, s3, 0x28
+               	fmv.d.x	ft0, a0
+               	addi	a1, s2, 0x28
                	fsd	ft0, 0x0(a1)
                	li	t1, 0x1
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x30
+               	addi	a1, s2, 0x30
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0x3ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x38
+               	addi	a1, s2, 0x38
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0x7ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x1
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x40
+               	addi	a1, s2, 0x40
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0x7ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x48
+               	addi	a1, s2, 0x48
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0x7ff8
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x50
+               	addi	a1, s2, 0x50
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0x7ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x1
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	fmv.d.x	ft0, a1
-               	addi	a1, s3, 0x58
-               	fsd	ft0, 0x0(a1)
-               	mv	s1, a0
+               	addi	a0, s2, 0x58
+               	fsd	ft0, 0x0(a0)
+               	lui	s3, 0xfcbf3
+               	addiw	s3, s3, -0x632
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x484
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x222
+               	slli	s3, s3, 0xc
+               	addi	s3, s3, 0x325
                	li	s4, 0x0
                	li	t0, 0xc
-               	bltu	s4, t0, 0x27c <corpus.cases.float.cmp_f64.checksum+0x214>
-               	j	0x43c <corpus.cases.float.cmp_f64.checksum+0x3d4>
+               	bltu	s4, t0, 0x2d4 <corpus.cases.float.cmp_f64.checksum+0x220>
+               	j	0x70c <corpus.cases.float.cmp_f64.checksum+0x658>
                	slli	t0, s4, 0x3
-               	add	s5, s3, t0
-               	mv	s6, s1
+               	add	s5, s2, t0
+               	mv	s6, s3
                	li	s7, 0x0
                	li	t0, 0xc
-               	bltu	s7, t0, 0x298 <corpus.cases.float.cmp_f64.checksum+0x230>
-               	j	0x42c <corpus.cases.float.cmp_f64.checksum+0x3c4>
+               	bltu	s7, t0, 0x2f0 <corpus.cases.float.cmp_f64.checksum+0x23c>
+               	j	0x6fc <corpus.cases.float.cmp_f64.checksum+0x648>
                	fld	fs0, 0x0(s5)
                	slli	t0, s7, 0x3
-               	add	a0, s3, t0
+               	add	a0, s2, t0
                	fld	fs1, 0x0(a0)
-               	feq.d	a1, fs0, fs1
+               	feq.d	a0, fs0, fs1
+               	zext.b	a1, a0
                	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x248>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x31c <corpus.cases.float.cmp_f64.checksum+0x268>
+               	j	0x350 <corpus.cases.float.cmp_f64.checksum+0x29c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x31c <corpus.cases.float.cmp_f64.checksum+0x268>
                	feq.d	a1, fs0, fs1
                	xori	a1, a1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x258>
-               	flt.d	s8, fs0, fs1
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x268>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x36c <corpus.cases.float.cmp_f64.checksum+0x2b8>
+               	j	0x3a0 <corpus.cases.float.cmp_f64.checksum+0x2ec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x36c <corpus.cases.float.cmp_f64.checksum+0x2b8>
+               	flt.d	a1, fs0, fs1
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <corpus.cases.float.cmp_f64.checksum+0x304>
+               	j	0x3ec <corpus.cases.float.cmp_f64.checksum+0x338>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b8 <corpus.cases.float.cmp_f64.checksum+0x304>
                	fle.d	a1, fs0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x274>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x404 <corpus.cases.float.cmp_f64.checksum+0x350>
+               	j	0x438 <corpus.cases.float.cmp_f64.checksum+0x384>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x404 <corpus.cases.float.cmp_f64.checksum+0x350>
                	flt.d	a1, fs1, fs0
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x280>
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x390>
                	fle.d	a1, fs1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x28c>
-               	bnez	s8, 0x308 <corpus.cases.float.cmp_f64.checksum+0x2a0>
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x39c>
+               	flt.d	a1, fs0, fs1
+               	bnez	a1, 0x468 <corpus.cases.float.cmp_f64.checksum+0x3b4>
                	li	a1, 0x0
-               	j	0x30c <corpus.cases.float.cmp_f64.checksum+0x2a4>
+               	j	0x46c <corpus.cases.float.cmp_f64.checksum+0x3b8>
                	li	a1, 0x1
                	fle.d	a2, fs0, fs1
-               	bnez	a2, 0x31c <corpus.cases.float.cmp_f64.checksum+0x2b4>
+               	bnez	a2, 0x47c <corpus.cases.float.cmp_f64.checksum+0x3c8>
                	mv	a2, a1
-               	j	0x320 <corpus.cases.float.cmp_f64.checksum+0x2b8>
+               	j	0x480 <corpus.cases.float.cmp_f64.checksum+0x3cc>
                	addiw	a2, a1, 0x2
                	flt.d	a1, fs1, fs0
-               	bnez	a1, 0x330 <corpus.cases.float.cmp_f64.checksum+0x2c8>
+               	bnez	a1, 0x490 <corpus.cases.float.cmp_f64.checksum+0x3dc>
                	mv	a1, a2
-               	j	0x334 <corpus.cases.float.cmp_f64.checksum+0x2cc>
+               	j	0x494 <corpus.cases.float.cmp_f64.checksum+0x3e0>
                	addiw	a1, a2, 0x4
                	fle.d	a2, fs1, fs0
-               	bnez	a2, 0x344 <corpus.cases.float.cmp_f64.checksum+0x2dc>
+               	bnez	a2, 0x4a4 <corpus.cases.float.cmp_f64.checksum+0x3f0>
                	mv	a2, a1
-               	j	0x348 <corpus.cases.float.cmp_f64.checksum+0x2e0>
+               	j	0x4a8 <corpus.cases.float.cmp_f64.checksum+0x3f4>
                	addiw	a2, a1, 0x8
                	feq.d	a1, fs0, fs1
-               	bnez	a1, 0x358 <corpus.cases.float.cmp_f64.checksum+0x2f0>
+               	bnez	a1, 0x4b8 <corpus.cases.float.cmp_f64.checksum+0x404>
                	mv	a1, a2
-               	j	0x35c <corpus.cases.float.cmp_f64.checksum+0x2f4>
+               	j	0x4bc <corpus.cases.float.cmp_f64.checksum+0x408>
                	addiw	a1, a2, 0x10
                	feq.d	a2, fs0, fs1
                	xori	a2, a2, 0x1
-               	bnez	a2, 0x370 <corpus.cases.float.cmp_f64.checksum+0x308>
+               	bnez	a2, 0x4d0 <corpus.cases.float.cmp_f64.checksum+0x41c>
                	mv	a2, a1
-               	j	0x374 <corpus.cases.float.cmp_f64.checksum+0x30c>
+               	j	0x4d4 <corpus.cases.float.cmp_f64.checksum+0x420>
                	addiw	a2, a1, 0x20
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x310>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.float.cmp_f64.checksum+0x434>
+               	j	0x51c <corpus.cases.float.cmp_f64.checksum+0x468>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.float.cmp_f64.checksum+0x434>
                	flt.d	a1, fs0, fs1
-               	bnez	a1, 0x38c <corpus.cases.float.cmp_f64.checksum+0x324>
-               	j	0x390 <corpus.cases.float.cmp_f64.checksum+0x328>
+               	bnez	a1, 0x528 <corpus.cases.float.cmp_f64.checksum+0x474>
+               	j	0x52c <corpus.cases.float.cmp_f64.checksum+0x478>
                	flt.d	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x328>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x540 <corpus.cases.float.cmp_f64.checksum+0x48c>
+               	j	0x574 <corpus.cases.float.cmp_f64.checksum+0x4c0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x540 <corpus.cases.float.cmp_f64.checksum+0x48c>
                	flt.d	a1, fs0, fs1
-               	bnez	a1, 0x3a8 <corpus.cases.float.cmp_f64.checksum+0x340>
+               	bnez	a1, 0x584 <corpus.cases.float.cmp_f64.checksum+0x4d0>
                	flt.d	a2, fs1, fs0
-               	j	0x3ac <corpus.cases.float.cmp_f64.checksum+0x344>
+               	j	0x588 <corpus.cases.float.cmp_f64.checksum+0x4d4>
                	mv	a2, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x348>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x59c <corpus.cases.float.cmp_f64.checksum+0x4e8>
+               	j	0x5d0 <corpus.cases.float.cmp_f64.checksum+0x51c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x59c <corpus.cases.float.cmp_f64.checksum+0x4e8>
                	flt.d	a1, fs0, fs1
                	li	t0, 0x1
                	zext.b	t1, a1
                	zext.b	t0, t0
                	xor	a2, t1, t0
                	snez	a2, a2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x36c>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5fc <corpus.cases.float.cmp_f64.checksum+0x548>
+               	j	0x630 <corpus.cases.float.cmp_f64.checksum+0x57c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5fc <corpus.cases.float.cmp_f64.checksum+0x548>
                	feq.d	a1, fs0, fs0
-               	bnez	a1, 0x3e8 <corpus.cases.float.cmp_f64.checksum+0x380>
-               	j	0x3ec <corpus.cases.float.cmp_f64.checksum+0x384>
+               	bnez	a1, 0x63c <corpus.cases.float.cmp_f64.checksum+0x588>
+               	j	0x640 <corpus.cases.float.cmp_f64.checksum+0x58c>
                	feq.d	a1, fs1, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x384>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x654 <corpus.cases.float.cmp_f64.checksum+0x5a0>
+               	j	0x688 <corpus.cases.float.cmp_f64.checksum+0x5d4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x654 <corpus.cases.float.cmp_f64.checksum+0x5a0>
                	feq.d	a1, fs0, fs0
                	xori	a1, a1, 0x1
-               	bnez	a1, 0x40c <corpus.cases.float.cmp_f64.checksum+0x3a4>
+               	bnez	a1, 0x6a0 <corpus.cases.float.cmp_f64.checksum+0x5ec>
                	feq.d	a2, fs1, fs1
                	xori	a2, a2, 0x1
-               	j	0x410 <corpus.cases.float.cmp_f64.checksum+0x3a8>
+               	j	0x6a4 <corpus.cases.float.cmp_f64.checksum+0x5f0>
                	mv	a2, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x3ac>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6b8 <corpus.cases.float.cmp_f64.checksum+0x604>
+               	j	0x6ec <corpus.cases.float.cmp_f64.checksum+0x638>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6b8 <corpus.cases.float.cmp_f64.checksum+0x604>
                	addi	s7, s7, 0x1
                	mv	s6, a0
                	li	t0, 0xc
-               	bltu	s7, t0, 0x298 <corpus.cases.float.cmp_f64.checksum+0x230>
+               	bltu	s7, t0, 0x2f0 <corpus.cases.float.cmp_f64.checksum+0x23c>
                	addi	s4, s4, 0x1
-               	mv	s1, s6
+               	mv	s3, s6
                	li	t0, 0xc
-               	bltu	s4, t0, 0x27c <corpus.cases.float.cmp_f64.checksum+0x214>
-               	addi	s4, s0, -0xe0
+               	bltu	s4, t0, 0x2d4 <corpus.cases.float.cmp_f64.checksum+0x220>
+               	addi	s4, s0, -0x78
                	mv	a0, s4
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x470 <corpus.cases.float.cmp_f64.checksum+0x408>
+               	bnez	a1, 0x740 <corpus.cases.float.cmp_f64.checksum+0x68c>
                	mv	a1, a0
                	li	a2, 0x20
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x458 <corpus.cases.float.cmp_f64.checksum+0x3f0>
-               	j	0x48c <corpus.cases.float.cmp_f64.checksum+0x424>
+               	bne	a2, t0, 0x728 <corpus.cases.float.cmp_f64.checksum+0x674>
+               	j	0x75c <corpus.cases.float.cmp_f64.checksum+0x6a8>
                	mv	a1, a0
                	li	a0, 0x20
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x478 <corpus.cases.float.cmp_f64.checksum+0x410>
+               	bne	a0, t0, 0x748 <corpus.cases.float.cmp_f64.checksum+0x694>
                	lui	t1, 0xff800
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	mv	a0, s4
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xbf800
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x4
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0x80000
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x8
                	fsw	ft0, 0x0(a0)
-               	fmv.w.x	ft0, s2
+               	fmv.w.x	ft0, s1
                	addi	a0, s4, 0xc
                	fsw	ft0, 0x0(a0)
                	li	t1, 0x1
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x10
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0x3f800
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x14
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7f800
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x18
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0x7fc00
-               	addw	a0, t1, s2
+               	addw	a0, t1, s1
                	fmv.w.x	ft0, a0
                	addi	a0, s4, 0x1c
                	fsw	ft0, 0x0(a0)
-               	li	s2, 0x0
+               	li	s1, 0x0
                	li	t0, 0xc
-               	bltu	s2, t0, 0x534 <corpus.cases.float.cmp_f64.checksum+0x4cc>
-               	j	0x5d4 <corpus.cases.float.cmp_f64.checksum+0x56c>
-               	slli	t0, s2, 0x3
-               	add	s5, s3, t0
-               	mv	s6, s1
+               	bltu	s1, t0, 0x804 <corpus.cases.float.cmp_f64.checksum+0x750>
+               	j	0x988 <corpus.cases.float.cmp_f64.checksum+0x8d4>
+               	slli	t0, s1, 0x3
+               	add	s5, s2, t0
+               	mv	s6, s3
                	li	s7, 0x0
                	li	t0, 0x8
-               	bltu	s7, t0, 0x550 <corpus.cases.float.cmp_f64.checksum+0x4e8>
-               	j	0x5c4 <corpus.cases.float.cmp_f64.checksum+0x55c>
+               	bltu	s7, t0, 0x820 <corpus.cases.float.cmp_f64.checksum+0x76c>
+               	j	0x978 <corpus.cases.float.cmp_f64.checksum+0x8c4>
                	fld	fs0, 0x0(s5)
                	slli	t0, s7, 0x2
                	add	a0, s4, t0
-               	flw	ft0, 0x0(a0)
-               	fcvt.d.s	fs1, ft0
-               	feq.d	a1, fs0, fs1
+               	flw	fs1, 0x0(a0)
+               	fcvt.d.s	ft0, fs1
+               	feq.d	a0, fs0, ft0
+               	zext.b	a1, a0
                	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x504>
-               	feq.d	a1, fs0, fs1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x850 <corpus.cases.float.cmp_f64.checksum+0x79c>
+               	j	0x884 <corpus.cases.float.cmp_f64.checksum+0x7d0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x850 <corpus.cases.float.cmp_f64.checksum+0x79c>
+               	fcvt.d.s	ft0, fs1
+               	feq.d	a1, fs0, ft0
                	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8a4 <corpus.cases.float.cmp_f64.checksum+0x7f0>
+               	j	0x8d8 <corpus.cases.float.cmp_f64.checksum+0x824>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8a4 <corpus.cases.float.cmp_f64.checksum+0x7f0>
+               	fcvt.d.s	ft0, fs1
+               	flt.d	a1, fs0, ft0
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8f4 <corpus.cases.float.cmp_f64.checksum+0x840>
+               	j	0x928 <corpus.cases.float.cmp_f64.checksum+0x874>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8f4 <corpus.cases.float.cmp_f64.checksum+0x840>
+               	fcvt.d.s	ft0, fs1
+               	fle.d	a1, fs0, ft0
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x514>
-               	flt.d	a1, fs0, fs1
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x884>
+               	fcvt.d.s	ft0, fs1
+               	flt.d	a1, ft0, fs0
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x520>
-               	fle.d	a1, fs0, fs1
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x89c>
+               	fcvt.d.s	ft0, fs1
+               	fle.d	a1, ft0, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x52c>
-               	flt.d	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x538>
-               	fle.d	a1, fs1, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x544>
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x8ac>
                	addi	s7, s7, 0x1
                	mv	s6, a0
                	li	t0, 0x8
-               	bltu	s7, t0, 0x550 <corpus.cases.float.cmp_f64.checksum+0x4e8>
-               	addi	s2, s2, 0x1
-               	mv	s1, s6
+               	bltu	s7, t0, 0x820 <corpus.cases.float.cmp_f64.checksum+0x76c>
+               	addi	s1, s1, 0x1
+               	mv	s3, s6
                	li	t0, 0xc
-               	bltu	s2, t0, 0x534 <corpus.cases.float.cmp_f64.checksum+0x4cc>
-               	mv	a0, s3
+               	bltu	s1, t0, 0x804 <corpus.cases.float.cmp_f64.checksum+0x750>
+               	mv	a0, s2
                	fld	ft0, 0x0(a0)
                	fld	ft1, 0x0(a0)
                	fmv.d	fs0, ft1
                	li	a0, 0x1
                	li	t0, 0xc
-               	bltu	a0, t0, 0x5f4 <corpus.cases.float.cmp_f64.checksum+0x58c>
-               	j	0x658 <corpus.cases.float.cmp_f64.checksum+0x5f0>
+               	bltu	a0, t0, 0x9a8 <corpus.cases.float.cmp_f64.checksum+0x8f4>
+               	j	0xa0c <corpus.cases.float.cmp_f64.checksum+0x958>
                	slli	t0, a0, 0x3
-               	add	a1, s3, t0
+               	add	a1, s2, t0
                	fld	ft1, 0x0(a1)
                	flt.d	a1, ft1, ft0
-               	bnez	a1, 0x610 <corpus.cases.float.cmp_f64.checksum+0x5a8>
+               	bnez	a1, 0x9c4 <corpus.cases.float.cmp_f64.checksum+0x910>
                	fmv.d	ft1, ft0
-               	j	0x61c <corpus.cases.float.cmp_f64.checksum+0x5b4>
+               	j	0x9d0 <corpus.cases.float.cmp_f64.checksum+0x91c>
                	slli	t0, a0, 0x3
-               	add	a1, s3, t0
+               	add	a1, s2, t0
                	fld	ft1, 0x0(a1)
                	slli	t0, a0, 0x3
-               	add	a1, s3, t0
+               	add	a1, s2, t0
                	fld	ft2, 0x0(a1)
                	flt.d	a1, fs0, ft2
-               	bnez	a1, 0x638 <corpus.cases.float.cmp_f64.checksum+0x5d0>
+               	bnez	a1, 0x9ec <corpus.cases.float.cmp_f64.checksum+0x938>
                	fmv.d	ft2, fs0
-               	j	0x644 <corpus.cases.float.cmp_f64.checksum+0x5dc>
+               	j	0x9f8 <corpus.cases.float.cmp_f64.checksum+0x944>
                	slli	t0, a0, 0x3
-               	add	a1, s3, t0
+               	add	a1, s2, t0
                	fld	ft2, 0x0(a1)
                	addi	a0, a0, 0x1
                	fmv.d	ft0, ft1
                	fmv.d	fs0, ft2
                	li	t0, 0xc
-               	bltu	a0, t0, 0x5f4 <corpus.cases.float.cmp_f64.checksum+0x58c>
-               	feq.d	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x67c <corpus.cases.float.cmp_f64.checksum+0x614>
-               	mv	a0, s1
+               	bltu	a0, t0, 0x9a8 <corpus.cases.float.cmp_f64.checksum+0x8f4>
+               	mv	a0, s3
                	fmv.d	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x604>
-               	mv	s2, a0
-               	j	0x690 <corpus.cases.float.cmp_f64.checksum+0x628>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x61c>
-               	mv	s2, a0
-               	feq.d	a0, fs0, fs0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x6b4 <corpus.cases.float.cmp_f64.checksum+0x64c>
-               	mv	a0, s2
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x960>
                	fmv.d	fa0, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x63c>
-               	mv	s1, a0
-               	j	0x6c8 <corpus.cases.float.cmp_f64.checksum+0x660>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x654>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x96c>
                	li	a1, 0x0
-               	li	a0, 0x0
+               	li	a2, 0x0
                	li	t0, 0xc
-               	bltu	a0, t0, 0x6dc <corpus.cases.float.cmp_f64.checksum+0x674>
-               	j	0x770 <corpus.cases.float.cmp_f64.checksum+0x708>
-               	slli	t0, a0, 0x3
-               	add	a2, s3, t0
-               	mv	a3, a1
-               	li	a4, 0x0
+               	bltu	a2, t0, 0xa3c <corpus.cases.float.cmp_f64.checksum+0x988>
+               	j	0xad0 <corpus.cases.float.cmp_f64.checksum+0xa1c>
+               	slli	t0, a2, 0x3
+               	add	a3, s2, t0
+               	mv	a4, a1
+               	li	a5, 0x0
                	li	t0, 0xc
-               	bltu	a4, t0, 0x6f8 <corpus.cases.float.cmp_f64.checksum+0x690>
-               	j	0x760 <corpus.cases.float.cmp_f64.checksum+0x6f8>
-               	fld	ft0, 0x0(a2)
-               	slli	t0, a4, 0x3
-               	add	a5, s3, t0
-               	fld	ft1, 0x0(a5)
-               	flt.d	a6, ft0, ft1
-               	zext.b	a7, a6
-               	addw	a6, a3, a7
-               	fld	ft0, 0x0(a2)
-               	fld	ft1, 0x0(a5)
-               	fle.d	a7, ft0, ft1
+               	bltu	a5, t0, 0xa58 <corpus.cases.float.cmp_f64.checksum+0x9a4>
+               	j	0xac0 <corpus.cases.float.cmp_f64.checksum+0xa0c>
+               	fld	ft0, 0x0(a3)
+               	slli	t0, a5, 0x3
+               	add	a6, s2, t0
+               	fld	ft1, 0x0(a6)
+               	flt.d	a7, ft0, ft1
                	zext.b	t5, a7
-               	addw	a7, a6, t5
-               	fld	ft0, 0x0(a2)
-               	fld	ft1, 0x0(a5)
+               	addw	a7, a4, t5
+               	fld	ft0, 0x0(a3)
+               	fld	ft1, 0x0(a6)
+               	fle.d	t5, ft0, ft1
+               	zext.b	t6, t5
+               	addw	t5, a7, t6
+               	fld	ft0, 0x0(a3)
+               	fld	ft1, 0x0(a6)
+               	feq.d	a7, ft0, ft1
+               	zext.b	t6, a7
+               	addw	a7, t5, t6
+               	fld	ft0, 0x0(a3)
+               	fld	ft1, 0x0(a6)
                	feq.d	a6, ft0, ft1
+               	xori	a6, a6, 0x1
                	zext.b	t5, a6
-               	addw	a6, a7, t5
-               	fld	ft0, 0x0(a2)
-               	fld	ft1, 0x0(a5)
-               	feq.d	a5, ft0, ft1
-               	xori	a5, a5, 0x1
-               	zext.b	a7, a5
-               	addw	a3, a6, a7
-               	addi	a4, a4, 0x1
+               	addw	a4, a7, t5
+               	addi	a5, a5, 0x1
                	li	t0, 0xc
-               	bltu	a4, t0, 0x6f8 <corpus.cases.float.cmp_f64.checksum+0x690>
-               	addi	a0, a0, 0x1
-               	mv	a1, a3
+               	bltu	a5, t0, 0xa58 <corpus.cases.float.cmp_f64.checksum+0x9a4>
+               	addi	a2, a2, 0x1
+               	mv	a1, a4
                	li	t0, 0xc
-               	bltu	a0, t0, 0x6dc <corpus.cases.float.cmp_f64.checksum+0x674>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.cmp_f64.checksum+0x70c>
+               	bltu	a2, t0, 0xa3c <corpus.cases.float.cmp_f64.checksum+0x988>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xae8 <corpus.cases.float.cmp_f64.checksum+0xa34>
+               	j	0xb1c <corpus.cases.float.cmp_f64.checksum+0xa68>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xae8 <corpus.cases.float.cmp_f64.checksum+0xa34>
                	ld	s1, 0xc8(sp)
                	ld	s2, 0xc0(sp)
                	ld	s3, 0xb8(sp)
@@ -491,9 +723,8 @@ Disassembly of section .text:
                	ld	s5, 0xa8(sp)
                	ld	s6, 0xa0(sp)
                	ld	s7, 0x98(sp)
-               	ld	s8, 0x90(sp)
-               	fld	fs0, 0x88(sp)
-               	fld	fs1, 0x80(sp)
+               	fld	fs0, 0x90(sp)
+               	fld	fs1, 0x88(sp)
                	ld	ra, 0xd8(sp)
                	ld	s0, 0xd0(sp)
                	addi	sp, sp, 0xe0

--- a/test/golden/riscv64-linux/float/special_f32.dis
+++ b/test/golden/riscv64-linux/float/special_f32.dis
@@ -9,778 +9,881 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.special_f32.fold32>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.s	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x54 <corpus.cases.float.special_f32.fold32+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.fold32+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x78 <corpus.cases.float.special_f32.fold32+0x68>
+               	fmv.x.w	a0, fa0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a0, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.float.special_f32.fold32+0x30>
+               	j	0x74 <corpus.cases.float.special_f32.fold32+0x64>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.float.special_f32.fold32+0x30>
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.fold32+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x88 <corpus.cases.float.special_f32.fold32+0x78>
+               	j	0xc8 <corpus.cases.float.special_f32.fold32+0xb8>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x100
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x88 <corpus.cases.float.special_f32.fold32+0x78>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.special_f32.checksum>:
-               	addi	sp, sp, -0xd0
-               	sd	ra, 0xc8(sp)
-               	sd	s0, 0xc0(sp)
-               	addi	s0, sp, 0xd0
-               	sd	s1, 0xb8(sp)
-               	sd	s2, 0xb0(sp)
-               	sd	s3, 0xa8(sp)
-               	sd	s4, 0xa0(sp)
-               	sd	s5, 0x98(sp)
-               	sd	s6, 0x90(sp)
-               	sd	s7, 0x88(sp)
-               	sd	s8, 0x80(sp)
-               	fsd	fs0, 0x78(sp)
-               	fsd	fs1, 0x70(sp)
-               	fsd	fs2, 0x68(sp)
-               	fsd	fs3, 0x60(sp)
-               	fsd	fs4, 0x58(sp)
-               	fsd	fs5, 0x50(sp)
-               	fsd	fs6, 0x48(sp)
-               	fsd	fs7, 0x40(sp)
-               	fsd	fs8, 0x38(sp)
-               	fsd	fs9, 0x30(sp)
-               	fsd	fs10, 0x28(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x60>
-               	mv	s2, a0
-               	sext.w	s3, s1
+               	addi	sp, sp, -0xc0
+               	sd	ra, 0xb8(sp)
+               	sd	s0, 0xb0(sp)
+               	addi	s0, sp, 0xc0
+               	sd	s1, 0xa8(sp)
+               	sd	s2, 0xa0(sp)
+               	sd	s3, 0x98(sp)
+               	sd	s4, 0x90(sp)
+               	sd	s5, 0x88(sp)
+               	sd	s6, 0x80(sp)
+               	sd	s7, 0x78(sp)
+               	fsd	fs0, 0x70(sp)
+               	fsd	fs1, 0x68(sp)
+               	fsd	fs2, 0x60(sp)
+               	fsd	fs3, 0x58(sp)
+               	fsd	fs4, 0x50(sp)
+               	fsd	fs5, 0x48(sp)
+               	fsd	fs6, 0x40(sp)
+               	fsd	fs7, 0x38(sp)
+               	fsd	fs8, 0x30(sp)
+               	fsd	fs9, 0x28(sp)
+               	fsd	fs10, 0x20(sp)
+               	sext.w	s1, a0
                	lui	t1, 0x3f800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs0, a0
                	lui	t1, 0xbf800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs1, a0
-               	fmv.w.x	fs2, s3
+               	fmv.w.x	fs2, s1
                	lui	t1, 0x80000
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs3, a0
                	lui	t1, 0x7f800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs4, a0
                	lui	t1, 0xff800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs5, a0
                	lui	t1, 0x7fc00
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs6, a0
                	lui	t1, 0x7f800
                	addiw	t1, t1, -0x1
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs7, a0
                	lui	t1, 0x800
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs8, a0
                	lui	t1, 0x800
                	addiw	t1, t1, -0x1
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs9, a0
                	li	t1, 0x1
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	fmv.w.x	fs10, a0
-               	feq.s	a0, fs2, fs2
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x190 <corpus.cases.float.special_f32.checksum+0x118>
-               	mv	a0, s2
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x108>
-               	mv	s1, a0
-               	j	0x1a4 <corpus.cases.float.special_f32.checksum+0x12c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x120>
-               	mv	s1, a0
-               	feq.s	a0, fs3, fs3
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1c8 <corpus.cases.float.special_f32.checksum+0x150>
-               	mv	a0, s1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x104>
                	fmv.s	fa0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x140>
-               	mv	s2, a0
-               	j	0x1dc <corpus.cases.float.special_f32.checksum+0x164>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x158>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x110>
                	fadd.s	ft0, fs2, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x204 <corpus.cases.float.special_f32.checksum+0x18c>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x17c>
-               	mv	s1, a0
-               	j	0x218 <corpus.cases.float.special_f32.checksum+0x1a0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x194>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x120>
                	fadd.s	ft0, fs2, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x240 <corpus.cases.float.special_f32.checksum+0x1c8>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1b8>
-               	mv	s2, a0
-               	j	0x254 <corpus.cases.float.special_f32.checksum+0x1dc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1d0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x130>
                	fadd.s	ft0, fs3, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x27c <corpus.cases.float.special_f32.checksum+0x204>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1f4>
-               	mv	s1, a0
-               	j	0x290 <corpus.cases.float.special_f32.checksum+0x218>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x20c>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x140>
                	fadd.s	ft0, fs3, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2b8 <corpus.cases.float.special_f32.checksum+0x240>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x230>
-               	mv	s2, a0
-               	j	0x2cc <corpus.cases.float.special_f32.checksum+0x254>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x248>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x150>
                	fsub.s	ft0, fs2, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2f4 <corpus.cases.float.special_f32.checksum+0x27c>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x26c>
-               	mv	s1, a0
-               	j	0x308 <corpus.cases.float.special_f32.checksum+0x290>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x284>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x160>
                	fsub.s	ft0, fs2, fs3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x330 <corpus.cases.float.special_f32.checksum+0x2b8>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2a8>
-               	mv	s2, a0
-               	j	0x344 <corpus.cases.float.special_f32.checksum+0x2cc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2c0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x170>
                	fsub.s	ft0, fs3, fs2
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2d8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x180>
                	fsub.s	ft0, fs3, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2e8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x190>
                	fmul.s	ft0, fs2, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x2f8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1a0>
                	fmul.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x308>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1b0>
                	fmul.s	ft0, fs3, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x318>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1c0>
                	fmul.s	ft0, fs3, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x328>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1d0>
                	fmul.s	ft0, fs3, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x338>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1e0>
                	fmul.s	ft0, fs2, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x348>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x1f0>
                	fneg.s	ft0, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x358>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x200>
                	fneg.s	ft0, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x368>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x210>
                	fdiv.s	ft0, fs2, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x378>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x220>
                	fdiv.s	ft0, fs2, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x388>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x230>
                	fdiv.s	ft0, fs3, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x398>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x240>
                	fdiv.s	ft0, fs3, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3a8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x250>
                	feq.s	a1, fs2, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3b4>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.float.special_f32.checksum+0x270>
+               	j	0x374 <corpus.cases.float.special_f32.checksum+0x2a4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.float.special_f32.checksum+0x270>
                	flt.s	a1, fs2, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3c0>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x38c <corpus.cases.float.special_f32.checksum+0x2bc>
+               	j	0x3c0 <corpus.cases.float.special_f32.checksum+0x2f0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x38c <corpus.cases.float.special_f32.checksum+0x2bc>
                	flt.s	a1, fs3, fs2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3cc>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3d8 <corpus.cases.float.special_f32.checksum+0x308>
+               	j	0x40c <corpus.cases.float.special_f32.checksum+0x33c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3d8 <corpus.cases.float.special_f32.checksum+0x308>
                	fmv.s	fa0, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3d8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x340>
                	fmv.s	fa0, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3e4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x34c>
                	fneg.s	ft0, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3f4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x35c>
                	fdiv.s	ft0, fs0, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x404>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x36c>
                	fdiv.s	ft0, fs0, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x414>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x37c>
                	fdiv.s	ft0, fs1, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x424>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x38c>
                	fdiv.s	ft0, fs1, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x434>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x39c>
                	fadd.s	ft0, fs4, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x444>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3ac>
                	fadd.s	ft0, fs4, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x454>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3bc>
                	fsub.s	ft0, fs4, fs5
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x464>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3cc>
                	fmul.s	ft0, fs4, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x474>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3dc>
                	fmul.s	ft0, fs4, fs5
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x484>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3ec>
                	fmul.s	ft0, fs4, fs1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x494>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x3fc>
                	fdiv.s	ft0, fs0, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4a4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x40c>
                	fdiv.s	ft0, fs1, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4b4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x41c>
                	fdiv.s	ft0, fs0, fs5
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4c4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x42c>
                	fdiv.s	ft0, fs4, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4d4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x43c>
                	fadd.s	ft0, fs7, fs7
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4e4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x44c>
                	flt.s	a1, fs7, fs4
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4f0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x460>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs7
                	flt.s	a1, fs5, ft0
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x504>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x47c>
                	fsub.s	ft0, fs4, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x514>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x48c>
                	fadd.s	ft0, fs5, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x524>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x49c>
                	fmul.s	ft0, fs4, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x534>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4ac>
                	fmul.s	ft0, fs5, fs3
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x544>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4bc>
                	fdiv.s	ft0, fs4, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x554>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4cc>
                	fdiv.s	ft0, fs2, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x564>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4dc>
                	fdiv.s	ft0, fs3, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x574>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x4ec>
                	fmv.x.w	a1, fs6
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x580>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x504>
                	feq.s	a1, fs6, fs6
                	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x590>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x51c>
                	feq.s	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x59c>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x530>
                	flt.s	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5a8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x544>
                	fle.s	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5b4>
-               	fneg.s	fs1, fs6
-               	fmv.x.w	a1, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5c4>
-               	fneg.s	ft0, fs1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x558>
+               	fneg.s	ft0, fs6
                	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5d4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x574>
+               	fneg.s	ft0, fs6
+               	fneg.s	ft1, ft0
+               	fmv.x.w	a1, ft1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x594>
                	fadd.s	ft0, fs6, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5e4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5a4>
                	fadd.s	ft0, fs0, fs6
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5f4>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5b4>
                	fmul.s	ft0, fs6, fs2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x604>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5c4>
                	fsub.s	ft0, fs6, fs6
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x614>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5d4>
                	fdiv.s	ft0, fs6, fs6
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x624>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5e4>
                	fdiv.s	ft0, fs6, fs4
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x634>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x5f4>
                	fmv.s	fa0, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x640>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x600>
                	fmv.s	fa0, fs9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x64c>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x60c>
                	fmv.s	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x658>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x618>
                	fadd.s	ft0, fs9, fs10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x668>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x628>
                	fsub.s	ft0, fs8, fs10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x678>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x638>
                	fadd.s	ft0, fs10, fs10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x688>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x648>
                	lui	t0, 0x3fc00
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6a0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x660>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6b8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x678>
                	fneg.s	ft0, fs10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6c8>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x688>
                	lui	t0, 0x4b000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs10, ft10
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6e0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6a0>
                	fdiv.s	ft0, fs9, fs8
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6f0>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6b0>
                	flt.s	a1, fs2, fs10
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6fc>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6c4>
                	feq.s	a1, fs10, fs2
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x708>
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6d8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs10
                	flt.s	a1, ft0, fs3
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x71c>
-               	mv	s1, a0
-               	li	s2, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x6f4>
+               	mv	s2, a0
+               	li	s3, 0x0
                	li	t0, 0x1e
-               	bltu	s2, t0, 0x7b0 <corpus.cases.float.special_f32.checksum+0x738>
-               	j	0x808 <corpus.cases.float.special_f32.checksum+0x790>
+               	bltu	s3, t0, 0x7e0 <corpus.cases.float.special_f32.checksum+0x710>
+               	j	0x80c <corpus.cases.float.special_f32.checksum+0x73c>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
-               	fmul.s	fs1, fs8, ft10
-               	feq.s	a0, fs1, fs1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7e0 <corpus.cases.float.special_f32.checksum+0x768>
-               	mv	a0, s1
-               	fmv.s	fa0, fs1
+               	fmul.s	fs8, fs8, ft10
+               	mv	a0, s2
+               	fmv.s	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x758>
-               	mv	s4, a0
-               	j	0x7f4 <corpus.cases.float.special_f32.checksum+0x77c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x770>
-               	mv	s4, a0
-               	addiw	s2, s2, 0x1
-               	mv	s1, s4
-               	fmv.d	fs8, fs1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x724>
+               	addiw	s3, s3, 0x1
+               	mv	s2, a0
                	li	t0, 0x1e
-               	bltu	s2, t0, 0x7b0 <corpus.cases.float.special_f32.checksum+0x738>
-               	addi	s2, s0, -0xc8
-               	mv	a0, s2
+               	bltu	s3, t0, 0x7e0 <corpus.cases.float.special_f32.checksum+0x710>
+               	addi	a0, s0, -0xc0
+               	mv	a1, a0
                	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x83c <corpus.cases.float.special_f32.checksum+0x7c4>
-               	mv	a1, a0
-               	li	a2, 0x20
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
+               	and	a2, a1, t0
+               	bnez	a2, 0x840 <corpus.cases.float.special_f32.checksum+0x770>
+               	mv	a2, a1
+               	li	a3, 0x20
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x824 <corpus.cases.float.special_f32.checksum+0x7ac>
-               	j	0x858 <corpus.cases.float.special_f32.checksum+0x7e0>
-               	mv	a1, a0
-               	li	a0, 0x20
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
+               	bne	a3, t0, 0x828 <corpus.cases.float.special_f32.checksum+0x758>
+               	j	0x85c <corpus.cases.float.special_f32.checksum+0x78c>
+               	mv	a2, a1
+               	li	a1, 0x20
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x844 <corpus.cases.float.special_f32.checksum+0x7cc>
-               	mv	a0, s2
-               	sw	zero, 0x0(a0)
-               	addi	a0, s2, 0x4
+               	bne	a1, t0, 0x848 <corpus.cases.float.special_f32.checksum+0x778>
+               	mv	a1, a0
+               	sw	zero, 0x0(a1)
+               	addi	a1, a0, 0x4
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0x8
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
                	li	t0, 0x1
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0xc
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0xc
                	lui	t0, 0x7f800
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0x10
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x10
                	lui	t0, 0x100
                	addiw	t0, t0, -0x800
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0x14
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x14
                	lui	t0, 0x7fc00
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0x18
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x18
                	lui	t0, 0x100
                	addiw	t0, t0, -0x3f2
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x153
-               	sw	t0, 0x0(a0)
-               	addi	a0, s2, 0x1c
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x1c
                	lui	t0, 0x7f800
                	addiw	t0, t0, 0x1
-               	sw	t0, 0x0(a0)
-               	li	s4, 0x0
+               	sw	t0, 0x0(a1)
+               	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x8e0 <corpus.cases.float.special_f32.checksum+0x868>
-               	j	0x91c <corpus.cases.float.special_f32.checksum+0x8a4>
-               	slli	a0, s4, 0x20
-               	srli	a0, a0, 0x20
-               	slli	t0, a0, 0x2
-               	add	a1, s2, t0
-               	lw	a0, 0x0(a1)
-               	addw	a1, a0, s3
-               	fmv.w.x	ft0, a1
-               	fmv.x.w	a1, ft0
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x88c>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	bltu	a1, t0, 0x8e4 <corpus.cases.float.special_f32.checksum+0x814>
+               	j	0x964 <corpus.cases.float.special_f32.checksum+0x894>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	slli	t0, a2, 0x2
+               	add	a3, a0, t0
+               	lw	a2, 0x0(a3)
+               	addw	a3, a2, s1
+               	fmv.w.x	ft0, a3
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a2, s2
+               	li	a4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x8e0 <corpus.cases.float.special_f32.checksum+0x868>
+               	bltu	a4, t0, 0x920 <corpus.cases.float.special_f32.checksum+0x850>
+               	j	0x954 <corpus.cases.float.special_f32.checksum+0x884>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x920 <corpus.cases.float.special_f32.checksum+0x850>
+               	addiw	a1, a1, 0x1
+               	mv	s2, a2
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x8e4 <corpus.cases.float.special_f32.checksum+0x814>
                	lui	t1, 0x1000
-               	addw	a0, t1, s3
+               	addw	a0, t1, s1
                	lui	t1, 0x1000
                	addiw	t1, t1, 0x1
-               	addw	s2, t1, s3
+               	addw	s3, t1, s1
                	lui	t1, 0x1000
                	addiw	t1, t1, 0x3
-               	addw	s4, t1, s3
+               	addw	s4, t1, s1
                	li	t1, -0x1
-               	addw	s5, t1, s3
+               	addw	s5, t1, s1
                	lui	t1, 0xff000
                	addiw	t1, t1, -0x1
-               	addw	s6, t1, s3
+               	addw	s6, t1, s1
                	lui	t1, 0x80000
-               	addw	s7, t1, s3
+               	addw	s7, t1, s1
                	fcvt.s.wu	ft0, a0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x980 <corpus.cases.float.special_f32.checksum+0x908>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8f8>
-               	mv	s8, a0
-               	j	0x994 <corpus.cases.float.special_f32.checksum+0x91c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x910>
-               	mv	s8, a0
-               	fcvt.s.wu	ft0, s2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9bc <corpus.cases.float.special_f32.checksum+0x944>
-               	mv	a0, s8
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x934>
-               	mv	s1, a0
-               	j	0x9d0 <corpus.cases.float.special_f32.checksum+0x958>
-               	mv	a0, s8
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x94c>
-               	mv	s1, a0
-               	fcvt.s.wu	ft0, s4
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9f8 <corpus.cases.float.special_f32.checksum+0x980>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x970>
-               	mv	s2, a0
-               	j	0xa0c <corpus.cases.float.special_f32.checksum+0x994>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x988>
-               	mv	s2, a0
-               	fcvt.s.wu	ft0, s5
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa34 <corpus.cases.float.special_f32.checksum+0x9bc>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9ac>
-               	mv	s1, a0
-               	j	0xa48 <corpus.cases.float.special_f32.checksum+0x9d0>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9c4>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8dc>
                	fcvt.s.wu	ft0, s3
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa70 <corpus.cases.float.special_f32.checksum+0x9f8>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0x9e8>
-               	mv	s2, a0
-               	j	0xa84 <corpus.cases.float.special_f32.checksum+0xa0c>
-               	mv	a0, s1
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8ec>
+               	fcvt.s.wu	ft0, s4
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa00>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x8fc>
+               	fcvt.s.wu	ft0, s5
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x90c>
+               	fcvt.s.wu	ft0, s1
+               	fmv.s	fa0, ft0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x91c>
                	fcvt.s.w	ft0, s6
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xaac <corpus.cases.float.special_f32.checksum+0xa34>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa24>
-               	mv	s1, a0
-               	j	0xac0 <corpus.cases.float.special_f32.checksum+0xa48>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa3c>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x92c>
                	fcvt.s.w	ft0, s7
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xae8 <corpus.cases.float.special_f32.checksum+0xa70>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa60>
-               	mv	s2, a0
-               	j	0xafc <corpus.cases.float.special_f32.checksum+0xa84>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f32.checksum+0xa78>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f32.checksum+0x93c>
                	lui	t0, 0x3fc00
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
                	lui	t0, 0x4b800
                	fmv.w.x	ft11, t0
-               	fmul.s	fs1, ft11, fs0
+               	fmul.s	ft1, ft11, fs0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
-               	fmul.s	fs3, ft11, fs0
+               	fmul.s	ft2, ft11, fs0
                	fmv.w.x	ft11, zero
-               	fsub.s	fs4, ft11, ft0
+               	fsub.s	ft3, ft11, ft0
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
-               	fmul.s	fs5, ft11, fs0
+               	fmul.s	ft4, ft11, fs0
                	fcvt.wu.s	a1, ft0, rtz
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x28>
-               	fcvt.wu.s	a1, fs1, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x34>
-               	fcvt.wu.s	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x40>
-               	fcvt.wu.s	a1, fs5, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x4c>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa68 <.Lpcrel_hi.0+0x3c>
+               	j	0xa9c <.Lpcrel_hi.0+0x70>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa68 <.Lpcrel_hi.0+0x3c>
+               	fcvt.wu.s	a1, ft1, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xab8 <.Lpcrel_hi.0+0x8c>
+               	j	0xaec <.Lpcrel_hi.0+0xc0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xab8 <.Lpcrel_hi.0+0x8c>
+               	fcvt.wu.s	a1, ft2, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb08 <.Lpcrel_hi.0+0xdc>
+               	j	0xb3c <.Lpcrel_hi.0+0x110>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb08 <.Lpcrel_hi.0+0xdc>
+               	fcvt.wu.s	a1, ft4, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb58 <.Lpcrel_hi.0+0x12c>
+               	j	0xb8c <.Lpcrel_hi.0+0x160>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb58 <.Lpcrel_hi.0+0x12c>
                	fcvt.wu.s	a1, fs2, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x58>
-               	fcvt.w.s	a1, fs4, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x64>
-               	fcvt.w.s	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x70>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xba8 <.Lpcrel_hi.0+0x17c>
+               	j	0xbdc <.Lpcrel_hi.0+0x1b0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xba8 <.Lpcrel_hi.0+0x17c>
+               	fcvt.w.s	a1, ft3, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbf4 <.Lpcrel_hi.0+0x1c8>
+               	j	0xc28 <.Lpcrel_hi.0+0x1fc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbf4 <.Lpcrel_hi.0+0x1c8>
+               	fcvt.w.s	a1, ft2, rtz
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc40 <.Lpcrel_hi.0+0x214>
+               	j	0xc74 <.Lpcrel_hi.0+0x248>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc40 <.Lpcrel_hi.0+0x214>
                	fmv.w.x	ft11, zero
-               	fsub.s	ft0, ft11, fs5
+               	fsub.s	ft0, ft11, ft4
                	fcvt.w.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x84>
-               	fcvt.l.s	a1, fs4, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x90>
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc94 <.Lpcrel_hi.0+0x268>
+               	j	0xcc8 <.Lpcrel_hi.0+0x29c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc94 <.Lpcrel_hi.0+0x268>
+               	fcvt.l.s	a1, ft3, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcdc <.Lpcrel_hi.0+0x2b0>
+               	j	0xd10 <.Lpcrel_hi.0+0x2e4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcdc <.Lpcrel_hi.0+0x2b0>
                	fmv.w.x	ft11, zero
-               	fsub.s	ft0, ft11, fs1
+               	fsub.s	ft0, ft11, ft1
                	fcvt.l.s	a1, ft0, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0xa4>
-               	ld	s1, 0xb8(sp)
-               	ld	s2, 0xb0(sp)
-               	ld	s3, 0xa8(sp)
-               	ld	s4, 0xa0(sp)
-               	ld	s5, 0x98(sp)
-               	ld	s6, 0x90(sp)
-               	ld	s7, 0x88(sp)
-               	ld	s8, 0x80(sp)
-               	fld	fs0, 0x78(sp)
-               	fld	fs1, 0x70(sp)
-               	fld	fs2, 0x68(sp)
-               	fld	fs3, 0x60(sp)
-               	fld	fs4, 0x58(sp)
-               	fld	fs5, 0x50(sp)
-               	fld	fs6, 0x48(sp)
-               	fld	fs7, 0x40(sp)
-               	fld	fs8, 0x38(sp)
-               	fld	fs9, 0x30(sp)
-               	fld	fs10, 0x28(sp)
-               	ld	ra, 0xc8(sp)
-               	ld	s0, 0xc0(sp)
-               	addi	sp, sp, 0xd0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd2c <.Lpcrel_hi.0+0x300>
+               	j	0xd60 <.Lpcrel_hi.0+0x334>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd2c <.Lpcrel_hi.0+0x300>
+               	ld	s1, 0xa8(sp)
+               	ld	s2, 0xa0(sp)
+               	ld	s3, 0x98(sp)
+               	ld	s4, 0x90(sp)
+               	ld	s5, 0x88(sp)
+               	ld	s6, 0x80(sp)
+               	ld	s7, 0x78(sp)
+               	fld	fs0, 0x70(sp)
+               	fld	fs1, 0x68(sp)
+               	fld	fs2, 0x60(sp)
+               	fld	fs3, 0x58(sp)
+               	fld	fs4, 0x50(sp)
+               	fld	fs5, 0x48(sp)
+               	fld	fs6, 0x40(sp)
+               	fld	fs7, 0x38(sp)
+               	fld	fs8, 0x30(sp)
+               	fld	fs9, 0x28(sp)
+               	fld	fs10, 0x20(sp)
+               	ld	ra, 0xb8(sp)
+               	ld	s0, 0xb0(sp)
+               	addi	sp, sp, 0xc0
                	ret

--- a/test/golden/riscv64-linux/float/special_f64.dis
+++ b/test/golden/riscv64-linux/float/special_f64.dis
@@ -8,46 +8,63 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.float.special_f64.fold64>:
-               	addi	sp, sp, -0x20
-               	sd	ra, 0x18(sp)
-               	sd	s0, 0x10(sp)
-               	addi	s0, sp, 0x20
-               	sd	s1, 0x8(sp)
-               	mv	s1, a0
+               	mv	a1, a0
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x50 <corpus.cases.float.special_f64.fold64+0x44>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.fold64+0x28>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	bnez	a0, 0x70 <corpus.cases.float.special_f64.fold64+0x64>
+               	fmv.x.d	a0, fa0
+               	mv	a2, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.float.special_f64.fold64+0x28>
+               	j	0x68 <corpus.cases.float.special_f64.fold64+0x5c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.float.special_f64.fold64+0x28>
+               	mv	a0, a2
                	ret
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.fold64+0x4c>
-               	ld	s1, 0x8(sp)
-               	ld	ra, 0x18(sp)
-               	ld	s0, 0x10(sp)
-               	addi	sp, sp, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x80 <corpus.cases.float.special_f64.fold64+0x74>
+               	j	0xb8 <corpus.cases.float.special_f64.fold64+0xac>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	li	t1, -0x1
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x80 <corpus.cases.float.special_f64.fold64+0x74>
+               	mv	a0, a1
                	ret
 
 <corpus.cases.float.special_f64.checksum>:
-               	addi	sp, sp, -0xf0
-               	sd	ra, 0xe8(sp)
-               	sd	s0, 0xe0(sp)
-               	addi	s0, sp, 0xf0
-               	sd	s1, 0xd8(sp)
-               	sd	s2, 0xd0(sp)
-               	sd	s3, 0xc8(sp)
-               	sd	s4, 0xc0(sp)
-               	sd	s5, 0xb8(sp)
-               	sd	s6, 0xb0(sp)
-               	sd	s7, 0xa8(sp)
-               	sd	s8, 0xa0(sp)
+               	addi	sp, sp, -0xe0
+               	sd	ra, 0xd8(sp)
+               	sd	s0, 0xd0(sp)
+               	addi	s0, sp, 0xe0
+               	sd	s1, 0xc8(sp)
+               	sd	s2, 0xc0(sp)
+               	sd	s3, 0xb8(sp)
+               	sd	s4, 0xb0(sp)
+               	sd	s5, 0xa8(sp)
+               	sd	s6, 0xa0(sp)
                	fsd	fs0, 0x98(sp)
                	fsd	fs1, 0x90(sp)
                	fsd	fs2, 0x88(sp)
@@ -60,9 +77,6 @@ Disassembly of section .text:
                	fsd	fs9, 0x50(sp)
                	fsd	fs10, 0x48(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x60>
-               	mv	s2, a0
                	lui	t1, 0x3ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -120,280 +134,278 @@ Disassembly of section .text:
                	li	t1, 0x1
                	add	a0, t1, s1
                	fmv.d.x	fs10, a0
-               	feq.d	a0, fs2, fs2
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1e8 <corpus.cases.float.special_f64.checksum+0x174>
-               	mv	a0, s2
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	fmv.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x164>
-               	mv	s3, a0
-               	j	0x1fc <corpus.cases.float.special_f64.checksum+0x188>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x17c>
-               	mv	s3, a0
-               	feq.d	a0, fs3, fs3
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x220 <corpus.cases.float.special_f64.checksum+0x1ac>
-               	mv	a0, s3
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x160>
                	fmv.d	fa0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x19c>
-               	mv	s2, a0
-               	j	0x234 <corpus.cases.float.special_f64.checksum+0x1c0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1b4>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x16c>
                	fadd.d	fa0, fs2, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x258 <corpus.cases.float.special_f64.checksum+0x1e4>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1d4>
-               	mv	s3, a0
-               	j	0x26c <corpus.cases.float.special_f64.checksum+0x1f8>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1ec>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x178>
                	fadd.d	fa0, fs2, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x290 <corpus.cases.float.special_f64.checksum+0x21c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x20c>
-               	mv	s2, a0
-               	j	0x2a4 <corpus.cases.float.special_f64.checksum+0x230>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x224>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x184>
                	fadd.d	fa0, fs3, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2c8 <corpus.cases.float.special_f64.checksum+0x254>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x244>
-               	mv	s3, a0
-               	j	0x2dc <corpus.cases.float.special_f64.checksum+0x268>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x25c>
-               	mv	s3, a0
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x190>
                	fadd.d	fa0, fs3, fs3
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x270>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x19c>
                	fsub.d	fa0, fs2, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x27c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1a8>
                	fsub.d	fa0, fs2, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x288>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1b4>
                	fsub.d	fa0, fs3, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x294>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1c0>
                	fsub.d	fa0, fs3, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2a0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1cc>
                	fmul.d	fa0, fs2, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2ac>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1d8>
                	fmul.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2b8>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1e4>
                	fmul.d	fa0, fs3, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2c4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1f0>
                	fmul.d	fa0, fs3, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2d0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x1fc>
                	fmul.d	fa0, fs3, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2dc>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x208>
                	fmul.d	fa0, fs2, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2e8>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x214>
                	fneg.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x2f4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x220>
                	fneg.d	fa0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x300>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x22c>
                	fdiv.d	fa0, fs2, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x30c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x238>
                	fdiv.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x318>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x244>
                	fdiv.d	fa0, fs3, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x324>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x250>
                	fdiv.d	fa0, fs3, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x330>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x25c>
                	feq.d	a1, fs2, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x33c>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x33c <corpus.cases.float.special_f64.checksum+0x27c>
+               	j	0x370 <corpus.cases.float.special_f64.checksum+0x2b0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x33c <corpus.cases.float.special_f64.checksum+0x27c>
                	flt.d	a1, fs2, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x348>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x388 <corpus.cases.float.special_f64.checksum+0x2c8>
+               	j	0x3bc <corpus.cases.float.special_f64.checksum+0x2fc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x388 <corpus.cases.float.special_f64.checksum+0x2c8>
                	flt.d	a1, fs3, fs2
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x354>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x308>
                	fmv.d	fa0, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x360>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x314>
                	fmv.d	fa0, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x36c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x320>
                	fneg.d	fa0, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x378>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x32c>
                	fdiv.d	fa0, fs0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x384>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x338>
                	fdiv.d	fa0, fs0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x390>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x344>
                	fdiv.d	fa0, fs1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x39c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x350>
                	fdiv.d	fa0, fs1, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3a8>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x35c>
                	fadd.d	fa0, fs4, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3b4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x368>
                	fadd.d	fa0, fs4, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3c0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x374>
                	fsub.d	fa0, fs4, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3cc>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x380>
                	fmul.d	fa0, fs4, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3d8>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x38c>
                	fmul.d	fa0, fs4, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3e4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x398>
                	fmul.d	fa0, fs4, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3f0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3a4>
                	fdiv.d	fa0, fs0, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3fc>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3b0>
                	fdiv.d	fa0, fs1, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x408>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3bc>
                	fdiv.d	fa0, fs0, fs5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x414>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3c8>
                	fdiv.d	fa0, fs4, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x420>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3d4>
                	fadd.d	fa0, fs7, fs7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x42c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3e0>
                	flt.d	a1, fs7, fs4
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x438>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x3f4>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs7
                	flt.d	a1, fs5, ft0
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x44c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x410>
                	fsub.d	fa0, fs4, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x458>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x41c>
                	fadd.d	fa0, fs5, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x464>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x428>
                	fmul.d	fa0, fs4, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x470>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x434>
                	fmul.d	fa0, fs5, fs3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x47c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x440>
                	fdiv.d	fa0, fs4, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x488>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x44c>
                	fdiv.d	fa0, fs2, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x494>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x458>
                	fdiv.d	fa0, fs3, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4a0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x464>
                	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4ac>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x470>
                	feq.d	a1, fs6, fs6
                	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4bc>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x488>
                	feq.d	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4c8>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x49c>
                	flt.d	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4d4>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4b0>
                	fle.d	a1, fs6, fs6
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4e0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4c4>
                	fneg.d	fs1, fs6
                	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4f0>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4d4>
                	fneg.d	ft0, fs1
                	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x500>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4e4>
                	fadd.d	fa0, fs6, fs0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x50c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4f0>
                	fadd.d	fa0, fs0, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x518>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x4fc>
                	fmul.d	fa0, fs6, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x524>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x508>
                	fsub.d	fa0, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x530>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x514>
                	fdiv.d	fa0, fs6, fs6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x53c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x520>
                	fdiv.d	fa0, fs6, fs4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x548>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x52c>
                	fmv.d	fa0, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x554>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x538>
                	fmv.d	fa0, fs9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x560>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x544>
                	fmv.d	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x56c>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x550>
                	fadd.d	fa0, fs9, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x578>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x55c>
                	fsub.d	fa0, fs8, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x584>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x568>
                	fadd.d	fa0, fs10, fs10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.special_f64.checksum+0x590>
+               	jalr	ra <corpus.cases.float.special_f64.checksum+0x574>
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
@@ -422,221 +434,316 @@ Disassembly of section .text:
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.2+0x18>
                	flt.d	a1, fs2, fs10
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x24>
+               	jalr	ra <.Lpcrel_hi.2+0x2c>
                	feq.d	a1, fs10, fs2
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x30>
+               	jalr	ra <.Lpcrel_hi.2+0x40>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs10
                	flt.d	a1, ft0, fs3
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x44>
+               	jalr	ra <.Lpcrel_hi.2+0x5c>
                	mv	s2, a0
                	li	s3, 0x0
                	li	t0, 0x3c
-               	bltu	s3, t0, 0x6a0 <.Lpcrel_hi.3>
-               	j	0x6f8 <.Lpcrel_hi.3+0x58>
+               	bltu	s3, t0, 0x6e8 <.Lpcrel_hi.3>
+               	j	0x714 <.Lpcrel_hi.3+0x2c>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fmul.d	fs1, fs8, ft10
-               	feq.d	a0, fs1, fs1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x6d0 <.Lpcrel_hi.3+0x30>
+               	fmul.d	fs8, fs8, ft10
                	mv	a0, s2
-               	fmv.d	fa0, fs1
+               	fmv.d	fa0, fs8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x20>
-               	mv	s4, a0
-               	j	0x6e4 <.Lpcrel_hi.3+0x44>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x38>
-               	mv	s4, a0
+               	jalr	ra <.Lpcrel_hi.3+0x14>
                	addi	s3, s3, 0x1
-               	mv	s2, s4
-               	fmv.d	fs8, fs1
+               	mv	s2, a0
                	li	t0, 0x3c
-               	bltu	s3, t0, 0x6a0 <.Lpcrel_hi.3>
-               	addi	s3, s0, -0xe8
-               	mv	a0, s3
+               	bltu	s3, t0, 0x6e8 <.Lpcrel_hi.3>
+               	addi	a0, s0, -0xd8
+               	mv	a1, a0
                	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x72c <.Lpcrel_hi.3+0x8c>
+               	and	a2, a1, t0
+               	bnez	a2, 0x748 <.Lpcrel_hi.3+0x60>
+               	mv	a2, a1
+               	li	a3, 0x40
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
+               	li	t0, 0x0
+               	bne	a3, t0, 0x730 <.Lpcrel_hi.3+0x48>
+               	j	0x764 <.Lpcrel_hi.3+0x7c>
+               	mv	a2, a1
+               	li	a1, 0x40
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x750 <.Lpcrel_hi.3+0x68>
                	mv	a1, a0
-               	li	a2, 0x40
                	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x714 <.Lpcrel_hi.3+0x74>
-               	j	0x748 <.Lpcrel_hi.3+0xa8>
-               	mv	a1, a0
-               	li	a0, 0x40
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x734 <.Lpcrel_hi.3+0x94>
-               	mv	a0, s3
-               	sd	zero, 0x0(a0)
-               	addi	a0, s3, 0x8
+               	addi	a1, a0, 0x8
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x10
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x10
                	li	t0, 0x1
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x18
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x18
                	lui	t0, 0x7ff0
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x20
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x20
                	lui	t0, 0xf0000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x28
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x28
                	lui	t0, 0x7ff8
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x30
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x30
                	lui	t0, 0xf8000
                	addiw	t0, t0, 0x1
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x3f2
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x153
-               	sd	t0, 0x0(a0)
-               	addi	a0, s3, 0x38
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x38
                	lui	t0, 0x7ff0
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1
-               	sd	t0, 0x0(a0)
-               	li	s4, 0x0
+               	sd	t0, 0x0(a1)
+               	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x804 <.Lpcrel_hi.3+0x164>
-               	j	0x838 <.Lpcrel_hi.3+0x198>
-               	slli	t0, s4, 0x3
-               	add	a0, s3, t0
-               	ld	a1, 0x0(a0)
-               	add	a0, a1, s1
-               	fmv.d.x	ft0, a0
-               	fmv.x.d	a1, ft0
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x180>
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
+               	bltu	a1, t0, 0x820 <.Lpcrel_hi.3+0x138>
+               	j	0x890 <.Lpcrel_hi.3+0x1a8>
+               	slli	t0, a1, 0x3
+               	add	a2, a0, t0
+               	ld	a3, 0x0(a2)
+               	add	a2, a3, s1
+               	fmv.d.x	ft0, a2
+               	fmv.x.d	a2, ft0
+               	mv	a3, s2
+               	li	a4, 0x0
                	li	t0, 0x8
-               	bltu	s4, t0, 0x804 <.Lpcrel_hi.3+0x164>
+               	bltu	a4, t0, 0x84c <.Lpcrel_hi.3+0x164>
+               	j	0x880 <.Lpcrel_hi.3+0x198>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x84c <.Lpcrel_hi.3+0x164>
+               	addi	a1, a1, 0x1
+               	mv	s2, a3
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x820 <.Lpcrel_hi.3+0x138>
                	fcvt.s.d	ft0, fs7
-               	fcvt.s.d	fs1, fs10
+               	fcvt.s.d	ft1, fs10
                	lui	t1, 0x36a0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	add	a0, t1, s1
-               	fmv.d.x	ft1, a0
-               	fcvt.s.d	fs4, ft1
+               	fmv.d.x	ft2, a0
+               	fcvt.s.d	ft3, ft2
                	lui	t1, 0x3ff0
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x10
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	add	a0, t1, s1
-               	fmv.d.x	ft1, a0
-               	fcvt.s.d	fs6, ft1
+               	fmv.d.x	ft2, a0
+               	fcvt.s.d	ft4, ft2
                	lui	t1, 0x3ff0
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x30
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	add	a0, t1, s1
-               	fmv.d.x	ft1, a0
-               	fcvt.s.d	fs7, ft1
-               	fcvt.s.d	fs8, fs3
+               	fmv.d.x	ft2, a0
+               	fcvt.s.d	ft5, ft2
+               	fcvt.s.d	fs1, fs3
                	fcvt.s.d	fs3, fs5
+               	fmv.x.w	a0, ft0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x918 <.Lpcrel_hi.3+0x230>
+               	j	0x94c <.Lpcrel_hi.3+0x264>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x918 <.Lpcrel_hi.3+0x230>
+               	fmv.x.w	a0, ft1
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x968 <.Lpcrel_hi.3+0x280>
+               	j	0x99c <.Lpcrel_hi.3+0x2b4>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x968 <.Lpcrel_hi.3+0x280>
+               	fmv.x.w	a0, ft3
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9b8 <.Lpcrel_hi.3+0x2d0>
+               	j	0x9ec <.Lpcrel_hi.3+0x304>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9b8 <.Lpcrel_hi.3+0x2d0>
+               	fmv.x.w	a0, ft4
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa08 <.Lpcrel_hi.3+0x320>
+               	j	0xa3c <.Lpcrel_hi.3+0x354>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa08 <.Lpcrel_hi.3+0x320>
+               	fmv.x.w	a0, ft5
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa58 <.Lpcrel_hi.3+0x370>
+               	j	0xa8c <.Lpcrel_hi.3+0x3a4>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa58 <.Lpcrel_hi.3+0x370>
+               	fmv.x.w	a0, fs1
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaa8 <.Lpcrel_hi.3+0x3c0>
+               	j	0xadc <.Lpcrel_hi.3+0x3f4>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaa8 <.Lpcrel_hi.3+0x3c0>
+               	fmv.x.w	a0, fs3
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaf8 <.Lpcrel_hi.3+0x410>
+               	j	0xb2c <.Lpcrel_hi.3+0x444>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xaf8 <.Lpcrel_hi.3+0x410>
+               	fcvt.d.s	fa0, ft3
                	mv	a0, s2
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x20c>
-               	fmv.s	fa0, fs1
+               	jalr	ra <.Lpcrel_hi.3+0x44c>
+               	fcvt.d.s	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x218>
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x224>
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x230>
-               	fmv.s	fa0, fs7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x23c>
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x248>
-               	fmv.s	fa0, fs3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x254>
-               	mv	s2, a0
-               	fcvt.d.s	fa0, fs4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x924 <.Lpcrel_hi.3+0x284>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x274>
-               	mv	s3, a0
-               	j	0x938 <.Lpcrel_hi.3+0x298>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x28c>
-               	mv	s3, a0
-               	fcvt.d.s	fa0, fs8
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x95c <.Lpcrel_hi.3+0x2bc>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2ac>
-               	mv	s2, a0
-               	j	0x970 <.Lpcrel_hi.3+0x2d0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2c4>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.3+0x458>
                	fcvt.d.s	fa0, fs3
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x994 <.Lpcrel_hi.3+0x2f4>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2e4>
-               	mv	s3, a0
-               	j	0x9a8 <.Lpcrel_hi.3+0x308>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x2fc>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.3+0x464>
                	lui	t1, 0x20000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	a0, t1, s1
+               	add	a1, t1, s1
                	lui	t1, 0x20000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -646,117 +753,40 @@ Disassembly of section .text:
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x3
-               	add	s4, t1, s1
+               	add	s3, t1, s1
                	li	t1, -0x1
-               	add	s5, t1, s1
+               	add	s4, t1, s1
                	lui	t1, 0xe0000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x1
-               	add	s6, t1, s1
+               	add	s5, t1, s1
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	add	s7, t1, s1
-               	fcvt.d.lu	fa0, a0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa34 <.Lpcrel_hi.3+0x394>
-               	mv	a0, s3
+               	add	s6, t1, s1
+               	fcvt.d.lu	fa0, a1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x384>
-               	mv	s8, a0
-               	j	0xa48 <.Lpcrel_hi.3+0x3a8>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x39c>
-               	mv	s8, a0
+               	jalr	ra <.Lpcrel_hi.3+0x4d8>
                	fcvt.d.lu	fa0, s2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa6c <.Lpcrel_hi.3+0x3cc>
-               	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3bc>
-               	mv	s2, a0
-               	j	0xa80 <.Lpcrel_hi.3+0x3e0>
-               	mv	a0, s8
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.3+0x4e4>
+               	fcvt.d.lu	fa0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3d4>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.3+0x4f0>
                	fcvt.d.lu	fa0, s4
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xaa4 <.Lpcrel_hi.3+0x404>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x3f4>
-               	mv	s3, a0
-               	j	0xab8 <.Lpcrel_hi.3+0x418>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x40c>
-               	mv	s3, a0
-               	fcvt.d.lu	fa0, s5
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xadc <.Lpcrel_hi.3+0x43c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x42c>
-               	mv	s2, a0
-               	j	0xaf0 <.Lpcrel_hi.3+0x450>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x444>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.3+0x4fc>
                	fcvt.d.lu	fa0, s1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb14 <.Lpcrel_hi.3+0x474>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x464>
-               	mv	s1, a0
-               	j	0xb28 <.Lpcrel_hi.3+0x488>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.3+0x508>
+               	fcvt.d.l	fa0, s5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x47c>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.3+0x514>
                	fcvt.d.l	fa0, s6
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb4c <.Lpcrel_hi.3+0x4ac>
-               	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x49c>
-               	mv	s2, a0
-               	j	0xb60 <.Lpcrel_hi.3+0x4c0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x4b4>
-               	mv	s2, a0
-               	fcvt.d.l	fa0, s7
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xb84 <.Lpcrel_hi.3+0x4e4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x4d4>
-               	mv	s1, a0
-               	j	0xb98 <.Lpcrel_hi.4>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x4ec>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.3+0x520>
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
@@ -766,60 +796,122 @@ Disassembly of section .text:
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fmul.d	fs3, ft11, fs0
+               	fmul.d	ft0, ft11, fs0
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fmul.d	fs4, ft11, fs0
+               	fmul.d	fs3, ft11, fs0
                	fmv.d.x	ft11, zero
-               	fsub.d	fs5, ft11, fs1
+               	fsub.d	fs4, ft11, fs1
 
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fmul.d	fs6, ft11, fs0
+               	fmul.d	fs5, ft11, fs0
                	fcvt.lu.d	a1, fs1, rtz
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x14>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc5c <.Lpcrel_hi.7+0x20>
+               	j	0xc90 <.Lpcrel_hi.7+0x54>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc5c <.Lpcrel_hi.7+0x20>
+               	fcvt.lu.d	a1, ft0, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xca4 <.Lpcrel_hi.7+0x68>
+               	j	0xcd8 <.Lpcrel_hi.7+0x9c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xca4 <.Lpcrel_hi.7+0x68>
                	fcvt.lu.d	a1, fs3, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x20>
-               	fcvt.lu.d	a1, fs4, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x2c>
-               	fcvt.lu.d	a1, fs6, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x38>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcec <.Lpcrel_hi.7+0xb0>
+               	j	0xd20 <.Lpcrel_hi.7+0xe4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcec <.Lpcrel_hi.7+0xb0>
+               	fcvt.lu.d	a1, fs5, rtz
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd34 <.Lpcrel_hi.7+0xf8>
+               	j	0xd68 <.Lpcrel_hi.7+0x12c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd34 <.Lpcrel_hi.7+0xf8>
                	fcvt.lu.d	a1, fs2, rtz
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x44>
-               	fcvt.l.d	a1, fs5, rtz
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x50>
+               	jalr	ra <.Lpcrel_hi.7+0x130>
                	fcvt.l.d	a1, fs4, rtz
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x5c>
+               	jalr	ra <.Lpcrel_hi.7+0x13c>
+               	fcvt.l.d	a1, fs3, rtz
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.7+0x148>
                	fmv.d.x	ft11, zero
-               	fsub.d	ft0, ft11, fs6
+               	fsub.d	ft0, ft11, fs5
                	fcvt.l.d	a1, ft0, rtz
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x70>
-               	fcvt.w.d	a1, fs5, rtz
+               	jalr	ra <.Lpcrel_hi.7+0x15c>
+               	fcvt.w.d	a1, fs4, rtz
+               	sext.w	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x7c>
+               	jalr	ra <.Lpcrel_hi.7+0x170>
                	fcvt.wu.d	a1, fs1, rtz
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x88>
-               	ld	s1, 0xd8(sp)
-               	ld	s2, 0xd0(sp)
-               	ld	s3, 0xc8(sp)
-               	ld	s4, 0xc0(sp)
-               	ld	s5, 0xb8(sp)
-               	ld	s6, 0xb0(sp)
-               	ld	s7, 0xa8(sp)
-               	ld	s8, 0xa0(sp)
+               	jalr	ra <.Lpcrel_hi.7+0x188>
+               	ld	s1, 0xc8(sp)
+               	ld	s2, 0xc0(sp)
+               	ld	s3, 0xb8(sp)
+               	ld	s4, 0xb0(sp)
+               	ld	s5, 0xa8(sp)
+               	ld	s6, 0xa0(sp)
                	fld	fs0, 0x98(sp)
                	fld	fs1, 0x90(sp)
                	fld	fs2, 0x88(sp)
@@ -831,7 +923,7 @@ Disassembly of section .text:
                	fld	fs8, 0x58(sp)
                	fld	fs9, 0x50(sp)
                	fld	fs10, 0x48(sp)
-               	ld	ra, 0xe8(sp)
-               	ld	s0, 0xe0(sp)
-               	addi	sp, sp, 0xf0
+               	ld	ra, 0xd8(sp)
+               	ld	s0, 0xd0(sp)
+               	addi	sp, sp, 0xe0
                	ret

--- a/test/golden/riscv64-linux/frame/frame_align.dis
+++ b/test/golden/riscv64-linux/frame/frame_align.dis
@@ -3,120 +3,255 @@ frame/frame_align.o:
 Disassembly of section .text:
 
 <corpus.cases.frame.frame_align.fold_f32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.frame.frame_align.fold_f32x4+0x44>
+               	j	0x78 <corpus.cases.frame.frame_align.fold_f32x4+0x78>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.frame.frame_align.fold_f32x4+0x44>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.frame.frame_align.fold_f32x4+0x9c>
+               	j	0xd0 <corpus.cases.frame.frame_align.fold_f32x4+0xd0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.frame.frame_align.fold_f32x4+0x9c>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.frame.frame_align.fold_f32x4+0xf4>
+               	j	0x128 <corpus.cases.frame.frame_align.fold_f32x4+0x128>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.frame.frame_align.fold_f32x4+0xf4>
+               	addi	a2, a1, 0xc
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.frame.frame_align.fold_f32x4+0x14c>
+               	j	0x180 <corpus.cases.frame.frame_align.fold_f32x4+0x180>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.frame.frame_align.fold_f32x4+0x14c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.frame.frame_align.fold_f64x2>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	fld	fa0, 0x0(a1)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f64x2+0x30>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_f64x2+0x48>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1c4 <corpus.cases.frame.frame_align.fold_f64x2+0x34>
+               	j	0x1f8 <corpus.cases.frame.frame_align.fold_f64x2+0x68>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1c4 <corpus.cases.frame.frame_align.fold_f64x2+0x34>
+               	addi	a2, a1, 0x8
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x214 <corpus.cases.frame.frame_align.fold_f64x2+0x84>
+               	j	0x248 <corpus.cases.frame.frame_align.fold_f64x2+0xb8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x214 <corpus.cases.frame.frame_align.fold_f64x2+0x84>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.frame.frame_align.fold_u32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_u32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_u32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x298 <corpus.cases.frame.frame_align.fold_u32x4+0x40>
+               	j	0x2cc <corpus.cases.frame.frame_align.fold_u32x4+0x74>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x298 <corpus.cases.frame.frame_align.fold_u32x4+0x40>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_u32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.frame.frame_align.fold_u32x4+0x94>
+               	j	0x320 <corpus.cases.frame.frame_align.fold_u32x4+0xc8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.frame.frame_align.fold_u32x4+0x94>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.fold_u32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x340 <corpus.cases.frame.frame_align.fold_u32x4+0xe8>
+               	j	0x374 <corpus.cases.frame.frame_align.fold_u32x4+0x11c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x340 <corpus.cases.frame.frame_align.fold_u32x4+0xe8>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x394 <corpus.cases.frame.frame_align.fold_u32x4+0x13c>
+               	j	0x3c8 <corpus.cases.frame.frame_align.fold_u32x4+0x170>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x394 <corpus.cases.frame.frame_align.fold_u32x4+0x13c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.frame.frame_align.spin>:
@@ -171,8 +306,8 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(t5)
                	li	t5, 0x0
                	li	t0, 0x4
-               	bltu	t5, t0, 0x290 <corpus.cases.frame.frame_align.spin+0xd4>
-               	j	0x408 <corpus.cases.frame.frame_align.spin+0x24c>
+               	bltu	t5, t0, 0x4ac <corpus.cases.frame.frame_align.spin+0xd4>
+               	j	0x624 <corpus.cases.frame.frame_align.spin+0x24c>
                	li	t0, 0x11
                	mul	t6, t5, t0
                	sext.w	s1, t6
@@ -266,7 +401,7 @@ Disassembly of section .text:
                	addi	t5, t5, 0x1
                	mv	a2, a5
                	li	t0, 0x4
-               	bltu	t5, t0, 0x290 <corpus.cases.frame.frame_align.spin+0xd4>
+               	bltu	t5, t0, 0x4ac <corpus.cases.frame.frame_align.spin+0xd4>
                	mv	a1, a2
                	flw	ft0, 0x0(a1)
                	addi	a1, a7, 0x3
@@ -297,8 +432,8 @@ Disassembly of section .text:
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0x4e0 <corpus.cases.frame.frame_align.spin+0x324>
-               	bnez	a3, 0x4b4 <corpus.cases.frame.frame_align.spin+0x2f8>
+               	bltu	a1, a2, 0x6fc <corpus.cases.frame.frame_align.spin+0x324>
+               	bnez	a3, 0x6d0 <corpus.cases.frame.frame_align.spin+0x2f8>
                	addi	a4, a1, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -308,8 +443,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x494 <corpus.cases.frame.frame_align.spin+0x2d8>
-               	j	0x538 <corpus.cases.frame.frame_align.spin+0x37c>
+               	bne	a6, t0, 0x6b0 <corpus.cases.frame.frame_align.spin+0x2d8>
+               	j	0x754 <corpus.cases.frame.frame_align.spin+0x37c>
                	addi	a4, a1, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -319,9 +454,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x4c0 <corpus.cases.frame.frame_align.spin+0x304>
-               	j	0x538 <corpus.cases.frame.frame_align.spin+0x37c>
-               	bnez	a3, 0x510 <corpus.cases.frame.frame_align.spin+0x354>
+               	bne	a6, t0, 0x6dc <corpus.cases.frame.frame_align.spin+0x304>
+               	j	0x754 <corpus.cases.frame.frame_align.spin+0x37c>
+               	bnez	a3, 0x72c <corpus.cases.frame.frame_align.spin+0x354>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x10
@@ -331,8 +466,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x4f0 <corpus.cases.frame.frame_align.spin+0x334>
-               	j	0x538 <corpus.cases.frame.frame_align.spin+0x37c>
+               	bne	a5, t0, 0x70c <corpus.cases.frame.frame_align.spin+0x334>
+               	j	0x754 <corpus.cases.frame.frame_align.spin+0x37c>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x10
@@ -342,7 +477,7 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x51c <corpus.cases.frame.frame_align.spin+0x360>
+               	bne	a2, t0, 0x738 <corpus.cases.frame.frame_align.spin+0x360>
                	ld	s1, 0xe8(sp)
                	ld	ra, 0xf8(sp)
                	ld	s0, 0xf0(sp)
@@ -354,1100 +489,673 @@ Disassembly of section .text:
                	sd	s0, -0x10(sp)
                	mv	s0, sp
                	andi	sp, sp, -0x40
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x640
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x658
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x660
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
+               	addi	sp, sp, -0x640
+               	sd	s1, 0x628(sp)
+               	sd	s2, 0x620(sp)
+               	sd	s3, 0x618(sp)
+               	sd	s4, 0x610(sp)
+               	sd	s5, 0x608(sp)
+               	sd	s6, 0x600(sp)
+               	sd	s7, 0x5f8(sp)
+               	sd	s8, 0x5f0(sp)
+               	sd	s9, 0x5e8(sp)
+               	sd	s10, 0x5e0(sp)
+               	sd	s11, 0x5d8(sp)
                	mv	s1, a0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x6d0
-               	add	s2, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x6e0
-               	add	s3, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x6f0
-               	add	s4, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x700
-               	add	s5, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x710
-               	add	s6, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x720
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x730
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x740
-               	add	s7, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x750
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x760
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x770
-               	add	s8, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x780
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x790
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7a0
-               	add	s9, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7b0
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7c0
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7d0
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7e0
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	add	a1, sp, t0
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x800
-               	add	s10, sp, t0
-               	addi	a1, sp, 0x7f0
-               	addi	a1, sp, 0x7e0
-               	addi	s11, sp, 0x7d0
-               	addi	a1, sp, 0x7c0
-               	addi	a1, sp, 0x7b0
-               	addi	a1, sp, 0x7a0
-               	addi	t2, sp, 0x790
-               	sd	t2, 0x50(sp)
-               	addi	a1, sp, 0x780
-               	addi	a1, sp, 0x770
-               	addi	t2, sp, 0x760
-               	sd	t2, 0x48(sp)
-               	addi	a1, sp, 0x750
-               	addi	a1, sp, 0x740
-               	addi	t2, sp, 0x730
-               	sd	t2, 0x40(sp)
-               	addi	a1, sp, 0x720
-               	addi	a1, sp, 0x710
-               	addi	a1, sp, 0x700
-               	addi	t2, sp, 0x6f0
-               	sd	t2, 0x38(sp)
-               	addi	a1, sp, 0x6e0
-               	addi	a1, sp, 0x6d0
-               	addi	t2, sp, 0x6c0
+               	addi	a0, sp, 0x5b0
+               	addi	t2, sp, 0x5a0
+               	sd	t2, 0x88(sp)
+               	addi	t2, sp, 0x590
+               	sd	t2, 0x80(sp)
+               	addi	s2, sp, 0x580
+               	addi	s3, sp, 0x570
+               	addi	a3, sp, 0x560
+               	addi	a3, sp, 0x550
+               	addi	s4, sp, 0x540
+               	addi	a3, sp, 0x530
+               	addi	a3, sp, 0x520
+               	addi	s5, sp, 0x510
+               	addi	a3, sp, 0x500
+               	addi	a3, sp, 0x4f0
+               	addi	s6, sp, 0x4e0
+               	addi	a3, sp, 0x4d0
+               	addi	a3, sp, 0x4c0
+               	addi	a3, sp, 0x4b0
+               	addi	a3, sp, 0x4a0
+               	addi	a3, sp, 0x490
+               	addi	s7, sp, 0x480
+               	addi	a3, sp, 0x470
+               	addi	a3, sp, 0x460
+               	addi	s8, sp, 0x450
+               	addi	a3, sp, 0x440
+               	addi	a3, sp, 0x430
+               	addi	a3, sp, 0x420
+               	addi	s9, sp, 0x410
+               	addi	a3, sp, 0x400
+               	addi	a3, sp, 0x3f0
+               	addi	s10, sp, 0x3e0
+               	addi	a3, sp, 0x3d0
+               	addi	a3, sp, 0x3c0
+               	addi	s11, sp, 0x3b0
+               	addi	a3, sp, 0x3a0
+               	addi	a3, sp, 0x390
+               	addi	a3, sp, 0x380
+               	addi	t2, sp, 0x370
                	sd	t2, 0x30(sp)
-               	addi	a1, sp, 0x6b0
-               	addi	a1, sp, 0x6a0
-               	addi	t2, sp, 0x690
+               	addi	a4, sp, 0x360
+               	addi	a4, sp, 0x350
+               	addi	t2, sp, 0x340
                	sd	t2, 0x28(sp)
-               	addi	a1, sp, 0x680
-               	addi	a1, sp, 0x670
-               	addi	a1, sp, 0x660
-               	addi	t2, sp, 0x650
+               	addi	a5, sp, 0x330
+               	addi	a5, sp, 0x320
+               	addi	t2, sp, 0x310
                	sd	t2, 0x20(sp)
-               	addi	a1, sp, 0x640
-               	addi	a1, sp, 0x630
-               	addi	a1, sp, 0x620
-               	addi	t2, sp, 0x610
+               	addi	a6, sp, 0x300
+               	addi	a6, sp, 0x2f0
+               	addi	a6, sp, 0x2e0
+               	addi	a6, sp, 0x2d0
+               	addi	a6, sp, 0x2c0
+               	addi	a6, sp, 0x2b0
+               	addi	a6, sp, 0x2a0
+               	addi	a6, sp, 0x290
+               	addi	a6, sp, 0x280
+               	addi	a6, sp, 0x270
+               	addi	a6, sp, 0x260
+               	addi	a6, sp, 0x250
+               	addi	t2, sp, 0x240
                	sd	t2, 0x18(sp)
-               	addi	a1, sp, 0x600
-               	addi	a1, sp, 0x5f0
-               	addi	a1, sp, 0x5e0
-               	addi	t2, sp, 0x5d0
-               	sd	t2, 0xc8(sp)
-               	addi	t2, sp, 0x5c0
-               	sd	t2, 0xc0(sp)
-               	addi	a1, sp, 0x5b0
-               	addi	a1, sp, 0x5a0
-               	addi	a1, sp, 0x590
-               	addi	a1, sp, 0x580
-               	addi	a1, sp, 0x570
-               	addi	a1, sp, 0x560
-               	addi	a1, sp, 0x550
-               	addi	a1, sp, 0x540
-               	addi	a1, sp, 0x530
-               	addi	a1, sp, 0x520
-               	addi	a1, sp, 0x510
-               	addi	a1, sp, 0x500
-               	addi	a1, sp, 0x4f0
-               	addi	a1, sp, 0x4e0
-               	addi	a1, sp, 0x4d0
-               	addi	a1, sp, 0x4c0
-               	addi	a1, sp, 0x4b0
-               	addi	a1, sp, 0x4a0
-               	addi	a1, sp, 0x490
-               	addi	a1, sp, 0x480
-               	addi	a1, sp, 0x470
-               	addi	a1, sp, 0x460
-               	addi	a1, sp, 0x450
-               	addi	a1, sp, 0x440
-               	addi	a1, sp, 0x430
-               	addi	a1, sp, 0x420
-               	addi	a1, sp, 0x410
-               	addi	a1, sp, 0x400
-               	addi	a1, sp, 0x3f0
-               	addi	a1, sp, 0x3e0
-               	addi	a1, sp, 0x3d0
-               	addi	a1, sp, 0x3c0
-               	addi	a1, sp, 0x3b0
-               	addi	a1, sp, 0x3a0
-               	addi	a1, sp, 0x390
-               	addi	a1, sp, 0x380
-               	addi	a1, sp, 0x370
-               	addi	a1, sp, 0x360
-               	addi	a1, sp, 0x350
-               	addi	a1, sp, 0x340
-               	addi	a1, sp, 0x330
-               	addi	a1, sp, 0x320
-               	addi	a1, sp, 0x310
-               	addi	a1, sp, 0x300
-               	addi	a1, sp, 0x2f0
-               	addi	a1, sp, 0x2e0
-               	addi	a1, sp, 0x2d0
-               	addi	a1, sp, 0x2c0
-               	addi	a1, sp, 0x2b0
-               	addi	a1, sp, 0x2a0
-               	addi	a1, sp, 0x290
-               	addi	a1, sp, 0x280
-               	addi	a1, sp, 0x270
-               	addi	a1, sp, 0x260
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x350>
-               	mv	t2, a0
-               	sd	t2, 0xb8(sp)
-               	ld	t2, 0xb8(sp)
                	fcvt.s.lu	ft0, s1
                	fcvt.d.lu	ft1, s1
-               	addi	a1, sp, 0x250
-               	mv	a0, a1
+               	addi	a7, sp, 0x230
+               	mv	t5, a7
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(a0)
+               	sw	t0, 0x0(t5)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft2, ft11
-               	addi	a0, a1, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, a1, 0x8
+               	addi	t5, a7, 0x4
+               	fsw	ft2, 0x0(t5)
+               	addi	t5, a7, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(a0)
+               	sw	t0, 0x0(t5)
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fneg.s	ft2, ft11
-               	addi	a0, a1, 0xc
-               	fsw	ft2, 0x0(a0)
-               	mv	a0, a1
-               	flw	ft2, 0x0(a0)
-               	mv	a0, s2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, a1, 0x4
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, a1, 0xc
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, sp, 0x240
-               	mv	a1, a0
+               	addi	t5, a7, 0xc
+               	fsw	ft2, 0x0(t5)
+               	mv	t5, a7
+               	flw	ft2, 0x0(t5)
+               	mv	t5, a0
+               	fsw	ft2, 0x0(t5)
+               	addi	t5, a7, 0x4
+               	flw	ft2, 0x0(t5)
+               	addi	t5, a0, 0x4
+               	fsw	ft2, 0x0(t5)
+               	addi	t5, a7, 0x8
+               	flw	ft2, 0x0(t5)
+               	addi	t5, a0, 0x8
+               	fsw	ft2, 0x0(t5)
+               	addi	t5, a7, 0xc
+               	flw	ft2, 0x0(t5)
+               	addi	a7, a0, 0xc
+               	fsw	ft2, 0x0(a7)
+               	addi	a7, sp, 0x220
+               	mv	t5, a7
                	lui	t0, 0x3ff4
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sd	t0, 0x0(t5)
+               	addi	t5, a7, 0x8
                	lui	t0, 0xfc00c
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	mv	a1, a0
-               	fld	ft2, 0x0(a1)
-               	mv	a1, s3
-               	fsd	ft2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fld	ft2, 0x0(a1)
-               	addi	a0, s3, 0x8
-               	fsd	ft2, 0x0(a0)
-               	addi	t2, sp, 0x230
-               	sd	t2, 0xb0(sp)
-               	ld	t2, 0xb0(sp)
-               	mv	a1, t2
+               	sd	t0, 0x0(t5)
+               	mv	t5, a7
+               	fld	ft2, 0x0(t5)
+               	ld	t2, 0x88(sp)
+               	mv	t5, t2
+               	fsd	ft2, 0x0(t5)
+               	addi	t5, a7, 0x8
+               	fld	ft2, 0x0(t5)
+               	ld	t2, 0x88(sp)
+               	addi	a7, t2, 0x8
+               	fsd	ft2, 0x0(a7)
+               	addi	a7, sp, 0x210
+               	mv	t5, a7
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xb0(sp)
-               	addi	a1, t2, 0x4
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0x4
                	li	t0, 0x1
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xb0(sp)
-               	addi	a1, t2, 0x8
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0x8
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xb0(sp)
-               	addi	a1, t2, 0xc
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0xc
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xb0(sp)
-               	mv	a1, t2
-               	lw	a0, 0x0(a1)
-               	mv	a1, s4
-               	sw	a0, 0x0(a1)
-               	ld	t2, 0xb0(sp)
-               	addi	a0, t2, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	sw	a1, 0x0(a0)
-               	ld	t2, 0xb0(sp)
-               	addi	a0, t2, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	sw	a1, 0x0(a0)
-               	ld	t2, 0xb0(sp)
-               	addi	a0, t2, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	sw	a1, 0x0(a0)
-               	addi	a0, sp, 0x220
-               	mv	a1, a0
+               	sw	t0, 0x0(t5)
+               	mv	t5, a7
+               	lw	t6, 0x0(t5)
+               	ld	t2, 0x80(sp)
+               	mv	t5, t2
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0x4
+               	lw	t6, 0x0(t5)
+               	ld	t2, 0x80(sp)
+               	addi	t5, t2, 0x4
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0x8
+               	lw	t6, 0x0(t5)
+               	ld	t2, 0x80(sp)
+               	addi	t5, t2, 0x8
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0xc
+               	lw	a7, 0x0(t5)
+               	ld	t2, 0x80(sp)
+               	addi	t5, t2, 0xc
+               	sw	a7, 0x0(t5)
+               	addi	a7, sp, 0x200
+               	mv	t5, a7
                	lui	t0, 0x3fe0
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sd	t0, 0x0(t5)
+               	addi	t5, a7, 0x8
                	lui	t0, 0x4019
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	mv	a1, a0
-               	fld	ft2, 0x0(a1)
-               	mv	a1, s5
-               	fsd	ft2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fld	ft2, 0x0(a1)
-               	addi	a0, s5, 0x8
-               	fsd	ft2, 0x0(a0)
-               	addi	t2, sp, 0x210
-               	sd	t2, 0xa8(sp)
-               	ld	t2, 0xa8(sp)
-               	mv	a1, t2
+               	sd	t0, 0x0(t5)
+               	mv	t5, a7
+               	fld	ft2, 0x0(t5)
+               	mv	t5, s2
+               	fsd	ft2, 0x0(t5)
+               	addi	t5, a7, 0x8
+               	fld	ft2, 0x0(t5)
+               	addi	a7, s2, 0x8
+               	fsd	ft2, 0x0(a7)
+               	addi	a7, sp, 0x1f0
+               	mv	t5, a7
                	lui	t0, 0xc3
                	addiw	t0, t0, -0x4d5
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1c3
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xa8(sp)
-               	addi	a1, t2, 0x4
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0x4
                	lui	t0, 0x86
                	addiw	t0, t0, -0x143
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x589
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xa8(sp)
-               	addi	a1, t2, 0x8
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0x8
                	li	t0, 0x7
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xa8(sp)
-               	addi	a1, t2, 0xc
+               	sw	t0, 0x0(t5)
+               	addi	t5, a7, 0xc
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x5
-               	sw	t0, 0x0(a1)
-               	ld	t2, 0xa8(sp)
+               	sw	t0, 0x0(t5)
+               	mv	t5, a7
+               	lw	t6, 0x0(t5)
+               	mv	t5, s3
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0x4
+               	lw	t6, 0x0(t5)
+               	addi	t5, s3, 0x4
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0x8
+               	lw	t6, 0x0(t5)
+               	addi	t5, s3, 0x8
+               	sw	t6, 0x0(t5)
+               	addi	t5, a7, 0xc
+               	lw	a7, 0x0(t5)
+               	addi	t5, s3, 0xc
+               	sw	a7, 0x0(t5)
+               	addi	t2, sp, 0x100
+               	sd	t2, 0x50(sp)
+               	ld	t2, 0x50(sp)
+               	mv	t5, t2
+               	li	t0, 0x7
+               	and	t6, t5, t0
+               	bnez	t6, 0xb4c <corpus.cases.frame.frame_align.checksum+0x3e4>
+               	mv	t6, t5
+               	li	a1, 0xc0
+               	sd	zero, 0x0(t6)
+               	addi	t6, t6, 0x8
+               	addi	a1, a1, -0x8
+               	li	t0, 0x0
+               	bne	a1, t0, 0xb34 <corpus.cases.frame.frame_align.checksum+0x3cc>
+               	j	0xb68 <corpus.cases.frame.frame_align.checksum+0x400>
+               	mv	a1, t5
+               	li	t5, 0xc0
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	t5, t5, -0x1
+               	li	t0, 0x0
+               	bne	t5, t0, 0xb54 <corpus.cases.frame.frame_align.checksum+0x3ec>
+               	addi	t2, sp, 0xc0
+               	sd	t2, 0x48(sp)
+               	ld	t2, 0x48(sp)
                	mv	a1, t2
-               	lw	a0, 0x0(a1)
-               	mv	a1, s6
-               	sw	a0, 0x0(a1)
-               	ld	t2, 0xa8(sp)
+               	li	t0, 0x7
+               	and	t6, a1, t0
+               	bnez	t6, 0xba4 <corpus.cases.frame.frame_align.checksum+0x43c>
+               	mv	t6, a1
+               	li	a2, 0x40
+               	sd	zero, 0x0(t6)
+               	addi	t6, t6, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0xb8c <corpus.cases.frame.frame_align.checksum+0x424>
+               	j	0xbc0 <corpus.cases.frame.frame_align.checksum+0x458>
+               	mv	a2, a1
+               	li	a1, 0x40
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xbac <corpus.cases.frame.frame_align.checksum+0x444>
+               	addi	a1, s1, 0x1
+               	sext.w	t2, a1
+               	sd	t2, 0x40(sp)
+               	addi	a1, s1, 0x3
+               	sext.w	t2, a1
+               	sd	t2, 0x38(sp)
+               	addi	a1, s1, 0x5
+               	sext.w	t2, a1
+               	sd	t2, 0x78(sp)
+               	addi	a1, s1, 0x7
+               	sext.w	t2, a1
+               	sd	t2, 0x70(sp)
+               	lui	t0, 0x10
+               	addiw	t0, t0, -0xf
+               	add	a1, s1, t0
+               	sext.w	t2, a1
+               	sd	t2, 0x68(sp)
+               	addi	a1, s1, 0xfb
+               	sext.w	t2, a1
+               	sd	t2, 0x60(sp)
+               	mv	a1, a0
+               	flw	ft2, 0x0(a1)
+               	fadd.s	ft3, ft2, ft0
+               	mv	a1, a0
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a0, s4, 0xc
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	fsw	ft3, 0x0(a0)
+               	ld	t2, 0x88(sp)
+               	addi	a0, t2, 0x8
+               	fld	ft0, 0x0(a0)
+               	fadd.d	ft2, ft0, ft1
+               	ld	t2, 0x88(sp)
+               	mv	a0, t2
+               	fld	ft0, 0x0(a0)
+               	mv	a0, s5
+               	fsd	ft0, 0x0(a0)
+               	ld	t2, 0x88(sp)
+               	addi	a0, t2, 0x8
+               	fld	ft0, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	fsd	ft0, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	fsd	ft2, 0x0(a0)
+               	ld	t2, 0x80(sp)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	sext.w	a0, s1
+               	addw	t2, a1, a0
+               	sd	t2, 0x58(sp)
+               	ld	t2, 0x80(sp)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	mv	a0, s6
+               	sw	a1, 0x0(a0)
+               	ld	t2, 0x80(sp)
                	addi	a0, t2, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s6, 0x4
                	sw	a1, 0x0(a0)
-               	ld	t2, 0xa8(sp)
+               	ld	t2, 0x80(sp)
                	addi	a0, t2, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s6, 0x8
                	sw	a1, 0x0(a0)
-               	ld	t2, 0xa8(sp)
+               	ld	t2, 0x80(sp)
                	addi	a0, t2, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s6, 0xc
                	sw	a1, 0x0(a0)
-               	addi	t2, sp, 0x140
-               	sd	t2, 0xa0(sp)
-               	ld	t3, 0xa0(sp)
-               	mv	t2, t3
-               	sd	t2, 0x98(sp)
-               	ld	t2, 0x98(sp)
-               	li	t0, 0x7
-               	and	a1, t2, t0
-               	bnez	a1, 0xb94 <corpus.cases.frame.frame_align.checksum+0x648>
-               	ld	t2, 0x98(sp)
-               	mv	a1, t2
-               	li	a0, 0xc0
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a0, a0, -0x8
-               	li	t0, 0x0
-               	bne	a0, t0, 0xb7c <corpus.cases.frame.frame_align.checksum+0x630>
-               	j	0xbb4 <corpus.cases.frame.frame_align.checksum+0x668>
-               	ld	t2, 0x98(sp)
-               	mv	a0, t2
-               	li	a1, 0xc0
-               	sb	zero, 0x0(a0)
-               	addi	a0, a0, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0xba0 <corpus.cases.frame.frame_align.checksum+0x654>
-               	addi	t2, sp, 0x100
-               	sd	t2, 0x90(sp)
-               	ld	t3, 0x90(sp)
-               	mv	t2, t3
-               	sd	t2, 0x88(sp)
-               	ld	t2, 0x88(sp)
-               	li	t0, 0x7
-               	and	a1, t2, t0
-               	bnez	a1, 0xbfc <corpus.cases.frame.frame_align.checksum+0x6b0>
-               	ld	t2, 0x88(sp)
-               	mv	a1, t2
-               	li	a0, 0x40
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a0, a0, -0x8
-               	li	t0, 0x0
-               	bne	a0, t0, 0xbe4 <corpus.cases.frame.frame_align.checksum+0x698>
-               	j	0xc1c <corpus.cases.frame.frame_align.checksum+0x6d0>
-               	ld	t2, 0x88(sp)
-               	mv	a0, t2
-               	li	a1, 0x40
-               	sb	zero, 0x0(a0)
-               	addi	a0, a0, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0xc08 <corpus.cases.frame.frame_align.checksum+0x6bc>
-               	addi	a0, s1, 0x1
-               	sext.w	t2, a0
-               	sd	t2, 0x80(sp)
-               	addi	a0, s1, 0x3
-               	sext.w	t2, a0
-               	sd	t2, 0x78(sp)
-               	addi	a0, s1, 0x5
-               	sext.w	t2, a0
-               	sd	t2, 0x70(sp)
-               	addi	a0, s1, 0x7
-               	sext.w	t2, a0
-               	sd	t2, 0x68(sp)
-               	lui	t0, 0x10
-               	addiw	t0, t0, -0xf
-               	add	a0, s1, t0
-               	sext.w	t2, a0
-               	sd	t2, 0x60(sp)
-               	addi	a0, s1, 0xfb
-               	sext.w	t2, a0
-               	sd	t2, 0x58(sp)
-               	mv	a0, s2
-               	flw	ft2, 0x0(a0)
-               	fadd.s	ft3, ft2, ft0
-               	mv	a0, s2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	fsw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	fsw	ft3, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	fld	ft0, 0x0(a0)
-               	fadd.d	ft2, ft0, ft1
-               	mv	a0, s3
-               	fld	ft0, 0x0(a0)
-               	mv	a0, s8
-               	fsd	ft0, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	fld	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	fsd	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	fsd	ft2, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lw	a1, 0x0(a0)
-               	sext.w	a0, s1
-               	addw	s2, a1, a0
-               	mv	a0, s4
-               	lw	a1, 0x0(a0)
-               	mv	a0, s9
-               	sw	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	sw	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	sw	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	sw	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	sw	s2, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft0, 0x0(a0)
-               	ld	t2, 0xb8(sp)
-               	mv	a0, t2
-               	fmv.s	fa0, ft0
+               	addi	a0, s6, 0x8
+               	ld	t2, 0x58(sp)
+               	sw	t2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x814>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x5d4>
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x5e0>
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x5ec>
+               	mv	a1, s4
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s4, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x828>
+               	addi	a1, s4, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s7, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s4, 0xc
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x83c>
+               	addi	a1, s4, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s7, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x668>
+               	mv	a1, s4
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x850>
+               	mv	a1, s4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
                	mv	a1, s8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x860>
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
                	addi	a1, s8, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x870>
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x884>
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x898>
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x8ac>
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x8c0>
-               	mv	a1, s7
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s7
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	mv	a1, s10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a1, s10, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a1, s10, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a1, s10, 0xc
-               	fsw	ft2, 0x0(a1)
-               	mv	a1, s10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x944>
-               	addi	a1, s10, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x958>
-               	addi	a1, s10, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x96c>
-               	addi	a1, s10, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x980>
-               	mv	a1, s7
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s7
+               	addi	a1, s4, 0xc
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	mv	a1, s11
+               	addi	a1, s8, 0xc
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a1, s11, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a1, s11, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a1, s11, 0xc
-               	fsw	ft2, 0x0(a1)
-               	mv	a1, s11
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa04>
-               	addi	a1, s11, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa18>
-               	addi	a1, s11, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa2c>
-               	addi	a1, s11, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa40>
-               	mv	a1, s5
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa50>
-               	addi	a1, s5, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa60>
                	mv	a1, s8
-               	fld	ft0, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x6e4>
+               	mv	a1, s2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x6f0>
                	mv	a1, s5
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s2
                	fld	ft1, 0x0(a1)
                	fmul.d	ft2, ft0, ft1
-               	ld	t2, 0x50(sp)
-               	mv	a1, t2
+               	mv	a1, s9
                	fsd	ft2, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	fld	ft0, 0x0(a1)
                	addi	a1, s5, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
                	fld	ft1, 0x0(a1)
                	fmul.d	ft2, ft0, ft1
-               	ld	t2, 0x50(sp)
-               	addi	a1, t2, 0x8
+               	addi	a1, s9, 0x8
                	fsd	ft2, 0x0(a1)
-               	ld	t2, 0x50(sp)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
+               	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xab4>
-               	ld	t2, 0x50(sp)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xac8>
-               	mv	a1, s8
-               	fld	ft0, 0x0(a1)
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x734>
                	mv	a1, s5
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s2
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	ld	t2, 0x48(sp)
-               	mv	a1, t2
+               	mv	a1, s10
                	fsd	ft2, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	fld	ft0, 0x0(a1)
                	addi	a1, s5, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	ld	t2, 0x48(sp)
-               	addi	a1, t2, 0x8
+               	addi	a1, s10, 0x8
                	fsd	ft2, 0x0(a1)
-               	ld	t2, 0x48(sp)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xb1c>
-               	ld	t2, 0x48(sp)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xb30>
-               	mv	a1, s8
-               	fld	ft0, 0x0(a1)
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x778>
                	mv	a1, s5
-               	fld	ft1, 0x0(a1)
-               	fdiv.d	ft2, ft0, ft1
-               	ld	t2, 0x40(sp)
-               	mv	a1, t2
-               	fsd	ft2, 0x0(a1)
-               	addi	a1, s8, 0x8
                	fld	ft0, 0x0(a1)
-               	addi	a1, s5, 0x8
+               	mv	a1, s2
                	fld	ft1, 0x0(a1)
                	fdiv.d	ft2, ft0, ft1
-               	ld	t2, 0x40(sp)
-               	addi	a1, t2, 0x8
+               	mv	a1, s11
                	fsd	ft2, 0x0(a1)
-               	ld	t2, 0x40(sp)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft1, 0x0(a1)
+               	fdiv.d	ft2, ft0, ft1
+               	addi	a1, s11, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xb84>
-               	ld	t2, 0x40(sp)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x7bc>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xb98>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x7c8>
                	mv	a1, s6
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xbac>
+               	lw	s2, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	mulw	a1, s2, s5
+               	ld	t2, 0x30(sp)
+               	mv	s2, t2
+               	sw	a1, 0x0(s2)
                	addi	a1, s6, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xbc0>
-               	addi	a1, s6, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xbd4>
-               	addi	a1, s6, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xbe8>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	mv	a1, s6
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, 0x38(sp)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, 0x38(sp)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, 0x38(sp)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, 0x38(sp)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	ld	t2, 0x38(sp)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xc80>
-               	ld	t2, 0x38(sp)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xc98>
-               	ld	t2, 0x38(sp)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xcb0>
-               	ld	t2, 0x38(sp)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xcc8>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	mv	a1, s6
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, 0x30(sp)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, 0x30(sp)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, 0x30(sp)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, 0x30(sp)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	ld	t2, 0x30(sp)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xd60>
-               	ld	t2, 0x30(sp)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xd78>
-               	ld	t2, 0x30(sp)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xd90>
-               	ld	t2, 0x30(sp)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xda8>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	mv	a1, s6
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, 0x28(sp)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, 0x28(sp)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, 0x28(sp)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, 0x28(sp)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	ld	t2, 0x28(sp)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe40>
-               	ld	t2, 0x28(sp)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe58>
-               	ld	t2, 0x28(sp)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe70>
-               	ld	t2, 0x28(sp)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe88>
-               	mv	s2, a0
-               	addi	s3, sp, 0xf0
-               	mv	a0, s3
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xea0>
-               	mv	a0, s3
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xeb8>
+               	lw	s2, 0x0(a1)
                	addi	a1, s3, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xecc>
+               	lw	s5, 0x0(a1)
+               	mulw	a1, s2, s5
+               	ld	t2, 0x30(sp)
+               	addi	s2, t2, 0x4
+               	sw	a1, 0x0(s2)
+               	addi	a1, s6, 0x8
+               	lw	s2, 0x0(a1)
                	addi	a1, s3, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xee0>
+               	lw	s5, 0x0(a1)
+               	mulw	a1, s2, s5
+               	ld	t2, 0x30(sp)
+               	addi	s2, t2, 0x8
+               	sw	a1, 0x0(s2)
+               	addi	a1, s6, 0xc
+               	lw	s2, 0x0(a1)
                	addi	a1, s3, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	lw	s5, 0x0(a1)
+               	mulw	a1, s2, s5
+               	ld	t2, 0x30(sp)
+               	addi	s2, t2, 0xc
+               	sw	a1, 0x0(s2)
+               	ld	t2, 0x30(sp)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xef4>
-               	mv	s2, a0
-               	mv	a0, s7
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x858>
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	mv	a1, s3
+               	lw	s2, 0x0(a1)
+               	addw	a1, a3, s2
+               	ld	t2, 0x28(sp)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s2, 0x0(a1)
+               	addw	a1, a3, s2
+               	ld	t2, 0x28(sp)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s2, 0x0(a1)
+               	addw	a1, a3, s2
+               	ld	t2, 0x28(sp)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s2, 0x0(a1)
+               	addw	a1, a3, s2
+               	ld	t2, 0x28(sp)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	ld	t2, 0x28(sp)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x8e8>
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	mv	a1, s3
+               	lw	a4, 0x0(a1)
+               	xor	a1, a3, a4
                	ld	t2, 0x20(sp)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a4, 0x0(a1)
+               	xor	a1, a3, a4
                	ld	t2, 0x20(sp)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a4, 0x0(a1)
+               	xor	a1, a3, a4
                	ld	t2, 0x20(sp)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a4, 0x0(a1)
+               	xor	a1, a3, a4
                	ld	t2, 0x20(sp)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	s3, sp, 0xe0
-               	mv	a0, s3
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
                	ld	t2, 0x20(sp)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xf90>
-               	mv	a0, s3
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xfa8>
-               	addi	a1, s3, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xfbc>
-               	addi	a1, s3, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xfd0>
-               	addi	a1, s3, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xfe4>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x978>
                	mv	s2, a0
-               	ld	t2, 0x90(sp)
+               	addi	s3, sp, 0xb0
+               	mv	a0, s3
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x990>
+               	mv	a0, s2
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x9a0>
+               	mv	s2, a0
+               	addi	s3, sp, 0xa0
+               	mv	a0, s3
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x9b8>
+               	mv	a0, s2
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x9c8>
+               	mv	s2, a0
+               	ld	t2, 0x48(sp)
                	mv	a0, t2
-               	mv	a1, s7
+               	mv	a1, s4
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s4, 0x8
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s4, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	mv	a0, s7
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, 0x18(sp)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, 0x18(sp)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, 0x18(sp)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, 0x18(sp)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	ld	t2, 0x90(sp)
+               	ld	t2, 0x48(sp)
                	addi	a0, t2, 0x10
-               	ld	t2, 0x18(sp)
-               	mv	a1, t2
+               	mv	a1, s7
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0x18(sp)
-               	addi	a1, t2, 0x4
+               	addi	a1, s7, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0x18(sp)
-               	addi	a1, t2, 0x8
+               	addi	a1, s7, 0x8
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0x18(sp)
-               	addi	a1, t2, 0xc
+               	addi	a1, s7, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	addi	s3, sp, 0xd0
+               	addi	s3, sp, 0x90
                	mv	a0, s3
-               	mv	a1, s7
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x111c>
-               	ld	t2, 0x90(sp)
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xa70>
+               	ld	t2, 0x48(sp)
                	addi	a0, t2, 0x20
                	mv	a1, s3
                	flw	ft0, 0x0(a1)
@@ -1465,117 +1173,61 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	mv	a0, s7
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, 0xc8(sp)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, 0xc8(sp)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, 0xc8(sp)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, 0xc8(sp)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	ld	t2, 0x90(sp)
+               	ld	t2, 0x48(sp)
                	addi	a0, t2, 0x30
-               	ld	t2, 0xc8(sp)
-               	mv	a1, t2
+               	mv	a1, s8
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0xc8(sp)
-               	addi	a1, t2, 0x4
+               	addi	a1, s8, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0xc8(sp)
-               	addi	a1, t2, 0x8
+               	addi	a1, s8, 0x8
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsw	ft0, 0x0(a1)
-               	ld	t2, 0xc8(sp)
-               	addi	a1, t2, 0xc
+               	addi	a1, s8, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
                	li	s3, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x17a0 <corpus.cases.frame.frame_align.checksum+0x1254>
-               	j	0x1874 <corpus.cases.frame.frame_align.checksum+0x1328>
+               	bltu	s3, t0, 0x1280 <corpus.cases.frame.frame_align.checksum+0xb18>
+               	j	0x1304 <corpus.cases.frame.frame_align.checksum+0xb9c>
                	li	t0, 0x10
                	mul	a0, s3, t0
-               	ld	t2, 0x90(sp)
+               	ld	t2, 0x48(sp)
                	add	a1, t2, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	ld	t2, 0xc0(sp)
+               	ld	t2, 0x18(sp)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	ld	t2, 0xc0(sp)
+               	ld	t2, 0x18(sp)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	ld	t2, 0xc0(sp)
+               	ld	t2, 0x18(sp)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0xc
                	flw	ft0, 0x0(a0)
-               	ld	t2, 0xc0(sp)
+               	ld	t2, 0x18(sp)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
-               	ld	t2, 0xc0(sp)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
                	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	ld	t2, 0x18(sp)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x12c8>
-               	ld	t2, 0xc0(sp)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x12e0>
-               	ld	t2, 0xc0(sp)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x12f8>
-               	ld	t2, 0xc0(sp)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x1310>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xb84>
                	addi	s3, s3, 0x1
                	mv	s2, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x17a0 <corpus.cases.frame.frame_align.checksum+0x1254>
+               	bltu	s3, t0, 0x1280 <corpus.cases.frame.frame_align.checksum+0xb18>
                	lui	t1, 0x1111
                	addiw	t1, t1, 0x111
                	slli	t1, t1, 0xc
@@ -1584,7 +1236,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x111
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x111
-               	add	s3, t1, s1
+               	add	a0, t1, s1
                	lui	t1, 0x7777
                	addiw	t1, t1, 0x777
                	slli	t1, t1, 0xc
@@ -1593,132 +1245,189 @@ Disassembly of section .text:
                	addi	t1, t1, 0x777
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x777
-               	xor	s4, t1, s1
-               	mv	a0, s2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x1378>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x1384>
+               	xor	a1, t1, s1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x135c <corpus.cases.frame.frame_align.checksum+0xbf4>
+               	j	0x1390 <corpus.cases.frame.frame_align.checksum+0xc28>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, s2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x135c <corpus.cases.frame.frame_align.checksum+0xbf4>
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x13a0 <corpus.cases.frame.frame_align.checksum+0xc38>
+               	j	0x13d4 <corpus.cases.frame.frame_align.checksum+0xc6c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, s2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x13a0 <corpus.cases.frame.frame_align.checksum+0xc38>
                	li	a1, 0x0
                	li	t0, 0x3
-               	bltu	a1, t0, 0x18e8 <corpus.cases.frame.frame_align.checksum+0x139c>
-               	j	0x1934 <corpus.cases.frame.frame_align.checksum+0x13e8>
+               	bltu	a1, t0, 0x13e4 <corpus.cases.frame.frame_align.checksum+0xc7c>
+               	j	0x1430 <corpus.cases.frame.frame_align.checksum+0xcc8>
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	a3, a2, s1
+               	mul	a3, a1, t0
+               	add	a4, a3, s1
                	li	t0, 0x40
-               	mul	a2, a1, t0
-               	ld	t2, 0xa0(sp)
-               	add	a4, t2, a2
-               	mv	a2, a4
-               	sd	a3, 0x0(a2)
-               	slli	a2, a1, 0x28
-               	xor	a3, a2, s3
-               	addi	a2, a4, 0x8
-               	sd	a3, 0x0(a2)
+               	mul	a3, a1, t0
+               	ld	t2, 0x50(sp)
+               	add	a5, t2, a3
+               	mv	a3, a5
+               	sd	a4, 0x0(a3)
+               	slli	a3, a1, 0x28
+               	xor	a4, a3, a0
+               	addi	a3, a5, 0x8
+               	sd	a4, 0x0(a3)
                	addi	a1, a1, 0x1
                	li	t0, 0x3
-               	bltu	a1, t0, 0x18e8 <corpus.cases.frame.frame_align.checksum+0x139c>
-               	mv	s1, a0
-               	li	s2, 0x0
+               	bltu	a1, t0, 0x13e4 <corpus.cases.frame.frame_align.checksum+0xc7c>
+               	li	a0, 0x0
                	li	t0, 0x3
-               	bltu	s2, t0, 0x1948 <corpus.cases.frame.frame_align.checksum+0x13fc>
-               	j	0x1990 <corpus.cases.frame.frame_align.checksum+0x1444>
+               	bltu	a0, t0, 0x1440 <corpus.cases.frame.frame_align.checksum+0xcd8>
+               	j	0x150c <corpus.cases.frame.frame_align.checksum+0xda4>
                	li	t0, 0x40
-               	mul	a0, s2, t0
-               	ld	t2, 0xa0(sp)
-               	add	s3, t2, a0
-               	mv	a0, s3
-               	ld	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x1418>
-               	addi	a1, s3, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x142c>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	mul	a1, a0, t0
+               	ld	t2, 0x50(sp)
+               	add	a3, t2, a1
+               	mv	a1, a3
+               	ld	a3, 0x0(a1)
+               	mv	a1, s2
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x146c <corpus.cases.frame.frame_align.checksum+0xd04>
+               	j	0x14a0 <corpus.cases.frame.frame_align.checksum+0xd38>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x146c <corpus.cases.frame.frame_align.checksum+0xd04>
+               	li	t0, 0x40
+               	mul	a3, a0, t0
+               	ld	t2, 0x50(sp)
+               	add	a4, t2, a3
+               	addi	a3, a4, 0x8
+               	ld	a4, 0x0(a3)
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c8 <corpus.cases.frame.frame_align.checksum+0xd60>
+               	j	0x14fc <corpus.cases.frame.frame_align.checksum+0xd94>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c8 <corpus.cases.frame.frame_align.checksum+0xd60>
+               	addi	a0, a0, 0x1
+               	mv	s2, a1
                	li	t0, 0x3
-               	bltu	s2, t0, 0x1948 <corpus.cases.frame.frame_align.checksum+0x13fc>
-               	mv	a0, s1
-               	ld	t2, 0x80(sp)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x1450>
+               	bltu	a0, t0, 0x1440 <corpus.cases.frame.frame_align.checksum+0xcd8>
+               	ld	t2, 0x40(sp)
+               	zext.b	a0, t2
                	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1524 <corpus.cases.frame.frame_align.checksum+0xdbc>
+               	j	0x1558 <corpus.cases.frame.frame_align.checksum+0xdf0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1524 <corpus.cases.frame.frame_align.checksum+0xdbc>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1568 <corpus.cases.frame.frame_align.checksum+0xe00>
+               	j	0x15a0 <corpus.cases.frame.frame_align.checksum+0xe38>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	li	t1, 0x0
+               	srl	a2, t1, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s2, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x1568 <corpus.cases.frame.frame_align.checksum+0xe00>
+               	ld	t2, 0x38(sp)
+               	zext.b	a1, t2
+               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x145c>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe44>
                	ld	t2, 0x78(sp)
-               	mv	a1, t2
+               	zext.b	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x146c>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe54>
                	ld	t2, 0x70(sp)
-               	mv	a1, t2
+               	zext.b	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x147c>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe64>
                	ld	t2, 0x68(sp)
-               	mv	a1, t2
+               	slli	a1, t2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x148c>
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe78>
                	ld	t2, 0x60(sp)
-               	mv	a1, t2
+               	zext.b	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x149c>
-               	ld	t2, 0x58(sp)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_align.checksum+0x14ac>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x658
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x660
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
+               	jalr	ra <corpus.cases.frame.frame_align.checksum+0xe88>
+               	ld	s1, 0x628(sp)
+               	ld	s2, 0x620(sp)
+               	ld	s3, 0x618(sp)
+               	ld	s4, 0x610(sp)
+               	ld	s5, 0x608(sp)
+               	ld	s6, 0x600(sp)
+               	ld	s7, 0x5f8(sp)
+               	ld	s8, 0x5f0(sp)
+               	ld	s9, 0x5e8(sp)
+               	ld	s10, 0x5e0(sp)
+               	ld	s11, 0x5d8(sp)
                	mv	sp, s0
                	ld	ra, -0x8(sp)
                	ld	s0, -0x10(sp)

--- a/test/golden/riscv64-linux/frame/frame_large.dis
+++ b/test/golden/riscv64-linux/frame/frame_large.dis
@@ -4,160 +4,228 @@ Disassembly of section .text:
 
 <corpus.cases.frame.frame_large.checksum>:
                	lui	t0, 0x2
-               	addiw	t0, t0, 0x50
+               	addiw	t0, t0, 0x20
                	sub	sp, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x48
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x40
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x2
-               	addiw	t0, t0, 0x50
-               	add	s0, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x38
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x30
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x28
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x20
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
                	lui	t1, 0x2
                	addiw	t1, t1, 0x18
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
+               	sd	ra, 0x0(t1)
                	lui	t1, 0x2
                	addiw	t1, t1, 0x10
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x2
+               	addiw	t0, t0, 0x20
+               	add	s0, sp, t0
                	lui	t1, 0x2
                	addiw	t1, t1, 0x8
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x2
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0xb8>
+               	sd	s1, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x450
-               	add	s2, s0, t0
-               	mv	a1, s2
+               	addiw	t0, t0, -0x418
+               	add	a1, s0, t0
+               	mv	a2, a1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x100 <corpus.cases.frame.frame_large.checksum+0x100>
-               	mv	a2, a1
-               	lui	a3, 0x1
-               	addiw	a3, a3, 0x400
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a3, a2, t0
+               	bnez	a3, 0x88 <corpus.cases.frame.frame_large.checksum+0x88>
+               	mv	a3, a2
+               	lui	a4, 0x1
+               	addiw	a4, a4, 0x400
+               	sd	zero, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xe8 <corpus.cases.frame.frame_large.checksum+0xe8>
-               	j	0x120 <corpus.cases.frame.frame_large.checksum+0x120>
-               	mv	a2, a1
-               	lui	a1, 0x1
-               	addiw	a1, a1, 0x400
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a4, t0, 0x70 <corpus.cases.frame.frame_large.checksum+0x70>
+               	j	0xa8 <corpus.cases.frame.frame_large.checksum+0xa8>
+               	mv	a3, a2
+               	lui	a2, 0x1
+               	addiw	a2, a2, 0x400
+               	sb	zero, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x10c <corpus.cases.frame.frame_large.checksum+0x10c>
+               	bne	a2, t0, 0x94 <corpus.cases.frame.frame_large.checksum+0x94>
                	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x3b0
-               	add	s3, s0, t0
-               	mv	a1, s3
+               	addiw	t0, t0, 0x3e8
+               	add	a2, s0, t0
+               	mv	a3, a2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x160 <corpus.cases.frame.frame_large.checksum+0x160>
-               	mv	a2, a1
+               	and	a4, a3, t0
+               	bnez	a4, 0xe8 <corpus.cases.frame.frame_large.checksum+0xe8>
+               	mv	a4, a3
+               	lui	a5, 0x1
+               	addiw	a5, a5, -0x800
+               	sd	zero, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xd0 <corpus.cases.frame.frame_large.checksum+0xd0>
+               	j	0x108 <corpus.cases.frame.frame_large.checksum+0x108>
+               	mv	a4, a3
                	lui	a3, 0x1
                	addiw	a3, a3, -0x800
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	sb	zero, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x148 <corpus.cases.frame.frame_large.checksum+0x148>
-               	j	0x180 <corpus.cases.frame.frame_large.checksum+0x180>
-               	mv	a2, a1
-               	lui	a1, 0x1
-               	addiw	a1, a1, -0x800
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x16c <corpus.cases.frame.frame_large.checksum+0x16c>
+               	bne	a3, t0, 0xf4 <corpus.cases.frame.frame_large.checksum+0xf4>
                	lui	t0, 0xffffe
-               	addiw	t0, t0, -0x50
-               	add	s4, s0, t0
-               	mv	a1, s4
+               	addiw	t0, t0, -0x18
+               	add	a3, s0, t0
+               	mv	a4, a3
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x1bc <corpus.cases.frame.frame_large.checksum+0x1bc>
-               	mv	a2, a1
-               	li	a3, 0x400
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a5, a4, t0
+               	bnez	a5, 0x144 <corpus.cases.frame.frame_large.checksum+0x144>
+               	mv	a5, a4
+               	li	a6, 0x400
+               	sd	zero, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x1a4 <corpus.cases.frame.frame_large.checksum+0x1a4>
-               	j	0x1d8 <corpus.cases.frame.frame_large.checksum+0x1d8>
-               	mv	a2, a1
-               	li	a1, 0x400
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a6, t0, 0x12c <corpus.cases.frame.frame_large.checksum+0x12c>
+               	j	0x160 <corpus.cases.frame.frame_large.checksum+0x160>
+               	mv	a5, a4
+               	li	a4, 0x400
+               	sb	zero, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1c4 <corpus.cases.frame.frame_large.checksum+0x1c4>
-               	mv	a1, s2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x1e4>
+               	bne	a4, t0, 0x14c <corpus.cases.frame.frame_large.checksum+0x14c>
+               	mv	a4, a1
+               	ld	a5, 0x0(a4)
+               	lui	a4, 0xfcbf3
+               	addiw	a4, a4, -0x632
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x484
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x222
+               	slli	a4, a4, 0xc
+               	addi	a4, a4, 0x325
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x198 <corpus.cases.frame.frame_large.checksum+0x198>
+               	j	0x1cc <corpus.cases.frame.frame_large.checksum+0x1cc>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x198 <corpus.cases.frame.frame_large.checksum+0x198>
                	lui	t0, 0x1
                	addiw	t0, t0, 0x3f8
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x200>
-               	mv	a1, s3
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x214>
-               	addi	a1, s3, 0x7fc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x228>
-               	mv	a1, s4
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x23c>
-               	addi	a1, s4, 0x3ff
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x250>
-               	li	a1, 0x0
+               	add	a5, a1, t0
+               	ld	a6, 0x0(a5)
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ec <corpus.cases.frame.frame_large.checksum+0x1ec>
+               	j	0x220 <corpus.cases.frame.frame_large.checksum+0x220>
+               	li	t0, 0x8
+               	mul	a7, a5, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ec <corpus.cases.frame.frame_large.checksum+0x1ec>
+               	mv	a5, a2
+               	lw	a6, 0x0(a5)
+               	slli	a5, a6, 0x20
+               	srli	a5, a5, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x240 <corpus.cases.frame.frame_large.checksum+0x240>
+               	j	0x274 <corpus.cases.frame.frame_large.checksum+0x274>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x240 <corpus.cases.frame.frame_large.checksum+0x240>
+               	addi	a5, a2, 0x7fc
+               	lw	a6, 0x0(a5)
+               	slli	a5, a6, 0x20
+               	srli	a5, a5, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x294 <corpus.cases.frame.frame_large.checksum+0x294>
+               	j	0x2c8 <corpus.cases.frame.frame_large.checksum+0x2c8>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x294 <corpus.cases.frame.frame_large.checksum+0x294>
+               	mv	a5, a3
+               	lbu	a6, 0x0(a5)
+               	zext.b	a5, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2e4 <corpus.cases.frame.frame_large.checksum+0x2e4>
+               	j	0x318 <corpus.cases.frame.frame_large.checksum+0x318>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2e4 <corpus.cases.frame.frame_large.checksum+0x2e4>
+               	addi	a5, a3, 0x3ff
+               	lbu	a6, 0x0(a5)
+               	zext.b	a5, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x334 <corpus.cases.frame.frame_large.checksum+0x334>
+               	j	0x368 <corpus.cases.frame.frame_large.checksum+0x368>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a4, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x334 <corpus.cases.frame.frame_large.checksum+0x334>
+               	li	a5, 0x0
                	li	t0, 0x280
-               	bltu	a1, t0, 0x268 <corpus.cases.frame.frame_large.checksum+0x268>
-               	j	0x2b0 <corpus.cases.frame.frame_large.checksum+0x2b0>
-               	add	a2, a1, s1
+               	bltu	a5, t0, 0x378 <corpus.cases.frame.frame_large.checksum+0x378>
+               	j	0x3c0 <corpus.cases.frame.frame_large.checksum+0x3c0>
+               	add	a6, a5, a0
                	lui	t0, 0x5852
                	addiw	t0, t0, -0xbd
                	slli	t0, t0, 0xc
@@ -166,193 +234,310 @@ Disassembly of section .text:
                	addi	t0, t0, -0x6a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd3
-               	mul	a3, a2, t0
-               	slli	a2, a1, 0x11
-               	xor	a4, a3, a2
-               	slli	t0, a1, 0x3
-               	add	a2, s2, t0
-               	sd	a4, 0x0(a2)
-               	addi	a1, a1, 0x1
+               	mul	a7, a6, t0
+               	slli	a6, a5, 0x11
+               	xor	t5, a7, a6
+               	slli	t0, a5, 0x3
+               	add	a6, a1, t0
+               	sd	t5, 0x0(a6)
+               	addi	a5, a5, 0x1
                	li	t0, 0x280
-               	bltu	a1, t0, 0x268 <corpus.cases.frame.frame_large.checksum+0x268>
-               	li	a1, 0x0
+               	bltu	a5, t0, 0x378 <corpus.cases.frame.frame_large.checksum+0x378>
+               	li	a5, 0x0
                	li	t0, 0x200
-               	bltu	a1, t0, 0x2c0 <corpus.cases.frame.frame_large.checksum+0x2c0>
-               	j	0x2fc <corpus.cases.frame.frame_large.checksum+0x2fc>
+               	bltu	a5, t0, 0x3d0 <corpus.cases.frame.frame_large.checksum+0x3d0>
+               	j	0x40c <corpus.cases.frame.frame_large.checksum+0x40c>
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	add	a3, a2, s1
-               	srli	a2, a1, 0x3
-               	xor	a4, a3, a2
-               	sext.w	a2, a4
-               	slli	t0, a1, 0x2
-               	add	a3, s3, t0
-               	sw	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	mul	a6, a5, t0
+               	add	a7, a6, a0
+               	srli	a6, a5, 0x3
+               	xor	t5, a7, a6
+               	sext.w	a6, t5
+               	slli	t0, a5, 0x2
+               	add	a7, a2, t0
+               	sw	a6, 0x0(a7)
+               	addi	a5, a5, 0x1
                	li	t0, 0x200
-               	bltu	a1, t0, 0x2c0 <corpus.cases.frame.frame_large.checksum+0x2c0>
-               	li	a1, 0x0
+               	bltu	a5, t0, 0x3d0 <corpus.cases.frame.frame_large.checksum+0x3d0>
+               	li	a5, 0x0
                	li	t0, 0x400
-               	bltu	a1, t0, 0x30c <corpus.cases.frame.frame_large.checksum+0x30c>
-               	j	0x338 <corpus.cases.frame.frame_large.checksum+0x338>
+               	bltu	a5, t0, 0x41c <corpus.cases.frame.frame_large.checksum+0x41c>
+               	j	0x448 <corpus.cases.frame.frame_large.checksum+0x448>
                	li	t0, 0x83
-               	mul	a2, a1, t0
-               	add	a3, a2, s1
-               	srli	a2, a1, 0x2
-               	xor	a4, a3, a2
-               	sext.w	a2, a4
-               	add	a3, s4, a1
-               	sb	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
+               	mul	a6, a5, t0
+               	add	a7, a6, a0
+               	srli	a6, a5, 0x2
+               	xor	t5, a7, a6
+               	sext.w	a6, t5
+               	add	a7, a3, a5
+               	sb	a6, 0x0(a7)
+               	addi	a5, a5, 0x1
                	li	t0, 0x400
-               	bltu	a1, t0, 0x30c <corpus.cases.frame.frame_large.checksum+0x30c>
-               	mv	s5, a0
-               	li	s6, 0x0
+               	bltu	a5, t0, 0x41c <corpus.cases.frame.frame_large.checksum+0x41c>
+               	li	a5, 0x0
                	li	t0, 0x40
-               	bltu	s6, t0, 0x34c <corpus.cases.frame.frame_large.checksum+0x34c>
-               	j	0x3f4 <corpus.cases.frame.frame_large.checksum+0x3f4>
+               	bltu	a5, t0, 0x458 <corpus.cases.frame.frame_large.checksum+0x458>
+               	j	0x5b8 <corpus.cases.frame.frame_large.checksum+0x5b8>
                	li	t0, 0x9
-               	mul	a0, s6, t0
-               	add	a1, a0, s1
-               	li	a0, 0x280
-               	bnez	a0, 0x364 <corpus.cases.frame.frame_large.checksum+0x364>
+               	mul	a6, a5, t0
+               	add	a7, a6, a0
+               	li	a6, 0x280
+               	bnez	a6, 0x470 <corpus.cases.frame.frame_large.checksum+0x470>
                	ebreak
-               	remu	a2, a1, a0
-               	slli	t0, a2, 0x3
-               	add	a0, s2, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x378>
+               	remu	t5, a7, a6
+               	slli	t0, t5, 0x3
+               	add	a6, a1, t0
+               	ld	a7, 0x0(a6)
+               	mv	a6, a4
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x494 <corpus.cases.frame.frame_large.checksum+0x494>
+               	j	0x4c8 <corpus.cases.frame.frame_large.checksum+0x4c8>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x494 <corpus.cases.frame.frame_large.checksum+0x494>
                	li	t0, 0xd
-               	mul	a1, s6, t0
-               	add	a2, a1, s1
-               	li	a1, 0x200
-               	bnez	a1, 0x398 <corpus.cases.frame.frame_large.checksum+0x398>
+               	mul	a7, a5, t0
+               	add	t5, a7, a0
+               	li	a7, 0x200
+               	bnez	a7, 0x4e0 <corpus.cases.frame.frame_large.checksum+0x4e0>
                	ebreak
-               	remu	a3, a2, a1
-               	slli	t0, a3, 0x2
-               	add	a1, s3, t0
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x3ac>
+               	remu	t6, t5, a7
+               	slli	t0, t6, 0x2
+               	add	a7, a2, t0
+               	lw	t5, 0x0(a7)
+               	slli	a7, t5, 0x20
+               	srli	a7, a7, 0x20
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x508 <corpus.cases.frame.frame_large.checksum+0x508>
+               	j	0x53c <corpus.cases.frame.frame_large.checksum+0x53c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x508 <corpus.cases.frame.frame_large.checksum+0x508>
                	li	t0, 0x1d
-               	mul	a1, s6, t0
-               	add	a2, a1, s1
-               	li	a1, 0x400
-               	bnez	a1, 0x3cc <corpus.cases.frame.frame_large.checksum+0x3cc>
+               	mul	a7, a5, t0
+               	add	t5, a7, a0
+               	li	a7, 0x400
+               	bnez	a7, 0x554 <corpus.cases.frame.frame_large.checksum+0x554>
                	ebreak
-               	remu	a3, a2, a1
-               	add	a1, s4, a3
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x3dc>
-               	addi	s6, s6, 0x1
-               	mv	s5, a0
+               	remu	t6, t5, a7
+               	add	a7, a3, t6
+               	lbu	t5, 0x0(a7)
+               	zext.b	a7, t5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x574 <corpus.cases.frame.frame_large.checksum+0x574>
+               	j	0x5a8 <corpus.cases.frame.frame_large.checksum+0x5a8>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x574 <corpus.cases.frame.frame_large.checksum+0x574>
+               	addi	a5, a5, 0x1
+               	mv	a4, a6
                	li	t0, 0x40
-               	bltu	s6, t0, 0x34c <corpus.cases.frame.frame_large.checksum+0x34c>
+               	bltu	a5, t0, 0x458 <corpus.cases.frame.frame_large.checksum+0x458>
                	lui	t0, 0x1
                	addiw	t0, t0, 0x3f8
-               	add	s6, s2, t0
-               	ld	a0, 0x0(s6)
-               	addi	a1, a0, 0x1
+               	add	a5, a1, t0
+               	ld	a6, 0x0(a5)
+               	addi	a5, a6, 0x1
                	li	t0, 0x1
-               	and	a0, s1, t0
+               	and	a6, a0, t0
                	li	t1, 0x27f
-               	sub	a2, t1, a0
-               	slli	t0, a2, 0x3
-               	add	a0, s2, t0
-               	sd	a1, 0x0(a0)
-               	addi	s7, s3, 0x7fc
-               	lw	a0, 0x0(s7)
-               	addiw	a1, a0, 0x7
+               	sub	a7, t1, a6
+               	slli	t0, a7, 0x3
+               	add	a6, a1, t0
+               	sd	a5, 0x0(a6)
+               	addi	a5, a2, 0x7fc
+               	lw	a6, 0x0(a5)
+               	addiw	a5, a6, 0x7
                	li	t0, 0x3
-               	and	a0, s1, t0
+               	and	a6, a0, t0
                	li	t1, 0x1ff
-               	sub	a2, t1, a0
-               	slli	t0, a2, 0x2
-               	add	a0, s3, t0
-               	sw	a1, 0x0(a0)
-               	addi	s8, s4, 0x3ff
-               	lbu	a0, 0x0(s8)
-               	addiw	a1, a0, 0xb
+               	sub	a7, t1, a6
+               	slli	t0, a7, 0x2
+               	add	a6, a2, t0
+               	sw	a5, 0x0(a6)
+               	addi	a5, a3, 0x3ff
+               	lbu	a6, 0x0(a5)
+               	addiw	a5, a6, 0xb
                	li	t0, 0x7
-               	and	a0, s1, t0
+               	and	a6, a0, t0
                	li	t1, 0x3ff
-               	sub	a2, t1, a0
-               	add	a0, s4, a2
-               	sb	a1, 0x0(a0)
+               	sub	a0, t1, a6
+               	add	a6, a3, a0
+               	sb	a5, 0x0(a6)
                	lui	t0, 0x1
                	addiw	t0, t0, 0x3f0
-               	add	a0, s2, t0
+               	add	a0, a1, t0
+               	ld	a5, 0x0(a0)
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x654 <corpus.cases.frame.frame_large.checksum+0x654>
+               	j	0x688 <corpus.cases.frame.frame_large.checksum+0x688>
+               	li	t0, 0x8
+               	mul	a6, a0, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x654 <corpus.cases.frame.frame_large.checksum+0x654>
+               	lui	t0, 0x1
+               	addiw	t0, t0, 0x3f8
+               	add	a0, a1, t0
                	ld	a1, 0x0(a0)
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x484>
-               	ld	a1, 0x0(s6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x490>
-               	addi	a1, s3, 0x7f0
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x4a4>
-               	lw	a1, 0x0(s7)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x4b0>
-               	addi	a1, s4, 0x3f8
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x4c4>
-               	lbu	a1, 0x0(s8)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_large.checksum+0x4d0>
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x38
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x30
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x28
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x20
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x18
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x10
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6a8 <corpus.cases.frame.frame_large.checksum+0x6a8>
+               	j	0x6dc <corpus.cases.frame.frame_large.checksum+0x6dc>
+               	li	t0, 0x8
+               	mul	a5, a0, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a4, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x6a8 <corpus.cases.frame.frame_large.checksum+0x6a8>
+               	addi	a0, a2, 0x7f0
+               	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6fc <corpus.cases.frame.frame_large.checksum+0x6fc>
+               	j	0x730 <corpus.cases.frame.frame_large.checksum+0x730>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a4, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6fc <corpus.cases.frame.frame_large.checksum+0x6fc>
+               	addi	a0, a2, 0x7fc
+               	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x750 <corpus.cases.frame.frame_large.checksum+0x750>
+               	j	0x784 <corpus.cases.frame.frame_large.checksum+0x784>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a5, a0, a2
+               	li	t0, 0xff
+               	and	a2, a5, t0
+               	xor	a5, a4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x750 <corpus.cases.frame.frame_large.checksum+0x750>
+               	addi	a0, a3, 0x3f8
+               	lbu	a1, 0x0(a0)
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7a0 <corpus.cases.frame.frame_large.checksum+0x7a0>
+               	j	0x7d4 <corpus.cases.frame.frame_large.checksum+0x7d4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a5, a0, a2
+               	li	t0, 0xff
+               	and	a2, a5, t0
+               	xor	a5, a4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7a0 <corpus.cases.frame.frame_large.checksum+0x7a0>
+               	addi	a0, a3, 0x3ff
+               	lbu	a1, 0x0(a0)
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7f0 <corpus.cases.frame.frame_large.checksum+0x7f0>
+               	j	0x824 <corpus.cases.frame.frame_large.checksum+0x824>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7f0 <corpus.cases.frame.frame_large.checksum+0x7f0>
+               	mv	a0, a4
                	lui	t1, 0x2
                	addiw	t1, t1, 0x8
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
+               	ld	s1, 0x0(t1)
                	lui	t1, 0x2
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, 0x48
+               	addiw	t1, t1, 0x18
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x2
-               	addiw	t1, t1, 0x40
+               	addiw	t1, t1, 0x10
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x2
-               	addiw	t0, t0, 0x50
+               	addiw	t0, t0, 0x20
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/frame/frame_spill.dis
+++ b/test/golden/riscv64-linux/frame/frame_spill.dis
@@ -11,33 +11,33 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.frame.frame_spill.checksum>:
-               	addi	sp, sp, -0x230
-               	sd	ra, 0x228(sp)
-               	sd	s0, 0x220(sp)
-               	addi	s0, sp, 0x230
-               	sd	s1, 0x218(sp)
-               	sd	s2, 0x210(sp)
-               	sd	s3, 0x208(sp)
-               	sd	s4, 0x200(sp)
-               	sd	s5, 0x1f8(sp)
-               	sd	s6, 0x1f0(sp)
-               	sd	s7, 0x1e8(sp)
-               	sd	s8, 0x1e0(sp)
-               	sd	s9, 0x1d8(sp)
-               	sd	s10, 0x1d0(sp)
-               	sd	s11, 0x1c8(sp)
-               	fsd	fs0, 0x1c0(sp)
-               	fsd	fs1, 0x1b8(sp)
-               	fsd	fs2, 0x1b0(sp)
-               	fsd	fs3, 0x1a8(sp)
-               	fsd	fs4, 0x1a0(sp)
-               	fsd	fs5, 0x198(sp)
-               	fsd	fs6, 0x190(sp)
-               	fsd	fs7, 0x188(sp)
-               	fsd	fs8, 0x180(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.frame.frame_spill.checksum+0x64>
+               	addi	sp, sp, -0x2a0
+               	sd	ra, 0x298(sp)
+               	sd	s0, 0x290(sp)
+               	addi	s0, sp, 0x2a0
+               	sd	s1, 0x288(sp)
+               	sd	s2, 0x280(sp)
+               	sd	s3, 0x278(sp)
+               	sd	s4, 0x270(sp)
+               	sd	s5, 0x268(sp)
+               	sd	s6, 0x260(sp)
+               	sd	s7, 0x258(sp)
+               	sd	s8, 0x250(sp)
+               	sd	s9, 0x248(sp)
+               	sd	s10, 0x240(sp)
+               	sd	s11, 0x238(sp)
+               	fsd	fs0, 0x230(sp)
+               	fsd	fs1, 0x228(sp)
+               	fsd	fs2, 0x220(sp)
+               	fsd	fs3, 0x218(sp)
+               	fsd	fs4, 0x210(sp)
+               	fsd	fs5, 0x208(sp)
+               	fsd	fs6, 0x200(sp)
+               	fsd	fs7, 0x1f8(sp)
+               	fsd	fs8, 0x1f0(sp)
+               	fsd	fs9, 0x1e8(sp)
+               	fsd	fs10, 0x1e0(sp)
+               	fsd	fs11, 0x1d8(sp)
                	lui	t1, 0x5852
                	addiw	t1, t1, -0xbd
                	slli	t1, t1, 0xc
@@ -46,7 +46,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x6a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0xd3
-               	add	a1, t1, s1
+               	add	a1, t1, a0
                	lui	t1, 0x1405
                	addiw	t1, t1, 0x7b8
                	slli	t1, t1, 0xc
@@ -55,7 +55,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x678
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x14f
-               	xor	a2, t1, s1
+               	xor	a2, t1, a0
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -64,7 +64,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	add	a3, t1, s1
+               	add	a3, t1, a0
                	lui	t1, 0xfc2b3
                	addiw	t1, t1, -0x51c
                	slli	t1, t1, 0xc
@@ -73,7 +73,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x2b1
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x4b1
-               	xor	a4, t1, s1
+               	xor	a4, t1, a0
                	lui	t1, 0x1656
                	addiw	t1, t1, 0x67b
                	slli	t1, t1, 0xc
@@ -82,7 +82,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x378
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x607
-               	add	a5, t1, s1
+               	add	a5, t1, a0
                	lui	t1, 0xf85ec
                	addiw	t1, t1, -0x359
                	slli	t1, t1, 0xc
@@ -91,7 +91,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x4d5
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x19d
-               	xor	a6, t1, s1
+               	xor	a6, t1, a0
                	lui	t1, 0x27d5
                	addiw	t1, t1, -0x14d
                	slli	t1, t1, 0xc
@@ -100,7 +100,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x566
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x7c5
-               	add	a7, t1, s1
+               	add	a7, t1, a0
                	lui	t1, 0x72a6
                	addiw	t1, t1, 0x3cd
                	slli	t1, t1, 0xc
@@ -109,7 +109,7 @@ Disassembly of section .text:
                	addi	t1, t1, 0x2d2
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x19f
-               	xor	t5, t1, s1
+               	xor	t5, t1, a0
                	lui	t1, 0x42f2
                	addiw	t1, t1, -0x158
                	slli	t1, t1, 0xc
@@ -118,7 +118,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x5af
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x475
-               	add	t6, t1, s1
+               	add	t6, t1, a0
                	lui	t1, 0x30bf
                	addiw	t1, t1, -0x1f
                	slli	t1, t1, 0xc
@@ -127,7 +127,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x7b2
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0xe1
-               	xor	s2, t1, s1
+               	xor	s1, t1, a0
                	lui	t1, 0x61c9
                	addiw	t1, t1, -0x79c
                	slli	t1, t1, 0xc
@@ -136,7 +136,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x3eb
-               	add	s3, t1, s1
+               	add	s2, t1, a0
                	lui	t1, 0x4cf4
                	addiw	t1, t1, 0x3f3
                	slli	t1, t1, 0xc
@@ -145,7 +145,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x446
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x64f
-               	xor	s4, t1, s1
+               	xor	s3, t1, a0
                	lui	t1, 0xfaaab
                	addiw	t1, t1, -0x555
                	slli	t1, t1, 0xc
@@ -154,7 +154,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x555
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x555
-               	add	s5, t1, s1
+               	add	s4, t1, a0
                	lui	t1, 0xfda3e
                	addiw	t1, t1, 0x39d
                	slli	t1, t1, 0xc
@@ -163,7 +163,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x46a
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x425
-               	xor	s6, t1, s1
+               	xor	s5, t1, a0
                	lui	t1, 0x1f2e
                	addiw	t1, t1, 0x513
                	slli	t1, t1, 0xc
@@ -172,7 +172,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x3dd
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x52f
-               	add	s7, t1, s1
+               	add	s6, t1, a0
                	lui	t1, 0x2d55
                	addiw	t1, t1, -0x18c
                	slli	t1, t1, 0xc
@@ -181,32 +181,31 @@ Disassembly of section .text:
                	addi	t1, t1, 0x1a9
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x77f
-               	xor	s8, t1, s1
+               	xor	s7, t1, a0
                	lui	t1, 0x9e
                	addiw	t1, t1, 0x378
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x64f
-               	add	s9, t1, s1
-               	sext.w	s10, s9
+               	add	s8, t1, a0
+               	sext.w	s9, s8
                	lui	t1, 0xa
                	addiw	t1, t1, -0x1c9
-               	xor	s9, t1, s1
-               	sext.w	s11, s9
+               	xor	s8, t1, a0
+               	sext.w	s10, s8
                	lui	t1, 0x86
                	addiw	t1, t1, -0x143
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x589
-               	add	s9, t1, s1
-               	sext.w	t2, s9
-               	sd	t2, -0xb8(s0)
+               	add	s8, t1, a0
+               	sext.w	s11, s8
                	lui	t1, 0xc3
                	addiw	t1, t1, -0x4d5
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x1c3
-               	xor	s9, t1, s1
-               	sext.w	t2, s9
-               	sd	t2, -0xc0(s0)
-               	fcvt.d.lu	ft0, s1
+               	xor	s8, t1, a0
+               	sext.w	t2, s8
+               	sd	t2, -0xd0(s0)
+               	fcvt.d.lu	ft0, a0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
@@ -247,34 +246,49 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fadd.d	fa0, ft11, ft0
-               	mv	s1, a0
-               	mv	s9, a1
-               	mv	t2, a2
-               	sd	t2, -0xc8(s0)
-               	mv	t2, a3
-               	sd	t2, -0x200(s0)
-               	mv	t2, a4
-               	sd	t2, -0x208(s0)
-               	mv	t2, a5
-               	sd	t2, -0x210(s0)
-               	mv	t2, a6
-               	sd	t2, -0x218(s0)
-               	mv	t2, a7
-               	sd	t2, -0x220(s0)
-               	mv	t2, t5
-               	sd	t2, -0x228(s0)
-               	mv	t2, t6
-               	sd	t2, -0x230(s0)
-               	mv	t2, s10
-               	sd	t2, -0x108(s0)
-               	mv	t2, s11
+               	lui	s8, 0xfcbf3
+               	addiw	s8, s8, -0x632
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x484
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x222
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x325
+               	mv	t2, a1
                	sd	t2, -0xd8(s0)
-               	ld	t3, -0xb8(s0)
+               	mv	t2, a2
+               	sd	t2, -0xe0(s0)
+               	mv	t2, a3
+               	sd	t2, -0x260(s0)
+               	mv	t2, a4
+               	sd	t2, -0x268(s0)
+               	mv	t2, a5
+               	sd	t2, -0x270(s0)
+               	mv	t2, a6
+               	sd	t2, -0x278(s0)
+               	mv	t2, a7
+               	sd	t2, -0x280(s0)
+               	mv	t2, t5
+               	sd	t2, -0x288(s0)
+               	mv	t2, t6
+               	sd	t2, -0x290(s0)
+               	mv	t2, s4
+               	sd	t2, -0x168(s0)
+               	mv	t2, s5
+               	sd	t2, -0x148(s0)
+               	mv	t2, s6
+               	sd	t2, -0x158(s0)
+               	mv	t2, s7
+               	sd	t2, -0x138(s0)
+               	mv	t2, s9
+               	sd	t2, -0x118(s0)
+               	mv	t2, s10
+               	sd	t2, -0x128(s0)
+               	mv	t2, s11
+               	sd	t2, -0xe8(s0)
+               	ld	t3, -0xd0(s0)
                	mv	t2, t3
-               	sd	t2, -0xf8(s0)
-               	ld	t3, -0xc0(s0)
-               	mv	t2, t3
-               	sd	t2, -0xd0(s0)
+               	sd	t2, -0x108(s0)
                	fmv.d	fs0, ft1
                	fmv.d	fs1, ft2
                	fmv.d	fs2, ft3
@@ -285,164 +299,175 @@ Disassembly of section .text:
                	fmv.d	fs7, fa0
                	li	s11, 0x0
                	li	t0, 0x18
-               	bltu	s11, t0, 0x428 <.Lpcrel_hi.7+0xac>
-               	j	0x81c <.Lpcrel_hi.15+0x114>
-               	slli	a0, s8, 0x1d
-               	srli	a1, s8, 0x23
+               	bltu	s11, t0, 0x460 <.Lpcrel_hi.7+0xe8>
+               	j	0x8c8 <.Lpcrel_hi.15+0x150>
+               	ld	t2, -0x138(s0)
+               	slli	a0, t2, 0x1d
+               	ld	t2, -0x138(s0)
+               	srli	a1, t2, 0x23
                	or	t2, a0, a1
-               	sd	t2, -0xe0(s0)
-               	ld	t3, -0xe0(s0)
-               	xor	t2, s9, t3
-               	sd	t2, -0xe8(s0)
-               	slli	a1, s9, 0x7
-               	srli	a0, s9, 0x39
-               	or	t2, a1, a0
                	sd	t2, -0xf0(s0)
-               	ld	t3, -0xc8(s0)
+               	ld	t3, -0xd8(s0)
                	ld	t4, -0xf0(s0)
+               	xor	t2, t3, t4
+               	sd	t2, -0xf8(s0)
+               	ld	t2, -0xd8(s0)
+               	slli	a1, t2, 0x7
+               	ld	t2, -0xd8(s0)
+               	srli	a0, t2, 0x39
+               	or	t2, a1, a0
+               	sd	t2, -0x100(s0)
+               	ld	t3, -0xe0(s0)
+               	ld	t4, -0x100(s0)
                	add	t2, t3, t4
-               	sd	t2, -0x1f8(s0)
-               	ld	t2, -0xc8(s0)
+               	sd	t2, -0x218(s0)
+               	ld	t2, -0xe0(s0)
                	slli	a0, t2, 0xb
-               	ld	t2, -0xc8(s0)
+               	ld	t2, -0xe0(s0)
                	srli	a1, t2, 0x35
                	or	t2, a0, a1
-               	sd	t2, -0x100(s0)
-               	ld	t2, -0x200(s0)
-               	ld	t3, -0x100(s0)
-               	xor	s10, t2, t3
-               	ld	t2, -0x200(s0)
+               	sd	t2, -0x110(s0)
+               	ld	t2, -0x260(s0)
+               	ld	t3, -0x110(s0)
+               	xor	s9, t2, t3
+               	ld	t2, -0x260(s0)
                	slli	a0, t2, 0xd
-               	ld	t2, -0x200(s0)
+               	ld	t2, -0x260(s0)
                	srli	a1, t2, 0x33
                	or	t2, a0, a1
-               	sd	t2, -0x110(s0)
-               	ld	t3, -0x208(s0)
-               	ld	t4, -0x110(s0)
-               	add	t2, t3, t4
-               	sd	t2, -0x118(s0)
-               	ld	t2, -0x208(s0)
+               	sd	t2, -0x120(s0)
+               	ld	t2, -0x268(s0)
+               	ld	t3, -0x120(s0)
+               	add	s10, t2, t3
+               	ld	t2, -0x268(s0)
                	slli	a0, t2, 0x11
-               	ld	t2, -0x208(s0)
+               	ld	t2, -0x268(s0)
                	srli	a1, t2, 0x2f
                	or	t2, a0, a1
-               	sd	t2, -0x120(s0)
-               	ld	t3, -0x210(s0)
-               	ld	t4, -0x120(s0)
-               	xor	t2, t3, t4
-               	sd	t2, -0x128(s0)
-               	ld	t2, -0x210(s0)
+               	sd	t2, -0x130(s0)
+               	ld	t2, -0x270(s0)
+               	ld	t3, -0x130(s0)
+               	xor	s7, t2, t3
+               	ld	t2, -0x270(s0)
                	slli	a0, t2, 0x13
-               	ld	t2, -0x210(s0)
+               	ld	t2, -0x270(s0)
                	srli	a1, t2, 0x2d
                	or	t2, a0, a1
-               	sd	t2, -0x130(s0)
-               	ld	t3, -0x218(s0)
-               	ld	t4, -0x130(s0)
-               	add	t2, t3, t4
-               	sd	t2, -0x138(s0)
-               	ld	t2, -0x218(s0)
+               	sd	t2, -0x140(s0)
+               	ld	t2, -0x278(s0)
+               	ld	t3, -0x140(s0)
+               	add	s5, t2, t3
+               	ld	t2, -0x278(s0)
                	slli	a0, t2, 0x17
-               	ld	t2, -0x218(s0)
+               	ld	t2, -0x278(s0)
                	srli	a1, t2, 0x29
                	or	t2, a0, a1
-               	sd	t2, -0x140(s0)
-               	ld	t3, -0x220(s0)
-               	ld	t4, -0x140(s0)
-               	xor	t2, t3, t4
-               	sd	t2, -0x148(s0)
-               	ld	t2, -0x220(s0)
+               	sd	t2, -0x150(s0)
+               	ld	t2, -0x280(s0)
+               	ld	t3, -0x150(s0)
+               	xor	s6, t2, t3
+               	ld	t2, -0x280(s0)
                	slli	a0, t2, 0x1f
-               	ld	t2, -0x220(s0)
+               	ld	t2, -0x280(s0)
                	srli	a1, t2, 0x21
                	or	t2, a0, a1
-               	sd	t2, -0x150(s0)
-               	ld	t3, -0x228(s0)
-               	ld	t4, -0x150(s0)
-               	add	t2, t3, t4
-               	sd	t2, -0x158(s0)
-               	ld	t2, -0x228(s0)
+               	sd	t2, -0x160(s0)
+               	ld	t2, -0x288(s0)
+               	ld	t3, -0x160(s0)
+               	add	s4, t2, t3
+               	ld	t2, -0x288(s0)
                	slli	a0, t2, 0x25
-               	ld	t2, -0x228(s0)
+               	ld	t2, -0x288(s0)
                	srli	a1, t2, 0x1b
                	or	t2, a0, a1
-               	sd	t2, -0x160(s0)
-               	ld	t3, -0x230(s0)
-               	ld	t4, -0x160(s0)
-               	xor	t2, t3, t4
-               	sd	t2, -0x168(s0)
-               	ld	t2, -0x230(s0)
-               	slli	a0, t2, 0x29
-               	ld	t2, -0x230(s0)
-               	srli	a1, t2, 0x17
-               	or	t2, a0, a1
                	sd	t2, -0x170(s0)
-               	ld	t3, -0x170(s0)
-               	add	t2, s2, t3
+               	ld	t3, -0x290(s0)
+               	ld	t4, -0x170(s0)
+               	xor	t2, t3, t4
                	sd	t2, -0x178(s0)
-               	slli	a0, s2, 0x2b
-               	srli	a1, s2, 0x15
+               	ld	t2, -0x290(s0)
+               	slli	a0, t2, 0x29
+               	ld	t2, -0x290(s0)
+               	srli	a1, t2, 0x17
                	or	t2, a0, a1
                	sd	t2, -0x180(s0)
                	ld	t3, -0x180(s0)
-               	xor	t2, s3, t3
+               	add	t2, s1, t3
                	sd	t2, -0x188(s0)
-               	slli	a0, s3, 0x2f
-               	srli	a1, s3, 0x11
+               	slli	a0, s1, 0x2b
+               	srli	a1, s1, 0x15
                	or	t2, a0, a1
                	sd	t2, -0x190(s0)
                	ld	t3, -0x190(s0)
-               	add	t2, s4, t3
+               	xor	t2, s2, t3
                	sd	t2, -0x198(s0)
-               	slli	a0, s4, 0x35
-               	srli	a1, s4, 0xb
+               	slli	a0, s2, 0x2f
+               	srli	a1, s2, 0x11
                	or	t2, a0, a1
                	sd	t2, -0x1a0(s0)
                	ld	t3, -0x1a0(s0)
-               	xor	t2, s5, t3
+               	add	t2, s3, t3
                	sd	t2, -0x1a8(s0)
-               	slli	a0, s5, 0x3b
-               	srli	a1, s5, 0x5
+               	slli	a0, s3, 0x35
+               	srli	a1, s3, 0xb
                	or	t2, a0, a1
                	sd	t2, -0x1b0(s0)
-               	ld	t3, -0x1b0(s0)
-               	add	t2, s6, t3
+               	ld	t3, -0x168(s0)
+               	ld	t4, -0x1b0(s0)
+               	xor	t2, t3, t4
                	sd	t2, -0x1b8(s0)
-               	slli	a0, s6, 0x3d
-               	srli	a1, s6, 0x3
+               	ld	t2, -0x168(s0)
+               	slli	a0, t2, 0x3b
+               	ld	t2, -0x168(s0)
+               	srli	a1, t2, 0x5
                	or	t2, a0, a1
                	sd	t2, -0x1c0(s0)
-               	ld	t3, -0x1c0(s0)
-               	xor	t2, s7, t3
+               	ld	t3, -0x148(s0)
+               	ld	t4, -0x1c0(s0)
+               	add	t2, t3, t4
                	sd	t2, -0x1c8(s0)
-               	slli	a0, s7, 0x3
-               	srli	a1, s7, 0x3d
+               	ld	t2, -0x148(s0)
+               	slli	a0, t2, 0x3d
+               	ld	t2, -0x148(s0)
+               	srli	a1, t2, 0x3
                	or	t2, a0, a1
                	sd	t2, -0x1d0(s0)
-               	ld	t2, -0x1d0(s0)
-               	add	s7, s8, t2
-               	ld	t2, -0xe8(s0)
-               	add	s8, t2, s11
-               	ld	t2, -0x1b8(s0)
+               	ld	t3, -0x158(s0)
+               	ld	t4, -0x1d0(s0)
+               	xor	t2, t3, t4
+               	sd	t2, -0x1d8(s0)
+               	ld	t2, -0x158(s0)
+               	slli	a0, t2, 0x3
+               	ld	t2, -0x158(s0)
+               	srli	a1, t2, 0x3d
+               	or	t2, a0, a1
+               	sd	t2, -0x1e0(s0)
+               	ld	t3, -0x138(s0)
+               	ld	t4, -0x1e0(s0)
+               	add	t2, t3, t4
+               	sd	t2, -0x1e8(s0)
+               	ld	t3, -0xf8(s0)
+               	add	t2, t3, s11
+               	sd	t2, -0x1f0(s0)
+               	ld	t2, -0x1c8(s0)
+               	sext.w	a0, t2
+               	ld	t3, -0x118(s0)
+               	xor	t2, t3, a0
+               	sd	t2, -0x1f8(s0)
+               	ld	t2, -0x218(s0)
+               	sext.w	a0, t2
+               	ld	t3, -0x128(s0)
+               	addw	t2, t3, a0
+               	sd	t2, -0x200(s0)
+               	sext.w	a0, s5
+               	ld	t3, -0xe8(s0)
+               	xor	t2, t3, a0
+               	sd	t2, -0x208(s0)
+               	ld	t2, -0x188(s0)
                	sext.w	a0, t2
                	ld	t3, -0x108(s0)
-               	xor	t2, t3, a0
-               	sd	t2, -0x1d8(s0)
-               	ld	t2, -0x1f8(s0)
-               	sext.w	a0, t2
-               	ld	t3, -0xd8(s0)
                	addw	t2, t3, a0
-               	sd	t2, -0x1e0(s0)
-               	ld	t2, -0x138(s0)
-               	sext.w	a0, t2
-               	ld	t3, -0xf8(s0)
-               	xor	t2, t3, a0
-               	sd	t2, -0x1e8(s0)
-               	ld	t2, -0x178(s0)
-               	sext.w	a0, t2
-               	ld	t3, -0xd0(s0)
-               	addw	t2, t3, a0
-               	sd	t2, -0x1f0(s0)
+               	sd	t2, -0x210(s0)
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
@@ -454,226 +479,480 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs1, ft10
-               	fadd.d	fs1, ft0, fs2
+               	fadd.d	fs9, ft0, fs2
 
 <.Lpcrel_hi.10>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs2, ft10
-               	fadd.d	fs2, ft0, fs3
+               	fadd.d	fs10, ft0, fs3
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs3, ft10
-               	fadd.d	fs3, ft0, fs4
+               	fadd.d	fs11, ft0, fs4
 
 <.Lpcrel_hi.12>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs4, ft10
-               	fadd.d	fs4, ft0, fs5
+               	fadd.d	ft11, ft0, fs5
+               	fsd	ft11, -0x228(s0)
 
 <.Lpcrel_hi.13>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs5, ft10
-               	fadd.d	fs5, ft0, fs6
+               	fadd.d	ft11, ft0, fs6
+               	fsd	ft11, -0x238(s0)
 
 <.Lpcrel_hi.14>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs6, ft10
-               	fadd.d	fs6, ft0, fs7
+               	fadd.d	ft11, ft0, fs7
+               	fsd	ft11, -0x248(s0)
 
 <.Lpcrel_hi.15>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs7, ft10
-               	fadd.d	fs7, ft0, fs0
-               	ld	t2, -0x1f8(s0)
-               	ld	t3, -0x178(s0)
+               	fadd.d	ft11, ft0, fs0
+               	fsd	ft11, -0x258(s0)
+               	ld	t2, -0x218(s0)
+               	ld	t3, -0x188(s0)
                	xor	a1, t2, t3
-               	mv	a0, s1
+               	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x20>
-               	ld	t2, -0x1e0(s0)
-               	mv	a1, t2
+               	jalr	ra <.Lpcrel_hi.15+0x24>
+               	ld	t2, -0x200(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x30>
-               	fadd.d	fa0, fs8, fs4
+               	jalr	ra <.Lpcrel_hi.15+0x38>
+               	fld	ft10, -0x228(s0)
+               	fadd.d	ft0, fs8, ft10
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x3c>
+               	jalr	ra <.Lpcrel_hi.15+0x4c>
                	addi	s11, s11, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x1f8(s0)
-               	mv	s9, t2
-               	mv	t2, s10
-               	sd	t2, -0xc8(s0)
-               	ld	t3, -0x118(s0)
-               	mv	t2, t3
-               	sd	t2, -0x200(s0)
-               	ld	t3, -0x128(s0)
-               	mv	t2, t3
-               	sd	t2, -0x208(s0)
-               	ld	t3, -0x138(s0)
-               	mv	t2, t3
-               	sd	t2, -0x210(s0)
-               	ld	t3, -0x148(s0)
-               	mv	t2, t3
-               	sd	t2, -0x218(s0)
-               	ld	t3, -0x158(s0)
-               	mv	t2, t3
-               	sd	t2, -0x220(s0)
-               	ld	t3, -0x168(s0)
-               	mv	t2, t3
-               	sd	t2, -0x228(s0)
-               	ld	t3, -0x178(s0)
-               	mv	t2, t3
-               	sd	t2, -0x230(s0)
-               	ld	t2, -0x188(s0)
-               	mv	s2, t2
-               	ld	t2, -0x198(s0)
-               	mv	s3, t2
-               	ld	t2, -0x1a8(s0)
-               	mv	s4, t2
-               	ld	t2, -0x1b8(s0)
-               	mv	s5, t2
-               	ld	t2, -0x1c8(s0)
-               	mv	s6, t2
-               	ld	t3, -0x1e0(s0)
-               	mv	t2, t3
-               	sd	t2, -0x108(s0)
-               	ld	t3, -0x1e8(s0)
+               	mv	s8, a0
+               	ld	t3, -0x218(s0)
                	mv	t2, t3
                	sd	t2, -0xd8(s0)
-               	ld	t3, -0x1f0(s0)
+               	mv	t2, s9
+               	sd	t2, -0xe0(s0)
+               	mv	t2, s10
+               	sd	t2, -0x260(s0)
+               	mv	t2, s7
+               	sd	t2, -0x268(s0)
+               	mv	t2, s5
+               	sd	t2, -0x270(s0)
+               	mv	t2, s6
+               	sd	t2, -0x278(s0)
+               	mv	t2, s4
+               	sd	t2, -0x280(s0)
+               	ld	t3, -0x178(s0)
                	mv	t2, t3
-               	sd	t2, -0xf8(s0)
+               	sd	t2, -0x288(s0)
+               	ld	t3, -0x188(s0)
+               	mv	t2, t3
+               	sd	t2, -0x290(s0)
+               	ld	t2, -0x198(s0)
+               	mv	s1, t2
+               	ld	t2, -0x1a8(s0)
+               	mv	s2, t2
+               	ld	t2, -0x1b8(s0)
+               	mv	s3, t2
+               	ld	t3, -0x1c8(s0)
+               	mv	t2, t3
+               	sd	t2, -0x168(s0)
                	ld	t3, -0x1d8(s0)
                	mv	t2, t3
-               	sd	t2, -0xd0(s0)
+               	sd	t2, -0x148(s0)
+               	ld	t3, -0x1e8(s0)
+               	mv	t2, t3
+               	sd	t2, -0x158(s0)
+               	ld	t3, -0x1f0(s0)
+               	mv	t2, t3
+               	sd	t2, -0x138(s0)
+               	ld	t3, -0x200(s0)
+               	mv	t2, t3
+               	sd	t2, -0x118(s0)
+               	ld	t3, -0x208(s0)
+               	mv	t2, t3
+               	sd	t2, -0x128(s0)
+               	ld	t3, -0x210(s0)
+               	mv	t2, t3
+               	sd	t2, -0xe8(s0)
+               	ld	t3, -0x1f8(s0)
+               	mv	t2, t3
+               	sd	t2, -0x108(s0)
                	fmv.d	fs0, fs8
+               	fmv.d	fs1, fs9
+               	fmv.d	fs2, fs10
+               	fmv.d	fs3, fs11
+               	fld	fs4, -0x228(s0)
+               	fld	fs5, -0x238(s0)
+               	fld	fs6, -0x248(s0)
+               	fld	fs7, -0x258(s0)
                	li	t0, 0x18
-               	bltu	s11, t0, 0x428 <.Lpcrel_hi.7+0xac>
-               	mv	a0, s1
-               	mv	a1, s9
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x11c>
-               	ld	t2, -0xc8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x12c>
-               	ld	t2, -0x200(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x13c>
-               	ld	t2, -0x208(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x14c>
-               	ld	t2, -0x210(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x15c>
-               	ld	t2, -0x218(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x16c>
-               	ld	t2, -0x220(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x17c>
-               	ld	t2, -0x228(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x18c>
-               	ld	t2, -0x230(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x19c>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1a8>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1b4>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1c0>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1cc>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1d8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1e4>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1f0>
-               	ld	t2, -0x108(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x200>
+               	bltu	s11, t0, 0x460 <.Lpcrel_hi.7+0xe8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8d8 <.Lpcrel_hi.15+0x160>
+               	j	0x910 <.Lpcrel_hi.15+0x198>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
                	ld	t2, -0xd8(s0)
-               	mv	a1, t2
+               	srl	t6, t2, a1
+               	li	t0, 0xff
+               	and	a1, t6, t0
+               	xor	t6, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, t6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x8d8 <.Lpcrel_hi.15+0x160>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x920 <.Lpcrel_hi.15+0x1a8>
+               	j	0x958 <.Lpcrel_hi.15+0x1e0>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0xe0(s0)
+               	srl	t6, t2, a1
+               	li	t0, 0xff
+               	and	a1, t6, t0
+               	xor	t6, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, t6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x920 <.Lpcrel_hi.15+0x1a8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x968 <.Lpcrel_hi.15+0x1f0>
+               	j	0x9a0 <.Lpcrel_hi.15+0x228>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x260(s0)
+               	srl	t6, t2, a1
+               	li	t0, 0xff
+               	and	a1, t6, t0
+               	xor	t6, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, t6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x968 <.Lpcrel_hi.15+0x1f0>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9b0 <.Lpcrel_hi.15+0x238>
+               	j	0x9e8 <.Lpcrel_hi.15+0x270>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x268(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9b0 <.Lpcrel_hi.15+0x238>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9f8 <.Lpcrel_hi.15+0x280>
+               	j	0xa30 <.Lpcrel_hi.15+0x2b8>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x270(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x9f8 <.Lpcrel_hi.15+0x280>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa40 <.Lpcrel_hi.15+0x2c8>
+               	j	0xa78 <.Lpcrel_hi.15+0x300>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x278(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa40 <.Lpcrel_hi.15+0x2c8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa88 <.Lpcrel_hi.15+0x310>
+               	j	0xac0 <.Lpcrel_hi.15+0x348>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x280(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa88 <.Lpcrel_hi.15+0x310>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xad0 <.Lpcrel_hi.15+0x358>
+               	j	0xb08 <.Lpcrel_hi.15+0x390>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x288(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xad0 <.Lpcrel_hi.15+0x358>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb18 <.Lpcrel_hi.15+0x3a0>
+               	j	0xb50 <.Lpcrel_hi.15+0x3d8>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x290(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb18 <.Lpcrel_hi.15+0x3a0>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb60 <.Lpcrel_hi.15+0x3e8>
+               	j	0xb94 <.Lpcrel_hi.15+0x41c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s1, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb60 <.Lpcrel_hi.15+0x3e8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xba4 <.Lpcrel_hi.15+0x42c>
+               	j	0xbd8 <.Lpcrel_hi.15+0x460>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xba4 <.Lpcrel_hi.15+0x42c>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xbe8 <.Lpcrel_hi.15+0x470>
+               	j	0xc1c <.Lpcrel_hi.15+0x4a4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	srl	a2, s3, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xbe8 <.Lpcrel_hi.15+0x470>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc2c <.Lpcrel_hi.15+0x4b4>
+               	j	0xc64 <.Lpcrel_hi.15+0x4ec>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x168(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc2c <.Lpcrel_hi.15+0x4b4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc74 <.Lpcrel_hi.15+0x4fc>
+               	j	0xcac <.Lpcrel_hi.15+0x534>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x148(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc74 <.Lpcrel_hi.15+0x4fc>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xcbc <.Lpcrel_hi.15+0x544>
+               	j	0xcf4 <.Lpcrel_hi.15+0x57c>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x158(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xcbc <.Lpcrel_hi.15+0x544>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xd04 <.Lpcrel_hi.15+0x58c>
+               	j	0xd3c <.Lpcrel_hi.15+0x5c4>
+               	li	t0, 0x8
+               	mul	a1, a0, t0
+               	ld	t2, -0x138(s0)
+               	srl	a2, t2, a1
+               	li	t0, 0xff
+               	and	a1, a2, t0
+               	xor	a2, s8, a1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a2, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xd04 <.Lpcrel_hi.15+0x58c>
+               	ld	t2, -0x118(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
+               	mv	a0, s8
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x210>
-               	ld	t2, -0xf8(s0)
-               	mv	a1, t2
+               	jalr	ra <.Lpcrel_hi.15+0x5d4>
+               	ld	t2, -0x128(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x220>
-               	ld	t2, -0xd0(s0)
-               	mv	a1, t2
+               	jalr	ra <.Lpcrel_hi.15+0x5e8>
+               	ld	t2, -0xe8(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x230>
-               	fmv.d	fa0, fs0
+               	jalr	ra <.Lpcrel_hi.15+0x5fc>
+               	ld	t2, -0x108(s0)
+               	slli	a1, t2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x23c>
-               	fmv.d	fa0, fs1
+               	jalr	ra <.Lpcrel_hi.15+0x610>
+               	fmv.x.d	a1, fs0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x248>
-               	fmv.d	fa0, fs2
+               	jalr	ra <.Lpcrel_hi.15+0x61c>
+               	fmv.x.d	a1, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x254>
-               	fmv.d	fa0, fs3
+               	jalr	ra <.Lpcrel_hi.15+0x628>
+               	fmv.x.d	a1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x260>
-               	fmv.d	fa0, fs4
+               	jalr	ra <.Lpcrel_hi.15+0x634>
+               	fmv.x.d	a1, fs3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x26c>
-               	fmv.d	fa0, fs5
+               	jalr	ra <.Lpcrel_hi.15+0x640>
+               	fmv.x.d	a1, fs4
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x278>
-               	fmv.d	fa0, fs6
+               	jalr	ra <.Lpcrel_hi.15+0x64c>
+               	fmv.x.d	a1, fs5
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x284>
-               	fmv.d	fa0, fs7
+               	jalr	ra <.Lpcrel_hi.15+0x658>
+               	fmv.x.d	a1, fs6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x290>
-               	ld	s1, 0x218(sp)
-               	ld	s2, 0x210(sp)
-               	ld	s3, 0x208(sp)
-               	ld	s4, 0x200(sp)
-               	ld	s5, 0x1f8(sp)
-               	ld	s6, 0x1f0(sp)
-               	ld	s7, 0x1e8(sp)
-               	ld	s8, 0x1e0(sp)
-               	ld	s9, 0x1d8(sp)
-               	ld	s10, 0x1d0(sp)
-               	ld	s11, 0x1c8(sp)
-               	fld	fs0, 0x1c0(sp)
-               	fld	fs1, 0x1b8(sp)
-               	fld	fs2, 0x1b0(sp)
-               	fld	fs3, 0x1a8(sp)
-               	fld	fs4, 0x1a0(sp)
-               	fld	fs5, 0x198(sp)
-               	fld	fs6, 0x190(sp)
-               	fld	fs7, 0x188(sp)
-               	fld	fs8, 0x180(sp)
-               	ld	ra, 0x228(sp)
-               	ld	s0, 0x220(sp)
-               	addi	sp, sp, 0x230
+               	jalr	ra <.Lpcrel_hi.15+0x664>
+               	fmv.x.d	a1, fs7
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.15+0x670>
+               	ld	s1, 0x288(sp)
+               	ld	s2, 0x280(sp)
+               	ld	s3, 0x278(sp)
+               	ld	s4, 0x270(sp)
+               	ld	s5, 0x268(sp)
+               	ld	s6, 0x260(sp)
+               	ld	s7, 0x258(sp)
+               	ld	s8, 0x250(sp)
+               	ld	s9, 0x248(sp)
+               	ld	s10, 0x240(sp)
+               	ld	s11, 0x238(sp)
+               	fld	fs0, 0x230(sp)
+               	fld	fs1, 0x228(sp)
+               	fld	fs2, 0x220(sp)
+               	fld	fs3, 0x218(sp)
+               	fld	fs4, 0x210(sp)
+               	fld	fs5, 0x208(sp)
+               	fld	fs6, 0x200(sp)
+               	fld	fs7, 0x1f8(sp)
+               	fld	fs8, 0x1f0(sp)
+               	fld	fs9, 0x1e8(sp)
+               	fld	fs10, 0x1e0(sp)
+               	fld	fs11, 0x1d8(sp)
+               	ld	ra, 0x298(sp)
+               	ld	s0, 0x290(sp)
+               	addi	sp, sp, 0x2a0
                	ret

--- a/test/golden/riscv64-linux/imm/imm_add.dis
+++ b/test/golden/riscv64-linux/imm/imm_add.dis
@@ -3,200 +3,397 @@ imm/imm_add.o:
 Disassembly of section .text:
 
 <corpus.cases.imm.imm_add.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	sd	s1, 0x18(sp)
+               	sd	s2, 0x10(sp)
+               	sd	s3, 0x8(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x28>
-               	mv	a1, a0
-               	sext.w	a2, s1
-               	addiw	s2, a2, 0x7ff
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x44>
-               	mv	a1, a0
+               	sext.w	a0, s1
+               	addiw	a1, a0, 0x7ff
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x60 <corpus.cases.imm.imm_add.checksum+0x60>
+               	j	0x94 <corpus.cases.imm.imm_add.checksum+0x94>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x60 <corpus.cases.imm.imm_add.checksum+0x60>
                	lui	t0, 0x1
                	addiw	t0, t0, -0x800
-               	addw	s3, s2, t0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x64>
-               	mv	a1, a0
+               	addw	a0, a1, t0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb8 <corpus.cases.imm.imm_add.checksum+0xb8>
+               	j	0xec <corpus.cases.imm.imm_add.checksum+0xec>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb8 <corpus.cases.imm.imm_add.checksum+0xb8>
                	lui	t0, 0x1
                	addiw	t0, t0, -0x1
-               	addw	s4, s3, t0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x84>
-               	mv	a1, a0
+               	addw	a1, a0, t0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x110 <corpus.cases.imm.imm_add.checksum+0x110>
+               	j	0x144 <corpus.cases.imm.imm_add.checksum+0x144>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x110 <corpus.cases.imm.imm_add.checksum+0x110>
                	lui	t0, 0x1
-               	addw	s3, s4, t0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0xa0>
-               	mv	a1, a0
+               	addw	a0, a1, t0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x164 <corpus.cases.imm.imm_add.checksum+0x164>
+               	j	0x198 <corpus.cases.imm.imm_add.checksum+0x198>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x164 <corpus.cases.imm.imm_add.checksum+0x164>
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	addw	s4, s3, t0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0xc0>
-               	mv	a1, a0
+               	addw	a1, a0, t0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1bc <corpus.cases.imm.imm_add.checksum+0x1bc>
+               	j	0x1f0 <corpus.cases.imm.imm_add.checksum+0x1f0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1bc <corpus.cases.imm.imm_add.checksum+0x1bc>
                	lui	t0, 0x80000
-               	addw	s3, s4, t0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0xdc>
-               	mv	a1, a0
+               	addw	a0, a1, t0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.imm.imm_add.checksum+0x210>
+               	j	0x244 <corpus.cases.imm.imm_add.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.imm.imm_add.checksum+0x210>
                	li	t0, -0x1
-               	addw	a2, s3, t0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0xf8>
-               	mv	a1, a0
-               	addi	s3, s1, 0x7ff
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x110>
-               	mv	a1, a0
-               	addi	s1, s3, -0x800
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x128>
-               	mv	a1, a0
+               	addw	a1, a0, t0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.imm.imm_add.checksum+0x264>
+               	j	0x298 <corpus.cases.imm.imm_add.checksum+0x298>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.imm.imm_add.checksum+0x264>
+               	addi	a0, s1, 0x7ff
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2ac <corpus.cases.imm.imm_add.checksum+0x2ac>
+               	j	0x2e0 <corpus.cases.imm.imm_add.checksum+0x2e0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2ac <corpus.cases.imm.imm_add.checksum+0x2ac>
+               	addi	a1, a0, -0x800
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2f4 <corpus.cases.imm.imm_add.checksum+0x2f4>
+               	j	0x328 <corpus.cases.imm.imm_add.checksum+0x328>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x2f4 <corpus.cases.imm.imm_add.checksum+0x2f4>
                	lui	t0, 0xfff
-               	add	s4, s1, t0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x144>
-               	mv	a1, a0
+               	add	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.imm.imm_add.checksum+0x340>
+               	j	0x374 <corpus.cases.imm.imm_add.checksum+0x374>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x340 <corpus.cases.imm.imm_add.checksum+0x340>
                	lui	t0, 0x1000
                	addiw	t0, t0, -0x1
-               	add	s5, s4, t0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x164>
-               	mv	a1, a0
+               	add	a1, a0, t0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x390 <corpus.cases.imm.imm_add.checksum+0x390>
+               	j	0x3c4 <corpus.cases.imm.imm_add.checksum+0x3c4>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x390 <corpus.cases.imm.imm_add.checksum+0x390>
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	add	s4, s5, t0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x184>
-               	mv	a1, a0
+               	add	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e0 <corpus.cases.imm.imm_add.checksum+0x3e0>
+               	j	0x414 <corpus.cases.imm.imm_add.checksum+0x414>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e0 <corpus.cases.imm.imm_add.checksum+0x3e0>
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	add	s5, s4, t0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x1a4>
-               	mv	a1, a0
+               	add	a1, a0, t0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x430 <corpus.cases.imm.imm_add.checksum+0x430>
+               	j	0x464 <corpus.cases.imm.imm_add.checksum+0x464>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x430 <corpus.cases.imm.imm_add.checksum+0x430>
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	add	s4, s5, t0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x1c8>
-               	mv	a1, a0
+               	add	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x484 <corpus.cases.imm.imm_add.checksum+0x484>
+               	j	0x4b8 <corpus.cases.imm.imm_add.checksum+0x4b8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x484 <corpus.cases.imm.imm_add.checksum+0x484>
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
-               	add	s5, s4, t0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x1e8>
-               	mv	a1, a0
+               	add	a1, a0, t0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4d4 <corpus.cases.imm.imm_add.checksum+0x4d4>
+               	j	0x508 <corpus.cases.imm.imm_add.checksum+0x508>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4d4 <corpus.cases.imm.imm_add.checksum+0x4d4>
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	add	a2, s5, t0
-               	mv	a0, a1
-               	mv	a1, a2
+               	add	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x52c <corpus.cases.imm.imm_add.checksum+0x52c>
+               	j	0x560 <corpus.cases.imm.imm_add.checksum+0x560>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x52c <corpus.cases.imm.imm_add.checksum+0x52c>
+               	sext.w	a0, s1
+               	addiw	s2, a0, 0x7ff
+               	sext.w	a1, s2
+               	mv	a0, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x210>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x570>
+               	addiw	s3, s2, -0x800
+               	sext.w	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x224>
-               	mv	a1, a0
-               	addiw	s4, s2, -0x800
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x23c>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x580>
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
-               	addw	s2, s4, t0
-               	mv	a0, a1
-               	mv	a1, s2
+               	addw	s2, s3, t0
+               	sext.w	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x25c>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x598>
                	lui	t0, 0x80000
-               	subw	a2, s2, t0
-               	mv	a0, a1
+               	subw	a1, s2, t0
+               	sext.w	a2, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x278>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x5b0>
+               	addi	s2, s1, 0x7ff
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x28c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x5c0>
+               	addi	s1, s2, -0x800
                	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x2a0>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x5d0>
                	lui	t0, 0x80000
                	addiw	t0, t0, -0x1
                	add	s2, s1, t0
-               	mv	a0, a1
                	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x2c0>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x5e8>
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sub	a2, s2, t0
-               	mv	a0, a1
-               	mv	a1, a2
+               	sub	a1, s2, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x2e8>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <corpus.cases.imm.imm_add.checksum+0x604>
+               	ld	s1, 0x18(sp)
+               	ld	s2, 0x10(sp)
+               	ld	s3, 0x8(sp)
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/imm/imm_addr.dis
+++ b/test/golden/riscv64-linux/imm/imm_addr.dis
@@ -4,69 +4,38 @@ Disassembly of section .text:
 
 <corpus.cases.imm.imm_addr.checksum>:
                	lui	t0, 0x9
-               	addiw	t0, t0, 0x360
+               	addiw	t0, t0, 0x330
                	sub	sp, sp, t0
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x358
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x350
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x9
-               	addiw	t0, t0, 0x360
-               	add	s0, sp, t0
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x348
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x340
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x338
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x330
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x328
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
+               	sd	ra, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x320
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x9
+               	addiw	t0, t0, 0x330
+               	add	s0, sp, t0
                	lui	t1, 0x9
                	addiw	t1, t1, 0x318
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
+               	sd	s1, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x310
                	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
+               	sd	s2, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x308
                	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x300
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0xdc>
+               	sd	s3, 0x0(t1)
                	lui	t0, 0xffff8
-               	addiw	t0, t0, -0x460
-               	add	s2, s0, t0
-               	mv	a1, s2
+               	addiw	t0, t0, -0x428
+               	add	s1, s0, t0
+               	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x124 <corpus.cases.imm.imm_addr.checksum+0x124>
+               	bnez	a2, 0xa8 <corpus.cases.imm.imm_addr.checksum+0xa8>
                	mv	a2, a1
                	lui	a3, 0x8
                	addiw	a3, a3, 0x400
@@ -74,8 +43,8 @@ Disassembly of section .text:
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x10c <corpus.cases.imm.imm_addr.checksum+0x10c>
-               	j	0x144 <corpus.cases.imm.imm_addr.checksum+0x144>
+               	bne	a3, t0, 0x90 <corpus.cases.imm.imm_addr.checksum+0x90>
+               	j	0xc8 <corpus.cases.imm.imm_addr.checksum+0xc8>
                	mv	a2, a1
                	lui	a1, 0x8
                	addiw	a1, a1, 0x400
@@ -83,260 +52,543 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x130 <corpus.cases.imm.imm_addr.checksum+0x130>
+               	bne	a1, t0, 0xb4 <corpus.cases.imm.imm_addr.checksum+0xb4>
                	lui	t0, 0xffff7
-               	addiw	t0, t0, -0x360
-               	add	s3, s0, t0
-               	mv	a1, s3
+               	addiw	t0, t0, -0x328
+               	add	a1, s0, t0
+               	mv	a2, a1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x184 <corpus.cases.imm.imm_addr.checksum+0x184>
-               	mv	a2, a1
-               	lui	a3, 0x1
-               	addiw	a3, a3, -0x100
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a3, a2, t0
+               	bnez	a3, 0x108 <corpus.cases.imm.imm_addr.checksum+0x108>
+               	mv	a3, a2
+               	lui	a4, 0x1
+               	addiw	a4, a4, -0x100
+               	sd	zero, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x16c <corpus.cases.imm.imm_addr.checksum+0x16c>
-               	j	0x1a4 <corpus.cases.imm.imm_addr.checksum+0x1a4>
-               	mv	a2, a1
-               	lui	a1, 0x1
-               	addiw	a1, a1, -0x100
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a4, t0, 0xf0 <corpus.cases.imm.imm_addr.checksum+0xf0>
+               	j	0x128 <corpus.cases.imm.imm_addr.checksum+0x128>
+               	mv	a3, a2
+               	lui	a2, 0x1
+               	addiw	a2, a2, -0x100
+               	sb	zero, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x190 <corpus.cases.imm.imm_addr.checksum+0x190>
-               	addi	a1, s1, 0x1
-               	mv	a2, s2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s1, 0x2
-               	addi	s4, s2, 0x7f8
-               	sd	a1, 0x0(s4)
-               	addi	a1, s1, 0x3
+               	bne	a2, t0, 0x114 <corpus.cases.imm.imm_addr.checksum+0x114>
+               	addi	a2, a0, 0x1
+               	mv	a3, s1
+               	sd	a2, 0x0(a3)
+               	addi	a2, a0, 0x2
+               	addi	a4, s1, 0x7f8
+               	sd	a2, 0x0(a4)
+               	addi	a2, a0, 0x3
                	lui	t0, 0x1
                	addiw	t0, t0, -0x800
-               	add	s5, s2, t0
-               	sd	a1, 0x0(s5)
-               	addi	a1, s1, 0x4
+               	add	a4, s1, t0
+               	sd	a2, 0x0(a4)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x8
                	addiw	t0, t0, -0x8
-               	add	s6, s2, t0
-               	sd	a1, 0x0(s6)
-               	addi	a1, s1, 0x5
+               	add	a4, s1, t0
+               	sd	a2, 0x0(a4)
+               	addi	a2, a0, 0x5
                	lui	t0, 0x8
-               	add	s7, s2, t0
-               	sd	a1, 0x0(s7)
-               	addi	a1, s1, 0x6
+               	add	a4, s1, t0
+               	sd	a2, 0x0(a4)
+               	addi	a2, a0, 0x6
                	lui	t0, 0x8
                	addiw	t0, t0, 0x3f8
-               	add	s8, s2, t0
-               	sd	a1, 0x0(s8)
-               	ld	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x20c>
-               	ld	a1, 0x0(s4)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x218>
-               	ld	a1, 0x0(s5)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x224>
-               	ld	a1, 0x0(s6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x230>
-               	ld	a1, 0x0(s7)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x23c>
-               	ld	a1, 0x0(s8)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x248>
-               	lui	a1, 0x1
-               	addiw	a1, a1, 0x80
-               	bnez	a1, 0x260 <corpus.cases.imm.imm_addr.checksum+0x260>
-               	ebreak
-               	remu	a2, s1, a1
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x1
-               	add	a1, s1, t0
-               	lui	a3, 0x1
-               	addiw	a3, a3, 0x80
-               	bnez	a3, 0x280 <corpus.cases.imm.imm_addr.checksum+0x280>
-               	ebreak
-               	remu	a4, a1, a3
+               	add	a4, s1, t0
+               	sd	a2, 0x0(a4)
+               	ld	a2, 0x0(a3)
+               	lui	a3, 0xfcbf3
+               	addiw	a3, a3, -0x632
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x484
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x222
+               	slli	a3, a3, 0xc
+               	addi	a3, a3, 0x325
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1c0 <corpus.cases.imm.imm_addr.checksum+0x1c0>
+               	j	0x1f4 <corpus.cases.imm.imm_addr.checksum+0x1f4>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1c0 <corpus.cases.imm.imm_addr.checksum+0x1c0>
+               	addi	a2, s1, 0x7f8
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20c <corpus.cases.imm.imm_addr.checksum+0x20c>
+               	j	0x240 <corpus.cases.imm.imm_addr.checksum+0x240>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20c <corpus.cases.imm.imm_addr.checksum+0x20c>
                	lui	t0, 0x1
                	addiw	t0, t0, -0x800
-               	add	a1, s1, t0
-               	lui	a3, 0x1
-               	addiw	a3, a3, 0x80
-               	bnez	a3, 0x2a0 <corpus.cases.imm.imm_addr.checksum+0x2a0>
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.imm.imm_addr.checksum+0x260>
+               	j	0x294 <corpus.cases.imm.imm_addr.checksum+0x294>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x260 <corpus.cases.imm.imm_addr.checksum+0x260>
+               	lui	t0, 0x8
+               	addiw	t0, t0, -0x8
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2b4 <corpus.cases.imm.imm_addr.checksum+0x2b4>
+               	j	0x2e8 <corpus.cases.imm.imm_addr.checksum+0x2e8>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2b4 <corpus.cases.imm.imm_addr.checksum+0x2b4>
+               	lui	t0, 0x8
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x304 <corpus.cases.imm.imm_addr.checksum+0x304>
+               	j	0x338 <corpus.cases.imm.imm_addr.checksum+0x338>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x304 <corpus.cases.imm.imm_addr.checksum+0x304>
+               	lui	t0, 0x8
+               	addiw	t0, t0, 0x3f8
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x358 <corpus.cases.imm.imm_addr.checksum+0x358>
+               	j	0x38c <corpus.cases.imm.imm_addr.checksum+0x38c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x358 <corpus.cases.imm.imm_addr.checksum+0x358>
+               	lui	a2, 0x1
+               	addiw	a2, a2, 0x80
+               	bnez	a2, 0x39c <corpus.cases.imm.imm_addr.checksum+0x39c>
                	ebreak
-               	remu	a5, a1, a3
-               	slli	t0, a2, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	addi	a3, a2, 0x7
-               	sd	a3, 0x0(a1)
+               	remu	a4, a0, a2
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x1
+               	add	a2, a0, t0
+               	lui	a5, 0x1
+               	addiw	a5, a5, 0x80
+               	bnez	a5, 0x3bc <corpus.cases.imm.imm_addr.checksum+0x3bc>
+               	ebreak
+               	remu	a6, a2, a5
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x800
+               	add	a2, a0, t0
+               	lui	a5, 0x1
+               	addiw	a5, a5, 0x80
+               	bnez	a5, 0x3dc <corpus.cases.imm.imm_addr.checksum+0x3dc>
+               	ebreak
+               	remu	a7, a2, a5
                	slli	t0, a4, 0x3
-               	add	s4, s2, t0
-               	ld	a2, 0x0(s4)
-               	addi	a3, a2, 0x8
-               	sd	a3, 0x0(s4)
-               	slli	t0, a5, 0x3
-               	add	s5, s2, t0
-               	ld	a2, 0x0(s5)
-               	addi	a3, a2, 0x9
-               	sd	a3, 0x0(s5)
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x2e8>
-               	ld	a1, 0x0(s4)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x2f4>
-               	ld	a1, 0x0(s5)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x300>
-               	li	a1, 0x60
-               	bnez	a1, 0x314 <corpus.cases.imm.imm_addr.checksum+0x314>
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	addi	a5, a4, 0x7
+               	sd	a5, 0x0(a2)
+               	slli	t0, a6, 0x3
+               	add	a4, s1, t0
+               	ld	a5, 0x0(a4)
+               	addi	t5, a5, 0x8
+               	sd	t5, 0x0(a4)
+               	slli	t0, a7, 0x3
+               	add	a4, s1, t0
+               	ld	a5, 0x0(a4)
+               	addi	t5, a5, 0x9
+               	sd	t5, 0x0(a4)
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x430 <corpus.cases.imm.imm_addr.checksum+0x430>
+               	j	0x464 <corpus.cases.imm.imm_addr.checksum+0x464>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	t5, a4, a5
+               	li	t0, 0xff
+               	and	a5, t5, t0
+               	xor	t5, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, t5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x430 <corpus.cases.imm.imm_addr.checksum+0x430>
+               	slli	t0, a6, 0x3
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x480 <corpus.cases.imm.imm_addr.checksum+0x480>
+               	j	0x4b4 <corpus.cases.imm.imm_addr.checksum+0x4b4>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x480 <corpus.cases.imm.imm_addr.checksum+0x480>
+               	slli	t0, a7, 0x3
+               	add	a2, s1, t0
+               	ld	a4, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4d0 <corpus.cases.imm.imm_addr.checksum+0x4d0>
+               	j	0x504 <corpus.cases.imm.imm_addr.checksum+0x504>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4d0 <corpus.cases.imm.imm_addr.checksum+0x4d0>
+               	li	a2, 0x60
+               	bnez	a2, 0x510 <corpus.cases.imm.imm_addr.checksum+0x510>
                	ebreak
-               	remu	a2, s1, a1
-               	addi	a1, s1, 0x3f
-               	li	a3, 0x60
-               	bnez	a3, 0x328 <corpus.cases.imm.imm_addr.checksum+0x328>
+               	remu	a4, a0, a2
+               	addi	a2, a0, 0x3f
+               	li	a5, 0x60
+               	bnez	a5, 0x524 <corpus.cases.imm.imm_addr.checksum+0x524>
                	ebreak
-               	remu	a4, a1, a3
+               	remu	a6, a2, a5
                	li	t0, 0x28
-               	mul	a1, a2, t0
-               	add	a2, s3, a1
-               	mv	a1, a2
+               	mul	a2, a4, t0
+               	add	a5, a1, a2
+               	mv	a2, a5
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a1)
-               	addi	a3, s1, 0xa
-               	addi	a5, a2, 0x8
-               	mv	s2, a5
-               	sd	a3, 0x0(s2)
-               	addi	a3, s1, 0xb
-               	addi	s4, a5, 0x8
-               	sd	a3, 0x0(s4)
-               	addi	a3, s1, 0xc
-               	addi	s5, a5, 0x10
-               	sd	a3, 0x0(s5)
-               	addi	s7, a2, 0x20
+               	sw	t0, 0x0(a2)
+               	addi	a7, a0, 0xa
+               	addi	t5, a5, 0x8
+               	mv	t6, t5
+               	sd	a7, 0x0(t6)
+               	addi	a7, a0, 0xb
+               	addi	t6, t5, 0x8
+               	sd	a7, 0x0(t6)
+               	addi	a7, a0, 0xc
+               	addi	t6, t5, 0x10
+               	sd	a7, 0x0(t6)
+               	addi	a7, a5, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sw	t0, 0x0(s7)
+               	sw	t0, 0x0(a7)
                	li	t0, 0x28
-               	mul	a2, a4, t0
-               	add	a3, s3, a2
-               	mv	s3, a3
+               	mul	a5, a6, t0
+               	add	a7, a1, a5
+               	mv	a5, a7
                	lui	t0, 0xac
                	addiw	t0, t0, -0x321
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xff
-               	sw	t0, 0x0(s3)
-               	addi	a2, s1, 0xd
-               	addi	a4, a3, 0x8
-               	mv	s8, a4
-               	sd	a2, 0x0(s8)
-               	addi	a2, s1, 0xe
-               	addi	s9, a4, 0x8
-               	sd	a2, 0x0(s9)
-               	addi	a2, s1, 0xf
-               	addi	s1, a4, 0x10
-               	sd	a2, 0x0(s1)
-               	addi	s10, a3, 0x20
+               	sw	t0, 0x0(a5)
+               	addi	a5, a0, 0xd
+               	addi	t5, a7, 0x8
+               	mv	t6, t5
+               	sd	a5, 0x0(t6)
+               	addi	a5, a0, 0xe
+               	addi	t6, t5, 0x8
+               	sd	a5, 0x0(t6)
+               	addi	a5, a0, 0xf
+               	addi	a0, t5, 0x10
+               	sd	a5, 0x0(a0)
+               	addi	a0, a7, 0x20
                	lui	t0, 0x1234
                	addiw	t0, t0, 0x567
-               	sw	t0, 0x0(s10)
-               	lw	a2, 0x0(a1)
+               	sw	t0, 0x0(a0)
+               	lw	a0, 0x0(a2)
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5f8 <corpus.cases.imm.imm_addr.checksum+0x5f8>
+               	j	0x62c <corpus.cases.imm.imm_addr.checksum+0x62c>
+               	li	t0, 0x8
+               	mul	a5, a0, t0
+               	srl	a7, a2, a5
+               	li	t0, 0xff
+               	and	a5, a7, t0
+               	xor	a7, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x5f8 <corpus.cases.imm.imm_addr.checksum+0x5f8>
+               	li	t0, 0x28
+               	mul	a0, a4, t0
+               	add	a2, a1, a0
+               	addi	a0, a2, 0x8
+               	mv	a2, a0
+               	ld	a0, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x654 <corpus.cases.imm.imm_addr.checksum+0x654>
+               	j	0x688 <corpus.cases.imm.imm_addr.checksum+0x688>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a7, a0, a5
+               	li	t0, 0xff
+               	and	a5, a7, t0
+               	xor	a7, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x654 <corpus.cases.imm.imm_addr.checksum+0x654>
+               	li	t0, 0x28
+               	mul	a0, a4, t0
+               	add	a2, a1, a0
+               	addi	a0, a2, 0x8
+               	addi	a2, a0, 0x8
+               	ld	a0, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6b0 <corpus.cases.imm.imm_addr.checksum+0x6b0>
+               	j	0x6e4 <corpus.cases.imm.imm_addr.checksum+0x6e4>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a7, a0, a5
+               	li	t0, 0xff
+               	and	a5, a7, t0
+               	xor	a7, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6b0 <corpus.cases.imm.imm_addr.checksum+0x6b0>
+               	li	t0, 0x28
+               	mul	a0, a4, t0
+               	add	a2, a1, a0
+               	addi	a0, a2, 0x8
+               	addi	a2, a0, 0x10
+               	ld	a0, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x70c <corpus.cases.imm.imm_addr.checksum+0x70c>
+               	j	0x740 <corpus.cases.imm.imm_addr.checksum+0x740>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a7, a0, a5
+               	li	t0, 0xff
+               	and	a5, a7, t0
+               	xor	a7, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x70c <corpus.cases.imm.imm_addr.checksum+0x70c>
+               	li	t0, 0x28
+               	mul	a0, a4, t0
+               	add	a2, a1, a0
+               	addi	a0, a2, 0x20
+               	lw	a2, 0x0(a0)
+               	slli	a0, a2, 0x20
+               	srli	a0, a0, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x76c <corpus.cases.imm.imm_addr.checksum+0x76c>
+               	j	0x7a0 <corpus.cases.imm.imm_addr.checksum+0x7a0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a3, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x76c <corpus.cases.imm.imm_addr.checksum+0x76c>
+               	li	t0, 0x28
+               	mul	a0, a6, t0
+               	add	a2, a1, a0
+               	mv	a0, a2
+               	lw	a2, 0x0(a0)
+               	slli	a0, a2, 0x20
+               	srli	a0, a0, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7cc <corpus.cases.imm.imm_addr.checksum+0x7cc>
+               	j	0x800 <corpus.cases.imm.imm_addr.checksum+0x800>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a3, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7cc <corpus.cases.imm.imm_addr.checksum+0x7cc>
+               	li	t0, 0x28
+               	mul	a0, a6, t0
+               	add	a2, a1, a0
+               	addi	a0, a2, 0x8
+               	mv	a2, a0
+               	ld	a0, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x828 <corpus.cases.imm.imm_addr.checksum+0x828>
+               	j	0x85c <corpus.cases.imm.imm_addr.checksum+0x85c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a3, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x828 <corpus.cases.imm.imm_addr.checksum+0x828>
+               	li	t0, 0x28
+               	mul	a0, a6, t0
+               	add	s2, a1, a0
+               	addi	s3, s2, 0x8
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	mv	a0, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x878>
+               	addi	a1, s3, 0x10
+               	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x3e8>
-               	ld	a1, 0x0(s2)
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x88c>
+               	addi	a1, s2, 0x20
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x3f4>
-               	ld	a1, 0x0(s4)
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x8a4>
+               	lui	t0, 0x8
+               	addiw	t0, t0, -0x8
+               	add	a1, s1, t0
+               	ld	a2, 0x0(a1)
+               	addi	a3, a2, 0x10
+               	sd	a3, 0x0(a1)
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x400>
-               	ld	a1, 0x0(s5)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x40c>
-               	lw	a1, 0x0(s7)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x418>
-               	lw	a1, 0x0(s3)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x424>
-               	ld	a1, 0x0(s8)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x430>
-               	ld	a1, 0x0(s9)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x43c>
-               	ld	a1, 0x0(s1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x448>
-               	lw	a1, 0x0(s10)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x454>
-               	ld	a1, 0x0(s6)
-               	addi	a2, a1, 0x10
-               	sd	a2, 0x0(s6)
-               	ld	a1, 0x0(s6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x46c>
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x348
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x340
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x338
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x330
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x328
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x320
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
+               	jalr	ra <corpus.cases.imm.imm_addr.checksum+0x8cc>
                	lui	t1, 0x9
                	addiw	t1, t1, 0x318
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
+               	ld	s1, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x310
                	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
+               	ld	s2, 0x0(t1)
                	lui	t1, 0x9
                	addiw	t1, t1, 0x308
                	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
+               	ld	s3, 0x0(t1)
                	lui	t1, 0x9
-               	addiw	t1, t1, 0x300
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x9
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x328
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x9
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x320
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x9
-               	addiw	t0, t0, 0x360
+               	addiw	t0, t0, 0x330
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/imm/imm_logic.dis
+++ b/test/golden/riscv64-linux/imm/imm_logic.dis
@@ -3,80 +3,179 @@ imm/imm_logic.o:
 Disassembly of section .text:
 
 <corpus.cases.imm.imm_logic.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	sd	s6, 0x0(sp)
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x2c>
-               	mv	a1, a0
-               	sext.w	s2, s1
+               	sext.w	a0, s1
                	lui	t0, 0x55555
                	addiw	t0, t0, 0x555
-               	or	s3, s2, t0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x50>
-               	mv	a1, a0
+               	or	a1, a0, t0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x64 <corpus.cases.imm.imm_logic.checksum+0x64>
+               	j	0x98 <corpus.cases.imm.imm_logic.checksum+0x98>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x64 <corpus.cases.imm.imm_logic.checksum+0x64>
                	lui	t0, 0x55555
                	addiw	t0, t0, 0x555
-               	xor	a2, s2, t0
+               	xor	a2, a0, t0
                	lui	t0, 0xf0f1
                	addiw	t0, t0, -0xf1
                	and	a3, a2, t0
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x7c>
-               	mv	a1, a0
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xc8 <corpus.cases.imm.imm_logic.checksum+0xc8>
+               	j	0xfc <corpus.cases.imm.imm_logic.checksum+0xfc>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xc8 <corpus.cases.imm.imm_logic.checksum+0xc8>
                	lui	t0, 0xffff0
-               	or	a2, s2, t0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x98>
-               	mv	a1, a0
+               	or	a2, a0, t0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x11c <corpus.cases.imm.imm_logic.checksum+0x11c>
+               	j	0x150 <corpus.cases.imm.imm_logic.checksum+0x150>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x11c <corpus.cases.imm.imm_logic.checksum+0x11c>
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	and	a2, s2, t0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0xb8>
-               	mv	a1, a0
-               	not	s4, s2
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0xd0>
-               	mv	a1, a0
+               	and	a2, a0, t0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x174 <corpus.cases.imm.imm_logic.checksum+0x174>
+               	j	0x1a8 <corpus.cases.imm.imm_logic.checksum+0x1a8>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x174 <corpus.cases.imm.imm_logic.checksum+0x174>
+               	not	a2, a0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1c4 <corpus.cases.imm.imm_logic.checksum+0x1c4>
+               	j	0x1f8 <corpus.cases.imm.imm_logic.checksum+0x1f8>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1c4 <corpus.cases.imm.imm_logic.checksum+0x1c4>
                	lui	t0, 0x55555
                	addiw	t0, t0, 0x555
-               	or	a2, s4, t0
-               	not	a3, a2
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0xf4>
-               	mv	a1, a0
+               	or	a3, a2, t0
+               	not	a2, a3
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x220 <corpus.cases.imm.imm_logic.checksum+0x220>
+               	j	0x254 <corpus.cases.imm.imm_logic.checksum+0x254>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x220 <corpus.cases.imm.imm_logic.checksum+0x220>
                	lui	t0, 0xf0f1
                	addiw	t0, t0, -0xf1
-               	and	a2, s2, t0
+               	and	a2, a0, t0
                	lui	t0, 0xffff0
-               	xor	a3, a2, t0
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x11c>
-               	mv	a1, a0
+               	xor	a0, a2, t0
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x280 <corpus.cases.imm.imm_logic.checksum+0x280>
+               	j	0x2b4 <corpus.cases.imm.imm_logic.checksum+0x2b4>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x280 <corpus.cases.imm.imm_logic.checksum+0x280>
                	lui	t0, 0x5555
                	addiw	t0, t0, 0x555
                	slli	t0, t0, 0xc
@@ -85,12 +184,24 @@ Disassembly of section .text:
                	addi	t0, t0, 0x555
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x555
-               	or	s5, s1, t0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x154>
-               	mv	a1, a0
+               	or	a0, s1, t0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e8 <corpus.cases.imm.imm_logic.checksum+0x2e8>
+               	j	0x31c <corpus.cases.imm.imm_logic.checksum+0x31c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e8 <corpus.cases.imm.imm_logic.checksum+0x2e8>
                	lui	t0, 0x5555
                	addiw	t0, t0, 0x555
                	slli	t0, t0, 0xc
@@ -99,7 +210,7 @@ Disassembly of section .text:
                	addi	t0, t0, 0x555
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x555
-               	xor	a2, s1, t0
+               	xor	a0, s1, t0
                	lui	t0, 0xf0f
                	addiw	t0, t0, 0xf1
                	slli	t0, t0, 0xc
@@ -108,23 +219,47 @@ Disassembly of section .text:
                	addi	t0, t0, 0xf1
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xf1
-               	and	a3, a2, t0
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x1b0>
-               	mv	a1, a0
+               	and	a2, a0, t0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x374 <corpus.cases.imm.imm_logic.checksum+0x374>
+               	j	0x3a8 <corpus.cases.imm.imm_logic.checksum+0x3a8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x374 <corpus.cases.imm.imm_logic.checksum+0x374>
                	lui	t0, 0xff000
                	addiw	t0, t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x10
                	slli	t0, t0, 0xc
-               	or	a2, s1, t0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x1dc>
-               	mv	a1, a0
+               	or	a0, s1, t0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3d0 <corpus.cases.imm.imm_logic.checksum+0x3d0>
+               	j	0x404 <corpus.cases.imm.imm_logic.checksum+0x404>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3d0 <corpus.cases.imm.imm_logic.checksum+0x3d0>
                	lui	t0, 0xff
                	addiw	t0, t0, 0x10
                	slli	t0, t0, 0xc
@@ -133,18 +268,42 @@ Disassembly of section .text:
                	addi	t0, t0, -0x10
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0xff
-               	and	a2, s1, t0
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x214>
-               	mv	a1, a0
-               	not	s6, s1
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x22c>
-               	mv	a1, a0
+               	and	a0, s1, t0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x438 <corpus.cases.imm.imm_logic.checksum+0x438>
+               	j	0x46c <corpus.cases.imm.imm_logic.checksum+0x46c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x438 <corpus.cases.imm.imm_logic.checksum+0x438>
+               	not	a0, s1
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x480 <corpus.cases.imm.imm_logic.checksum+0x480>
+               	j	0x4b4 <corpus.cases.imm.imm_logic.checksum+0x4b4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x480 <corpus.cases.imm.imm_logic.checksum+0x480>
                	lui	t0, 0x5555
                	addiw	t0, t0, 0x555
                	slli	t0, t0, 0xc
@@ -153,13 +312,25 @@ Disassembly of section .text:
                	addi	t0, t0, 0x555
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x555
-               	or	a2, s6, t0
-               	not	a3, a2
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x268>
-               	mv	a1, a0
+               	or	a2, a0, t0
+               	not	a0, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4ec <corpus.cases.imm.imm_logic.checksum+0x4ec>
+               	j	0x520 <corpus.cases.imm.imm_logic.checksum+0x520>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4ec <corpus.cases.imm.imm_logic.checksum+0x4ec>
                	lui	t0, 0xf0f
                	addiw	t0, t0, 0xf1
                	slli	t0, t0, 0xc
@@ -168,48 +339,96 @@ Disassembly of section .text:
                	addi	t0, t0, 0xf1
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xf1
-               	and	a2, s1, t0
+               	and	a0, s1, t0
                	lui	t0, 0xff000
                	addiw	t0, t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x10
                	slli	t0, t0, 0xc
-               	xor	a3, a2, t0
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x2b8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x2cc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x2e0>
-               	mv	a1, a0
-               	xor	a2, s2, s4
+               	xor	a2, a0, t0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x56c <corpus.cases.imm.imm_logic.checksum+0x56c>
+               	j	0x5a0 <corpus.cases.imm.imm_logic.checksum+0x5a0>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x56c <corpus.cases.imm.imm_logic.checksum+0x56c>
+               	sext.w	a0, s1
+               	lui	t0, 0x55555
+               	addiw	t0, t0, 0x555
+               	or	a2, a0, t0
+               	sext.w	a3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5c4 <corpus.cases.imm.imm_logic.checksum+0x5c4>
+               	j	0x5f8 <corpus.cases.imm.imm_logic.checksum+0x5f8>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5c4 <corpus.cases.imm.imm_logic.checksum+0x5c4>
+               	not	a2, a0
+               	sext.w	a3, a2
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x610 <corpus.cases.imm.imm_logic.checksum+0x610>
+               	j	0x644 <corpus.cases.imm.imm_logic.checksum+0x644>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a1, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x610 <corpus.cases.imm.imm_logic.checksum+0x610>
+               	xor	a3, a0, a2
                	lui	t0, 0xf0f1
                	addiw	t0, t0, -0xf1
-               	and	a3, a2, t0
+               	and	a0, a3, t0
+               	sext.w	a2, a0
                	mv	a0, a1
-               	mv	a1, a3
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x304>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
+               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x660>
+               	lui	t0, 0x5555
+               	addiw	t0, t0, 0x555
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x555
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x555
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x555
+               	or	a1, s1, t0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x318>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
+               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x68c>
+               	not	s2, s1
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x32c>
-               	mv	a1, a0
-               	xor	a2, s1, s6
+               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x69c>
+               	xor	a1, s1, s2
                	lui	t0, 0xf0f
                	addiw	t0, t0, 0xf1
                	slli	t0, t0, 0xc
@@ -218,18 +437,13 @@ Disassembly of section .text:
                	addi	t0, t0, 0xf1
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xf1
-               	and	a3, a2, t0
-               	mv	a0, a1
-               	mv	a1, a3
+               	and	a2, a1, t0
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x368>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	s6, 0x0(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	jalr	ra <corpus.cases.imm.imm_logic.checksum+0x6d0>
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/imm/imm_mov.dis
+++ b/test/golden/riscv64-linux/imm/imm_mov.dis
@@ -3,153 +3,321 @@ imm/imm_mov.o:
 Disassembly of section .text:
 
 <corpus.cases.imm.imm_mov.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x20>
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
                	li	t0, 0x0
-               	beq	s1, t0, 0x38 <corpus.cases.imm.imm_mov.checksum+0x38>
+               	beq	a0, t0, 0x20 <corpus.cases.imm.imm_mov.checksum+0x20>
                	lui	a1, 0x80000
-               	j	0x3c <corpus.cases.imm.imm_mov.checksum+0x3c>
+               	j	0x24 <corpus.cases.imm.imm_mov.checksum+0x24>
                	li	a1, 0x7ff
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x3c>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x5c <corpus.cases.imm.imm_mov.checksum+0x5c>
+               	j	0x90 <corpus.cases.imm.imm_mov.checksum+0x90>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x5c <corpus.cases.imm.imm_mov.checksum+0x5c>
                	li	t0, 0x1
-               	beq	s1, t0, 0x64 <corpus.cases.imm.imm_mov.checksum+0x64>
-               	lui	a1, 0xf8000
-               	slli	a1, a1, 0xc
-               	slli	a1, a1, 0xc
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, -0x1
-               	j	0x70 <corpus.cases.imm.imm_mov.checksum+0x70>
-               	lui	a1, 0x100
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x70>
+               	beq	a0, t0, 0xb0 <corpus.cases.imm.imm_mov.checksum+0xb0>
+               	lui	a2, 0xf8000
+               	slli	a2, a2, 0xc
+               	slli	a2, a2, 0xc
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, -0x1
+               	j	0xbc <corpus.cases.imm.imm_mov.checksum+0xbc>
+               	lui	a2, 0x100
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, -0x1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xcc <corpus.cases.imm.imm_mov.checksum+0xcc>
+               	j	0x100 <corpus.cases.imm.imm_mov.checksum+0x100>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xcc <corpus.cases.imm.imm_mov.checksum+0xcc>
                	li	t0, 0x2
-               	beq	s1, t0, 0x8c <corpus.cases.imm.imm_mov.checksum+0x8c>
-               	lui	a1, 0xf0f1
-               	addiw	a1, a1, -0xf1
-               	j	0x94 <corpus.cases.imm.imm_mov.checksum+0x94>
-               	lui	a1, 0x55555
-               	addiw	a1, a1, 0x555
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x94>
-               	li	t0, 0x3
-               	beq	s1, t0, 0xbc <corpus.cases.imm.imm_mov.checksum+0xbc>
-               	lui	a1, 0xff000
-               	addiw	a1, a1, 0x100
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, -0x10
-               	slli	a1, a1, 0xc
-               	j	0xdc <corpus.cases.imm.imm_mov.checksum+0xdc>
-               	lui	a1, 0x5555
-               	addiw	a1, a1, 0x555
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, 0x555
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, 0x555
-               	slli	a1, a1, 0xc
-               	addi	a1, a1, 0x555
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0xdc>
-               	addi	s2, s0, -0x40
-               	mv	a1, s2
-               	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x118 <corpus.cases.imm.imm_mov.checksum+0x118>
-               	mv	a2, a1
-               	li	a3, 0x18
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x100 <corpus.cases.imm.imm_mov.checksum+0x100>
-               	j	0x134 <corpus.cases.imm.imm_mov.checksum+0x134>
-               	mv	a2, a1
-               	li	a1, 0x18
-               	sb	zero, 0x0(a2)
+               	beq	a0, t0, 0x114 <corpus.cases.imm.imm_mov.checksum+0x114>
+               	lui	a2, 0xf0f1
+               	addiw	a2, a2, -0xf1
+               	j	0x11c <corpus.cases.imm.imm_mov.checksum+0x11c>
+               	lui	a2, 0x55555
+               	addiw	a2, a2, 0x555
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.imm.imm_mov.checksum+0x134>
+               	j	0x168 <corpus.cases.imm.imm_mov.checksum+0x168>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
                	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x134 <corpus.cases.imm.imm_mov.checksum+0x134>
+               	li	t0, 0x3
+               	beq	a0, t0, 0x188 <corpus.cases.imm.imm_mov.checksum+0x188>
+               	lui	a2, 0xff000
+               	addiw	a2, a2, 0x100
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, -0x10
+               	slli	a2, a2, 0xc
+               	j	0x1a8 <corpus.cases.imm.imm_mov.checksum+0x1a8>
+               	lui	a2, 0x5555
+               	addiw	a2, a2, 0x555
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x555
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x555
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x555
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1b8 <corpus.cases.imm.imm_mov.checksum+0x1b8>
+               	j	0x1ec <corpus.cases.imm.imm_mov.checksum+0x1ec>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1b8 <corpus.cases.imm.imm_mov.checksum+0x1b8>
+               	addi	a2, s0, -0x28
+               	mv	a3, a2
+               	li	t0, 0x7
+               	and	a4, a3, t0
+               	bnez	a4, 0x220 <corpus.cases.imm.imm_mov.checksum+0x220>
+               	mv	a4, a3
+               	li	a5, 0x18
+               	sd	zero, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a1, t0, 0x120 <corpus.cases.imm.imm_mov.checksum+0x120>
-               	mv	a1, s2
+               	bne	a5, t0, 0x208 <corpus.cases.imm.imm_mov.checksum+0x208>
+               	j	0x23c <corpus.cases.imm.imm_mov.checksum+0x23c>
+               	mv	a4, a3
+               	li	a3, 0x18
+               	sb	zero, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x228 <corpus.cases.imm.imm_mov.checksum+0x228>
+               	mv	a3, a2
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x8
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	addi	a1, s2, 0x10
+               	sd	t0, 0x0(a3)
+               	addi	a3, a2, 0x10
                	lui	t0, 0x100
                	addiw	t0, t0, -0x10
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(a1)
-               	li	a1, 0x3
-               	bnez	a1, 0x17c <corpus.cases.imm.imm_mov.checksum+0x17c>
+               	sd	t0, 0x0(a3)
+               	li	a3, 0x3
+               	bnez	a3, 0x284 <corpus.cases.imm.imm_mov.checksum+0x284>
                	ebreak
-               	remu	s3, s1, a1
-               	slli	t0, s3, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x190>
-               	addi	a1, s3, 0x1
-               	li	a2, 0x3
-               	bnez	a2, 0x1a8 <corpus.cases.imm.imm_mov.checksum+0x1a8>
+               	remu	a4, a0, a3
+               	slli	t0, a4, 0x3
+               	add	a3, a2, t0
+               	ld	a5, 0x0(a3)
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2a4 <corpus.cases.imm.imm_mov.checksum+0x2a4>
+               	j	0x2d8 <corpus.cases.imm.imm_mov.checksum+0x2d8>
+               	li	t0, 0x8
+               	mul	a6, a3, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a1, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a7, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2a4 <corpus.cases.imm.imm_mov.checksum+0x2a4>
+               	addi	a3, a4, 0x1
+               	li	a5, 0x3
+               	bnez	a5, 0x2e8 <corpus.cases.imm.imm_mov.checksum+0x2e8>
                	ebreak
-               	remu	a3, a1, a2
-               	slli	t0, a3, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1bc>
-               	addi	a1, s3, 0x2
-               	li	a2, 0x3
-               	bnez	a2, 0x1d4 <corpus.cases.imm.imm_mov.checksum+0x1d4>
+               	remu	a6, a3, a5
+               	slli	t0, a6, 0x3
+               	add	a3, a2, t0
+               	ld	a5, 0x0(a3)
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x308 <corpus.cases.imm.imm_mov.checksum+0x308>
+               	j	0x33c <corpus.cases.imm.imm_mov.checksum+0x33c>
+               	li	t0, 0x8
+               	mul	a6, a3, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a1, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a7, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x308 <corpus.cases.imm.imm_mov.checksum+0x308>
+               	addi	a3, a4, 0x2
+               	li	a4, 0x3
+               	bnez	a4, 0x34c <corpus.cases.imm.imm_mov.checksum+0x34c>
                	ebreak
-               	remu	a3, a1, a2
-               	slli	t0, a3, 0x3
-               	add	a1, s2, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x1e8>
-               	sext.w	a1, s1
+               	remu	a5, a3, a4
+               	slli	t0, a5, 0x3
+               	add	a3, a2, t0
+               	ld	a2, 0x0(a3)
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x36c <corpus.cases.imm.imm_mov.checksum+0x36c>
+               	j	0x3a0 <corpus.cases.imm.imm_mov.checksum+0x3a0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a1, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x36c <corpus.cases.imm.imm_mov.checksum+0x36c>
+               	sext.w	a2, a0
                	li	t1, 0x7ff
-               	addw	a2, t1, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x200>
-               	lui	a1, 0x80000
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x20c>
-               	lui	a1, 0xf8000
-               	slli	a1, a1, 0xc
-               	slli	a1, a1, 0xc
-               	slli	a1, a1, 0xc
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x224>
-               	lui	a1, 0x55555
-               	addiw	a1, a1, 0x555
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.imm.imm_mov.checksum+0x234>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	addw	a0, t1, a2
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x3c4 <corpus.cases.imm.imm_mov.checksum+0x3c4>
+               	j	0x3f8 <corpus.cases.imm.imm_mov.checksum+0x3f8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x3c4 <corpus.cases.imm.imm_mov.checksum+0x3c4>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x408 <corpus.cases.imm.imm_mov.checksum+0x408>
+               	j	0x444 <corpus.cases.imm.imm_mov.checksum+0x444>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x80
+               	slli	t1, t1, 0xc
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x408 <corpus.cases.imm.imm_mov.checksum+0x408>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x454 <corpus.cases.imm.imm_mov.checksum+0x454>
+               	j	0x498 <corpus.cases.imm.imm_mov.checksum+0x498>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0xf8000
+               	slli	t1, t1, 0xc
+               	slli	t1, t1, 0xc
+               	slli	t1, t1, 0xc
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x454 <corpus.cases.imm.imm_mov.checksum+0x454>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4a8 <corpus.cases.imm.imm_mov.checksum+0x4a8>
+               	j	0x4e4 <corpus.cases.imm.imm_mov.checksum+0x4e4>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	lui	t1, 0x55555
+               	addiw	t1, t1, 0x555
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x4a8 <corpus.cases.imm.imm_mov.checksum+0x4a8>
+               	mv	a0, a1
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret

--- a/test/golden/riscv64-linux/mem/addr_modes.dis
+++ b/test/golden/riscv64-linux/mem/addr_modes.dis
@@ -4,221 +4,215 @@ Disassembly of section .text:
 
 <corpus.cases.mem.addr_modes.checksum>:
                	lui	t0, 0x3
-               	addiw	t0, t0, 0x440
+               	addiw	t0, t0, 0x430
                	sub	sp, sp, t0
-               	lui	t1, 0x3
-               	addiw	t1, t1, 0x438
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x3
-               	addiw	t1, t1, 0x430
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x3
-               	addiw	t0, t0, 0x440
-               	add	s0, sp, t0
                	lui	t1, 0x3
                	addiw	t1, t1, 0x428
                	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
+               	sd	ra, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x420
                	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x3
+               	addiw	t0, t0, 0x430
+               	add	s0, sp, t0
                	lui	t1, 0x3
                	addiw	t1, t1, 0x418
                	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
+               	sd	s1, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x410
                	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
+               	sd	s2, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x408
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
+               	sd	s3, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x400
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
+               	sd	s4, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3f8
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
+               	sd	s5, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3f0
                	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
+               	sd	s6, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3e8
                	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
+               	sd	s7, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3e0
                	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
+               	sd	s8, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3d8
                	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
+               	sd	s9, 0x0(t1)
+               	lui	t1, 0x3
+               	addiw	t1, t1, 0x3d0
+               	add	t1, sp, t1
+               	sd	s10, 0x0(t1)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xec>
-               	addi	s2, s0, -0xa8
-               	mv	a1, s2
+               	addi	s2, s0, -0x1a0
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x128 <corpus.cases.mem.addr_modes.checksum+0x128>
-               	mv	a2, a1
-               	li	a3, 0x40
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x110 <corpus.cases.mem.addr_modes.checksum+0x110>
+               	mv	a1, a0
+               	li	a2, 0x40
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x110 <corpus.cases.mem.addr_modes.checksum+0x110>
-               	j	0x144 <corpus.cases.mem.addr_modes.checksum+0x144>
-               	mv	a2, a1
-               	li	a1, 0x40
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xf8 <corpus.cases.mem.addr_modes.checksum+0xf8>
+               	j	0x12c <corpus.cases.mem.addr_modes.checksum+0x12c>
+               	mv	a1, a0
+               	li	a0, 0x40
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x130 <corpus.cases.mem.addr_modes.checksum+0x130>
-               	addi	s3, s0, -0x128
-               	mv	a1, s3
+               	bne	a0, t0, 0x118 <corpus.cases.mem.addr_modes.checksum+0x118>
+               	addi	s3, s0, -0x220
+               	mv	a0, s3
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x178 <corpus.cases.mem.addr_modes.checksum+0x178>
-               	mv	a2, a1
-               	li	a3, 0x80
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x160 <corpus.cases.mem.addr_modes.checksum+0x160>
+               	mv	a1, a0
+               	li	a2, 0x80
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x160 <corpus.cases.mem.addr_modes.checksum+0x160>
-               	j	0x194 <corpus.cases.mem.addr_modes.checksum+0x194>
-               	mv	a2, a1
-               	li	a1, 0x80
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x148 <corpus.cases.mem.addr_modes.checksum+0x148>
+               	j	0x17c <corpus.cases.mem.addr_modes.checksum+0x17c>
+               	mv	a1, a0
+               	li	a0, 0x80
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x180 <corpus.cases.mem.addr_modes.checksum+0x180>
-               	addi	s4, s0, -0x228
-               	mv	a1, s4
+               	bne	a0, t0, 0x168 <corpus.cases.mem.addr_modes.checksum+0x168>
+               	addi	s4, s0, -0x320
+               	mv	a0, s4
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x1c8 <corpus.cases.mem.addr_modes.checksum+0x1c8>
-               	mv	a2, a1
-               	li	a3, 0x100
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x1b0 <corpus.cases.mem.addr_modes.checksum+0x1b0>
+               	mv	a1, a0
+               	li	a2, 0x100
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x1b0 <corpus.cases.mem.addr_modes.checksum+0x1b0>
-               	j	0x1e4 <corpus.cases.mem.addr_modes.checksum+0x1e4>
-               	mv	a2, a1
-               	li	a1, 0x100
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x198 <corpus.cases.mem.addr_modes.checksum+0x198>
+               	j	0x1cc <corpus.cases.mem.addr_modes.checksum+0x1cc>
+               	mv	a1, a0
+               	li	a0, 0x100
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1d0 <corpus.cases.mem.addr_modes.checksum+0x1d0>
-               	addi	s5, s0, -0x428
-               	mv	a1, s5
+               	bne	a0, t0, 0x1b8 <corpus.cases.mem.addr_modes.checksum+0x1b8>
+               	addi	s5, s0, -0x520
+               	mv	a0, s5
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x218 <corpus.cases.mem.addr_modes.checksum+0x218>
-               	mv	a2, a1
-               	li	a3, 0x200
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x200 <corpus.cases.mem.addr_modes.checksum+0x200>
+               	mv	a1, a0
+               	li	a2, 0x200
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x200 <corpus.cases.mem.addr_modes.checksum+0x200>
-               	j	0x234 <corpus.cases.mem.addr_modes.checksum+0x234>
-               	mv	a2, a1
-               	li	a1, 0x200
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x1e8 <corpus.cases.mem.addr_modes.checksum+0x1e8>
+               	j	0x21c <corpus.cases.mem.addr_modes.checksum+0x21c>
+               	mv	a1, a0
+               	li	a0, 0x200
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x220 <corpus.cases.mem.addr_modes.checksum+0x220>
+               	bne	a0, t0, 0x208 <corpus.cases.mem.addr_modes.checksum+0x208>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
+               	addiw	t0, t0, 0x6e0
                	add	s6, s0, t0
-               	mv	a1, s6
+               	mv	a0, s6
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x270 <corpus.cases.mem.addr_modes.checksum+0x270>
-               	mv	a2, a1
-               	li	a3, 0x400
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x258 <corpus.cases.mem.addr_modes.checksum+0x258>
+               	mv	a1, a0
+               	li	a2, 0x400
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x258 <corpus.cases.mem.addr_modes.checksum+0x258>
-               	j	0x28c <corpus.cases.mem.addr_modes.checksum+0x28c>
-               	mv	a2, a1
-               	li	a1, 0x400
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x240 <corpus.cases.mem.addr_modes.checksum+0x240>
+               	j	0x274 <corpus.cases.mem.addr_modes.checksum+0x274>
+               	mv	a1, a0
+               	li	a0, 0x400
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x278 <corpus.cases.mem.addr_modes.checksum+0x278>
+               	bne	a0, t0, 0x260 <corpus.cases.mem.addr_modes.checksum+0x260>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
+               	addiw	t0, t0, 0x3e0
                	add	s7, s0, t0
-               	mv	a1, s7
+               	mv	a0, s7
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x2c8 <corpus.cases.mem.addr_modes.checksum+0x2c8>
-               	mv	a2, a1
-               	li	a3, 0x300
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x2b0 <corpus.cases.mem.addr_modes.checksum+0x2b0>
+               	mv	a1, a0
+               	li	a2, 0x300
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x2b0 <corpus.cases.mem.addr_modes.checksum+0x2b0>
-               	j	0x2e4 <corpus.cases.mem.addr_modes.checksum+0x2e4>
-               	mv	a2, a1
-               	li	a1, 0x300
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x298 <corpus.cases.mem.addr_modes.checksum+0x298>
+               	j	0x2cc <corpus.cases.mem.addr_modes.checksum+0x2cc>
+               	mv	a1, a0
+               	li	a0, 0x300
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2d0 <corpus.cases.mem.addr_modes.checksum+0x2d0>
-               	li	a1, 0x0
+               	bne	a0, t0, 0x2b8 <corpus.cases.mem.addr_modes.checksum+0x2b8>
+               	li	a0, 0x0
                	li	t0, 0x40
-               	bltu	a1, t0, 0x2f4 <corpus.cases.mem.addr_modes.checksum+0x2f4>
-               	j	0x444 <corpus.cases.mem.addr_modes.checksum+0x444>
+               	bltu	a0, t0, 0x2dc <corpus.cases.mem.addr_modes.checksum+0x2dc>
+               	j	0x42c <corpus.cases.mem.addr_modes.checksum+0x42c>
                	li	t0, 0x3
-               	mul	a2, a1, t0
-               	addi	a3, a2, 0x1
-               	add	a2, a3, s1
-               	sext.w	a3, a2
-               	add	a2, s2, a1
-               	sb	a3, 0x0(a2)
+               	mul	a1, a0, t0
+               	addi	a2, a1, 0x1
+               	add	a1, a2, s1
+               	sext.w	a2, a1
+               	add	a1, s2, a0
+               	sb	a2, 0x0(a1)
                	li	t0, 0x44f
-               	mul	a2, a1, t0
-               	addi	a3, a2, 0x7
-               	add	a2, a3, s1
-               	sext.w	a3, a2
-               	slli	t0, a1, 0x1
-               	add	a2, s3, t0
-               	sh	a3, 0x0(a2)
+               	mul	a1, a0, t0
+               	addi	a2, a1, 0x7
+               	add	a1, a2, s1
+               	sext.w	a2, a1
+               	slli	t0, a0, 0x1
+               	add	a1, s3, t0
+               	sh	a2, 0x0(a1)
                	lui	t0, 0x9e
                	addiw	t0, t0, 0x378
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x64f
-               	mul	a2, a1, t0
-               	addi	a3, a2, 0xb
-               	add	a2, a3, s1
-               	sext.w	a3, a2
-               	slli	t0, a1, 0x2
-               	add	a2, s4, t0
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x1
+               	mul	a1, a0, t0
+               	addi	a2, a1, 0xb
+               	add	a1, a2, s1
+               	sext.w	a2, a1
+               	slli	t0, a0, 0x2
+               	add	a1, s4, t0
+               	sw	a2, 0x0(a1)
+               	addi	a1, a0, 0x1
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -227,60 +221,67 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	mul	a3, t1, a2
-               	add	a4, a3, s1
-               	slli	t0, a1, 0x3
-               	add	a3, s5, t0
-               	sd	a4, 0x0(a3)
+               	mul	a2, t1, a1
+               	add	a3, a2, s1
+               	slli	t0, a0, 0x3
+               	add	a2, s5, t0
+               	sd	a3, 0x0(a2)
                	li	t0, 0x5
-               	mul	a3, a1, t0
-               	addi	a4, a3, 0x2
-               	add	a3, a4, s1
-               	sext.w	a4, a3
+               	mul	a2, a0, t0
+               	addi	a3, a2, 0x2
+               	add	a2, a3, s1
+               	sext.w	a3, a2
                	li	t0, 0x10
-               	mul	a3, a1, t0
-               	add	a5, s6, a3
-               	mv	a3, a5
-               	sh	a4, 0x0(a3)
-               	addi	a3, a1, 0x80
-               	sext.w	a4, a3
-               	addi	a3, a5, 0x2
-               	sb	a4, 0x0(a3)
+               	mul	a2, a0, t0
+               	add	a4, s6, a2
+               	mv	a2, a4
+               	sh	a3, 0x0(a2)
+               	addi	a2, a0, 0x80
+               	sext.w	a3, a2
+               	addi	a2, a4, 0x2
+               	sb	a3, 0x0(a2)
                	lui	t1, 0x10000
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0x1b3
-               	mul	a3, t1, a2
-               	add	a4, a3, s1
-               	addi	a3, a5, 0x8
-               	sd	a4, 0x0(a3)
+               	mul	a2, t1, a1
+               	add	a3, a2, s1
+               	addi	a2, a4, 0x8
+               	sd	a3, 0x0(a2)
                	li	t0, 0x11
-               	mul	a3, a1, t0
-               	addi	a4, a3, 0x1
-               	add	a5, a4, s1
-               	sext.w	a4, a5
+               	mul	a2, a0, t0
+               	addi	a3, a2, 0x1
+               	add	a4, a3, s1
+               	sext.w	a3, a4
                	li	t0, 0xc
-               	mul	a5, a1, t0
-               	add	a6, s7, a5
-               	mv	a5, a6
-               	sw	a4, 0x0(a5)
-               	addi	a4, a3, 0x2
-               	add	a5, a4, s1
-               	sext.w	a4, a5
-               	addi	a5, a6, 0x4
-               	sw	a4, 0x0(a5)
-               	addi	a4, a3, 0x3
-               	add	a3, a4, s1
-               	sext.w	a4, a3
-               	addi	a3, a6, 0x8
-               	sw	a4, 0x0(a3)
-               	mv	a1, a2
+               	mul	a4, a0, t0
+               	add	a5, s7, a4
+               	mv	a4, a5
+               	sw	a3, 0x0(a4)
+               	addi	a3, a2, 0x2
+               	add	a4, a3, s1
+               	sext.w	a3, a4
+               	addi	a4, a5, 0x4
+               	sw	a3, 0x0(a4)
+               	addi	a3, a2, 0x3
+               	add	a2, a3, s1
+               	sext.w	a3, a2
+               	addi	a2, a5, 0x8
+               	sw	a3, 0x0(a2)
+               	mv	a0, a1
                	li	t0, 0x40
-               	bltu	a1, t0, 0x2f4 <corpus.cases.mem.addr_modes.checksum+0x2f4>
-               	mv	s8, a0
+               	bltu	a0, t0, 0x2dc <corpus.cases.mem.addr_modes.checksum+0x2dc>
+               	lui	s8, 0xfcbf3
+               	addiw	s8, s8, -0x632
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x484
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x222
+               	slli	s8, s8, 0xc
+               	addi	s8, s8, 0x325
                	li	s9, 0x0
                	li	t0, 0x40
-               	bltu	s9, t0, 0x458 <corpus.cases.mem.addr_modes.checksum+0x458>
-               	j	0x568 <corpus.cases.mem.addr_modes.checksum+0x568>
+               	bltu	s9, t0, 0x45c <corpus.cases.mem.addr_modes.checksum+0x45c>
+               	j	0x6ac <corpus.cases.mem.addr_modes.checksum+0x6ac>
                	li	t0, 0xd
                	mul	a0, s9, t0
                	add	a1, a0, s1
@@ -288,142 +289,271 @@ Disassembly of section .text:
                	and	s10, a1, t0
                	add	a0, s2, s10
                	lbu	a1, 0x0(a0)
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x478>
+               	zext.b	a0, a1
+               	mv	a1, s8
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.mem.addr_modes.checksum+0x490>
+               	j	0x4c4 <corpus.cases.mem.addr_modes.checksum+0x4c4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x490 <corpus.cases.mem.addr_modes.checksum+0x490>
                	slli	t0, s10, 0x1
-               	add	a1, s3, t0
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x490>
+               	add	a0, s3, t0
+               	lhu	a2, 0x0(a0)
+               	slli	a0, a2, 0x30
+               	srli	a0, a0, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.mem.addr_modes.checksum+0x4e8>
+               	j	0x51c <corpus.cases.mem.addr_modes.checksum+0x51c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4e8 <corpus.cases.mem.addr_modes.checksum+0x4e8>
                	slli	t0, s10, 0x2
-               	add	a1, s4, t0
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x4a8>
-               	slli	t0, s10, 0x3
-               	add	a1, s5, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x4c0>
-               	li	t0, 0x10
-               	mul	a1, s10, t0
-               	add	s11, s6, a1
-               	mv	a1, s11
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x4e0>
-               	addi	a1, s11, 0x2
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x4f4>
-               	addi	a1, s11, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x508>
-               	li	t0, 0xc
-               	mul	a1, s10, t0
-               	add	s10, s7, a1
-               	mv	a1, s10
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x528>
-               	addi	a1, s10, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x53c>
-               	addi	a1, s10, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x550>
-               	addi	s9, s9, 0x1
-               	mv	s8, a0
-               	li	t0, 0x40
-               	bltu	s9, t0, 0x458 <corpus.cases.mem.addr_modes.checksum+0x458>
-               	li	s3, 0x0
-               	li	t0, 0x20
-               	bltu	s3, t0, 0x578 <corpus.cases.mem.addr_modes.checksum+0x578>
-               	j	0x62c <corpus.cases.mem.addr_modes.checksum+0x62c>
-               	li	t0, 0x2
-               	mul	s7, s3, t0
-               	slli	t0, s7, 0x2
                	add	a0, s4, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x590>
-               	slli	a1, s3, 0x1
-               	slli	t0, a1, 0x2
-               	add	a2, s4, t0
-               	lw	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5a8>
-               	addi	s9, s3, 0x1
-               	li	t0, 0x2
-               	mul	a1, s9, t0
-               	addi	a2, a1, -0x2
-               	slli	t0, a2, 0x3
-               	add	a1, s5, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5d0>
-               	li	t1, 0x3f
-               	sub	a1, t1, s3
-               	add	a2, s2, a1
-               	lbu	a1, 0x0(a2)
+               	lw	a2, 0x0(a0)
+               	slli	a0, a2, 0x20
+               	srli	a0, a0, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x540 <corpus.cases.mem.addr_modes.checksum+0x540>
+               	j	0x574 <corpus.cases.mem.addr_modes.checksum+0x574>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x540 <corpus.cases.mem.addr_modes.checksum+0x540>
+               	slli	t0, s10, 0x3
+               	add	a0, s5, t0
+               	ld	a2, 0x0(a0)
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x590 <corpus.cases.mem.addr_modes.checksum+0x590>
+               	j	0x5c4 <corpus.cases.mem.addr_modes.checksum+0x5c4>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x590 <corpus.cases.mem.addr_modes.checksum+0x590>
+               	li	t0, 0x10
+               	mul	a0, s10, t0
+               	add	a2, s6, a0
+               	mv	a0, a2
+               	lhu	a2, 0x0(a0)
+               	slli	a3, a2, 0x30
+               	srli	a3, a3, 0x30
+               	mv	a0, a1
+               	mv	a1, a3
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x5e8>
-               	add	a1, s7, s1
-               	li	t0, 0x3f
-               	and	a2, a1, t0
                	li	t0, 0x10
-               	mul	a1, a2, t0
+               	mul	a1, s10, t0
+               	add	a2, s6, a1
+               	addi	a1, a2, 0x2
+               	lbu	a2, 0x0(a1)
+               	zext.b	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x608>
+               	li	t0, 0x10
+               	mul	a1, s10, t0
                	add	a2, s6, a1
                	addi	a1, a2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x614>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x628>
+               	li	t0, 0xc
+               	mul	a1, s10, t0
+               	add	a2, s7, a1
+               	mv	a1, a2
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x64c>
+               	li	t0, 0xc
+               	mul	a1, s10, t0
+               	add	a2, s7, a1
+               	addi	a1, a2, 0x4
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x670>
+               	li	t0, 0xc
+               	mul	a1, s10, t0
+               	add	a2, s7, a1
+               	addi	a1, a2, 0x8
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x694>
+               	addi	s9, s9, 0x1
                	mv	s8, a0
-               	mv	s3, s9
+               	li	t0, 0x40
+               	bltu	s9, t0, 0x45c <corpus.cases.mem.addr_modes.checksum+0x45c>
+               	li	s3, 0x0
                	li	t0, 0x20
-               	bltu	s3, t0, 0x578 <corpus.cases.mem.addr_modes.checksum+0x578>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	s2, s0, t0
+               	bltu	s3, t0, 0x6bc <corpus.cases.mem.addr_modes.checksum+0x6bc>
+               	j	0x83c <corpus.cases.mem.addr_modes.checksum+0x83c>
+               	li	t0, 0x2
+               	mul	a0, s3, t0
+               	slli	t0, a0, 0x2
+               	add	a1, s4, t0
+               	lw	a0, 0x0(a1)
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	mv	a0, s8
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6ec <corpus.cases.mem.addr_modes.checksum+0x6ec>
+               	j	0x720 <corpus.cases.mem.addr_modes.checksum+0x720>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6ec <corpus.cases.mem.addr_modes.checksum+0x6ec>
+               	slli	a1, s3, 0x1
+               	slli	t0, a1, 0x2
+               	add	a2, s4, t0
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x748 <corpus.cases.mem.addr_modes.checksum+0x748>
+               	j	0x77c <corpus.cases.mem.addr_modes.checksum+0x77c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x748 <corpus.cases.mem.addr_modes.checksum+0x748>
+               	addi	a1, s3, 0x1
+               	li	t0, 0x2
+               	mul	a2, a1, t0
+               	addi	a1, a2, -0x2
+               	slli	t0, a1, 0x3
+               	add	a2, s5, t0
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7a8 <corpus.cases.mem.addr_modes.checksum+0x7a8>
+               	j	0x7dc <corpus.cases.mem.addr_modes.checksum+0x7dc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7a8 <corpus.cases.mem.addr_modes.checksum+0x7a8>
+               	li	t1, 0x3f
+               	sub	a1, t1, s3
+               	add	a2, s2, a1
+               	lbu	a1, 0x0(a2)
+               	zext.b	a2, a1
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x7f4>
+               	li	t0, 0x2
+               	mul	a1, s3, t0
+               	add	a2, a1, s1
+               	li	t0, 0x3f
+               	and	a1, a2, t0
+               	li	t0, 0x10
+               	mul	a2, a1, t0
+               	add	a1, s6, a2
+               	addi	a2, a1, 0x8
+               	ld	a1, 0x0(a2)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x824>
+               	addi	s3, s3, 0x1
+               	mv	s8, a0
+               	li	t0, 0x20
+               	bltu	s3, t0, 0x6bc <corpus.cases.mem.addr_modes.checksum+0x6bc>
+               	addi	s2, s0, -0x160
                	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x668 <corpus.cases.mem.addr_modes.checksum+0x668>
+               	bnez	a1, 0x870 <corpus.cases.mem.addr_modes.checksum+0x870>
                	mv	a1, a0
                	li	a2, 0x100
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x650 <corpus.cases.mem.addr_modes.checksum+0x650>
-               	j	0x684 <corpus.cases.mem.addr_modes.checksum+0x684>
+               	bne	a2, t0, 0x858 <corpus.cases.mem.addr_modes.checksum+0x858>
+               	j	0x88c <corpus.cases.mem.addr_modes.checksum+0x88c>
                	mv	a1, a0
                	li	a0, 0x100
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x670 <corpus.cases.mem.addr_modes.checksum+0x670>
+               	bne	a0, t0, 0x878 <corpus.cases.mem.addr_modes.checksum+0x878>
                	li	a0, 0x0
                	li	t0, 0x8
-               	bltu	a0, t0, 0x694 <corpus.cases.mem.addr_modes.checksum+0x694>
-               	j	0x6f0 <corpus.cases.mem.addr_modes.checksum+0x6f0>
+               	bltu	a0, t0, 0x89c <corpus.cases.mem.addr_modes.checksum+0x89c>
+               	j	0x8f8 <corpus.cases.mem.addr_modes.checksum+0x8f8>
                	li	t0, 0x47
                	mul	a1, a0, t0
                	li	t0, 0x20
@@ -431,8 +561,8 @@ Disassembly of section .text:
                	add	a3, s2, a2
                	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	a2, t0, 0x6b8 <corpus.cases.mem.addr_modes.checksum+0x6b8>
-               	j	0x6e4 <corpus.cases.mem.addr_modes.checksum+0x6e4>
+               	bltu	a2, t0, 0x8c0 <corpus.cases.mem.addr_modes.checksum+0x8c0>
+               	j	0x8ec <corpus.cases.mem.addr_modes.checksum+0x8ec>
                	li	t0, 0xd
                	mul	a4, a2, t0
                	add	a5, a1, a4
@@ -443,217 +573,348 @@ Disassembly of section .text:
                	sw	a5, 0x0(a4)
                	addi	a2, a2, 0x1
                	li	t0, 0x8
-               	bltu	a2, t0, 0x6b8 <corpus.cases.mem.addr_modes.checksum+0x6b8>
+               	bltu	a2, t0, 0x8c0 <corpus.cases.mem.addr_modes.checksum+0x8c0>
                	addi	a0, a0, 0x1
                	li	t0, 0x8
-               	bltu	a0, t0, 0x694 <corpus.cases.mem.addr_modes.checksum+0x694>
+               	bltu	a0, t0, 0x89c <corpus.cases.mem.addr_modes.checksum+0x89c>
                	li	s3, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x700 <corpus.cases.mem.addr_modes.checksum+0x700>
-               	j	0x76c <corpus.cases.mem.addr_modes.checksum+0x76c>
+               	bltu	s3, t0, 0x908 <corpus.cases.mem.addr_modes.checksum+0x908>
+               	j	0xa14 <corpus.cases.mem.addr_modes.checksum+0xa14>
                	li	t0, 0x20
                	mul	a0, s3, t0
-               	add	s4, s2, a0
-               	addi	a0, s4, 0xc
+               	add	a1, s2, a0
+               	addi	a0, a1, 0xc
                	lw	a1, 0x0(a0)
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x718>
-               	addi	a1, s2, 0x60
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	mv	a1, s8
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x938 <corpus.cases.mem.addr_modes.checksum+0x938>
+               	j	0x96c <corpus.cases.mem.addr_modes.checksum+0x96c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x938 <corpus.cases.mem.addr_modes.checksum+0x938>
+               	addi	a0, s2, 0x60
                	slli	t0, s3, 0x2
-               	add	a2, a1, t0
-               	lw	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x730>
-               	add	a1, s3, s1
+               	add	a2, a0, t0
+               	lw	a0, 0x0(a2)
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x994 <corpus.cases.mem.addr_modes.checksum+0x994>
+               	j	0x9c8 <corpus.cases.mem.addr_modes.checksum+0x9c8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x994 <corpus.cases.mem.addr_modes.checksum+0x994>
+               	li	t0, 0x20
+               	mul	a0, s3, t0
+               	add	a2, s2, a0
+               	add	a0, s3, s1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	slli	t0, a2, 0x2
-               	add	a1, s4, t0
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	and	a3, a0, t0
+               	slli	t0, a3, 0x2
+               	add	a0, a2, t0
+               	lw	a2, 0x0(a0)
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a0, a1
+               	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x754>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x9fc>
                	addi	s3, s3, 0x1
                	mv	s8, a0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x700 <corpus.cases.mem.addr_modes.checksum+0x700>
+               	bltu	s3, t0, 0x908 <corpus.cases.mem.addr_modes.checksum+0x908>
                	addi	a0, s2, 0xe0
                	addi	a1, a0, 0x1c
-               	lw	a2, 0x0(a1)
-               	mv	a0, s8
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x780>
-               	mv	a1, s2
-               	mv	a2, a1
-               	lw	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x794>
+               	lw	a0, 0x0(a1)
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa38 <corpus.cases.mem.addr_modes.checksum+0xa38>
+               	j	0xa6c <corpus.cases.mem.addr_modes.checksum+0xa6c>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s8, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa38 <corpus.cases.mem.addr_modes.checksum+0xa38>
+               	mv	a0, s2
+               	mv	a1, a0
+               	lw	a0, 0x0(a1)
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa90 <corpus.cases.mem.addr_modes.checksum+0xa90>
+               	j	0xac4 <corpus.cases.mem.addr_modes.checksum+0xac4>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s8, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa90 <corpus.cases.mem.addr_modes.checksum+0xa90>
                	lui	t0, 0xffffd
-               	addiw	t0, t0, -0x438
+               	addiw	t0, t0, -0x430
                	add	s2, s0, t0
-               	mv	a1, s2
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x7dc <corpus.cases.mem.addr_modes.checksum+0x7dc>
-               	mv	a2, a1
-               	lui	a3, 0x3
-               	addiw	a3, a3, -0x7f0
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0xb04 <corpus.cases.mem.addr_modes.checksum+0xb04>
+               	mv	a1, a0
+               	lui	a2, 0x3
+               	addiw	a2, a2, -0x7f0
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x7c4 <corpus.cases.mem.addr_modes.checksum+0x7c4>
-               	j	0x7fc <corpus.cases.mem.addr_modes.checksum+0x7fc>
-               	mv	a2, a1
-               	lui	a1, 0x3
-               	addiw	a1, a1, -0x7f0
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0xaec <corpus.cases.mem.addr_modes.checksum+0xaec>
+               	j	0xb24 <corpus.cases.mem.addr_modes.checksum+0xb24>
+               	mv	a1, a0
+               	lui	a0, 0x3
+               	addiw	a0, a0, -0x7f0
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x7e8 <corpus.cases.mem.addr_modes.checksum+0x7e8>
+               	bne	a0, t0, 0xb10 <corpus.cases.mem.addr_modes.checksum+0xb10>
                	lui	t1, 0x12345
                	addiw	t1, t1, 0x678
-               	add	a1, t1, s1
-               	mv	a2, s2
-               	sd	a1, 0x0(a2)
-               	sext.w	a1, s1
+               	add	a0, t1, s1
+               	mv	a1, s2
+               	sd	a0, 0x0(a1)
+               	sext.w	a0, s1
                	lui	t1, 0x9abce
                	addiw	t1, t1, -0x110
-               	addw	a2, t1, a1
+               	addw	a1, t1, a0
                	lui	t0, 0x2
                	addiw	t0, t0, 0x8
-               	add	a1, s2, t0
-               	sw	a2, 0x0(a1)
-               	sext.w	a1, s1
+               	add	a0, s2, t0
+               	sw	a1, 0x0(a0)
+               	sext.w	a0, s1
                	lui	t1, 0x1
                	addiw	t1, t1, 0x234
-               	addw	a2, t1, a1
+               	addw	a1, t1, a0
                	lui	t0, 0x3
                	addiw	t0, t0, -0x7f4
-               	add	a1, s2, t0
-               	sh	a2, 0x0(a1)
-               	li	a1, 0x0
+               	add	a0, s2, t0
+               	sh	a1, 0x0(a0)
+               	li	a0, 0x0
                	li	t0, 0x400
-               	bltu	a1, t0, 0x860 <corpus.cases.mem.addr_modes.checksum+0x860>
-               	j	0x888 <corpus.cases.mem.addr_modes.checksum+0x888>
+               	bltu	a0, t0, 0xb88 <corpus.cases.mem.addr_modes.checksum+0xb88>
+               	j	0xbb0 <corpus.cases.mem.addr_modes.checksum+0xbb0>
                	li	t0, 0x1f
-               	mul	a2, a1, t0
-               	add	a3, a2, s1
-               	addi	a2, s2, 0x8
-               	slli	t0, a1, 0x3
-               	add	a4, a2, t0
-               	sd	a3, 0x0(a4)
-               	addi	a1, a1, 0x1
+               	mul	a1, a0, t0
+               	add	a2, a1, s1
+               	addi	a1, s2, 0x8
+               	slli	t0, a0, 0x3
+               	add	a3, a1, t0
+               	sd	a2, 0x0(a3)
+               	addi	a0, a0, 0x1
                	li	t0, 0x400
-               	bltu	a1, t0, 0x860 <corpus.cases.mem.addr_modes.checksum+0x860>
-               	li	a1, 0x0
+               	bltu	a0, t0, 0xb88 <corpus.cases.mem.addr_modes.checksum+0xb88>
+               	li	a0, 0x0
                	li	t0, 0x200
-               	bltu	a1, t0, 0x898 <corpus.cases.mem.addr_modes.checksum+0x898>
-               	j	0x8cc <corpus.cases.mem.addr_modes.checksum+0x8cc>
+               	bltu	a0, t0, 0xbc0 <corpus.cases.mem.addr_modes.checksum+0xbc0>
+               	j	0xbf4 <corpus.cases.mem.addr_modes.checksum+0xbf4>
                	li	t0, 0x25
-               	mul	a2, a1, t0
-               	add	a3, a2, s1
-               	sext.w	a2, a3
+               	mul	a1, a0, t0
+               	add	a2, a1, s1
+               	sext.w	a1, a2
                	lui	t0, 0x2
                	addiw	t0, t0, 0xc
-               	add	a3, s2, t0
-               	slli	t0, a1, 0x2
-               	add	a4, a3, t0
-               	sw	a2, 0x0(a4)
-               	addi	a1, a1, 0x1
+               	add	a2, s2, t0
+               	slli	t0, a0, 0x2
+               	add	a3, a2, t0
+               	sw	a1, 0x0(a3)
+               	addi	a0, a0, 0x1
                	li	t0, 0x200
-               	bltu	a1, t0, 0x898 <corpus.cases.mem.addr_modes.checksum+0x898>
-               	mv	a1, s2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x8d8>
-               	addi	s3, s2, 0x8
-               	mv	a1, s3
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x8f0>
+               	bltu	a0, t0, 0xbc0 <corpus.cases.mem.addr_modes.checksum+0xbc0>
+               	mv	a0, s2
+               	ld	a1, 0x0(a0)
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc0c <corpus.cases.mem.addr_modes.checksum+0xc0c>
+               	j	0xc40 <corpus.cases.mem.addr_modes.checksum+0xc40>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s8, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xc0c <corpus.cases.mem.addr_modes.checksum+0xc0c>
+               	addi	a0, s2, 0x8
+               	mv	a1, a0
+               	ld	a0, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc5c <corpus.cases.mem.addr_modes.checksum+0xc5c>
+               	j	0xc90 <corpus.cases.mem.addr_modes.checksum+0xc90>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s8, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc5c <corpus.cases.mem.addr_modes.checksum+0xc5c>
+               	addi	a0, s2, 0x8
                	lui	t0, 0x2
                	addiw	t0, t0, -0x8
-               	add	a1, s3, t0
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x90c>
+               	add	a1, a0, t0
+               	ld	a0, 0x0(a1)
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xcb4 <corpus.cases.mem.addr_modes.checksum+0xcb4>
+               	j	0xce8 <corpus.cases.mem.addr_modes.checksum+0xce8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s8, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s8, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xcb4 <corpus.cases.mem.addr_modes.checksum+0xcb4>
+               	addi	a0, s2, 0x8
                	addi	a1, s1, 0x2bc
                	li	a2, 0x400
-               	bnez	a2, 0x924 <corpus.cases.mem.addr_modes.checksum+0x924>
+               	bnez	a2, 0xcfc <corpus.cases.mem.addr_modes.checksum+0xcfc>
                	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x3
-               	add	a1, s3, t0
+               	add	a1, a0, t0
                	ld	a2, 0x0(a1)
+               	mv	a0, s8
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x938>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xd14>
                	lui	t0, 0x2
                	addiw	t0, t0, 0x8
                	add	a1, s2, t0
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x954>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xd34>
                	lui	t0, 0x2
                	addiw	t0, t0, 0xc
-               	add	s3, s2, t0
-               	mv	a1, s3
-               	lw	a2, 0x0(a1)
+               	add	a1, s2, t0
+               	mv	a2, a1
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x974>
-               	addi	a1, s3, 0x7fc
-               	lw	a2, 0x0(a1)
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xd5c>
+               	lui	t0, 0x2
+               	addiw	t0, t0, 0xc
+               	add	a1, s2, t0
+               	addi	a2, a1, 0x7fc
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x988>
-               	addi	a1, s1, 0x12c
-               	li	a2, 0x200
-               	bnez	a2, 0x9a0 <corpus.cases.mem.addr_modes.checksum+0x9a0>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xd84>
+               	lui	t0, 0x2
+               	addiw	t0, t0, 0xc
+               	add	a1, s2, t0
+               	addi	a2, s1, 0x12c
+               	li	a3, 0x200
+               	bnez	a3, 0xda8 <corpus.cases.mem.addr_modes.checksum+0xda8>
                	ebreak
-               	remu	a3, a1, a2
-               	slli	t0, a3, 0x2
-               	add	a1, s3, t0
-               	lw	a2, 0x0(a1)
+               	remu	a4, a2, a3
+               	slli	t0, a4, 0x2
+               	add	a2, a1, t0
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x9b4>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xdc4>
                	lui	t0, 0x3
                	addiw	t0, t0, -0x7f4
                	add	a1, s2, t0
                	lhu	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x9d0>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xde4>
                	lui	a1, 0x2
                	addiw	a1, a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x9e0>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xdf4>
                	lui	a1, 0x2
                	addiw	a1, a1, 0xc
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0x9f0>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xe04>
                	lui	a1, 0x3
                	addiw	a1, a1, -0x7f4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xa00>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xe14>
                	lui	a1, 0x3
                	addiw	a1, a1, -0x7f0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xa10>
+               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xe24>
                	li	a1, 0x0
                	li	a2, 0x0
                	li	t0, 0x400
-               	bltu	a1, t0, 0xa2c <corpus.cases.mem.addr_modes.checksum+0xa2c>
-               	j	0xa50 <corpus.cases.mem.addr_modes.checksum+0xa50>
+               	bltu	a1, t0, 0xe40 <corpus.cases.mem.addr_modes.checksum+0xe40>
+               	j	0xe64 <corpus.cases.mem.addr_modes.checksum+0xe64>
                	addi	a3, s2, 0x8
                	slli	t0, a1, 0x3
                	add	a4, a3, t0
@@ -662,15 +923,29 @@ Disassembly of section .text:
                	mul	a4, a3, a1
                	xor	a2, a2, a4
                	li	t0, 0x400
-               	bltu	a1, t0, 0xa2c <corpus.cases.mem.addr_modes.checksum+0xa2c>
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xa54>
+               	bltu	a1, t0, 0xe40 <corpus.cases.mem.addr_modes.checksum+0xe40>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xe74 <corpus.cases.mem.addr_modes.checksum+0xe74>
+               	j	0xea8 <corpus.cases.mem.addr_modes.checksum+0xea8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xe74 <corpus.cases.mem.addr_modes.checksum+0xe74>
                	li	a1, 0x0
                	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	a1, t0, 0xa70 <corpus.cases.mem.addr_modes.checksum+0xa70>
-               	j	0xaa8 <corpus.cases.mem.addr_modes.checksum+0xaa8>
+               	bltu	a1, t0, 0xebc <corpus.cases.mem.addr_modes.checksum+0xebc>
+               	j	0xef4 <corpus.cases.mem.addr_modes.checksum+0xef4>
                	lui	t0, 0x2
                	addiw	t0, t0, 0xc
                	add	a3, s2, t0
@@ -684,63 +959,73 @@ Disassembly of section .text:
                	add	a2, a2, a5
                	addi	a1, a1, 0x1
                	li	t0, 0x200
-               	bltu	a1, t0, 0xa70 <corpus.cases.mem.addr_modes.checksum+0xa70>
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.addr_modes.checksum+0xaac>
-               	lui	t1, 0x3
-               	addiw	t1, t1, 0x428
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x3
-               	addiw	t1, t1, 0x420
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
+               	bltu	a1, t0, 0xebc <corpus.cases.mem.addr_modes.checksum+0xebc>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf04 <corpus.cases.mem.addr_modes.checksum+0xf04>
+               	j	0xf38 <corpus.cases.mem.addr_modes.checksum+0xf38>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf04 <corpus.cases.mem.addr_modes.checksum+0xf04>
                	lui	t1, 0x3
                	addiw	t1, t1, 0x418
                	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
+               	ld	s1, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x410
                	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
+               	ld	s2, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x408
                	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
+               	ld	s3, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x400
                	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
+               	ld	s4, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3f8
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
+               	ld	s5, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3f0
                	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
+               	ld	s6, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3e8
                	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
+               	ld	s7, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3e0
                	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
+               	ld	s8, 0x0(t1)
                	lui	t1, 0x3
                	addiw	t1, t1, 0x3d8
                	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
+               	ld	s9, 0x0(t1)
                	lui	t1, 0x3
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x3d0
+               	add	t1, sp, t1
+               	ld	s10, 0x0(t1)
+               	lui	t1, 0x3
+               	addiw	t1, t1, 0x428
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x3
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x420
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x3
-               	addiw	t0, t0, 0x440
+               	addiw	t0, t0, 0x430
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/mem/array_index.dis
+++ b/test/golden/riscv64-linux/mem/array_index.dis
@@ -3,40 +3,75 @@ mem/array_index.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.array_index.fold_cell>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lhu	a2, 0x0(a1)
-               	addi	a1, s0, -0x2e
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	ld	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.fold_cell+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.fold_cell+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.fold_cell+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1e
+               	lbu	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a4, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.array_index.fold_cell+0x48>
+               	j	0x7c <corpus.cases.mem.array_index.fold_cell+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.array_index.fold_cell+0x48>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.array_index.fold_cell+0x90>
+               	j	0xc4 <corpus.cases.mem.array_index.fold_cell+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.array_index.fold_cell+0x90>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.array_index.fold_cell+0xd4>
+               	j	0x108 <corpus.cases.mem.array_index.fold_cell+0x108>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.array_index.fold_cell+0xd4>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.array_index.checksum>:
@@ -49,180 +84,271 @@ Disassembly of section .text:
                	sd	s3, 0x178(sp)
                	sd	s4, 0x170(sp)
                	sd	s5, 0x168(sp)
-               	sd	s6, 0x160(sp)
-               	sd	s7, 0x158(sp)
-               	sd	s8, 0x150(sp)
-               	sd	s9, 0x148(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x74
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x3c>
-               	addi	s3, s0, -0xf4
-               	mv	a1, s3
-               	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x104 <corpus.cases.mem.array_index.checksum+0x78>
-               	mv	a2, a1
-               	li	a3, 0x80
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0xec <corpus.cases.mem.array_index.checksum+0x60>
-               	j	0x120 <corpus.cases.mem.array_index.checksum+0x94>
-               	mv	a2, a1
-               	li	a1, 0x80
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x10c <corpus.cases.mem.array_index.checksum+0x80>
-               	li	a1, 0x0
-               	li	t0, 0x20
-               	bltu	a1, t0, 0x130 <corpus.cases.mem.array_index.checksum+0xa4>
-               	j	0x168 <corpus.cases.mem.array_index.checksum+0xdc>
-               	addi	a2, a1, 0x1
-               	lui	t1, 0x9e
-               	addiw	t1, t1, 0x378
-               	slli	t1, t1, 0xc
-               	addi	t1, t1, -0x64f
-               	mul	a3, t1, a2
-               	add	a4, a3, s1
-               	sext.w	a3, a4
-               	slli	t0, a1, 0x2
-               	add	a4, s3, t0
-               	sw	a3, 0x0(a4)
-               	mv	a1, a2
-               	li	t0, 0x20
-               	bltu	a1, t0, 0x130 <corpus.cases.mem.array_index.checksum+0xa4>
-               	mv	a1, s3
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0xe8>
-               	addi	a1, s3, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0xfc>
-               	addi	a1, s3, 0x3c
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x110>
-               	addi	a1, s3, 0x7c
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x124>
-               	mv	s4, a0
-               	li	s5, 0x0
-               	li	t0, 0x20
-               	bltu	s5, t0, 0x1cc <corpus.cases.mem.array_index.checksum+0x140>
-               	j	0x20c <corpus.cases.mem.array_index.checksum+0x180>
-               	li	t0, 0x7
-               	mul	a0, s5, t0
-               	add	a1, a0, s1
-               	li	t0, 0x1f
-               	and	a0, a1, t0
-               	slli	t0, a0, 0x2
-               	add	a1, s3, t0
-               	lw	a2, 0x0(a1)
-               	mv	a0, s4
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x168>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	li	t0, 0x20
-               	bltu	s5, t0, 0x1cc <corpus.cases.mem.array_index.checksum+0x140>
-               	li	s5, 0x20
-               	li	t1, 0x0
-               	bltu	t1, s5, 0x21c <corpus.cases.mem.array_index.checksum+0x190>
-               	j	0x244 <corpus.cases.mem.array_index.checksum+0x1b8>
-               	addi	s5, s5, -0x1
-               	slli	t0, s5, 0x2
-               	add	a0, s3, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x1a4>
-               	mv	s4, a0
-               	li	t1, 0x0
-               	bltu	t1, s5, 0x21c <corpus.cases.mem.array_index.checksum+0x190>
-               	li	s5, 0x0
-               	li	t0, 0x20
-               	bltu	s5, t0, 0x254 <corpus.cases.mem.array_index.checksum+0x1c8>
-               	j	0x27c <corpus.cases.mem.array_index.checksum+0x1f0>
-               	slli	t0, s5, 0x2
-               	add	a0, s3, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x1d8>
-               	addi	s5, s5, 0x5
-               	mv	s4, a0
-               	li	t0, 0x20
-               	bltu	s5, t0, 0x254 <corpus.cases.mem.array_index.checksum+0x1c8>
-               	addi	s3, s0, -0x124
+               	addi	s2, s0, -0x54
+               	addi	s3, s0, -0x140
                	mv	a0, s3
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x2b0 <corpus.cases.mem.array_index.checksum+0x224>
+               	bnez	a1, 0x178 <corpus.cases.mem.array_index.checksum+0x60>
                	mv	a1, a0
-               	li	a2, 0x30
+               	li	a2, 0x80
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x298 <corpus.cases.mem.array_index.checksum+0x20c>
-               	j	0x2cc <corpus.cases.mem.array_index.checksum+0x240>
+               	bne	a2, t0, 0x160 <corpus.cases.mem.array_index.checksum+0x48>
+               	j	0x194 <corpus.cases.mem.array_index.checksum+0x7c>
                	mv	a1, a0
-               	li	a0, 0x30
+               	li	a0, 0x80
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x2b8 <corpus.cases.mem.array_index.checksum+0x22c>
+               	bne	a0, t0, 0x180 <corpus.cases.mem.array_index.checksum+0x68>
                	li	a0, 0x0
-               	li	t0, 0x4
-               	bltu	a0, t0, 0x2dc <corpus.cases.mem.array_index.checksum+0x250>
-               	j	0x338 <corpus.cases.mem.array_index.checksum+0x2ac>
-               	li	t0, 0x64
-               	mul	a1, a0, t0
-               	li	t0, 0xc
-               	mul	a2, a0, t0
-               	add	a3, s3, a2
-               	li	a2, 0x0
-               	li	t0, 0x6
-               	bltu	a2, t0, 0x300 <corpus.cases.mem.array_index.checksum+0x274>
-               	j	0x32c <corpus.cases.mem.array_index.checksum+0x2a0>
-               	li	t0, 0x7
-               	mul	a4, a2, t0
-               	add	a5, a1, a4
-               	add	a4, a5, s1
-               	sext.w	a5, a4
-               	slli	t0, a2, 0x1
-               	add	a4, a3, t0
-               	sh	a5, 0x0(a4)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x6
-               	bltu	a2, t0, 0x300 <corpus.cases.mem.array_index.checksum+0x274>
-               	addi	a0, a0, 0x1
-               	li	t0, 0x4
-               	bltu	a0, t0, 0x2dc <corpus.cases.mem.array_index.checksum+0x250>
+               	li	t0, 0x20
+               	bltu	a0, t0, 0x1a4 <corpus.cases.mem.array_index.checksum+0x8c>
+               	j	0x1dc <corpus.cases.mem.array_index.checksum+0xc4>
+               	addi	a1, a0, 0x1
+               	lui	t1, 0x9e
+               	addiw	t1, t1, 0x378
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0x64f
+               	mul	a2, t1, a1
+               	add	a3, a2, s1
+               	sext.w	a2, a3
+               	slli	t0, a0, 0x2
+               	add	a3, s3, t0
+               	sw	a2, 0x0(a3)
+               	mv	a0, a1
+               	li	t0, 0x20
+               	bltu	a0, t0, 0x1a4 <corpus.cases.mem.array_index.checksum+0x8c>
                	mv	a0, s3
-               	mv	a1, a0
-               	lhu	a2, 0x0(a1)
-               	mv	a0, s4
-               	mv	a1, a2
+               	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	lui	a1, 0xfcbf3
+               	addiw	a1, a1, -0x632
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x484
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x222
+               	slli	a1, a1, 0xc
+               	addi	a1, a1, 0x325
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21c <corpus.cases.mem.array_index.checksum+0x104>
+               	j	0x250 <corpus.cases.mem.array_index.checksum+0x138>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21c <corpus.cases.mem.array_index.checksum+0x104>
+               	addi	a0, s3, 0x4
+               	lw	a2, 0x0(a0)
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a0, a1
+               	mv	a1, a3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x2c0>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x150>
+               	addi	a1, s3, 0x3c
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x168>
+               	addi	a1, s3, 0x7c
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x180>
+               	li	a1, 0x0
+               	li	t0, 0x20
+               	bltu	a1, t0, 0x2b0 <corpus.cases.mem.array_index.checksum+0x198>
+               	j	0x330 <corpus.cases.mem.array_index.checksum+0x218>
+               	li	t0, 0x7
+               	mul	a2, a1, t0
+               	add	a3, a2, s1
+               	li	t0, 0x1f
+               	and	a2, a3, t0
+               	slli	t0, a2, 0x2
+               	add	a3, s3, t0
+               	lw	a2, 0x0(a3)
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2ec <corpus.cases.mem.array_index.checksum+0x1d4>
+               	j	0x320 <corpus.cases.mem.array_index.checksum+0x208>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2ec <corpus.cases.mem.array_index.checksum+0x1d4>
+               	addi	a1, a1, 0x1
+               	mv	a0, a2
+               	li	t0, 0x20
+               	bltu	a1, t0, 0x2b0 <corpus.cases.mem.array_index.checksum+0x198>
+               	li	a1, 0x20
+               	li	t1, 0x0
+               	bltu	t1, a1, 0x340 <corpus.cases.mem.array_index.checksum+0x228>
+               	j	0x3b0 <corpus.cases.mem.array_index.checksum+0x298>
+               	addi	a2, a1, -0x1
+               	slli	t0, a2, 0x2
+               	add	a3, s3, t0
+               	lw	a4, 0x0(a3)
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a4, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x36c <corpus.cases.mem.array_index.checksum+0x254>
+               	j	0x3a0 <corpus.cases.mem.array_index.checksum+0x288>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x36c <corpus.cases.mem.array_index.checksum+0x254>
+               	mv	a0, a4
+               	mv	a1, a2
+               	li	t1, 0x0
+               	bltu	t1, a1, 0x340 <corpus.cases.mem.array_index.checksum+0x228>
+               	li	a1, 0x0
+               	li	t0, 0x20
+               	bltu	a1, t0, 0x3c0 <corpus.cases.mem.array_index.checksum+0x2a8>
+               	j	0x42c <corpus.cases.mem.array_index.checksum+0x314>
+               	slli	t0, a1, 0x2
+               	add	a2, s3, t0
+               	lw	a3, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3e8 <corpus.cases.mem.array_index.checksum+0x2d0>
+               	j	0x41c <corpus.cases.mem.array_index.checksum+0x304>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3e8 <corpus.cases.mem.array_index.checksum+0x2d0>
+               	addi	a1, a1, 0x5
+               	mv	a0, a3
+               	li	t0, 0x20
+               	bltu	a1, t0, 0x3c0 <corpus.cases.mem.array_index.checksum+0x2a8>
+               	addi	s3, s0, -0x84
+               	mv	a1, s3
+               	li	t0, 0x7
+               	and	a2, a1, t0
+               	bnez	a2, 0x460 <corpus.cases.mem.array_index.checksum+0x348>
+               	mv	a2, a1
+               	li	a3, 0x30
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
+               	li	t0, 0x0
+               	bne	a3, t0, 0x448 <corpus.cases.mem.array_index.checksum+0x330>
+               	j	0x47c <corpus.cases.mem.array_index.checksum+0x364>
+               	mv	a2, a1
+               	li	a1, 0x30
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x468 <corpus.cases.mem.array_index.checksum+0x350>
+               	li	a1, 0x0
+               	li	t0, 0x4
+               	bltu	a1, t0, 0x48c <corpus.cases.mem.array_index.checksum+0x374>
+               	j	0x4e8 <corpus.cases.mem.array_index.checksum+0x3d0>
+               	li	t0, 0x64
+               	mul	a2, a1, t0
+               	li	t0, 0xc
+               	mul	a3, a1, t0
+               	add	a4, s3, a3
+               	li	a3, 0x0
+               	li	t0, 0x6
+               	bltu	a3, t0, 0x4b0 <corpus.cases.mem.array_index.checksum+0x398>
+               	j	0x4dc <corpus.cases.mem.array_index.checksum+0x3c4>
+               	li	t0, 0x7
+               	mul	a5, a3, t0
+               	add	a6, a2, a5
+               	add	a5, a6, s1
+               	sext.w	a6, a5
+               	slli	t0, a3, 0x1
+               	add	a5, a4, t0
+               	sh	a6, 0x0(a5)
+               	addi	a3, a3, 0x1
+               	li	t0, 0x6
+               	bltu	a3, t0, 0x4b0 <corpus.cases.mem.array_index.checksum+0x398>
+               	addi	a1, a1, 0x1
+               	li	t0, 0x4
+               	bltu	a1, t0, 0x48c <corpus.cases.mem.array_index.checksum+0x374>
+               	mv	a1, s3
+               	mv	a2, a1
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x50c <corpus.cases.mem.array_index.checksum+0x3f4>
+               	j	0x540 <corpus.cases.mem.array_index.checksum+0x428>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x50c <corpus.cases.mem.array_index.checksum+0x3f4>
                	addi	a1, s3, 0x24
                	addi	a2, a1, 0xa
                	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x2d4>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x440>
                	addi	a1, s1, 0x2
                	li	t0, 0x3
                	and	a2, a1, t0
@@ -235,214 +361,279 @@ Disassembly of section .text:
                	slli	t0, a3, 0x1
                	add	a1, a2, t0
                	lhu	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x310>
-               	mv	s4, a0
-               	li	s5, 0x0
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x480>
+               	li	a1, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x3b8 <corpus.cases.mem.array_index.checksum+0x32c>
-               	j	0x410 <corpus.cases.mem.array_index.checksum+0x384>
+               	bltu	a1, t0, 0x5b0 <corpus.cases.mem.array_index.checksum+0x498>
+               	j	0x64c <corpus.cases.mem.array_index.checksum+0x534>
                	li	t0, 0xc
-               	mul	a0, s5, t0
-               	add	s6, s3, a0
-               	mv	s7, s4
-               	li	s8, 0x0
-               	li	t0, 0x6
-               	bltu	s8, t0, 0x3d8 <corpus.cases.mem.array_index.checksum+0x34c>
-               	j	0x400 <corpus.cases.mem.array_index.checksum+0x374>
-               	slli	t0, s8, 0x1
-               	add	a0, s6, t0
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x35c>
-               	addi	s8, s8, 0x1
-               	mv	s7, a0
-               	li	t0, 0x6
-               	bltu	s8, t0, 0x3d8 <corpus.cases.mem.array_index.checksum+0x34c>
-               	addi	s5, s5, 0x1
-               	mv	s4, s7
-               	li	t0, 0x4
-               	bltu	s5, t0, 0x3b8 <corpus.cases.mem.array_index.checksum+0x32c>
-               	li	s5, 0x0
-               	li	t0, 0x6
-               	bltu	s5, t0, 0x420 <corpus.cases.mem.array_index.checksum+0x394>
-               	j	0x478 <corpus.cases.mem.array_index.checksum+0x3ec>
-               	mv	s6, s4
-               	li	s7, 0x0
-               	li	t0, 0x4
-               	bltu	s7, t0, 0x434 <corpus.cases.mem.array_index.checksum+0x3a8>
-               	j	0x468 <corpus.cases.mem.array_index.checksum+0x3dc>
-               	li	t0, 0xc
-               	mul	a0, s7, t0
-               	add	a1, s3, a0
-               	slli	t0, s5, 0x1
-               	add	a0, a1, t0
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x3c4>
-               	addi	s7, s7, 0x1
-               	mv	s6, a0
-               	li	t0, 0x4
-               	bltu	s7, t0, 0x434 <corpus.cases.mem.array_index.checksum+0x3a8>
-               	addi	s5, s5, 0x1
-               	mv	s4, s6
-               	li	t0, 0x6
-               	bltu	s5, t0, 0x420 <corpus.cases.mem.array_index.checksum+0x394>
-               	addi	s3, s0, -0x13f
-               	mv	a0, s3
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x4b4 <corpus.cases.mem.array_index.checksum+0x428>
-               	mv	a1, a0
-               	li	a2, 0x18
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x494 <corpus.cases.mem.array_index.checksum+0x408>
-               	sh	zero, 0x0(a1)
-               	sb	zero, 0x2(a1)
-               	j	0x4d0 <corpus.cases.mem.array_index.checksum+0x444>
-               	mv	a1, a0
-               	li	a0, 0x1b
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x4bc <corpus.cases.mem.array_index.checksum+0x430>
-               	li	a0, 0x0
-               	li	t0, 0x3
-               	bltu	a0, t0, 0x4e0 <corpus.cases.mem.array_index.checksum+0x454>
-               	j	0x564 <corpus.cases.mem.array_index.checksum+0x4d8>
-               	li	t0, 0x9
-               	mul	a1, a0, t0
-               	li	t0, 0x9
-               	mul	a2, a0, t0
+               	mul	a2, a1, t0
                	add	a3, s3, a2
+               	mv	a2, a0
+               	li	a4, 0x0
+               	li	t0, 0x6
+               	bltu	a4, t0, 0x5d0 <corpus.cases.mem.array_index.checksum+0x4b8>
+               	j	0x63c <corpus.cases.mem.array_index.checksum+0x524>
+               	slli	t0, a4, 0x1
+               	add	a5, a3, t0
+               	lhu	a6, 0x0(a5)
+               	slli	a5, a6, 0x30
+               	srli	a5, a5, 0x30
+               	mv	a6, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x5f8 <corpus.cases.mem.array_index.checksum+0x4e0>
+               	j	0x62c <corpus.cases.mem.array_index.checksum+0x514>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x5f8 <corpus.cases.mem.array_index.checksum+0x4e0>
+               	addi	a4, a4, 0x1
+               	mv	a2, a6
+               	li	t0, 0x6
+               	bltu	a4, t0, 0x5d0 <corpus.cases.mem.array_index.checksum+0x4b8>
+               	addi	a1, a1, 0x1
+               	mv	a0, a2
+               	li	t0, 0x4
+               	bltu	a1, t0, 0x5b0 <corpus.cases.mem.array_index.checksum+0x498>
+               	li	a1, 0x0
+               	li	t0, 0x6
+               	bltu	a1, t0, 0x65c <corpus.cases.mem.array_index.checksum+0x544>
+               	j	0x6f8 <corpus.cases.mem.array_index.checksum+0x5e0>
+               	mv	a2, a0
+               	li	a3, 0x0
+               	li	t0, 0x4
+               	bltu	a3, t0, 0x670 <corpus.cases.mem.array_index.checksum+0x558>
+               	j	0x6e8 <corpus.cases.mem.array_index.checksum+0x5d0>
+               	li	t0, 0xc
+               	mul	a4, a3, t0
+               	add	a5, s3, a4
+               	slli	t0, a1, 0x1
+               	add	a4, a5, t0
+               	lhu	a5, 0x0(a4)
+               	slli	a4, a5, 0x30
+               	srli	a4, a4, 0x30
+               	mv	a5, a2
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x6a4 <corpus.cases.mem.array_index.checksum+0x58c>
+               	j	0x6d8 <corpus.cases.mem.array_index.checksum+0x5c0>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x6a4 <corpus.cases.mem.array_index.checksum+0x58c>
+               	addi	a3, a3, 0x1
+               	mv	a2, a5
+               	li	t0, 0x4
+               	bltu	a3, t0, 0x670 <corpus.cases.mem.array_index.checksum+0x558>
+               	addi	a1, a1, 0x1
+               	mv	a0, a2
+               	li	t0, 0x6
+               	bltu	a1, t0, 0x65c <corpus.cases.mem.array_index.checksum+0x544>
+               	addi	a1, s0, -0x9f
+               	mv	a2, a1
+               	li	t0, 0x7
+               	and	a3, a2, t0
+               	bnez	a3, 0x734 <corpus.cases.mem.array_index.checksum+0x61c>
+               	mv	a3, a2
+               	li	a4, 0x18
+               	sd	zero, 0x0(a3)
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x714 <corpus.cases.mem.array_index.checksum+0x5fc>
+               	sh	zero, 0x0(a3)
+               	sb	zero, 0x2(a3)
+               	j	0x750 <corpus.cases.mem.array_index.checksum+0x638>
+               	mv	a3, a2
+               	li	a2, 0x1b
+               	sb	zero, 0x0(a3)
+               	addi	a3, a3, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x73c <corpus.cases.mem.array_index.checksum+0x624>
                	li	a2, 0x0
                	li	t0, 0x3
-               	bltu	a2, t0, 0x504 <corpus.cases.mem.array_index.checksum+0x478>
-               	j	0x558 <corpus.cases.mem.array_index.checksum+0x4cc>
-               	li	t0, 0x3
+               	bltu	a2, t0, 0x760 <corpus.cases.mem.array_index.checksum+0x648>
+               	j	0x7e4 <corpus.cases.mem.array_index.checksum+0x6cc>
+               	li	t0, 0x9
+               	mul	a3, a2, t0
+               	li	t0, 0x9
                	mul	a4, a2, t0
                	add	a5, a1, a4
-               	li	t0, 0x3
-               	mul	a4, a2, t0
-               	add	a6, a3, a4
                	li	a4, 0x0
                	li	t0, 0x3
-               	bltu	a4, t0, 0x52c <corpus.cases.mem.array_index.checksum+0x4a0>
-               	j	0x54c <corpus.cases.mem.array_index.checksum+0x4c0>
-               	add	a7, a5, a4
-               	add	t5, a7, s1
-               	sext.w	a7, t5
-               	add	t5, a6, a4
-               	sb	a7, 0x0(t5)
+               	bltu	a4, t0, 0x784 <corpus.cases.mem.array_index.checksum+0x66c>
+               	j	0x7d8 <corpus.cases.mem.array_index.checksum+0x6c0>
+               	li	t0, 0x3
+               	mul	a6, a4, t0
+               	add	a7, a3, a6
+               	li	t0, 0x3
+               	mul	a6, a4, t0
+               	add	t5, a5, a6
+               	li	a6, 0x0
+               	li	t0, 0x3
+               	bltu	a6, t0, 0x7ac <corpus.cases.mem.array_index.checksum+0x694>
+               	j	0x7cc <corpus.cases.mem.array_index.checksum+0x6b4>
+               	add	t6, a7, a6
+               	add	s3, t6, s1
+               	sext.w	t6, s3
+               	add	s3, t5, a6
+               	sb	t6, 0x0(s3)
+               	addi	a6, a6, 0x1
+               	li	t0, 0x3
+               	bltu	a6, t0, 0x7ac <corpus.cases.mem.array_index.checksum+0x694>
                	addi	a4, a4, 0x1
                	li	t0, 0x3
-               	bltu	a4, t0, 0x52c <corpus.cases.mem.array_index.checksum+0x4a0>
+               	bltu	a4, t0, 0x784 <corpus.cases.mem.array_index.checksum+0x66c>
                	addi	a2, a2, 0x1
                	li	t0, 0x3
-               	bltu	a2, t0, 0x504 <corpus.cases.mem.array_index.checksum+0x478>
-               	addi	a0, a0, 0x1
+               	bltu	a2, t0, 0x760 <corpus.cases.mem.array_index.checksum+0x648>
+               	li	a2, 0x0
                	li	t0, 0x3
-               	bltu	a0, t0, 0x4e0 <corpus.cases.mem.array_index.checksum+0x454>
-               	li	s5, 0x0
+               	bltu	a2, t0, 0x7f4 <corpus.cases.mem.array_index.checksum+0x6dc>
+               	j	0x8b8 <corpus.cases.mem.array_index.checksum+0x7a0>
+               	mv	a3, a0
+               	li	a4, 0x0
                	li	t0, 0x3
-               	bltu	s5, t0, 0x574 <corpus.cases.mem.array_index.checksum+0x4e8>
-               	j	0x5f8 <corpus.cases.mem.array_index.checksum+0x56c>
-               	mv	s6, s4
-               	li	s7, 0x0
+               	bltu	a4, t0, 0x808 <corpus.cases.mem.array_index.checksum+0x6f0>
+               	j	0x8a8 <corpus.cases.mem.array_index.checksum+0x790>
+               	mv	a5, a3
+               	li	a6, 0x0
                	li	t0, 0x3
-               	bltu	s7, t0, 0x588 <corpus.cases.mem.array_index.checksum+0x4fc>
-               	j	0x5e8 <corpus.cases.mem.array_index.checksum+0x55c>
-               	mv	s8, s6
-               	li	s9, 0x0
-               	li	t0, 0x3
-               	bltu	s9, t0, 0x59c <corpus.cases.mem.array_index.checksum+0x510>
-               	j	0x5d8 <corpus.cases.mem.array_index.checksum+0x54c>
+               	bltu	a6, t0, 0x81c <corpus.cases.mem.array_index.checksum+0x704>
+               	j	0x898 <corpus.cases.mem.array_index.checksum+0x780>
                	li	t0, 0x9
-               	mul	a0, s9, t0
-               	add	a1, s3, a0
+               	mul	a7, a6, t0
+               	add	t5, a1, a7
                	li	t0, 0x3
-               	mul	a0, s7, t0
-               	add	a2, a1, a0
-               	add	a0, a2, s5
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x534>
-               	addi	s9, s9, 0x1
-               	mv	s8, a0
+               	mul	a7, a4, t0
+               	add	t6, t5, a7
+               	add	a7, t6, a2
+               	lbu	t5, 0x0(a7)
+               	zext.b	a7, t5
+               	mv	t5, a5
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x854 <corpus.cases.mem.array_index.checksum+0x73c>
+               	j	0x888 <corpus.cases.mem.array_index.checksum+0x770>
+               	li	t0, 0x8
+               	mul	s3, t6, t0
+               	srl	s4, a7, s3
+               	li	t0, 0xff
+               	and	s3, s4, t0
+               	xor	s4, t5, s3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s4, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x854 <corpus.cases.mem.array_index.checksum+0x73c>
+               	addi	a6, a6, 0x1
+               	mv	a5, t5
                	li	t0, 0x3
-               	bltu	s9, t0, 0x59c <corpus.cases.mem.array_index.checksum+0x510>
-               	addi	s7, s7, 0x1
-               	mv	s6, s8
+               	bltu	a6, t0, 0x81c <corpus.cases.mem.array_index.checksum+0x704>
+               	addi	a4, a4, 0x1
+               	mv	a3, a5
                	li	t0, 0x3
-               	bltu	s7, t0, 0x588 <corpus.cases.mem.array_index.checksum+0x4fc>
-               	addi	s5, s5, 0x1
-               	mv	s4, s6
+               	bltu	a4, t0, 0x808 <corpus.cases.mem.array_index.checksum+0x6f0>
+               	addi	a2, a2, 0x1
+               	mv	a0, a3
                	li	t0, 0x3
-               	bltu	s5, t0, 0x574 <corpus.cases.mem.array_index.checksum+0x4e8>
-               	addi	a0, s3, 0x12
-               	mv	a1, a0
-               	addi	a0, a1, 0x1
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x580>
-               	addi	a1, s1, 0x1
-               	li	a2, 0x3
-               	bnez	a2, 0x624 <corpus.cases.mem.array_index.checksum+0x598>
-               	ebreak
-               	remu	a3, a1, a2
-               	li	t0, 0x9
-               	mul	a1, a3, t0
-               	add	a2, s3, a1
-               	addi	a1, s1, 0x2
+               	bltu	a2, t0, 0x7f4 <corpus.cases.mem.array_index.checksum+0x6dc>
+               	addi	a2, a1, 0x12
+               	mv	a3, a2
+               	addi	a2, a3, 0x1
+               	lbu	a3, 0x0(a2)
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x8dc <corpus.cases.mem.array_index.checksum+0x7c4>
+               	j	0x910 <corpus.cases.mem.array_index.checksum+0x7f8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x8dc <corpus.cases.mem.array_index.checksum+0x7c4>
+               	addi	a2, s1, 0x1
                	li	a3, 0x3
-               	bnez	a3, 0x644 <corpus.cases.mem.array_index.checksum+0x5b8>
+               	bnez	a3, 0x920 <corpus.cases.mem.array_index.checksum+0x808>
                	ebreak
-               	remu	a4, a1, a3
+               	remu	a4, a2, a3
+               	li	t0, 0x9
+               	mul	a2, a4, t0
+               	add	a3, a1, a2
+               	addi	a1, s1, 0x2
+               	li	a2, 0x3
+               	bnez	a2, 0x940 <corpus.cases.mem.array_index.checksum+0x828>
+               	ebreak
+               	remu	a4, a1, a2
                	li	t0, 0x3
                	mul	a1, a4, t0
-               	add	a3, a2, a1
+               	add	a2, a3, a1
                	li	a1, 0x3
-               	bnez	a1, 0x660 <corpus.cases.mem.array_index.checksum+0x5d4>
+               	bnez	a1, 0x95c <corpus.cases.mem.array_index.checksum+0x844>
                	ebreak
-               	remu	a2, s1, a1
-               	add	a1, a3, a2
+               	remu	a3, s1, a1
+               	add	a1, a2, a3
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
+               	zext.b	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x5e4>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0x854>
                	addi	s3, s0, -0x190
                	mv	a1, s3
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x6ac <corpus.cases.mem.array_index.checksum+0x620>
+               	bnez	a2, 0x9a8 <corpus.cases.mem.array_index.checksum+0x890>
                	mv	a2, a1
                	li	a3, 0x50
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x694 <corpus.cases.mem.array_index.checksum+0x608>
-               	j	0x6c8 <corpus.cases.mem.array_index.checksum+0x63c>
+               	bne	a3, t0, 0x990 <corpus.cases.mem.array_index.checksum+0x878>
+               	j	0x9c4 <corpus.cases.mem.array_index.checksum+0x8ac>
                	mv	a2, a1
                	li	a1, 0x50
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x6b4 <corpus.cases.mem.array_index.checksum+0x628>
+               	bne	a1, t0, 0x9b0 <corpus.cases.mem.array_index.checksum+0x898>
                	li	a1, 0x0
                	li	t0, 0x5
-               	bltu	a1, t0, 0x6d8 <corpus.cases.mem.array_index.checksum+0x64c>
-               	j	0x738 <corpus.cases.mem.array_index.checksum+0x6ac>
+               	bltu	a1, t0, 0x9d4 <corpus.cases.mem.array_index.checksum+0x8bc>
+               	j	0xa34 <corpus.cases.mem.array_index.checksum+0x91c>
                	li	t0, 0x3
                	mul	a2, a1, t0
                	addi	a3, a2, 0x1
@@ -466,67 +657,164 @@ Disassembly of section .text:
                	addi	a2, a4, 0x8
                	sd	a3, 0x0(a2)
                	li	t0, 0x5
-               	bltu	a1, t0, 0x6d8 <corpus.cases.mem.array_index.checksum+0x64c>
+               	bltu	a1, t0, 0x9d4 <corpus.cases.mem.array_index.checksum+0x8bc>
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x74c <corpus.cases.mem.array_index.checksum+0x6c0>
-               	j	0x7a8 <corpus.cases.mem.array_index.checksum+0x71c>
+               	bltu	s5, t0, 0xa48 <corpus.cases.mem.array_index.checksum+0x930>
+               	j	0xb48 <corpus.cases.mem.array_index.checksum+0xa30>
                	li	t0, 0x10
                	mul	a0, s5, t0
                	add	a1, s3, a0
-               	mv	a0, a1
-               	lhu	a2, 0x0(a0)
-               	addi	a0, a1, 0x2
-               	lbu	s6, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s7, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s0, -0xb0
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0xacc <corpus.cases.mem.array_index.checksum+0x9b4>
+               	bnez	a1, 0xaa0 <corpus.cases.mem.array_index.checksum+0x988>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xa80 <corpus.cases.mem.array_index.checksum+0x968>
+               	j	0xb24 <corpus.cases.mem.array_index.checksum+0xa0c>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xaac <corpus.cases.mem.array_index.checksum+0x994>
+               	j	0xb24 <corpus.cases.mem.array_index.checksum+0xa0c>
+               	bnez	a1, 0xafc <corpus.cases.mem.array_index.checksum+0x9e4>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xadc <corpus.cases.mem.array_index.checksum+0x9c4>
+               	j	0xb24 <corpus.cases.mem.array_index.checksum+0xa0c>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0xb08 <corpus.cases.mem.array_index.checksum+0x9f0>
+               	ld	a1, 0x0(a0)
+               	ld	a2, 0x8(a0)
+               	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6ec>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x6f8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x704>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xa18>
                	addi	s5, s5, 0x1
                	mv	s4, a0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x74c <corpus.cases.mem.array_index.checksum+0x6c0>
+               	bltu	s5, t0, 0xa48 <corpus.cases.mem.array_index.checksum+0x930>
                	addi	a0, s1, 0x3
                	li	a1, 0x5
-               	bnez	a1, 0x7b8 <corpus.cases.mem.array_index.checksum+0x72c>
+               	bnez	a1, 0xb58 <corpus.cases.mem.array_index.checksum+0xa40>
                	ebreak
                	remu	a2, a0, a1
                	li	t0, 0x10
                	mul	a0, a2, t0
                	add	a1, s3, a0
-               	mv	a0, a1
-               	lhu	a2, 0x0(a0)
-               	addi	a0, a1, 0x2
-               	lbu	s5, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s6, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s0, -0xc0
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0xbe0 <corpus.cases.mem.array_index.checksum+0xac8>
+               	bnez	a1, 0xbb4 <corpus.cases.mem.array_index.checksum+0xa9c>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0xb94 <corpus.cases.mem.array_index.checksum+0xa7c>
+               	j	0xc38 <corpus.cases.mem.array_index.checksum+0xb20>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0xbc0 <corpus.cases.mem.array_index.checksum+0xaa8>
+               	j	0xc38 <corpus.cases.mem.array_index.checksum+0xb20>
+               	bnez	a1, 0xc10 <corpus.cases.mem.array_index.checksum+0xaf8>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0xbf0 <corpus.cases.mem.array_index.checksum+0xad8>
+               	j	0xc38 <corpus.cases.mem.array_index.checksum+0xb20>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0xc1c <corpus.cases.mem.array_index.checksum+0xb04>
+               	ld	a1, 0x0(a0)
+               	ld	a2, 0x8(a0)
+               	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x75c>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x768>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x774>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xb2c>
                	addi	a1, s3, 0x40
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x788>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc68 <corpus.cases.mem.array_index.checksum+0xb50>
+               	j	0xc9c <corpus.cases.mem.array_index.checksum+0xb84>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc68 <corpus.cases.mem.array_index.checksum+0xb50>
                	addi	a1, s1, 0x1
                	li	a2, 0x5
-               	bnez	a2, 0x82c <corpus.cases.mem.array_index.checksum+0x7a0>
+               	bnez	a2, 0xcac <corpus.cases.mem.array_index.checksum+0xb94>
                	ebreak
                	remu	a3, a1, a2
                	li	t0, 0x10
@@ -534,37 +822,38 @@ Disassembly of section .text:
                	add	a2, s3, a1
                	mv	a1, a2
                	lhu	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7bc>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xbb4>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x7c8>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xbc0>
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x890 <corpus.cases.mem.array_index.checksum+0x804>
+               	bnez	a2, 0xd14 <corpus.cases.mem.array_index.checksum+0xbfc>
                	mv	a2, a1
                	li	a3, 0x18
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x874 <corpus.cases.mem.array_index.checksum+0x7e8>
+               	bne	a3, t0, 0xcf8 <corpus.cases.mem.array_index.checksum+0xbe0>
                	sw	zero, 0x0(a2)
-               	j	0x8ac <corpus.cases.mem.array_index.checksum+0x820>
+               	j	0xd30 <corpus.cases.mem.array_index.checksum+0xc18>
                	mv	a2, a1
                	li	a1, 0x1c
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x898 <corpus.cases.mem.array_index.checksum+0x80c>
+               	bne	a1, t0, 0xd1c <corpus.cases.mem.array_index.checksum+0xc04>
                	sext.w	a1, s1
                	li	a2, 0x0
                	li	t0, 0x7
-               	bltu	a2, t0, 0x8c0 <corpus.cases.mem.array_index.checksum+0x834>
-               	j	0x8ec <corpus.cases.mem.array_index.checksum+0x860>
+               	bltu	a2, t0, 0xd44 <corpus.cases.mem.array_index.checksum+0xc2c>
+               	j	0xd70 <corpus.cases.mem.array_index.checksum+0xc58>
                	sext.w	a3, a2
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
@@ -575,40 +864,85 @@ Disassembly of section .text:
                	sw	a3, 0x0(a4)
                	addi	a2, a2, 0x1
                	li	t0, 0x7
-               	bltu	a2, t0, 0x8c0 <corpus.cases.mem.array_index.checksum+0x834>
-               	li	a1, 0x11
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x864>
-               	mv	s3, a0
-               	li	s4, 0x0
+               	bltu	a2, t0, 0xd44 <corpus.cases.mem.array_index.checksum+0xc2c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd80 <corpus.cases.mem.array_index.checksum+0xc68>
+               	j	0xdb8 <corpus.cases.mem.array_index.checksum+0xca0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x11
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd80 <corpus.cases.mem.array_index.checksum+0xc68>
+               	li	a1, 0x0
                	li	t0, 0x7
-               	bltu	s4, t0, 0x90c <corpus.cases.mem.array_index.checksum+0x880>
-               	j	0x950 <corpus.cases.mem.array_index.checksum+0x8c4>
+               	bltu	a1, t0, 0xdc8 <corpus.cases.mem.array_index.checksum+0xcb0>
+               	j	0xe50 <corpus.cases.mem.array_index.checksum+0xd38>
                	li	t0, 0x3
-               	mul	a0, s4, t0
-               	add	a1, a0, s1
-               	li	a0, 0x7
-               	bnez	a0, 0x924 <corpus.cases.mem.array_index.checksum+0x898>
+               	mul	a2, a1, t0
+               	add	a3, a2, s1
+               	li	a2, 0x7
+               	bnez	a2, 0xde0 <corpus.cases.mem.array_index.checksum+0xcc8>
                	ebreak
-               	remu	a2, a1, a0
-               	slli	t0, a2, 0x2
-               	add	a0, s2, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x8ac>
-               	addi	s4, s4, 0x1
-               	mv	s3, a0
+               	remu	a4, a3, a2
+               	slli	t0, a4, 0x2
+               	add	a2, s2, t0
+               	lw	a3, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xe0c <corpus.cases.mem.array_index.checksum+0xcf4>
+               	j	0xe40 <corpus.cases.mem.array_index.checksum+0xd28>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xe0c <corpus.cases.mem.array_index.checksum+0xcf4>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x7
-               	bltu	s4, t0, 0x90c <corpus.cases.mem.array_index.checksum+0x880>
-               	mv	a0, s3
-               	lui	a1, 0x1
-               	addiw	a1, a1, 0x234
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x8d0>
+               	bltu	a1, t0, 0xdc8 <corpus.cases.mem.array_index.checksum+0xcb0>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xe60 <corpus.cases.mem.array_index.checksum+0xd48>
+               	j	0xe9c <corpus.cases.mem.array_index.checksum+0xd84>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x234
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xe60 <corpus.cases.mem.array_index.checksum+0xd48>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x8dc>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xd88>
                	mv	a1, s2
                	lw	a2, 0x0(a1)
                	addi	a1, s2, 0x4
@@ -627,28 +961,26 @@ Disassembly of section .text:
                	addiw	t0, t0, 0xf0
                	xor	s1, a2, t0
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x930>
-               	mv	a1, s1
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xde0>
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x93c>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xdf0>
                	li	a1, 0x11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x948>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xdfc>
                	lui	a1, 0x1
                	addiw	a1, a1, 0x234
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.array_index.checksum+0x958>
+               	jalr	ra <corpus.cases.mem.array_index.checksum+0xe0c>
                	ld	s1, 0x188(sp)
                	ld	s2, 0x180(sp)
                	ld	s3, 0x178(sp)
                	ld	s4, 0x170(sp)
                	ld	s5, 0x168(sp)
-               	ld	s6, 0x160(sp)
-               	ld	s7, 0x158(sp)
-               	ld	s8, 0x150(sp)
-               	ld	s9, 0x148(sp)
                	ld	ra, 0x198(sp)
                	ld	s0, 0x190(sp)
                	addi	sp, sp, 0x1a0

--- a/test/golden/riscv64-linux/mem/global_data.dis
+++ b/test/golden/riscv64-linux/mem/global_data.dis
@@ -3,40 +3,75 @@ mem/global_data.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.global_data.fold_cell>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lhu	a2, 0x0(a1)
-               	addi	a1, s0, -0x2e
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	ld	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.fold_cell+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.fold_cell+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.fold_cell+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1e
+               	lbu	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a4, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.global_data.fold_cell+0x48>
+               	j	0x7c <corpus.cases.mem.global_data.fold_cell+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.global_data.fold_cell+0x48>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.global_data.fold_cell+0x90>
+               	j	0xc4 <corpus.cases.mem.global_data.fold_cell+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.global_data.fold_cell+0x90>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.global_data.fold_cell+0xd4>
+               	j	0x108 <corpus.cases.mem.global_data.fold_cell+0x108>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.global_data.fold_cell+0xd4>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.global_data.fold_globals>:
@@ -44,192 +79,459 @@ Disassembly of section .text:
                	sd	ra, 0x28(sp)
                	sd	s0, 0x20(sp)
                	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	mv	a1, a0
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
-               	lbu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x10>
-               	mv	a1, a0
+               	lbu	a1, 0x0(t0)
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x144 <.Lpcrel_hi.0+0x1c>
+               	j	0x178 <.Lpcrel_hi.1>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x144 <.Lpcrel_hi.0+0x1c>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
-               	lhu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x10>
-               	mv	a1, a0
+               	lhu	a1, 0x0(t0)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x198 <.Lpcrel_hi.1+0x20>
+               	j	0x1cc <.Lpcrel_hi.2>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x198 <.Lpcrel_hi.1+0x20>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
-               	lw	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x10>
-               	mv	a1, a0
+               	lw	a1, 0x0(t0)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <.Lpcrel_hi.2+0x20>
+               	j	0x220 <.Lpcrel_hi.3>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1ec <.Lpcrel_hi.2+0x20>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x10>
-               	mv	a1, a0
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x238 <.Lpcrel_hi.3+0x18>
+               	j	0x26c <.Lpcrel_hi.4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x238 <.Lpcrel_hi.3+0x18>
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
-               	lbu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.4+0x10>
-               	mv	a1, a0
+               	lbu	a1, 0x0(t0)
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x28c <.Lpcrel_hi.4+0x20>
+               	j	0x2c0 <.Lpcrel_hi.5>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x28c <.Lpcrel_hi.4+0x20>
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
-               	lhu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x10>
-               	mv	a1, a0
+               	lhu	a1, 0x0(t0)
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <.Lpcrel_hi.5+0x20>
+               	j	0x314 <.Lpcrel_hi.6>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2e0 <.Lpcrel_hi.5+0x20>
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
-               	lw	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x10>
-               	mv	a1, a0
+               	lw	a1, 0x0(t0)
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x330 <.Lpcrel_hi.6+0x1c>
+               	j	0x364 <.Lpcrel_hi.7>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x330 <.Lpcrel_hi.6+0x1c>
 
 <.Lpcrel_hi.7>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x10>
-               	mv	a1, a0
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x37c <.Lpcrel_hi.7+0x18>
+               	j	0x3b0 <.Lpcrel_hi.8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x37c <.Lpcrel_hi.7+0x18>
 
 <.Lpcrel_hi.8>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x14>
-               	mv	a1, a0
+               	jalr	ra <.Lpcrel_hi.8+0x1c>
 
 <.Lpcrel_hi.9>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	fld	ft0, 0x0(a1)
+               	fmv.x.d	a1, ft0
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.9+0x10>
 
 <.Lpcrel_hi.10>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-               	mv	s2, a0
-               	li	s3, 0x0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1e0 <.Lpcrel_hi.10+0x1c>
-               	j	0x208 <.Lpcrel_hi.11>
-               	slli	t0, s3, 0x2
-               	add	a0, s1, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x2c>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	bltu	a2, t0, 0x404 <.Lpcrel_hi.10+0x18>
+               	j	0x470 <.Lpcrel_hi.10+0x84>
+               	slli	t0, a2, 0x2
+               	add	a3, a1, t0
+               	lw	a4, 0x0(a3)
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a4, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x42c <.Lpcrel_hi.10+0x40>
+               	j	0x460 <.Lpcrel_hi.10+0x74>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x42c <.Lpcrel_hi.10+0x40>
+               	addi	a2, a2, 0x1
+               	mv	a0, a4
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1e0 <.Lpcrel_hi.10+0x1c>
+               	bltu	a2, t0, 0x404 <.Lpcrel_hi.10+0x18>
+               	addi	a1, s0, -0x20
+               	mv	a2, a1
 
 <.Lpcrel_hi.11>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	lhu	a1, 0x0(a0)
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x4ec <.Lpcrel_hi.11+0x74>
+               	bnez	a4, 0x4c0 <.Lpcrel_hi.11+0x48>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x4a0 <.Lpcrel_hi.11+0x28>
+               	j	0x544 <.Lpcrel_hi.11+0xcc>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x4cc <.Lpcrel_hi.11+0x54>
+               	j	0x544 <.Lpcrel_hi.11+0xcc>
+               	bnez	a4, 0x51c <.Lpcrel_hi.11+0xa4>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x4fc <.Lpcrel_hi.11+0x84>
+               	j	0x544 <.Lpcrel_hi.11+0xcc>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x528 <.Lpcrel_hi.11+0xb0>
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
+               	mv	a1, a2
+               	mv	a2, a3
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.11+0xdc>
 
 <.Lpcrel_hi.12>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	lbu	s1, 0x0(a0)
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	addi	a2, s0, -0x30
+               	mv	a3, a2
+               	mv	a4, a1
+               	or	a1, a3, a4
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a3, a4, 0x5dc <.Lpcrel_hi.12+0x80>
+               	bnez	a1, 0x5b0 <.Lpcrel_hi.12+0x54>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x590 <.Lpcrel_hi.12+0x34>
+               	j	0x634 <.Lpcrel_hi.12+0xd8>
+               	addi	a5, a3, 0x10
+               	addi	a6, a4, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x5bc <.Lpcrel_hi.12+0x60>
+               	j	0x634 <.Lpcrel_hi.12+0xd8>
+               	bnez	a1, 0x60c <.Lpcrel_hi.12+0xb0>
+               	mv	a1, a3
+               	mv	a5, a4
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x5ec <.Lpcrel_hi.12+0x90>
+               	j	0x634 <.Lpcrel_hi.12+0xd8>
+               	mv	a1, a3
+               	mv	a3, a4
+               	li	a4, 0x10
+               	lbu	a5, 0x0(a3)
+               	sb	a5, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a3, a3, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x618 <.Lpcrel_hi.12+0xbc>
+               	ld	a1, 0x0(a2)
+               	ld	a3, 0x8(a2)
+               	mv	a2, a3
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.12+0xe4>
 
 <.Lpcrel_hi.13>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	ld	s3, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x10>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x1c>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x28>
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	mv	a2, a1
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x670 <.Lpcrel_hi.13+0x28>
+               	j	0x6a4 <.Lpcrel_hi.14>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x670 <.Lpcrel_hi.13+0x28>
 
 <.Lpcrel_hi.14>:
                	auipc	a1, 0x0
                	mv	a1, a1
-               	mv	a2, a1
-               	lhu	a3, 0x0(a2)
                	addi	a2, a1, 0x2
-               	lbu	s1, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	ld	s2, 0x0(a2)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x24>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x30>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x3c>
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6cc <.Lpcrel_hi.14+0x28>
+               	j	0x700 <.Lpcrel_hi.15>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x6cc <.Lpcrel_hi.14+0x28>
 
 <.Lpcrel_hi.15>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-               	mv	a1, s1
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x14>
-               	addi	a1, s1, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x28>
-               	addi	a1, s1, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x3c>
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	addi	a2, a1, 0x4
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x728 <.Lpcrel_hi.15+0x28>
+               	j	0x75c <.Lpcrel_hi.16>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x728 <.Lpcrel_hi.15+0x28>
 
 <.Lpcrel_hi.16>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.16+0x10>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x780 <.Lpcrel_hi.16+0x24>
+               	j	0x7b4 <.Lpcrel_hi.16+0x58>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x780 <.Lpcrel_hi.16+0x24>
                	ld	ra, 0x28(sp)
                	ld	s0, 0x20(sp)
                	addi	sp, sp, 0x30
@@ -355,8 +657,8 @@ Disassembly of section .text:
                	sext.w	a2, a0
                	li	a3, 0x0
                	li	t0, 0x6
-               	bltu	a3, t0, 0x438 <.Lpcrel_hi.39+0x1c>
-               	j	0x464 <.Lpcrel_hi.40>
+               	bltu	a3, t0, 0x8f0 <.Lpcrel_hi.39+0x1c>
+               	j	0x91c <.Lpcrel_hi.40>
                	slli	t0, a3, 0x2
                	add	a4, a1, t0
                	lw	a5, 0x0(a4)
@@ -367,7 +669,7 @@ Disassembly of section .text:
                	sw	a7, 0x0(a4)
                	addi	a3, a3, 0x1
                	li	t0, 0x6
-               	bltu	a3, t0, 0x438 <.Lpcrel_hi.39+0x1c>
+               	bltu	a3, t0, 0x8f0 <.Lpcrel_hi.39+0x1c>
 
 <.Lpcrel_hi.40>:
                	auipc	a1, 0x0
@@ -402,8 +704,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x52c <.Lpcrel_hi.43+0x74>
-               	bnez	a4, 0x500 <.Lpcrel_hi.43+0x48>
+               	bltu	a2, a3, 0x9e4 <.Lpcrel_hi.43+0x74>
+               	bnez	a4, 0x9b8 <.Lpcrel_hi.43+0x48>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -413,8 +715,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x4e0 <.Lpcrel_hi.43+0x28>
-               	j	0x584 <.Lpcrel_hi.44>
+               	bne	a7, t0, 0x998 <.Lpcrel_hi.43+0x28>
+               	j	0xa3c <.Lpcrel_hi.44>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -424,9 +726,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x50c <.Lpcrel_hi.43+0x54>
-               	j	0x584 <.Lpcrel_hi.44>
-               	bnez	a4, 0x55c <.Lpcrel_hi.43+0xa4>
+               	bne	a7, t0, 0x9c4 <.Lpcrel_hi.43+0x54>
+               	j	0xa3c <.Lpcrel_hi.44>
+               	bnez	a4, 0xa14 <.Lpcrel_hi.43+0xa4>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -436,8 +738,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x53c <.Lpcrel_hi.43+0x84>
-               	j	0x584 <.Lpcrel_hi.44>
+               	bne	a6, t0, 0x9f4 <.Lpcrel_hi.43+0x84>
+               	j	0xa3c <.Lpcrel_hi.44>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x10
@@ -447,7 +749,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x568 <.Lpcrel_hi.43+0xb0>
+               	bne	a3, t0, 0xa20 <.Lpcrel_hi.43+0xb0>
 
 <.Lpcrel_hi.44>:
                	auipc	a2, 0x0
@@ -457,8 +759,8 @@ Disassembly of section .text:
                	or	a1, a3, a2
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a2, 0x600 <.Lpcrel_hi.44+0x7c>
-               	bnez	a1, 0x5d4 <.Lpcrel_hi.44+0x50>
+               	bltu	a3, a2, 0xab8 <.Lpcrel_hi.44+0x7c>
+               	bnez	a1, 0xa8c <.Lpcrel_hi.44+0x50>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -468,8 +770,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x5b4 <.Lpcrel_hi.44+0x30>
-               	j	0x658 <.Lpcrel_hi.45>
+               	bne	a6, t0, 0xa6c <.Lpcrel_hi.44+0x30>
+               	j	0xb10 <.Lpcrel_hi.45>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -479,9 +781,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x5e0 <.Lpcrel_hi.44+0x5c>
-               	j	0x658 <.Lpcrel_hi.45>
-               	bnez	a1, 0x630 <.Lpcrel_hi.44+0xac>
+               	bne	a6, t0, 0xa98 <.Lpcrel_hi.44+0x5c>
+               	j	0xb10 <.Lpcrel_hi.45>
+               	bnez	a1, 0xae8 <.Lpcrel_hi.44+0xac>
                	mv	a1, a3
                	mv	a4, a2
                	li	a5, 0x10
@@ -491,8 +793,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x610 <.Lpcrel_hi.44+0x8c>
-               	j	0x658 <.Lpcrel_hi.45>
+               	bne	a5, t0, 0xac8 <.Lpcrel_hi.44+0x8c>
+               	j	0xb10 <.Lpcrel_hi.45>
                	mv	a1, a3
                	mv	a3, a2
                	li	a2, 0x10
@@ -502,13 +804,13 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x63c <.Lpcrel_hi.44+0xb8>
+               	bne	a2, t0, 0xaf4 <.Lpcrel_hi.44+0xb8>
 
 <.Lpcrel_hi.45>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x3
-               	bnez	a2, 0x66c <.Lpcrel_hi.45+0x14>
+               	bnez	a2, 0xb24 <.Lpcrel_hi.45+0x14>
                	ebreak
                	remu	a3, a0, a2
                	slli	t0, a3, 0x1
@@ -516,7 +818,7 @@ Disassembly of section .text:
                	lhu	a3, 0x0(a2)
                	addiw	a2, a3, 0x64
                	li	a3, 0x3
-               	bnez	a3, 0x68c <.Lpcrel_hi.45+0x34>
+               	bnez	a3, 0xb44 <.Lpcrel_hi.45+0x34>
                	ebreak
                	remu	a4, a0, a3
                	slli	t0, a4, 0x1
@@ -536,28 +838,31 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.mem.global_data.checksum>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	sd	s2, 0x80(sp)
-               	sd	s3, 0x78(sp)
-               	sd	s4, 0x70(sp)
-               	sd	s5, 0x68(sp)
-               	sd	s6, 0x60(sp)
-               	sd	s7, 0x58(sp)
-               	sd	s8, 0x50(sp)
-               	sd	s9, 0x48(sp)
-               	sd	s10, 0x40(sp)
+               	addi	sp, sp, -0xb0
+               	sd	ra, 0xa8(sp)
+               	sd	s0, 0xa0(sp)
+               	addi	s0, sp, 0xb0
+               	sd	s1, 0x98(sp)
+               	sd	s2, 0x90(sp)
+               	sd	s3, 0x88(sp)
+               	sd	s4, 0x80(sp)
+               	sd	s5, 0x78(sp)
+               	sd	s6, 0x70(sp)
+               	sd	s7, 0x68(sp)
+               	sd	s8, 0x60(sp)
+               	sd	s9, 0x58(sp)
+               	sd	s10, 0x50(sp)
                	mv	s1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.checksum+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.checksum+0x4c>
-               	mv	a1, a0
+               	jalr	ra <corpus.cases.mem.global_data.checksum+0x5c>
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -566,137 +871,131 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	add	a2, t1, s1
-               	mv	a0, a1
-               	mv	a1, a2
+               	add	a1, t1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.checksum+0x84>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.global_data.checksum+0x88>
                	lui	a1, 0xffed3
                	addiw	a1, a1, -0x687
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_data.checksum+0x9c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.global_data.checksum+0x98>
+               	lui	a1, 0x3fc4
+               	slli	a1, a1, 0xc
+               	slli	a1, a1, 0xc
+               	slli	a1, a1, 0xc
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.global_data.checksum+0xb0>
 
 <.Lpcrel_hi.47>:
-               	auipc	t0, 0x0
-               	fld	fa0, 0x0(t0)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.47+0x8>
-
-<.Lpcrel_hi.48>:
                	auipc	s2, 0x0
                	mv	s2, s2
 
-<.Lpcrel_hi.49>:
+<.Lpcrel_hi.48>:
                	auipc	s3, 0x0
                	mv	s3, s3
 
-<.Lpcrel_hi.50>:
+<.Lpcrel_hi.49>:
                	auipc	s4, 0x0
                	mv	s4, s4
 
-<.Lpcrel_hi.51>:
+<.Lpcrel_hi.50>:
                	auipc	s5, 0x0
                	mv	s5, s5
 
-<.Lpcrel_hi.52>:
+<.Lpcrel_hi.51>:
                	auipc	s6, 0x0
                	mv	s6, s6
 
-<.Lpcrel_hi.53>:
+<.Lpcrel_hi.52>:
                	auipc	s7, 0x0
                	mv	s7, s7
 
-<.Lpcrel_hi.54>:
+<.Lpcrel_hi.53>:
                	auipc	s8, 0x0
                	mv	s8, s8
                	mv	s9, a0
                	li	s10, 0x0
                	li	t0, 0x5
-               	bltu	s10, t0, 0x7cc <.Lpcrel_hi.54+0x1c>
-               	j	0xb50 <.Lpcrel_hi.78>
+               	bltu	s10, t0, 0xc80 <.Lpcrel_hi.53+0x1c>
+               	j	0x1004 <.Lpcrel_hi.77>
                	addi	a0, s10, 0x1
                	add	a1, a0, s1
 
-<.Lpcrel_hi.55>:
+<.Lpcrel_hi.54>:
                	auipc	t0, 0x0
                	lbu	a0, 0x0(t0)
                	sext.w	a2, a1
                	addw	a3, a0, a2
 
-<.Lpcrel_hi.56>:
+<.Lpcrel_hi.55>:
                	auipc	t0, 0x0
                	sb	a3, 0x0(t0)
 
-<.Lpcrel_hi.57>:
+<.Lpcrel_hi.56>:
                	auipc	t0, 0x0
                	lhu	a0, 0x0(t0)
                	sext.w	a3, a1
                	addw	a4, a0, a3
 
-<.Lpcrel_hi.58>:
+<.Lpcrel_hi.57>:
                	auipc	t0, 0x0
                	sh	a4, 0x0(t0)
 
-<.Lpcrel_hi.59>:
+<.Lpcrel_hi.58>:
                	auipc	t0, 0x0
                	lw	a0, 0x0(t0)
                	sext.w	a4, a1
                	addw	a5, a0, a4
 
-<.Lpcrel_hi.60>:
+<.Lpcrel_hi.59>:
                	auipc	t0, 0x0
                	sw	a5, 0x0(t0)
 
-<.Lpcrel_hi.61>:
+<.Lpcrel_hi.60>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	add	a5, a0, a1
 
-<.Lpcrel_hi.62>:
+<.Lpcrel_hi.61>:
                	auipc	t0, 0x0
                	sd	a5, 0x0(t0)
 
-<.Lpcrel_hi.63>:
+<.Lpcrel_hi.62>:
                	auipc	t0, 0x0
                	lbu	a0, 0x0(t0)
                	addw	a5, a0, a2
 
-<.Lpcrel_hi.64>:
+<.Lpcrel_hi.63>:
                	auipc	t0, 0x0
                	sb	a5, 0x0(t0)
 
-<.Lpcrel_hi.65>:
+<.Lpcrel_hi.64>:
                	auipc	t0, 0x0
                	lhu	a0, 0x0(t0)
                	addw	a2, a0, a3
 
-<.Lpcrel_hi.66>:
+<.Lpcrel_hi.65>:
                	auipc	t0, 0x0
                	sh	a2, 0x0(t0)
 
-<.Lpcrel_hi.67>:
+<.Lpcrel_hi.66>:
                	auipc	t0, 0x0
                	lw	a0, 0x0(t0)
                	addw	a2, a0, a4
 
-<.Lpcrel_hi.68>:
+<.Lpcrel_hi.67>:
                	auipc	t0, 0x0
                	sw	a2, 0x0(t0)
 
-<.Lpcrel_hi.69>:
+<.Lpcrel_hi.68>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	add	a2, a0, a1
 
-<.Lpcrel_hi.70>:
+<.Lpcrel_hi.69>:
                	auipc	t0, 0x0
                	sd	a2, 0x0(t0)
 
-<.Lpcrel_hi.71>:
+<.Lpcrel_hi.70>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	flw	ft0, 0x0(a0)
@@ -704,35 +1003,35 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
 
-<.Lpcrel_hi.72>:
+<.Lpcrel_hi.71>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	fsw	ft1, 0x0(a0)
 
-<.Lpcrel_hi.73>:
+<.Lpcrel_hi.72>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	fld	ft0, 0x0(a0)
 
-<.Lpcrel_hi.74>:
+<.Lpcrel_hi.73>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
 
-<.Lpcrel_hi.75>:
+<.Lpcrel_hi.74>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fadd.d	ft0, ft1, ft10
 
-<.Lpcrel_hi.76>:
+<.Lpcrel_hi.75>:
                	auipc	a0, 0x0
                	mv	a0, a0
                	fsd	ft0, 0x0(a0)
                	sext.w	a0, a1
                	li	a2, 0x0
                	li	t0, 0x6
-               	bltu	a2, t0, 0x8e8 <.Lpcrel_hi.76+0x20>
-               	j	0x914 <.Lpcrel_hi.76+0x4c>
+               	bltu	a2, t0, 0xd9c <.Lpcrel_hi.75+0x20>
+               	j	0xdc8 <.Lpcrel_hi.75+0x4c>
                	slli	t0, a2, 0x2
                	add	a3, s2, t0
                	lw	a4, 0x0(a3)
@@ -743,7 +1042,7 @@ Disassembly of section .text:
                	sw	a6, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x6
-               	bltu	a2, t0, 0x8e8 <.Lpcrel_hi.76+0x20>
+               	bltu	a2, t0, 0xd9c <.Lpcrel_hi.75+0x20>
                	lhu	a0, 0x0(s3)
                	sext.w	a2, a1
                	addw	a3, a0, a2
@@ -757,17 +1056,17 @@ Disassembly of section .text:
                	mul	a2, a0, t0
                	add	a0, a2, a1
                	sd	a0, 0x0(s5)
-               	addi	a0, s0, -0xa0
+               	addi	a0, s0, -0xb0
                	mv	a2, a0
 
-<.Lpcrel_hi.77>:
+<.Lpcrel_hi.76>:
                	auipc	a3, 0x0
                	mv	a3, a3
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x9c4 <.Lpcrel_hi.77+0x74>
-               	bnez	a4, 0x998 <.Lpcrel_hi.77+0x48>
+               	bltu	a2, a3, 0xe78 <.Lpcrel_hi.76+0x74>
+               	bnez	a4, 0xe4c <.Lpcrel_hi.76+0x48>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -777,8 +1076,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x978 <.Lpcrel_hi.77+0x28>
-               	j	0xa1c <.Lpcrel_hi.77+0xcc>
+               	bne	a7, t0, 0xe2c <.Lpcrel_hi.76+0x28>
+               	j	0xed0 <.Lpcrel_hi.76+0xcc>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	li	a7, 0x10
@@ -788,9 +1087,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x9a4 <.Lpcrel_hi.77+0x54>
-               	j	0xa1c <.Lpcrel_hi.77+0xcc>
-               	bnez	a4, 0x9f4 <.Lpcrel_hi.77+0xa4>
+               	bne	a7, t0, 0xe58 <.Lpcrel_hi.76+0x54>
+               	j	0xed0 <.Lpcrel_hi.76+0xcc>
+               	bnez	a4, 0xea8 <.Lpcrel_hi.76+0xa4>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -800,8 +1099,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x9d4 <.Lpcrel_hi.77+0x84>
-               	j	0xa1c <.Lpcrel_hi.77+0xcc>
+               	bne	a6, t0, 0xe88 <.Lpcrel_hi.76+0x84>
+               	j	0xed0 <.Lpcrel_hi.76+0xcc>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x10
@@ -811,14 +1110,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xa00 <.Lpcrel_hi.77+0xb0>
+               	bne	a3, t0, 0xeb4 <.Lpcrel_hi.76+0xb0>
                	mv	a2, s6
                	mv	a3, a0
                	or	a0, a2, a3
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a2, a3, 0xa90 <.Lpcrel_hi.77+0x140>
-               	bnez	a0, 0xa64 <.Lpcrel_hi.77+0x114>
+               	bltu	a2, a3, 0xf44 <.Lpcrel_hi.76+0x140>
+               	bnez	a0, 0xf18 <.Lpcrel_hi.76+0x114>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -828,8 +1127,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xa44 <.Lpcrel_hi.77+0xf4>
-               	j	0xae8 <.Lpcrel_hi.77+0x198>
+               	bne	a6, t0, 0xef8 <.Lpcrel_hi.76+0xf4>
+               	j	0xf9c <.Lpcrel_hi.76+0x198>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -839,9 +1138,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xa70 <.Lpcrel_hi.77+0x120>
-               	j	0xae8 <.Lpcrel_hi.77+0x198>
-               	bnez	a0, 0xac0 <.Lpcrel_hi.77+0x170>
+               	bne	a6, t0, 0xf24 <.Lpcrel_hi.76+0x120>
+               	j	0xf9c <.Lpcrel_hi.76+0x198>
+               	bnez	a0, 0xf74 <.Lpcrel_hi.76+0x170>
                	mv	a0, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -851,8 +1150,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xaa0 <.Lpcrel_hi.77+0x150>
-               	j	0xae8 <.Lpcrel_hi.77+0x198>
+               	bne	a5, t0, 0xf54 <.Lpcrel_hi.76+0x150>
+               	j	0xf9c <.Lpcrel_hi.76+0x198>
                	mv	a0, a2
                	mv	a2, a3
                	li	a3, 0x10
@@ -862,9 +1161,9 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xacc <.Lpcrel_hi.77+0x17c>
+               	bne	a3, t0, 0xf80 <.Lpcrel_hi.76+0x17c>
                	li	a0, 0x3
-               	bnez	a0, 0xaf4 <.Lpcrel_hi.77+0x1a4>
+               	bnez	a0, 0xfa8 <.Lpcrel_hi.76+0x1a4>
                	ebreak
                	remu	a2, a1, a0
                	slli	t0, a2, 0x1
@@ -872,7 +1171,7 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a0)
                	addiw	a0, a2, 0x64
                	li	a2, 0x3
-               	bnez	a2, 0xb14 <.Lpcrel_hi.77+0x1c4>
+               	bnez	a2, 0xfc8 <.Lpcrel_hi.76+0x1c4>
                	ebreak
                	remu	a3, a1, a2
                	slli	t0, a3, 0x1
@@ -884,13 +1183,13 @@ Disassembly of section .text:
                	sw	a1, 0x0(s8)
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.77+0x1e8>
+               	jalr	ra <.Lpcrel_hi.76+0x1e8>
                	addi	s10, s10, 0x1
                	mv	s9, a0
                	li	t0, 0x5
-               	bltu	s10, t0, 0x7cc <.Lpcrel_hi.54+0x1c>
+               	bltu	s10, t0, 0xc80 <.Lpcrel_hi.53+0x1c>
 
-<.Lpcrel_hi.78>:
+<.Lpcrel_hi.77>:
                	auipc	t0, 0x0
                	ld	a0, 0x0(t0)
                	lui	t0, 0xf9e37
@@ -903,28 +1202,28 @@ Disassembly of section .text:
                	addi	t0, t0, -0x3eb
                	xor	a1, a0, t0
 
-<.Lpcrel_hi.79>:
+<.Lpcrel_hi.78>:
                	auipc	t0, 0x0
                	sd	a1, 0x0(t0)
 
-<.Lpcrel_hi.80>:
+<.Lpcrel_hi.79>:
                	auipc	t0, 0x0
                	ld	a1, 0x0(t0)
                	mv	a0, s9
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.80+0xc>
+               	jalr	ra <.Lpcrel_hi.79+0xc>
                	addi	a1, s0, -0x70
                	addi	a2, s0, -0x80
                	mv	a3, a2
 
-<.Lpcrel_hi.81>:
+<.Lpcrel_hi.80>:
                	auipc	a4, 0x0
                	mv	a4, a4
                	or	a5, a3, a4
                	li	t0, 0x7
                	and	a5, a5, t0
-               	bltu	a3, a4, 0xc18 <.Lpcrel_hi.81+0x74>
-               	bnez	a5, 0xbec <.Lpcrel_hi.81+0x48>
+               	bltu	a3, a4, 0x10cc <.Lpcrel_hi.80+0x74>
+               	bnez	a5, 0x10a0 <.Lpcrel_hi.80+0x48>
                	addi	a6, a3, 0x10
                	addi	a7, a4, 0x10
                	li	t5, 0x10
@@ -934,8 +1233,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a6)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0xbcc <.Lpcrel_hi.81+0x28>
-               	j	0xc70 <.Lpcrel_hi.81+0xcc>
+               	bne	t5, t0, 0x1080 <.Lpcrel_hi.80+0x28>
+               	j	0x1124 <.Lpcrel_hi.80+0xcc>
                	addi	a6, a3, 0x10
                	addi	a7, a4, 0x10
                	li	t5, 0x10
@@ -945,9 +1244,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a6)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0xbf8 <.Lpcrel_hi.81+0x54>
-               	j	0xc70 <.Lpcrel_hi.81+0xcc>
-               	bnez	a5, 0xc48 <.Lpcrel_hi.81+0xa4>
+               	bne	t5, t0, 0x10ac <.Lpcrel_hi.80+0x54>
+               	j	0x1124 <.Lpcrel_hi.80+0xcc>
+               	bnez	a5, 0x10fc <.Lpcrel_hi.80+0xa4>
                	mv	a5, a3
                	mv	a6, a4
                	li	a7, 0x10
@@ -957,8 +1256,8 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xc28 <.Lpcrel_hi.81+0x84>
-               	j	0xc70 <.Lpcrel_hi.81+0xcc>
+               	bne	a7, t0, 0x10dc <.Lpcrel_hi.80+0x84>
+               	j	0x1124 <.Lpcrel_hi.80+0xcc>
                	mv	a5, a3
                	mv	a3, a4
                	li	a4, 0x10
@@ -968,14 +1267,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0xc54 <.Lpcrel_hi.81+0xb0>
+               	bne	a4, t0, 0x1108 <.Lpcrel_hi.80+0xb0>
                	mv	a3, a1
                	mv	a4, a2
                	or	a2, a3, a4
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a3, a4, 0xce4 <.Lpcrel_hi.81+0x140>
-               	bnez	a2, 0xcb8 <.Lpcrel_hi.81+0x114>
+               	bltu	a3, a4, 0x1198 <.Lpcrel_hi.80+0x140>
+               	bnez	a2, 0x116c <.Lpcrel_hi.80+0x114>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -985,8 +1284,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xc98 <.Lpcrel_hi.81+0xf4>
-               	j	0xd3c <.Lpcrel_hi.81+0x198>
+               	bne	a7, t0, 0x114c <.Lpcrel_hi.80+0xf4>
+               	j	0x11f0 <.Lpcrel_hi.80+0x198>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -996,9 +1295,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0xcc4 <.Lpcrel_hi.81+0x120>
-               	j	0xd3c <.Lpcrel_hi.81+0x198>
-               	bnez	a2, 0xd14 <.Lpcrel_hi.81+0x170>
+               	bne	a7, t0, 0x1178 <.Lpcrel_hi.80+0x120>
+               	j	0x11f0 <.Lpcrel_hi.80+0x198>
+               	bnez	a2, 0x11c8 <.Lpcrel_hi.80+0x170>
                	mv	a2, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -1008,8 +1307,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xcf4 <.Lpcrel_hi.81+0x150>
-               	j	0xd3c <.Lpcrel_hi.81+0x198>
+               	bne	a6, t0, 0x11a8 <.Lpcrel_hi.80+0x150>
+               	j	0x11f0 <.Lpcrel_hi.80+0x198>
                	mv	a2, a3
                	mv	a3, a4
                	li	a4, 0x10
@@ -1019,7 +1318,7 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0xd20 <.Lpcrel_hi.81+0x17c>
+               	bne	a4, t0, 0x11d4 <.Lpcrel_hi.80+0x17c>
                	addi	a2, a1, 0x8
                	ld	a3, 0x0(a2)
                	addi	a4, a3, 0x1
@@ -1030,8 +1329,8 @@ Disassembly of section .text:
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0xdc4 <.Lpcrel_hi.81+0x220>
-               	bnez	a1, 0xd98 <.Lpcrel_hi.81+0x1f4>
+               	bltu	a3, a4, 0x1278 <.Lpcrel_hi.80+0x220>
+               	bnez	a1, 0x124c <.Lpcrel_hi.80+0x1f4>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -1041,8 +1340,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xd78 <.Lpcrel_hi.81+0x1d4>
-               	j	0xe1c <.Lpcrel_hi.82>
+               	bne	a7, t0, 0x122c <.Lpcrel_hi.80+0x1d4>
+               	j	0x12d0 <.Lpcrel_hi.81>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -1052,9 +1351,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0xda4 <.Lpcrel_hi.81+0x200>
-               	j	0xe1c <.Lpcrel_hi.82>
-               	bnez	a1, 0xdf4 <.Lpcrel_hi.81+0x250>
+               	bne	a7, t0, 0x1258 <.Lpcrel_hi.80+0x200>
+               	j	0x12d0 <.Lpcrel_hi.81>
+               	bnez	a1, 0x12a8 <.Lpcrel_hi.80+0x250>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -1064,8 +1363,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xdd4 <.Lpcrel_hi.81+0x230>
-               	j	0xe1c <.Lpcrel_hi.82>
+               	bne	a6, t0, 0x1288 <.Lpcrel_hi.80+0x230>
+               	j	0x12d0 <.Lpcrel_hi.81>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x10
@@ -1075,17 +1374,17 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0xe00 <.Lpcrel_hi.81+0x25c>
+               	bne	a4, t0, 0x12b4 <.Lpcrel_hi.80+0x25c>
 
-<.Lpcrel_hi.82>:
+<.Lpcrel_hi.81>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xe94 <.Lpcrel_hi.82+0x78>
-               	bnez	a2, 0xe68 <.Lpcrel_hi.82+0x4c>
+               	bltu	a1, a3, 0x1348 <.Lpcrel_hi.81+0x78>
+               	bnez	a2, 0x131c <.Lpcrel_hi.81+0x4c>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -1095,8 +1394,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xe48 <.Lpcrel_hi.82+0x2c>
-               	j	0xeec <.Lpcrel_hi.83>
+               	bne	a6, t0, 0x12fc <.Lpcrel_hi.81+0x2c>
+               	j	0x13a0 <.Lpcrel_hi.81+0xd0>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	li	a6, 0x10
@@ -1106,9 +1405,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xe74 <.Lpcrel_hi.82+0x58>
-               	j	0xeec <.Lpcrel_hi.83>
-               	bnez	a2, 0xec4 <.Lpcrel_hi.82+0xa8>
+               	bne	a6, t0, 0x1328 <.Lpcrel_hi.81+0x58>
+               	j	0x13a0 <.Lpcrel_hi.81+0xd0>
+               	bnez	a2, 0x1378 <.Lpcrel_hi.81+0xa8>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -1118,8 +1417,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xea4 <.Lpcrel_hi.82+0x88>
-               	j	0xeec <.Lpcrel_hi.83>
+               	bne	a5, t0, 0x1358 <.Lpcrel_hi.81+0x88>
+               	j	0x13a0 <.Lpcrel_hi.81+0xd0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x10
@@ -1129,44 +1428,81 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xed0 <.Lpcrel_hi.82+0xb4>
+               	bne	a3, t0, 0x1384 <.Lpcrel_hi.81+0xb4>
+               	addi	a1, s0, -0xa0
+               	mv	a2, a1
 
-<.Lpcrel_hi.83>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	lhu	a2, 0x0(a1)
-
-<.Lpcrel_hi.84>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	lbu	s1, 0x0(a1)
-
-<.Lpcrel_hi.85>:
-               	auipc	a1, 0x0
-               	mv	a1, a1
-               	ld	s2, 0x0(a1)
+<.Lpcrel_hi.82>:
+               	auipc	a3, 0x0
+               	mv	a3, a3
+               	or	a4, a2, a3
+               	li	t0, 0x7
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0x141c <.Lpcrel_hi.82+0x74>
+               	bnez	a4, 0x13f0 <.Lpcrel_hi.82+0x48>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	t5, 0x0(a6)
+               	sd	t5, 0x0(a5)
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x13d0 <.Lpcrel_hi.82+0x28>
+               	j	0x1474 <.Lpcrel_hi.82+0xcc>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	li	a7, 0x10
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	t5, 0x0(a6)
+               	sb	t5, 0x0(a5)
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x13fc <.Lpcrel_hi.82+0x54>
+               	j	0x1474 <.Lpcrel_hi.82+0xcc>
+               	bnez	a4, 0x144c <.Lpcrel_hi.82+0xa4>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x142c <.Lpcrel_hi.82+0x84>
+               	j	0x1474 <.Lpcrel_hi.82+0xcc>
+               	mv	a4, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1458 <.Lpcrel_hi.82+0xb0>
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
                	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.85+0x10>
-               	mv	a1, s1
+               	jalr	ra <.Lpcrel_hi.82+0xdc>
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.85+0x1c>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.85+0x28>
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.85+0x30>
-               	ld	s1, 0x88(sp)
-               	ld	s2, 0x80(sp)
-               	ld	s3, 0x78(sp)
-               	ld	s4, 0x70(sp)
-               	ld	s5, 0x68(sp)
-               	ld	s6, 0x60(sp)
-               	ld	s7, 0x58(sp)
-               	ld	s8, 0x50(sp)
-               	ld	s9, 0x48(sp)
-               	ld	s10, 0x40(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	jalr	ra <.Lpcrel_hi.82+0xe4>
+               	ld	s1, 0x98(sp)
+               	ld	s2, 0x90(sp)
+               	ld	s3, 0x88(sp)
+               	ld	s4, 0x80(sp)
+               	ld	s5, 0x78(sp)
+               	ld	s6, 0x70(sp)
+               	ld	s7, 0x68(sp)
+               	ld	s8, 0x60(sp)
+               	ld	s9, 0x58(sp)
+               	ld	s10, 0x50(sp)
+               	ld	ra, 0xa8(sp)
+               	ld	s0, 0xa0(sp)
+               	addi	sp, sp, 0xb0
                	ret

--- a/test/golden/riscv64-linux/mem/global_zero.dis
+++ b/test/golden/riscv64-linux/mem/global_zero.dis
@@ -3,239 +3,519 @@ mem/global_zero.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.global_zero.fold_cell>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lhu	a2, 0x0(a1)
-               	addi	a1, s0, -0x2e
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	ld	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_zero.fold_cell+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_zero.fold_cell+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_zero.fold_cell+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1e
+               	lbu	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a4, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.global_zero.fold_cell+0x48>
+               	j	0x7c <corpus.cases.mem.global_zero.fold_cell+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.global_zero.fold_cell+0x48>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.global_zero.fold_cell+0x90>
+               	j	0xc4 <corpus.cases.mem.global_zero.fold_cell+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.global_zero.fold_cell+0x90>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.global_zero.fold_cell+0xd4>
+               	j	0x108 <corpus.cases.mem.global_zero.fold_cell+0x108>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.global_zero.fold_cell+0xd4>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.global_zero.fold_zeros>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	a1, a0
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	sd	s1, 0x38(sp)
+               	sd	s2, 0x30(sp)
+               	sd	s3, 0x28(sp)
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
-               	lbu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x10>
-               	mv	a1, a0
+               	lbu	a1, 0x0(t0)
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x150 <.Lpcrel_hi.0+0x1c>
+               	j	0x184 <.Lpcrel_hi.1>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x150 <.Lpcrel_hi.0+0x1c>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
-               	lhu	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x10>
-               	mv	a1, a0
+               	lhu	a1, 0x0(t0)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a4 <.Lpcrel_hi.1+0x20>
+               	j	0x1d8 <.Lpcrel_hi.2>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a4 <.Lpcrel_hi.1+0x20>
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
-               	lw	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x10>
-               	mv	a1, a0
+               	lw	a1, 0x0(t0)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1f8 <.Lpcrel_hi.2+0x20>
+               	j	0x22c <.Lpcrel_hi.3>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1f8 <.Lpcrel_hi.2+0x20>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x10>
-               	mv	a1, a0
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x244 <.Lpcrel_hi.3+0x18>
+               	j	0x278 <.Lpcrel_hi.4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x244 <.Lpcrel_hi.3+0x18>
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
-               	lw	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.4+0x10>
-               	mv	a1, a0
+               	lw	a1, 0x0(t0)
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x294 <.Lpcrel_hi.4+0x1c>
+               	j	0x2c8 <.Lpcrel_hi.5>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x294 <.Lpcrel_hi.4+0x1c>
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x10>
-               	mv	a1, a0
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <.Lpcrel_hi.5+0x18>
+               	j	0x314 <.Lpcrel_hi.6>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2e0 <.Lpcrel_hi.5+0x18>
 
 <.Lpcrel_hi.6>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x14>
-               	mv	a1, a0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x33c <.Lpcrel_hi.6+0x28>
+               	j	0x370 <.Lpcrel_hi.7>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x33c <.Lpcrel_hi.6+0x28>
 
 <.Lpcrel_hi.7>:
-               	auipc	a2, 0x0
-               	mv	a2, a2
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.7+0x10>
-               	mv	a1, a0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	fld	ft0, 0x0(a1)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x390 <.Lpcrel_hi.7+0x20>
+               	j	0x3c4 <.Lpcrel_hi.8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x390 <.Lpcrel_hi.7+0x20>
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
-               	ld	a2, 0x0(t0)
-               	mv	a0, a1
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.8+0x10>
+               	ld	a1, 0x0(t0)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3dc <.Lpcrel_hi.8+0x18>
+               	j	0x410 <.Lpcrel_hi.9>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3dc <.Lpcrel_hi.8+0x18>
 
 <.Lpcrel_hi.9>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-               	mv	s2, a0
-               	li	s3, 0x0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	s3, t0, 0x1cc <.Lpcrel_hi.9+0x1c>
-               	j	0x1f4 <.Lpcrel_hi.10>
-               	slli	t0, s3, 0x2
-               	add	a0, s1, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x2c>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	bltu	a2, t0, 0x428 <.Lpcrel_hi.9+0x18>
+               	j	0x494 <.Lpcrel_hi.10>
+               	slli	t0, a2, 0x2
+               	add	a3, a1, t0
+               	lw	a4, 0x0(a3)
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	mv	a4, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x450 <.Lpcrel_hi.9+0x40>
+               	j	0x484 <.Lpcrel_hi.9+0x74>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a4, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a4, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x450 <.Lpcrel_hi.9+0x40>
+               	addi	a2, a2, 0x1
+               	mv	a0, a4
                	li	t0, 0x200
-               	bltu	s3, t0, 0x1cc <.Lpcrel_hi.9+0x1c>
+               	bltu	a2, t0, 0x428 <.Lpcrel_hi.9+0x18>
 
 <.Lpcrel_hi.10>:
                	auipc	s1, 0x0
                	mv	s1, s1
+               	mv	s2, a0
                	li	s3, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x20c <.Lpcrel_hi.10+0x18>
-               	j	0x268 <.Lpcrel_hi.11>
+               	bltu	s3, t0, 0x4b0 <.Lpcrel_hi.10+0x1c>
+               	j	0x5b0 <.Lpcrel_hi.11>
                	li	t0, 0x10
                	mul	a0, s3, t0
                	add	a1, s1, a0
-               	mv	a0, a1
-               	lhu	a2, 0x0(a0)
-               	addi	a0, a1, 0x2
-               	lbu	s4, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s5, 0x0(a0)
-               	mv	a0, s2
+               	addi	a0, s0, -0x38
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x534 <.Lpcrel_hi.10+0xa0>
+               	bnez	a1, 0x508 <.Lpcrel_hi.10+0x74>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x4e8 <.Lpcrel_hi.10+0x54>
+               	j	0x58c <.Lpcrel_hi.10+0xf8>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x514 <.Lpcrel_hi.10+0x80>
+               	j	0x58c <.Lpcrel_hi.10+0xf8>
+               	bnez	a1, 0x564 <.Lpcrel_hi.10+0xd0>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x544 <.Lpcrel_hi.10+0xb0>
+               	j	0x58c <.Lpcrel_hi.10+0xf8>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x570 <.Lpcrel_hi.10+0xdc>
+               	ld	a1, 0x0(a0)
+               	ld	a2, 0x8(a0)
+               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x44>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x50>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x5c>
+               	jalr	ra <.Lpcrel_hi.10+0x104>
                	addi	s3, s3, 0x1
                	mv	s2, a0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x20c <.Lpcrel_hi.10+0x18>
+               	bltu	s3, t0, 0x4b0 <.Lpcrel_hi.10+0x1c>
 
 <.Lpcrel_hi.11>:
                	auipc	a0, 0x0
                	mv	a0, a0
-               	mv	a1, a0
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	ld	s3, 0x0(a1)
+               	addi	a1, s0, -0x48
+               	mv	a2, a1
+               	mv	a3, a0
+               	or	a0, a2, a3
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a2, a3, 0x630 <.Lpcrel_hi.11+0x80>
+               	bnez	a0, 0x604 <.Lpcrel_hi.11+0x54>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x5e4 <.Lpcrel_hi.11+0x34>
+               	j	0x688 <.Lpcrel_hi.11+0xd8>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x610 <.Lpcrel_hi.11+0x60>
+               	j	0x688 <.Lpcrel_hi.11+0xd8>
+               	bnez	a0, 0x660 <.Lpcrel_hi.11+0xb0>
+               	mv	a0, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x640 <.Lpcrel_hi.11+0x90>
+               	j	0x688 <.Lpcrel_hi.11+0xd8>
+               	mv	a0, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x66c <.Lpcrel_hi.11+0xbc>
+               	ld	a2, 0x0(a1)
+               	ld	a3, 0x8(a1)
                	mv	a0, s2
                	mv	a1, a2
+               	mv	a2, a3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x28>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x34>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x40>
+               	jalr	ra <.Lpcrel_hi.11+0xec>
 
 <.Lpcrel_hi.12>:
-               	auipc	s1, 0x0
-               	mv	s1, s1
-               	mv	s2, a0
-               	li	s3, 0x0
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x2cc <.Lpcrel_hi.12+0x1c>
-               	j	0x2f4 <.Lpcrel_hi.13>
-               	slli	t0, s3, 0x3
-               	add	a0, s1, t0
-               	ld	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x2c>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	bltu	a2, t0, 0x6bc <.Lpcrel_hi.12+0x18>
+               	j	0x720 <.Lpcrel_hi.13>
+               	slli	t0, a2, 0x3
+               	add	a3, a1, t0
+               	ld	a4, 0x0(a3)
+               	mv	a3, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x6dc <.Lpcrel_hi.12+0x38>
+               	j	0x710 <.Lpcrel_hi.12+0x6c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a3, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x6dc <.Lpcrel_hi.12+0x38>
+               	addi	a2, a2, 0x1
+               	mv	a0, a3
                	li	t0, 0x4
-               	bltu	s3, t0, 0x2cc <.Lpcrel_hi.12+0x1c>
+               	bltu	a2, t0, 0x6bc <.Lpcrel_hi.12+0x18>
 
 <.Lpcrel_hi.13>:
-               	auipc	a0, 0x0
-               	mv	a0, a0
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x10>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	auipc	a1, 0x0
+               	mv	a1, a1
+               	lbu	a2, 0x0(a1)
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x740 <.Lpcrel_hi.13+0x20>
+               	j	0x774 <.Lpcrel_hi.13+0x54>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x740 <.Lpcrel_hi.13+0x20>
+               	ld	s1, 0x38(sp)
+               	ld	s2, 0x30(sp)
+               	ld	s3, 0x28(sp)
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.mem.global_zero.checksum>:
@@ -245,12 +525,16 @@ Disassembly of section .text:
                	addi	s0, sp, 0x50
                	sd	s1, 0x38(sp)
                	mv	s1, a0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_zero.checksum+0x18>
-               	mv	a1, a0
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.global_zero.checksum+0x28>
+               	jalr	ra <corpus.cases.mem.global_zero.checksum+0x38>
                	sext.w	a1, s1
                	li	t1, 0xc8
                	addw	a2, t1, a1
@@ -335,8 +619,8 @@ Disassembly of section .text:
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	a2, t0, 0x468 <.Lpcrel_hi.23+0x18>
-               	j	0x4a0 <.Lpcrel_hi.24>
+               	bltu	a2, t0, 0x8d8 <.Lpcrel_hi.23+0x18>
+               	j	0x910 <.Lpcrel_hi.24>
                	addi	a3, a2, 0x1
                	lui	t1, 0x9e
                	addiw	t1, t1, 0x378
@@ -350,15 +634,15 @@ Disassembly of section .text:
                	sw	a4, 0x0(a5)
                	mv	a2, a3
                	li	t0, 0x200
-               	bltu	a2, t0, 0x468 <.Lpcrel_hi.23+0x18>
+               	bltu	a2, t0, 0x8d8 <.Lpcrel_hi.23+0x18>
 
 <.Lpcrel_hi.24>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	a2, t0, 0x4b8 <.Lpcrel_hi.24+0x18>
-               	j	0x52c <.Lpcrel_hi.25>
+               	bltu	a2, t0, 0x928 <.Lpcrel_hi.24+0x18>
+               	j	0x99c <.Lpcrel_hi.25>
                	li	t0, 0xb
                	mul	a3, a2, t0
                	addi	a4, a3, 0x3
@@ -387,7 +671,7 @@ Disassembly of section .text:
                	addi	a3, a5, 0x8
                	sd	a4, 0x0(a3)
                	li	t0, 0x8
-               	bltu	a2, t0, 0x4b8 <.Lpcrel_hi.24+0x18>
+               	bltu	a2, t0, 0x928 <.Lpcrel_hi.24+0x18>
 
 <.Lpcrel_hi.25>:
                	auipc	a1, 0x0
@@ -398,8 +682,8 @@ Disassembly of section .text:
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x5ac <.Lpcrel_hi.25+0x80>
-               	bnez	a1, 0x580 <.Lpcrel_hi.25+0x54>
+               	bltu	a3, a4, 0xa1c <.Lpcrel_hi.25+0x80>
+               	bnez	a1, 0x9f0 <.Lpcrel_hi.25+0x54>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -409,8 +693,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x560 <.Lpcrel_hi.25+0x34>
-               	j	0x604 <.Lpcrel_hi.26>
+               	bne	a7, t0, 0x9d0 <.Lpcrel_hi.25+0x34>
+               	j	0xa74 <.Lpcrel_hi.26>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	li	a7, 0x10
@@ -420,9 +704,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x58c <.Lpcrel_hi.25+0x60>
-               	j	0x604 <.Lpcrel_hi.26>
-               	bnez	a1, 0x5dc <.Lpcrel_hi.25+0xb0>
+               	bne	a7, t0, 0x9fc <.Lpcrel_hi.25+0x60>
+               	j	0xa74 <.Lpcrel_hi.26>
+               	bnez	a1, 0xa4c <.Lpcrel_hi.25+0xb0>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -432,8 +716,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x5bc <.Lpcrel_hi.25+0x90>
-               	j	0x604 <.Lpcrel_hi.26>
+               	bne	a6, t0, 0xa2c <.Lpcrel_hi.25+0x90>
+               	j	0xa74 <.Lpcrel_hi.26>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x10
@@ -443,7 +727,7 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x5e8 <.Lpcrel_hi.25+0xbc>
+               	bne	a4, t0, 0xa58 <.Lpcrel_hi.25+0xbc>
 
 <.Lpcrel_hi.26>:
                	auipc	a1, 0x0
@@ -453,8 +737,8 @@ Disassembly of section .text:
                	or	a2, a3, a1
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a3, a1, 0x680 <.Lpcrel_hi.26+0x7c>
-               	bnez	a2, 0x654 <.Lpcrel_hi.26+0x50>
+               	bltu	a3, a1, 0xaf0 <.Lpcrel_hi.26+0x7c>
+               	bnez	a2, 0xac4 <.Lpcrel_hi.26+0x50>
                	addi	a4, a3, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -464,8 +748,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x634 <.Lpcrel_hi.26+0x30>
-               	j	0x6d8 <.Lpcrel_hi.27>
+               	bne	a6, t0, 0xaa4 <.Lpcrel_hi.26+0x30>
+               	j	0xb48 <.Lpcrel_hi.27>
                	addi	a4, a3, 0x10
                	addi	a5, a1, 0x10
                	li	a6, 0x10
@@ -475,9 +759,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x660 <.Lpcrel_hi.26+0x5c>
-               	j	0x6d8 <.Lpcrel_hi.27>
-               	bnez	a2, 0x6b0 <.Lpcrel_hi.26+0xac>
+               	bne	a6, t0, 0xad0 <.Lpcrel_hi.26+0x5c>
+               	j	0xb48 <.Lpcrel_hi.27>
+               	bnez	a2, 0xb20 <.Lpcrel_hi.26+0xac>
                	mv	a2, a3
                	mv	a4, a1
                	li	a5, 0x10
@@ -487,8 +771,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x690 <.Lpcrel_hi.26+0x8c>
-               	j	0x6d8 <.Lpcrel_hi.27>
+               	bne	a5, t0, 0xb00 <.Lpcrel_hi.26+0x8c>
+               	j	0xb48 <.Lpcrel_hi.27>
                	mv	a2, a3
                	mv	a3, a1
                	li	a1, 0x10
@@ -498,15 +782,15 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x6bc <.Lpcrel_hi.26+0xb8>
+               	bne	a1, t0, 0xb2c <.Lpcrel_hi.26+0xb8>
 
 <.Lpcrel_hi.27>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0x6f0 <.Lpcrel_hi.27+0x18>
-               	j	0x71c <.Lpcrel_hi.28>
+               	bltu	a2, t0, 0xb60 <.Lpcrel_hi.27+0x18>
+               	j	0xb8c <.Lpcrel_hi.28>
                	addi	a3, a2, 0x1
                	lui	t1, 0x12345
                	addiw	t1, t1, 0x678
@@ -517,7 +801,7 @@ Disassembly of section .text:
                	sd	a5, 0x0(a4)
                	mv	a2, a3
                	li	t0, 0x4
-               	bltu	a2, t0, 0x6f0 <.Lpcrel_hi.27+0x18>
+               	bltu	a2, t0, 0xb60 <.Lpcrel_hi.27+0x18>
 
 <.Lpcrel_hi.28>:
                	auipc	a1, 0x0
@@ -531,20 +815,37 @@ Disassembly of section .text:
                	auipc	a1, 0x0
                	mv	a1, a1
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.29+0x10>
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc8 <.Lpcrel_hi.29+0x24>
+               	j	0xbfc <.Lpcrel_hi.30>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xbc8 <.Lpcrel_hi.29+0x24>
 
 <.Lpcrel_hi.30>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.30+0x10>
+               	jalr	ra <.Lpcrel_hi.30+0x14>
                	addi	a1, s1, 0x1f4
                	li	a2, 0x200
-               	bnez	a2, 0x774 <.Lpcrel_hi.30+0x28>
+               	bnez	a2, 0xc28 <.Lpcrel_hi.30+0x2c>
                	ebreak
                	remu	a3, a1, a2
 
@@ -554,30 +855,33 @@ Disassembly of section .text:
                	slli	t0, a3, 0x2
                	add	a2, a1, t0
                	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.31+0x14>
+               	jalr	ra <.Lpcrel_hi.31+0x20>
 
 <.Lpcrel_hi.32>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x200
-               	bltu	a2, t0, 0x7ac <.Lpcrel_hi.32+0x18>
-               	j	0x7c4 <.Lpcrel_hi.33>
+               	bltu	a2, t0, 0xc6c <.Lpcrel_hi.32+0x18>
+               	j	0xc84 <.Lpcrel_hi.33>
                	slli	t0, a2, 0x2
                	add	a3, a1, t0
                	sw	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x200
-               	bltu	a2, t0, 0x7ac <.Lpcrel_hi.32+0x18>
+               	bltu	a2, t0, 0xc6c <.Lpcrel_hi.32+0x18>
 
 <.Lpcrel_hi.33>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	a2, t0, 0x7dc <.Lpcrel_hi.33+0x18>
-               	j	0x8dc <.Lpcrel_hi.34>
+               	bltu	a2, t0, 0xc9c <.Lpcrel_hi.33+0x18>
+               	j	0xd9c <.Lpcrel_hi.34>
                	addi	a3, s0, -0x38
                	mv	a4, a3
                	sh	zero, 0x0(a4)
@@ -593,8 +897,8 @@ Disassembly of section .text:
                	or	a3, a4, a5
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a4, a5, 0x878 <.Lpcrel_hi.33+0xb4>
-               	bnez	a3, 0x84c <.Lpcrel_hi.33+0x88>
+               	bltu	a4, a5, 0xd38 <.Lpcrel_hi.33+0xb4>
+               	bnez	a3, 0xd0c <.Lpcrel_hi.33+0x88>
                	addi	a6, a4, 0x10
                	addi	a7, a5, 0x10
                	li	t5, 0x10
@@ -604,8 +908,8 @@ Disassembly of section .text:
                	sd	t6, 0x0(a6)
                	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	t5, t0, 0x82c <.Lpcrel_hi.33+0x68>
-               	j	0x8d0 <.Lpcrel_hi.33+0x10c>
+               	bne	t5, t0, 0xcec <.Lpcrel_hi.33+0x68>
+               	j	0xd90 <.Lpcrel_hi.33+0x10c>
                	addi	a6, a4, 0x10
                	addi	a7, a5, 0x10
                	li	t5, 0x10
@@ -615,9 +919,9 @@ Disassembly of section .text:
                	sb	t6, 0x0(a6)
                	addi	t5, t5, -0x1
                	li	t0, 0x0
-               	bne	t5, t0, 0x858 <.Lpcrel_hi.33+0x94>
-               	j	0x8d0 <.Lpcrel_hi.33+0x10c>
-               	bnez	a3, 0x8a8 <.Lpcrel_hi.33+0xe4>
+               	bne	t5, t0, 0xd18 <.Lpcrel_hi.33+0x94>
+               	j	0xd90 <.Lpcrel_hi.33+0x10c>
+               	bnez	a3, 0xd68 <.Lpcrel_hi.33+0xe4>
                	mv	a3, a4
                	mv	a6, a5
                	li	a7, 0x10
@@ -627,8 +931,8 @@ Disassembly of section .text:
                	addi	a6, a6, 0x8
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x888 <.Lpcrel_hi.33+0xc4>
-               	j	0x8d0 <.Lpcrel_hi.33+0x10c>
+               	bne	a7, t0, 0xd48 <.Lpcrel_hi.33+0xc4>
+               	j	0xd90 <.Lpcrel_hi.33+0x10c>
                	mv	a3, a4
                	mv	a4, a5
                	li	a5, 0x10
@@ -638,10 +942,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x1
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x8b4 <.Lpcrel_hi.33+0xf0>
+               	bne	a5, t0, 0xd74 <.Lpcrel_hi.33+0xf0>
                	addi	a2, a2, 0x1
                	li	t0, 0x8
-               	bltu	a2, t0, 0x7dc <.Lpcrel_hi.33+0x18>
+               	bltu	a2, t0, 0xc9c <.Lpcrel_hi.33+0x18>
 
 <.Lpcrel_hi.34>:
                	auipc	t0, 0x0
@@ -696,8 +1000,8 @@ Disassembly of section .text:
                	or	a1, a3, a2
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a2, 0x9c4 <.Lpcrel_hi.43+0x7c>
-               	bnez	a1, 0x998 <.Lpcrel_hi.43+0x50>
+               	bltu	a3, a2, 0xe84 <.Lpcrel_hi.43+0x7c>
+               	bnez	a1, 0xe58 <.Lpcrel_hi.43+0x50>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -707,8 +1011,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x978 <.Lpcrel_hi.43+0x30>
-               	j	0xa1c <.Lpcrel_hi.44>
+               	bne	a6, t0, 0xe38 <.Lpcrel_hi.43+0x30>
+               	j	0xedc <.Lpcrel_hi.44>
                	addi	a4, a3, 0x10
                	addi	a5, a2, 0x10
                	li	a6, 0x10
@@ -718,9 +1022,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x9a4 <.Lpcrel_hi.43+0x5c>
-               	j	0xa1c <.Lpcrel_hi.44>
-               	bnez	a1, 0x9f4 <.Lpcrel_hi.43+0xac>
+               	bne	a6, t0, 0xe64 <.Lpcrel_hi.43+0x5c>
+               	j	0xedc <.Lpcrel_hi.44>
+               	bnez	a1, 0xeb4 <.Lpcrel_hi.43+0xac>
                	mv	a1, a3
                	mv	a4, a2
                	li	a5, 0x10
@@ -730,8 +1034,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x9d4 <.Lpcrel_hi.43+0x8c>
-               	j	0xa1c <.Lpcrel_hi.44>
+               	bne	a5, t0, 0xe94 <.Lpcrel_hi.43+0x8c>
+               	j	0xedc <.Lpcrel_hi.44>
                	mv	a1, a3
                	mv	a3, a2
                	li	a2, 0x10
@@ -741,21 +1045,21 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0xa00 <.Lpcrel_hi.43+0xb8>
+               	bne	a2, t0, 0xec0 <.Lpcrel_hi.43+0xb8>
 
 <.Lpcrel_hi.44>:
                	auipc	a1, 0x0
                	mv	a1, a1
                	li	a2, 0x0
                	li	t0, 0x4
-               	bltu	a2, t0, 0xa34 <.Lpcrel_hi.44+0x18>
-               	j	0xa4c <.Lpcrel_hi.45>
+               	bltu	a2, t0, 0xef4 <.Lpcrel_hi.44+0x18>
+               	j	0xf0c <.Lpcrel_hi.45>
                	slli	t0, a2, 0x3
                	add	a3, a1, t0
                	sd	zero, 0x0(a3)
                	addi	a2, a2, 0x1
                	li	t0, 0x4
-               	bltu	a2, t0, 0xa34 <.Lpcrel_hi.44+0x18>
+               	bltu	a2, t0, 0xef4 <.Lpcrel_hi.44+0x18>
 
 <.Lpcrel_hi.45>:
                	auipc	a1, 0x0

--- a/test/golden/riscv64-linux/mem/loadstore.dis
+++ b/test/golden/riscv64-linux/mem/loadstore.dis
@@ -3,83 +3,179 @@ mem/loadstore.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.loadstore.fold_packed>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	lbu	a4, 0x0(a3)
-               	addi	a3, a1, 0x1
-               	lbu	s1, 0x0(a3)
-               	addi	a3, a1, 0x2
-               	lbu	s2, 0x0(a3)
-               	addi	a3, a1, 0x3
-               	lbu	s3, 0x0(a3)
-               	addi	a3, a1, 0x4
-               	lhu	s4, 0x0(a3)
-               	addi	a3, a1, 0x6
-               	lhu	s5, 0x0(a3)
-               	addi	a3, a1, 0x8
-               	lw	s6, 0x0(a3)
-               	addi	a3, a1, 0x10
-               	ld	s7, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0x78>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0x8c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0xa0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0xb4>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0xc8>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0xdc>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0xf0>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.fold_packed+0x104>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a5, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a6, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lhu	a7, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lhu	t5, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lw	t6, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	ld	a1, 0x0(a2)
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.mem.loadstore.fold_packed+0x6c>
+               	j	0xa0 <corpus.cases.mem.loadstore.fold_packed+0xa0>
+               	li	t0, 0x8
+               	mul	s1, a3, t0
+               	srl	s2, a2, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, a0, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s2, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.mem.loadstore.fold_packed+0x6c>
+               	zext.b	a2, a4
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb4 <corpus.cases.mem.loadstore.fold_packed+0xb4>
+               	j	0xe8 <corpus.cases.mem.loadstore.fold_packed+0xe8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	s1, a2, a4
+               	li	t0, 0xff
+               	and	a4, s1, t0
+               	xor	s1, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s1, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb4 <corpus.cases.mem.loadstore.fold_packed+0xb4>
+               	zext.b	a2, a5
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xfc <corpus.cases.mem.loadstore.fold_packed+0xfc>
+               	j	0x130 <corpus.cases.mem.loadstore.fold_packed+0x130>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xfc <corpus.cases.mem.loadstore.fold_packed+0xfc>
+               	zext.b	a2, a6
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x144 <corpus.cases.mem.loadstore.fold_packed+0x144>
+               	j	0x178 <corpus.cases.mem.loadstore.fold_packed+0x178>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x144 <corpus.cases.mem.loadstore.fold_packed+0x144>
+               	slli	a2, a7, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x190 <corpus.cases.mem.loadstore.fold_packed+0x190>
+               	j	0x1c4 <corpus.cases.mem.loadstore.fold_packed+0x1c4>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x190 <corpus.cases.mem.loadstore.fold_packed+0x190>
+               	slli	a2, t5, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1dc <corpus.cases.mem.loadstore.fold_packed+0x1dc>
+               	j	0x210 <corpus.cases.mem.loadstore.fold_packed+0x210>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1dc <corpus.cases.mem.loadstore.fold_packed+0x1dc>
+               	slli	a2, t6, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x228 <corpus.cases.mem.loadstore.fold_packed+0x228>
+               	j	0x25c <corpus.cases.mem.loadstore.fold_packed+0x25c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x228 <corpus.cases.mem.loadstore.fold_packed+0x228>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x26c <corpus.cases.mem.loadstore.fold_packed+0x26c>
+               	j	0x2a0 <corpus.cases.mem.loadstore.fold_packed+0x2a0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x26c <corpus.cases.mem.loadstore.fold_packed+0x26c>
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.loadstore.checksum>:
@@ -94,91 +190,37 @@ Disassembly of section .text:
                	sd	s5, 0xd8(sp)
                	sd	s6, 0xd0(sp)
                	sd	s7, 0xc8(sp)
-               	sd	s8, 0xc0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x34>
-               	addi	s2, s0, -0x68
-               	mv	a1, s2
+               	addi	s2, s0, -0xa0
+               	mv	a0, s2
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x1a8 <corpus.cases.mem.loadstore.checksum+0x70>
-               	mv	a2, a1
-               	li	a3, 0x18
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x31c <corpus.cases.mem.loadstore.checksum+0x64>
+               	mv	a1, a0
+               	li	a2, 0x18
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x190 <corpus.cases.mem.loadstore.checksum+0x58>
-               	j	0x1c4 <corpus.cases.mem.loadstore.checksum+0x8c>
-               	mv	a2, a1
-               	li	a1, 0x18
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x304 <corpus.cases.mem.loadstore.checksum+0x4c>
+               	j	0x338 <corpus.cases.mem.loadstore.checksum+0x80>
+               	mv	a1, a0
+               	li	a0, 0x18
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1b0 <corpus.cases.mem.loadstore.checksum+0x78>
-               	addi	a1, s0, -0x80
-               	mv	a2, a1
-               	mv	a3, s2
-               	or	a4, a2, a3
+               	bne	a0, t0, 0x324 <corpus.cases.mem.loadstore.checksum+0x6c>
+               	addi	a0, s0, -0xb8
+               	mv	a1, a0
+               	mv	a2, s2
+               	or	a3, a1, a2
                	li	t0, 0x7
-               	and	a4, a4, t0
-               	bltu	a2, a3, 0x23c <corpus.cases.mem.loadstore.checksum+0x104>
-               	bnez	a4, 0x210 <corpus.cases.mem.loadstore.checksum+0xd8>
+               	and	a3, a3, t0
+               	bltu	a1, a2, 0x3b0 <corpus.cases.mem.loadstore.checksum+0xf8>
+               	bnez	a3, 0x384 <corpus.cases.mem.loadstore.checksum+0xcc>
+               	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
-               	addi	a6, a3, 0x18
-               	li	a7, 0x18
-               	addi	a5, a5, -0x8
-               	addi	a6, a6, -0x8
-               	ld	t5, 0x0(a6)
-               	sd	t5, 0x0(a5)
-               	addi	a7, a7, -0x8
-               	li	t0, 0x0
-               	bne	a7, t0, 0x1f0 <corpus.cases.mem.loadstore.checksum+0xb8>
-               	j	0x294 <corpus.cases.mem.loadstore.checksum+0x15c>
-               	addi	a5, a2, 0x18
-               	addi	a6, a3, 0x18
-               	li	a7, 0x18
-               	addi	a5, a5, -0x1
-               	addi	a6, a6, -0x1
-               	lbu	t5, 0x0(a6)
-               	sb	t5, 0x0(a5)
-               	addi	a7, a7, -0x1
-               	li	t0, 0x0
-               	bne	a7, t0, 0x21c <corpus.cases.mem.loadstore.checksum+0xe4>
-               	j	0x294 <corpus.cases.mem.loadstore.checksum+0x15c>
-               	bnez	a4, 0x26c <corpus.cases.mem.loadstore.checksum+0x134>
-               	mv	a4, a2
-               	mv	a5, a3
-               	li	a6, 0x18
-               	ld	a7, 0x0(a5)
-               	sd	a7, 0x0(a4)
-               	addi	a4, a4, 0x8
-               	addi	a5, a5, 0x8
-               	addi	a6, a6, -0x8
-               	li	t0, 0x0
-               	bne	a6, t0, 0x24c <corpus.cases.mem.loadstore.checksum+0x114>
-               	j	0x294 <corpus.cases.mem.loadstore.checksum+0x15c>
-               	mv	a4, a2
-               	mv	a2, a3
-               	li	a3, 0x18
-               	lbu	a5, 0x0(a2)
-               	sb	a5, 0x0(a4)
-               	addi	a4, a4, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
-               	li	t0, 0x0
-               	bne	a3, t0, 0x278 <corpus.cases.mem.loadstore.checksum+0x140>
-               	addi	a2, s0, -0x98
-               	mv	a3, a1
-               	or	a1, a2, a3
-               	li	t0, 0x7
-               	and	a1, a1, t0
-               	bltu	a2, a3, 0x308 <corpus.cases.mem.loadstore.checksum+0x1d0>
-               	bnez	a1, 0x2dc <corpus.cases.mem.loadstore.checksum+0x1a4>
-               	addi	a4, a2, 0x18
-               	addi	a5, a3, 0x18
                	li	a6, 0x18
                	addi	a4, a4, -0x8
                	addi	a5, a5, -0x8
@@ -186,10 +228,10 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2bc <corpus.cases.mem.loadstore.checksum+0x184>
-               	j	0x360 <corpus.cases.mem.loadstore.checksum+0x228>
-               	addi	a4, a2, 0x18
-               	addi	a5, a3, 0x18
+               	bne	a6, t0, 0x364 <corpus.cases.mem.loadstore.checksum+0xac>
+               	j	0x408 <corpus.cases.mem.loadstore.checksum+0x150>
+               	addi	a4, a1, 0x18
+               	addi	a5, a2, 0x18
                	li	a6, 0x18
                	addi	a4, a4, -0x1
                	addi	a5, a5, -0x1
@@ -197,33 +239,92 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2e8 <corpus.cases.mem.loadstore.checksum+0x1b0>
-               	j	0x360 <corpus.cases.mem.loadstore.checksum+0x228>
-               	bnez	a1, 0x338 <corpus.cases.mem.loadstore.checksum+0x200>
-               	mv	a1, a2
-               	mv	a4, a3
+               	bne	a6, t0, 0x390 <corpus.cases.mem.loadstore.checksum+0xd8>
+               	j	0x408 <corpus.cases.mem.loadstore.checksum+0x150>
+               	bnez	a3, 0x3e0 <corpus.cases.mem.loadstore.checksum+0x128>
+               	mv	a3, a1
+               	mv	a4, a2
                	li	a5, 0x18
                	ld	a6, 0x0(a4)
-               	sd	a6, 0x0(a1)
-               	addi	a1, a1, 0x8
+               	sd	a6, 0x0(a3)
+               	addi	a3, a3, 0x8
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x318 <corpus.cases.mem.loadstore.checksum+0x1e0>
-               	j	0x360 <corpus.cases.mem.loadstore.checksum+0x228>
+               	bne	a5, t0, 0x3c0 <corpus.cases.mem.loadstore.checksum+0x108>
+               	j	0x408 <corpus.cases.mem.loadstore.checksum+0x150>
+               	mv	a3, a1
                	mv	a1, a2
-               	mv	a2, a3
-               	li	a3, 0x18
-               	lbu	a4, 0x0(a2)
-               	sb	a4, 0x0(a1)
+               	li	a2, 0x18
+               	lbu	a4, 0x0(a1)
+               	sb	a4, 0x0(a3)
+               	addi	a3, a3, 0x1
                	addi	a1, a1, 0x1
-               	addi	a2, a2, 0x1
-               	addi	a3, a3, -0x1
+               	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x344 <corpus.cases.mem.loadstore.checksum+0x20c>
-               	addi	a1, s0, -0x98
+               	bne	a2, t0, 0x3ec <corpus.cases.mem.loadstore.checksum+0x134>
+               	addi	a1, s0, -0xd0
+               	mv	a2, a0
+               	or	a0, a1, a2
+               	li	t0, 0x7
+               	and	a0, a0, t0
+               	bltu	a1, a2, 0x47c <corpus.cases.mem.loadstore.checksum+0x1c4>
+               	bnez	a0, 0x450 <corpus.cases.mem.loadstore.checksum+0x198>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x8
+               	addi	a4, a4, -0x8
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a3)
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x430 <corpus.cases.mem.loadstore.checksum+0x178>
+               	j	0x4d4 <corpus.cases.mem.loadstore.checksum+0x21c>
+               	addi	a3, a1, 0x18
+               	addi	a4, a2, 0x18
+               	li	a5, 0x18
+               	addi	a3, a3, -0x1
+               	addi	a4, a4, -0x1
+               	lbu	a6, 0x0(a4)
+               	sb	a6, 0x0(a3)
+               	addi	a5, a5, -0x1
+               	li	t0, 0x0
+               	bne	a5, t0, 0x45c <corpus.cases.mem.loadstore.checksum+0x1a4>
+               	j	0x4d4 <corpus.cases.mem.loadstore.checksum+0x21c>
+               	bnez	a0, 0x4ac <corpus.cases.mem.loadstore.checksum+0x1f4>
+               	mv	a0, a1
+               	mv	a3, a2
+               	li	a4, 0x18
+               	ld	a5, 0x0(a3)
+               	sd	a5, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a3, a3, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x48c <corpus.cases.mem.loadstore.checksum+0x1d4>
+               	j	0x4d4 <corpus.cases.mem.loadstore.checksum+0x21c>
+               	mv	a0, a1
+               	mv	a1, a2
+               	li	a2, 0x18
+               	lbu	a3, 0x0(a1)
+               	sb	a3, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, -0x1
+               	li	t0, 0x0
+               	bne	a2, t0, 0x4b8 <corpus.cases.mem.loadstore.checksum+0x200>
+               	addi	a1, s0, -0xd0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x22c>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x240>
                	lui	t1, 0xffedd
                	addiw	t1, t1, -0x456
                	slli	t1, t1, 0xc
@@ -260,14 +361,14 @@ Disassembly of section .text:
                	sw	a1, 0x0(a2)
                	addi	a1, s2, 0x10
                	sd	s3, 0x0(a1)
-               	addi	a1, s0, -0xb0
+               	addi	a1, s0, -0xe8
                	mv	a2, a1
                	mv	a3, s2
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x474 <corpus.cases.mem.loadstore.checksum+0x33c>
-               	bnez	a4, 0x448 <corpus.cases.mem.loadstore.checksum+0x310>
+               	bltu	a2, a3, 0x608 <corpus.cases.mem.loadstore.checksum+0x350>
+               	bnez	a4, 0x5dc <corpus.cases.mem.loadstore.checksum+0x324>
                	addi	a5, a2, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -277,8 +378,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x428 <corpus.cases.mem.loadstore.checksum+0x2f0>
-               	j	0x4cc <corpus.cases.mem.loadstore.checksum+0x394>
+               	bne	a7, t0, 0x5bc <corpus.cases.mem.loadstore.checksum+0x304>
+               	j	0x660 <corpus.cases.mem.loadstore.checksum+0x3a8>
                	addi	a5, a2, 0x18
                	addi	a6, a3, 0x18
                	li	a7, 0x18
@@ -288,9 +389,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x454 <corpus.cases.mem.loadstore.checksum+0x31c>
-               	j	0x4cc <corpus.cases.mem.loadstore.checksum+0x394>
-               	bnez	a4, 0x4a4 <corpus.cases.mem.loadstore.checksum+0x36c>
+               	bne	a7, t0, 0x5e8 <corpus.cases.mem.loadstore.checksum+0x330>
+               	j	0x660 <corpus.cases.mem.loadstore.checksum+0x3a8>
+               	bnez	a4, 0x638 <corpus.cases.mem.loadstore.checksum+0x380>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x18
@@ -300,8 +401,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x484 <corpus.cases.mem.loadstore.checksum+0x34c>
-               	j	0x4cc <corpus.cases.mem.loadstore.checksum+0x394>
+               	bne	a6, t0, 0x618 <corpus.cases.mem.loadstore.checksum+0x360>
+               	j	0x660 <corpus.cases.mem.loadstore.checksum+0x3a8>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x18
@@ -311,14 +412,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x4b0 <corpus.cases.mem.loadstore.checksum+0x378>
-               	addi	a2, s0, -0xc8
+               	bne	a3, t0, 0x644 <corpus.cases.mem.loadstore.checksum+0x38c>
+               	addi	a2, s0, -0x100
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x540 <corpus.cases.mem.loadstore.checksum+0x408>
-               	bnez	a1, 0x514 <corpus.cases.mem.loadstore.checksum+0x3dc>
+               	bltu	a2, a3, 0x6d4 <corpus.cases.mem.loadstore.checksum+0x41c>
+               	bnez	a1, 0x6a8 <corpus.cases.mem.loadstore.checksum+0x3f0>
                	addi	a4, a2, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -328,8 +429,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x4f4 <corpus.cases.mem.loadstore.checksum+0x3bc>
-               	j	0x598 <corpus.cases.mem.loadstore.checksum+0x460>
+               	bne	a6, t0, 0x688 <corpus.cases.mem.loadstore.checksum+0x3d0>
+               	j	0x72c <corpus.cases.mem.loadstore.checksum+0x474>
                	addi	a4, a2, 0x18
                	addi	a5, a3, 0x18
                	li	a6, 0x18
@@ -339,9 +440,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x520 <corpus.cases.mem.loadstore.checksum+0x3e8>
-               	j	0x598 <corpus.cases.mem.loadstore.checksum+0x460>
-               	bnez	a1, 0x570 <corpus.cases.mem.loadstore.checksum+0x438>
+               	bne	a6, t0, 0x6b4 <corpus.cases.mem.loadstore.checksum+0x3fc>
+               	j	0x72c <corpus.cases.mem.loadstore.checksum+0x474>
+               	bnez	a1, 0x704 <corpus.cases.mem.loadstore.checksum+0x44c>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x18
@@ -351,8 +452,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x550 <corpus.cases.mem.loadstore.checksum+0x418>
-               	j	0x598 <corpus.cases.mem.loadstore.checksum+0x460>
+               	bne	a5, t0, 0x6e4 <corpus.cases.mem.loadstore.checksum+0x42c>
+               	j	0x72c <corpus.cases.mem.loadstore.checksum+0x474>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x18
@@ -362,15 +463,15 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x57c <corpus.cases.mem.loadstore.checksum+0x444>
-               	addi	a1, s0, -0xc8
+               	bne	a3, t0, 0x710 <corpus.cases.mem.loadstore.checksum+0x458>
+               	addi	a1, s0, -0x100
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x464>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x478>
                	mv	s4, a0
                	li	s5, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0x5b8 <corpus.cases.mem.loadstore.checksum+0x480>
-               	j	0x7ac <corpus.cases.mem.loadstore.checksum+0x674>
+               	bltu	s5, t0, 0x74c <corpus.cases.mem.loadstore.checksum+0x494>
+               	j	0x940 <corpus.cases.mem.loadstore.checksum+0x688>
                	addi	s6, s5, 0x1
                	mul	a0, s3, s6
                	add	a1, a0, s1
@@ -385,14 +486,14 @@ Disassembly of section .text:
                	sext.w	a1, a0
                	addi	a0, s2, 0x8
                	sw	a1, 0x0(a0)
-               	addi	a0, s0, -0xe0
+               	addi	a0, s0, -0x60
                	mv	a1, a0
                	mv	a2, s2
                	or	a3, a1, a2
                	li	t0, 0x7
                	and	a3, a3, t0
-               	bltu	a1, a2, 0x668 <corpus.cases.mem.loadstore.checksum+0x530>
-               	bnez	a3, 0x63c <corpus.cases.mem.loadstore.checksum+0x504>
+               	bltu	a1, a2, 0x7fc <corpus.cases.mem.loadstore.checksum+0x544>
+               	bnez	a3, 0x7d0 <corpus.cases.mem.loadstore.checksum+0x518>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -402,8 +503,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x61c <corpus.cases.mem.loadstore.checksum+0x4e4>
-               	j	0x6c0 <corpus.cases.mem.loadstore.checksum+0x588>
+               	bne	a6, t0, 0x7b0 <corpus.cases.mem.loadstore.checksum+0x4f8>
+               	j	0x854 <corpus.cases.mem.loadstore.checksum+0x59c>
                	addi	a4, a1, 0x18
                	addi	a5, a2, 0x18
                	li	a6, 0x18
@@ -413,9 +514,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x648 <corpus.cases.mem.loadstore.checksum+0x510>
-               	j	0x6c0 <corpus.cases.mem.loadstore.checksum+0x588>
-               	bnez	a3, 0x698 <corpus.cases.mem.loadstore.checksum+0x560>
+               	bne	a6, t0, 0x7dc <corpus.cases.mem.loadstore.checksum+0x524>
+               	j	0x854 <corpus.cases.mem.loadstore.checksum+0x59c>
+               	bnez	a3, 0x82c <corpus.cases.mem.loadstore.checksum+0x574>
                	mv	a3, a1
                	mv	a4, a2
                	li	a5, 0x18
@@ -425,8 +526,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x678 <corpus.cases.mem.loadstore.checksum+0x540>
-               	j	0x6c0 <corpus.cases.mem.loadstore.checksum+0x588>
+               	bne	a5, t0, 0x80c <corpus.cases.mem.loadstore.checksum+0x554>
+               	j	0x854 <corpus.cases.mem.loadstore.checksum+0x59c>
                	mv	a3, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -436,14 +537,14 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x6a4 <corpus.cases.mem.loadstore.checksum+0x56c>
-               	addi	a1, s0, -0xf8
+               	bne	a2, t0, 0x838 <corpus.cases.mem.loadstore.checksum+0x580>
+               	addi	a1, s0, -0x78
                	mv	a2, a0
                	or	a0, a1, a2
                	li	t0, 0x7
                	and	a0, a0, t0
-               	bltu	a1, a2, 0x734 <corpus.cases.mem.loadstore.checksum+0x5fc>
-               	bnez	a0, 0x708 <corpus.cases.mem.loadstore.checksum+0x5d0>
+               	bltu	a1, a2, 0x8c8 <corpus.cases.mem.loadstore.checksum+0x610>
+               	bnez	a0, 0x89c <corpus.cases.mem.loadstore.checksum+0x5e4>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -453,8 +554,8 @@ Disassembly of section .text:
                	sd	a6, 0x0(a3)
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x6e8 <corpus.cases.mem.loadstore.checksum+0x5b0>
-               	j	0x78c <corpus.cases.mem.loadstore.checksum+0x654>
+               	bne	a5, t0, 0x87c <corpus.cases.mem.loadstore.checksum+0x5c4>
+               	j	0x920 <corpus.cases.mem.loadstore.checksum+0x668>
                	addi	a3, a1, 0x18
                	addi	a4, a2, 0x18
                	li	a5, 0x18
@@ -464,9 +565,9 @@ Disassembly of section .text:
                	sb	a6, 0x0(a3)
                	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x714 <corpus.cases.mem.loadstore.checksum+0x5dc>
-               	j	0x78c <corpus.cases.mem.loadstore.checksum+0x654>
-               	bnez	a0, 0x764 <corpus.cases.mem.loadstore.checksum+0x62c>
+               	bne	a5, t0, 0x8a8 <corpus.cases.mem.loadstore.checksum+0x5f0>
+               	j	0x920 <corpus.cases.mem.loadstore.checksum+0x668>
+               	bnez	a0, 0x8f8 <corpus.cases.mem.loadstore.checksum+0x640>
                	mv	a0, a1
                	mv	a3, a2
                	li	a4, 0x18
@@ -476,8 +577,8 @@ Disassembly of section .text:
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x744 <corpus.cases.mem.loadstore.checksum+0x60c>
-               	j	0x78c <corpus.cases.mem.loadstore.checksum+0x654>
+               	bne	a4, t0, 0x8d8 <corpus.cases.mem.loadstore.checksum+0x620>
+               	j	0x920 <corpus.cases.mem.loadstore.checksum+0x668>
                	mv	a0, a1
                	mv	a1, a2
                	li	a2, 0x18
@@ -487,20 +588,20 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a2, a2, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x770 <corpus.cases.mem.loadstore.checksum+0x638>
-               	addi	a1, s0, -0xf8
+               	bne	a2, t0, 0x904 <corpus.cases.mem.loadstore.checksum+0x64c>
+               	addi	a1, s0, -0x78
                	mv	a0, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x65c>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x670>
                	mv	s4, a0
                	mv	s5, s6
                	li	t0, 0x8
-               	bltu	s5, t0, 0x5b8 <corpus.cases.mem.loadstore.checksum+0x480>
+               	bltu	s5, t0, 0x74c <corpus.cases.mem.loadstore.checksum+0x494>
                	li	s2, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x7bc <corpus.cases.mem.loadstore.checksum+0x684>
-               	j	0x894 <corpus.cases.mem.loadstore.checksum+0x75c>
-               	addi	s2, s2, 0x1
+               	bltu	s2, t0, 0x950 <corpus.cases.mem.loadstore.checksum+0x698>
+               	j	0xb60 <corpus.cases.mem.loadstore.checksum+0x8a8>
+               	addi	a0, s2, 0x1
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -509,101 +610,195 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	mul	a0, t1, s2
-               	add	s5, a0, s1
-               	sext.w	s6, s5
-               	srli	a0, s5, 0x8
-               	sext.w	s7, a0
-               	srli	a0, s5, 0x10
-               	sext.w	s8, a0
-               	mv	a0, s4
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x6cc>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x6d8>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x6e4>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x6f0>
-               	slli	a1, s6, 0x38
+               	mul	a1, t1, a0
+               	add	a0, a1, s1
+               	sext.w	s5, a0
+               	srli	a1, a0, 0x8
+               	sext.w	s6, a1
+               	srli	a1, a0, 0x10
+               	sext.w	s7, a1
+               	slli	a1, s5, 0x38
                	srai	a1, a1, 0x38
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x700>
-               	slli	a1, s7, 0x30
+               	mv	a2, s4
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9ac <corpus.cases.mem.loadstore.checksum+0x6f4>
+               	j	0x9e0 <corpus.cases.mem.loadstore.checksum+0x728>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9ac <corpus.cases.mem.loadstore.checksum+0x6f4>
+               	slli	a1, s6, 0x30
                	srai	a1, a1, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9f8 <corpus.cases.mem.loadstore.checksum+0x740>
+               	j	0xa2c <corpus.cases.mem.loadstore.checksum+0x774>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x9f8 <corpus.cases.mem.loadstore.checksum+0x740>
+               	sext.w	a1, s7
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa40 <corpus.cases.mem.loadstore.checksum+0x788>
+               	j	0xa74 <corpus.cases.mem.loadstore.checksum+0x7bc>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa40 <corpus.cases.mem.loadstore.checksum+0x788>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa84 <corpus.cases.mem.loadstore.checksum+0x7cc>
+               	j	0xab8 <corpus.cases.mem.loadstore.checksum+0x800>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa84 <corpus.cases.mem.loadstore.checksum+0x7cc>
+               	slli	a0, s5, 0x38
+               	srai	a0, a0, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xad0 <corpus.cases.mem.loadstore.checksum+0x818>
+               	j	0xb04 <corpus.cases.mem.loadstore.checksum+0x84c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xad0 <corpus.cases.mem.loadstore.checksum+0x818>
+               	slli	a1, s6, 0x30
+               	srai	a1, a1, 0x30
+               	mv	a0, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x710>
-               	sext.w	a1, s8
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x858>
+               	sext.w	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x71c>
-               	zext.b	a1, s6
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x864>
+               	zext.b	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x728>
-               	slli	a1, s7, 0x30
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x870>
+               	slli	a1, s6, 0x30
                	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x738>
-               	slli	a1, s8, 0x20
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x880>
+               	slli	a1, s7, 0x20
                	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x748>
-               	mv	s4, a0
-               	li	t0, 0x6
-               	bltu	s2, t0, 0x7bc <corpus.cases.mem.loadstore.checksum+0x684>
-               	addi	s1, s0, -0x108
-               	mv	a0, s1
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x8c8 <corpus.cases.mem.loadstore.checksum+0x790>
-               	mv	a1, a0
-               	li	a2, 0x10
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x8b0 <corpus.cases.mem.loadstore.checksum+0x778>
-               	j	0x8e4 <corpus.cases.mem.loadstore.checksum+0x7ac>
-               	mv	a1, a0
-               	li	a0, 0x10
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x8d0 <corpus.cases.mem.loadstore.checksum+0x798>
-               	li	a0, 0x0
-               	li	t0, 0x10
-               	bltu	a0, t0, 0x8f4 <corpus.cases.mem.loadstore.checksum+0x7bc>
-               	j	0x928 <corpus.cases.mem.loadstore.checksum+0x7f0>
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	li	t0, 0x8
-               	mul	a2, a1, t0
-               	srl	a1, s3, a2
-               	sext.w	a2, a1
-               	sext.w	a1, a0
-               	addw	a3, a2, a1
-               	add	a1, s1, a0
-               	sb	a3, 0x0(a1)
-               	addi	a0, a0, 0x1
-               	li	t0, 0x10
-               	bltu	a0, t0, 0x8f4 <corpus.cases.mem.loadstore.checksum+0x7bc>
-               	li	s2, 0x0
-               	li	t0, 0x10
-               	bltu	s2, t0, 0x938 <corpus.cases.mem.loadstore.checksum+0x800>
-               	j	0x95c <corpus.cases.mem.loadstore.checksum+0x824>
-               	add	a0, s1, s2
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x80c>
+               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x890>
                	addi	s2, s2, 0x1
                	mv	s4, a0
+               	li	t0, 0x6
+               	bltu	s2, t0, 0x950 <corpus.cases.mem.loadstore.checksum+0x698>
+               	addi	a0, s0, -0x88
+               	mv	a1, a0
+               	li	t0, 0x7
+               	and	a2, a1, t0
+               	bnez	a2, 0xb94 <corpus.cases.mem.loadstore.checksum+0x8dc>
+               	mv	a2, a1
+               	li	a3, 0x10
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
+               	li	t0, 0x0
+               	bne	a3, t0, 0xb7c <corpus.cases.mem.loadstore.checksum+0x8c4>
+               	j	0xbb0 <corpus.cases.mem.loadstore.checksum+0x8f8>
+               	mv	a2, a1
+               	li	a1, 0x10
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0xb9c <corpus.cases.mem.loadstore.checksum+0x8e4>
+               	li	a1, 0x0
                	li	t0, 0x10
-               	bltu	s2, t0, 0x938 <corpus.cases.mem.loadstore.checksum+0x800>
+               	bltu	a1, t0, 0xbc0 <corpus.cases.mem.loadstore.checksum+0x908>
+               	j	0xbf4 <corpus.cases.mem.loadstore.checksum+0x93c>
+               	li	t0, 0x7
+               	and	a2, a1, t0
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a2, s3, a3
+               	sext.w	a3, a2
+               	sext.w	a2, a1
+               	addw	a4, a3, a2
+               	add	a2, a0, a1
+               	sb	a4, 0x0(a2)
+               	addi	a1, a1, 0x1
+               	li	t0, 0x10
+               	bltu	a1, t0, 0xbc0 <corpus.cases.mem.loadstore.checksum+0x908>
+               	li	a1, 0x0
+               	li	t0, 0x10
+               	bltu	a1, t0, 0xc04 <corpus.cases.mem.loadstore.checksum+0x94c>
+               	j	0xc68 <corpus.cases.mem.loadstore.checksum+0x9b0>
+               	add	a2, a0, a1
+               	lbu	a3, 0x0(a2)
+               	zext.b	a2, a3
+               	mv	a3, s4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xc24 <corpus.cases.mem.loadstore.checksum+0x96c>
+               	j	0xc58 <corpus.cases.mem.loadstore.checksum+0x9a0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xc24 <corpus.cases.mem.loadstore.checksum+0x96c>
+               	addi	a1, a1, 0x1
+               	mv	s4, a3
+               	li	t0, 0x10
+               	bltu	a1, t0, 0xc04 <corpus.cases.mem.loadstore.checksum+0x94c>
                	lui	t0, 0xf9e37
                	addiw	t0, t0, 0x79c
                	slli	t0, t0, 0xc
@@ -612,14 +807,43 @@ Disassembly of section .text:
                	addi	t0, t0, 0x4a8
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x3eb
-               	xor	s1, s3, t0
+               	xor	a0, s3, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc9c <corpus.cases.mem.loadstore.checksum+0x9e4>
+               	j	0xcd0 <corpus.cases.mem.loadstore.checksum+0xa18>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc9c <corpus.cases.mem.loadstore.checksum+0x9e4>
+               	addi	a1, a0, 0x1
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xce4 <corpus.cases.mem.loadstore.checksum+0xa2c>
+               	j	0xd18 <corpus.cases.mem.loadstore.checksum+0xa60>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xce4 <corpus.cases.mem.loadstore.checksum+0xa2c>
                	mv	a0, s4
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x850>
-               	addi	a1, s1, 0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.loadstore.checksum+0x85c>
                	ld	s1, 0xf8(sp)
                	ld	s2, 0xf0(sp)
                	ld	s3, 0xe8(sp)
@@ -627,7 +851,6 @@ Disassembly of section .text:
                	ld	s5, 0xd8(sp)
                	ld	s6, 0xd0(sp)
                	ld	s7, 0xc8(sp)
-               	ld	s8, 0xc0(sp)
                	ld	ra, 0x108(sp)
                	ld	s0, 0x100(sp)
                	addi	sp, sp, 0x110

--- a/test/golden/riscv64-linux/mem/ptr_arith.dis
+++ b/test/golden/riscv64-linux/mem/ptr_arith.dis
@@ -3,46 +3,81 @@ mem/ptr_arith.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.ptr_arith.fold_cell>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lhu	a2, 0x0(a1)
-               	addi	a1, s0, -0x2e
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	ld	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.fold_cell+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.fold_cell+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.fold_cell+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1e
+               	lbu	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	ld	a4, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.ptr_arith.fold_cell+0x48>
+               	j	0x7c <corpus.cases.mem.ptr_arith.fold_cell+0x7c>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.mem.ptr_arith.fold_cell+0x48>
+               	zext.b	a1, a3
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.ptr_arith.fold_cell+0x90>
+               	j	0xc4 <corpus.cases.mem.ptr_arith.fold_cell+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.ptr_arith.fold_cell+0x90>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.ptr_arith.fold_cell+0xd4>
+               	j	0x108 <corpus.cases.mem.ptr_arith.fold_cell+0x108>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a4, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd4 <corpus.cases.mem.ptr_arith.fold_cell+0xd4>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.ptr_arith.bump>:
                	li	a2, 0x0
-               	bltu	a2, a1, 0x98 <corpus.cases.mem.ptr_arith.bump+0xc>
-               	j	0xbc <corpus.cases.mem.ptr_arith.bump+0x30>
+               	bltu	a2, a1, 0x124 <corpus.cases.mem.ptr_arith.bump+0xc>
+               	j	0x148 <corpus.cases.mem.ptr_arith.bump+0x30>
                	slli	t0, a2, 0x2
                	add	a3, a0, t0
                	lw	a4, 0x0(a3)
@@ -51,113 +86,183 @@ Disassembly of section .text:
                	addiw	a4, a6, 0x1
                	sw	a4, 0x0(a3)
                	addi	a2, a2, 0x1
-               	bltu	a2, a1, 0x98 <corpus.cases.mem.ptr_arith.bump+0xc>
+               	bltu	a2, a1, 0x124 <corpus.cases.mem.ptr_arith.bump+0xc>
                	ret
 
 <corpus.cases.mem.ptr_arith.checksum>:
-               	addi	sp, sp, -0x110
-               	sd	ra, 0x108(sp)
-               	sd	s0, 0x100(sp)
-               	addi	s0, sp, 0x110
-               	sd	s1, 0xf8(sp)
-               	sd	s2, 0xf0(sp)
-               	sd	s3, 0xe8(sp)
-               	sd	s4, 0xe0(sp)
-               	sd	s5, 0xd8(sp)
-               	sd	s6, 0xd0(sp)
-               	sd	s7, 0xc8(sp)
-               	sd	s8, 0xc0(sp)
+               	addi	sp, sp, -0x120
+               	sd	ra, 0x118(sp)
+               	sd	s0, 0x110(sp)
+               	addi	s0, sp, 0x120
+               	sd	s1, 0x108(sp)
+               	sd	s2, 0x100(sp)
+               	sd	s3, 0xf8(sp)
+               	sd	s4, 0xf0(sp)
+               	sd	s5, 0xe8(sp)
+               	sd	s6, 0xe0(sp)
                	mv	s1, a0
-               	addi	s2, s0, -0x70
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x38>
-               	addi	s3, s0, -0xb0
-               	mv	a1, s3
+               	addi	s2, s0, -0x60
+               	addi	s3, s0, -0xc0
+               	mv	a0, s3
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x134 <corpus.cases.mem.ptr_arith.checksum+0x74>
-               	mv	a2, a1
-               	li	a3, 0x40
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x1b0 <corpus.cases.mem.ptr_arith.checksum+0x64>
+               	mv	a1, a0
+               	li	a2, 0x40
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x11c <corpus.cases.mem.ptr_arith.checksum+0x5c>
-               	j	0x150 <corpus.cases.mem.ptr_arith.checksum+0x90>
-               	mv	a2, a1
-               	li	a1, 0x40
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a2, t0, 0x198 <corpus.cases.mem.ptr_arith.checksum+0x4c>
+               	j	0x1cc <corpus.cases.mem.ptr_arith.checksum+0x80>
+               	mv	a1, a0
+               	li	a0, 0x40
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x13c <corpus.cases.mem.ptr_arith.checksum+0x7c>
-               	li	a1, 0x0
+               	bne	a0, t0, 0x1b8 <corpus.cases.mem.ptr_arith.checksum+0x6c>
+               	li	a0, 0x0
                	li	t0, 0x10
-               	bltu	a1, t0, 0x160 <corpus.cases.mem.ptr_arith.checksum+0xa0>
-               	j	0x198 <corpus.cases.mem.ptr_arith.checksum+0xd8>
-               	addi	a2, a1, 0x1
+               	bltu	a0, t0, 0x1dc <corpus.cases.mem.ptr_arith.checksum+0x90>
+               	j	0x214 <corpus.cases.mem.ptr_arith.checksum+0xc8>
+               	addi	a1, a0, 0x1
                	lui	t1, 0x9e
                	addiw	t1, t1, 0x378
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x64f
-               	mul	a3, t1, a2
-               	add	a4, a3, s1
-               	sext.w	a3, a4
-               	slli	t0, a1, 0x2
-               	add	a4, s3, t0
-               	sw	a3, 0x0(a4)
-               	mv	a1, a2
+               	mul	a2, t1, a1
+               	add	a3, a2, s1
+               	sext.w	a2, a3
+               	slli	t0, a0, 0x2
+               	add	a3, s3, t0
+               	sw	a2, 0x0(a3)
+               	mv	a0, a1
                	li	t0, 0x10
-               	bltu	a1, t0, 0x160 <corpus.cases.mem.ptr_arith.checksum+0xa0>
+               	bltu	a0, t0, 0x1dc <corpus.cases.mem.ptr_arith.checksum+0x90>
                	mv	s4, s3
                	addi	s5, s3, 0x20
-               	mv	s6, a0
-               	li	s7, 0x0
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
                	li	t0, 0x10
-               	bltu	s7, t0, 0x1b4 <corpus.cases.mem.ptr_arith.checksum+0xf4>
-               	j	0x1dc <corpus.cases.mem.ptr_arith.checksum+0x11c>
-               	slli	t0, s7, 0x2
-               	add	a0, s4, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x104>
-               	addi	s7, s7, 0x1
-               	mv	s6, a0
+               	bltu	a1, t0, 0x24c <corpus.cases.mem.ptr_arith.checksum+0x100>
+               	j	0x2b8 <corpus.cases.mem.ptr_arith.checksum+0x16c>
+               	slli	t0, a1, 0x2
+               	add	a2, s4, t0
+               	lw	a3, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x274 <corpus.cases.mem.ptr_arith.checksum+0x128>
+               	j	0x2a8 <corpus.cases.mem.ptr_arith.checksum+0x15c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x274 <corpus.cases.mem.ptr_arith.checksum+0x128>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x10
-               	bltu	s7, t0, 0x1b4 <corpus.cases.mem.ptr_arith.checksum+0xf4>
-               	li	s7, -0x8
+               	bltu	a1, t0, 0x24c <corpus.cases.mem.ptr_arith.checksum+0x100>
+               	li	a1, -0x8
                	li	t0, 0x8
-               	blt	s7, t0, 0x1ec <corpus.cases.mem.ptr_arith.checksum+0x12c>
-               	j	0x214 <corpus.cases.mem.ptr_arith.checksum+0x154>
-               	slli	t0, s7, 0x2
-               	add	a0, s5, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x13c>
-               	addi	s7, s7, 0x1
-               	mv	s6, a0
+               	blt	a1, t0, 0x2c8 <corpus.cases.mem.ptr_arith.checksum+0x17c>
+               	j	0x334 <corpus.cases.mem.ptr_arith.checksum+0x1e8>
+               	slli	t0, a1, 0x2
+               	add	a2, s5, t0
+               	lw	a3, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
                	li	t0, 0x8
-               	blt	s7, t0, 0x1ec <corpus.cases.mem.ptr_arith.checksum+0x12c>
+               	bltu	a4, t0, 0x2f0 <corpus.cases.mem.ptr_arith.checksum+0x1a4>
+               	j	0x324 <corpus.cases.mem.ptr_arith.checksum+0x1d8>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2f0 <corpus.cases.mem.ptr_arith.checksum+0x1a4>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
+               	li	t0, 0x8
+               	blt	a1, t0, 0x2c8 <corpus.cases.mem.ptr_arith.checksum+0x17c>
                	lw	a1, 0x0(s5)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x15c>
-               	addi	a1, s5, -0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x170>
-               	addi	a1, s5, 0x1c
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x184>
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	a1, t0, 0x25c <corpus.cases.mem.ptr_arith.checksum+0x19c>
-               	j	0x284 <corpus.cases.mem.ptr_arith.checksum+0x1c4>
+               	bltu	a1, t0, 0x350 <corpus.cases.mem.ptr_arith.checksum+0x204>
+               	j	0x384 <corpus.cases.mem.ptr_arith.checksum+0x238>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x350 <corpus.cases.mem.ptr_arith.checksum+0x204>
+               	addi	a1, s5, -0x4
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a4 <corpus.cases.mem.ptr_arith.checksum+0x258>
+               	j	0x3d8 <corpus.cases.mem.ptr_arith.checksum+0x28c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3a4 <corpus.cases.mem.ptr_arith.checksum+0x258>
+               	addi	a1, s5, 0x1c
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x29c>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x400 <corpus.cases.mem.ptr_arith.checksum+0x2b4>
+               	j	0x428 <corpus.cases.mem.ptr_arith.checksum+0x2dc>
                	slli	t0, a1, 0x2
                	add	a2, s5, t0
                	lw	a3, 0x0(a2)
@@ -167,82 +272,142 @@ Disassembly of section .text:
                	sw	a3, 0x0(a2)
                	addi	a1, a1, 0x1
                	li	t0, 0x8
-               	bltu	a1, t0, 0x25c <corpus.cases.mem.ptr_arith.checksum+0x19c>
-               	mv	s6, a0
-               	li	s7, 0x0
+               	bltu	a1, t0, 0x400 <corpus.cases.mem.ptr_arith.checksum+0x2b4>
+               	li	a1, 0x0
                	li	t0, 0x10
-               	bltu	s7, t0, 0x298 <corpus.cases.mem.ptr_arith.checksum+0x1d8>
-               	j	0x2c0 <corpus.cases.mem.ptr_arith.checksum+0x200>
-               	slli	t0, s7, 0x2
-               	add	a0, s3, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x1e8>
-               	addi	s7, s7, 0x1
-               	mv	s6, a0
+               	bltu	a1, t0, 0x438 <corpus.cases.mem.ptr_arith.checksum+0x2ec>
+               	j	0x4a4 <corpus.cases.mem.ptr_arith.checksum+0x358>
+               	slli	t0, a1, 0x2
+               	add	a2, s3, t0
+               	lw	a3, 0x0(a2)
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x460 <corpus.cases.mem.ptr_arith.checksum+0x314>
+               	j	0x494 <corpus.cases.mem.ptr_arith.checksum+0x348>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a2, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x460 <corpus.cases.mem.ptr_arith.checksum+0x314>
+               	addi	a1, a1, 0x1
+               	mv	a0, a3
                	li	t0, 0x10
-               	bltu	s7, t0, 0x298 <corpus.cases.mem.ptr_arith.checksum+0x1d8>
-               	addi	s7, s3, 0x14
-               	lw	a0, 0x0(s7)
+               	bltu	a1, t0, 0x438 <corpus.cases.mem.ptr_arith.checksum+0x2ec>
+               	addi	s6, s3, 0x14
+               	lw	a1, 0x0(s6)
                	lui	t0, 0xf0f0f
                	addiw	t0, t0, 0xf0
-               	xor	a1, a0, t0
-               	sw	a1, 0x0(s7)
-               	lw	a1, 0x0(s7)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x220>
-               	lw	a1, 0x0(s7)
+               	xor	a2, a1, t0
+               	sw	a2, 0x0(s6)
+               	lw	a1, 0x0(s6)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d8 <corpus.cases.mem.ptr_arith.checksum+0x38c>
+               	j	0x50c <corpus.cases.mem.ptr_arith.checksum+0x3c0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4d8 <corpus.cases.mem.ptr_arith.checksum+0x38c>
+               	lw	a1, 0x0(s6)
                	addiw	a2, a1, 0x3
-               	sw	a2, 0x0(s7)
-               	lw	a1, 0x0(s7)
+               	sw	a2, 0x0(s6)
+               	lw	a1, 0x0(s6)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x534 <corpus.cases.mem.ptr_arith.checksum+0x3e8>
+               	j	0x568 <corpus.cases.mem.ptr_arith.checksum+0x41c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x534 <corpus.cases.mem.ptr_arith.checksum+0x3e8>
+               	addi	a1, s3, 0x14
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x238>
-               	lw	a1, 0x0(s7)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x244>
-               	xor	a1, s7, s7
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x42c>
+               	xor	a1, s6, s6
                	seqz	a1, a1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x254>
-               	xor	a1, s7, s4
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x444>
+               	xor	a1, s6, s4
                	seqz	a1, a1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x264>
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x45c>
                	li	t0, 0x0
                	xor	a1, s4, t0
                	seqz	a1, a1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x278>
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x478>
                	xor	a1, s5, s4
                	snez	a1, a1
+               	zext.b	a2, a1
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x288>
-               	addi	s3, s0, -0x110
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x490>
+               	addi	s3, s0, -0x120
                	mv	a1, s3
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x384 <corpus.cases.mem.ptr_arith.checksum+0x2c4>
+               	bnez	a2, 0x618 <corpus.cases.mem.ptr_arith.checksum+0x4cc>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x36c <corpus.cases.mem.ptr_arith.checksum+0x2ac>
-               	j	0x3a0 <corpus.cases.mem.ptr_arith.checksum+0x2e0>
+               	bne	a3, t0, 0x600 <corpus.cases.mem.ptr_arith.checksum+0x4b4>
+               	j	0x634 <corpus.cases.mem.ptr_arith.checksum+0x4e8>
                	mv	a2, a1
                	li	a1, 0x60
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x38c <corpus.cases.mem.ptr_arith.checksum+0x2cc>
+               	bne	a1, t0, 0x620 <corpus.cases.mem.ptr_arith.checksum+0x4d4>
                	li	a1, 0x0
                	li	t0, 0x6
-               	bltu	a1, t0, 0x3b0 <corpus.cases.mem.ptr_arith.checksum+0x2f0>
-               	j	0x410 <corpus.cases.mem.ptr_arith.checksum+0x350>
+               	bltu	a1, t0, 0x644 <corpus.cases.mem.ptr_arith.checksum+0x4f8>
+               	j	0x6a4 <corpus.cases.mem.ptr_arith.checksum+0x558>
                	li	t0, 0x5
                	mul	a2, a1, t0
                	addi	a3, a2, 0x1
@@ -266,36 +431,77 @@ Disassembly of section .text:
                	addi	a2, a4, 0x8
                	sd	a3, 0x0(a2)
                	li	t0, 0x6
-               	bltu	a1, t0, 0x3b0 <corpus.cases.mem.ptr_arith.checksum+0x2f0>
+               	bltu	a1, t0, 0x644 <corpus.cases.mem.ptr_arith.checksum+0x4f8>
                	addi	s4, s3, 0x20
                	mv	s5, a0
                	li	s6, -0x2
                	li	t0, 0x4
-               	blt	s6, t0, 0x428 <corpus.cases.mem.ptr_arith.checksum+0x368>
-               	j	0x484 <corpus.cases.mem.ptr_arith.checksum+0x3c4>
+               	blt	s6, t0, 0x6bc <corpus.cases.mem.ptr_arith.checksum+0x570>
+               	j	0x7bc <corpus.cases.mem.ptr_arith.checksum+0x670>
                	li	t0, 0x10
                	mul	a0, s6, t0
                	add	a1, s4, a0
-               	mv	a0, a1
-               	lhu	a2, 0x0(a0)
-               	addi	a0, a1, 0x2
-               	lbu	s7, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s8, 0x0(a0)
-               	mv	a0, s5
+               	addi	a0, s0, -0x70
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x740 <corpus.cases.mem.ptr_arith.checksum+0x5f4>
+               	bnez	a1, 0x714 <corpus.cases.mem.ptr_arith.checksum+0x5c8>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x6f4 <corpus.cases.mem.ptr_arith.checksum+0x5a8>
+               	j	0x798 <corpus.cases.mem.ptr_arith.checksum+0x64c>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x720 <corpus.cases.mem.ptr_arith.checksum+0x5d4>
+               	j	0x798 <corpus.cases.mem.ptr_arith.checksum+0x64c>
+               	bnez	a1, 0x770 <corpus.cases.mem.ptr_arith.checksum+0x624>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x750 <corpus.cases.mem.ptr_arith.checksum+0x604>
+               	j	0x798 <corpus.cases.mem.ptr_arith.checksum+0x64c>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x77c <corpus.cases.mem.ptr_arith.checksum+0x630>
+               	ld	a1, 0x0(a0)
+               	ld	a2, 0x8(a0)
+               	mv	a0, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x394>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x3a0>
-               	mv	a1, s8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x3ac>
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x658>
                	addi	s6, s6, 0x1
                	mv	s5, a0
                	li	t0, 0x4
-               	blt	s6, t0, 0x428 <corpus.cases.mem.ptr_arith.checksum+0x368>
+               	blt	s6, t0, 0x6bc <corpus.cases.mem.ptr_arith.checksum+0x570>
                	addi	a0, s4, 0x10
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
@@ -308,155 +514,287 @@ Disassembly of section .text:
                	sh	a2, 0x0(a1)
                	li	s4, 0x0
                	li	t0, 0x6
-               	bltu	s4, t0, 0x4bc <corpus.cases.mem.ptr_arith.checksum+0x3fc>
-               	j	0x518 <corpus.cases.mem.ptr_arith.checksum+0x458>
+               	bltu	s4, t0, 0x7f4 <corpus.cases.mem.ptr_arith.checksum+0x6a8>
+               	j	0x8f4 <corpus.cases.mem.ptr_arith.checksum+0x7a8>
                	li	t0, 0x10
                	mul	a0, s4, t0
                	add	a1, s3, a0
-               	mv	a0, a1
-               	lhu	a2, 0x0(a0)
-               	addi	a0, a1, 0x2
-               	lbu	s6, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	s7, 0x0(a0)
-               	mv	a0, s5
+               	addi	a0, s0, -0x80
+               	mv	a2, a0
+               	mv	a3, a1
+               	or	a1, a2, a3
+               	li	t0, 0x7
+               	and	a1, a1, t0
+               	bltu	a2, a3, 0x878 <corpus.cases.mem.ptr_arith.checksum+0x72c>
+               	bnez	a1, 0x84c <corpus.cases.mem.ptr_arith.checksum+0x700>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x82c <corpus.cases.mem.ptr_arith.checksum+0x6e0>
+               	j	0x8d0 <corpus.cases.mem.ptr_arith.checksum+0x784>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	li	a6, 0x10
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
+               	li	t0, 0x0
+               	bne	a6, t0, 0x858 <corpus.cases.mem.ptr_arith.checksum+0x70c>
+               	j	0x8d0 <corpus.cases.mem.ptr_arith.checksum+0x784>
+               	bnez	a1, 0x8a8 <corpus.cases.mem.ptr_arith.checksum+0x75c>
                	mv	a1, a2
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x888 <corpus.cases.mem.ptr_arith.checksum+0x73c>
+               	j	0x8d0 <corpus.cases.mem.ptr_arith.checksum+0x784>
+               	mv	a1, a2
+               	mv	a2, a3
+               	li	a3, 0x10
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a2, a2, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x8b4 <corpus.cases.mem.ptr_arith.checksum+0x768>
+               	ld	a1, 0x0(a0)
+               	ld	a2, 0x8(a0)
+               	mv	a0, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x428>
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x434>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x440>
+               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x790>
                	addi	s4, s4, 0x1
                	mv	s5, a0
                	li	t0, 0x6
-               	bltu	s4, t0, 0x4bc <corpus.cases.mem.ptr_arith.checksum+0x3fc>
+               	bltu	s4, t0, 0x7f4 <corpus.cases.mem.ptr_arith.checksum+0x6a8>
                	addi	a0, s3, 0x40
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	li	t0, 0x3
                	mul	a2, a0, t0
                	sd	a2, 0x0(a1)
-               	ld	a2, 0x0(a1)
-               	mv	a0, s5
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x47c>
-               	mv	a1, s3
-               	mv	a2, a1
-               	lhu	a1, 0x0(a2)
-               	addiw	a3, a1, 0x1
-               	sh	a3, 0x0(a2)
-               	lhu	a1, 0x0(a2)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x49c>
-               	mv	a1, s2
-               	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x594 <corpus.cases.mem.ptr_arith.checksum+0x4d4>
-               	mv	a2, a1
-               	li	a3, 0x20
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x57c <corpus.cases.mem.ptr_arith.checksum+0x4bc>
-               	j	0x5b0 <corpus.cases.mem.ptr_arith.checksum+0x4f0>
-               	mv	a2, a1
-               	li	a1, 0x20
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x59c <corpus.cases.mem.ptr_arith.checksum+0x4dc>
-               	sext.w	a1, s1
-               	lui	t1, 0x12345
-               	addiw	t1, t1, 0x678
-               	addw	s3, t1, a1
-               	lui	t1, 0x9abce
-               	addiw	t1, t1, -0x110
-               	addw	s4, t1, a1
-               	sext.w	a1, s1
-               	li	a2, 0x0
-               	li	t0, 0x8
-               	bltu	a2, t0, 0x5e0 <corpus.cases.mem.ptr_arith.checksum+0x520>
-               	j	0x60c <corpus.cases.mem.ptr_arith.checksum+0x54c>
-               	sext.w	a3, a2
-               	li	t0, 0x7
-               	mulw	a4, a3, t0
-               	addiw	a3, a4, 0x3
-               	addw	a4, a3, a1
-               	slli	t0, a2, 0x2
-               	add	a3, s2, t0
-               	sw	a4, 0x0(a3)
-               	addi	a2, a2, 0x1
-               	li	t0, 0x8
-               	bltu	a2, t0, 0x5e0 <corpus.cases.mem.ptr_arith.checksum+0x520>
-               	addi	s1, s2, 0xc
-               	mv	s5, a0
-               	li	s6, -0x3
-               	li	t0, 0x5
-               	blt	s6, t0, 0x624 <corpus.cases.mem.ptr_arith.checksum+0x564>
-               	j	0x64c <corpus.cases.mem.ptr_arith.checksum+0x58c>
-               	slli	t0, s6, 0x2
-               	add	a0, s1, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x574>
-               	addi	s6, s6, 0x1
-               	mv	s5, a0
-               	li	t0, 0x5
-               	blt	s6, t0, 0x624 <corpus.cases.mem.ptr_arith.checksum+0x564>
-               	mv	a0, s2
+               	ld	a0, 0x0(a1)
                	li	a1, 0x0
                	li	t0, 0x8
-               	bltu	a1, t0, 0x660 <corpus.cases.mem.ptr_arith.checksum+0x5a0>
-               	j	0x688 <corpus.cases.mem.ptr_arith.checksum+0x5c8>
-               	slli	t0, a1, 0x2
-               	add	a2, a0, t0
-               	lw	a3, 0x0(a2)
-               	sext.w	a4, a1
-               	addw	a5, a3, a4
-               	addiw	a3, a5, 0x1
-               	sw	a3, 0x0(a2)
+               	bltu	a1, t0, 0x920 <corpus.cases.mem.ptr_arith.checksum+0x7d4>
+               	j	0x954 <corpus.cases.mem.ptr_arith.checksum+0x808>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
                	addi	a1, a1, 0x1
                	li	t0, 0x8
-               	bltu	a1, t0, 0x660 <corpus.cases.mem.ptr_arith.checksum+0x5a0>
+               	bltu	a1, t0, 0x920 <corpus.cases.mem.ptr_arith.checksum+0x7d4>
+               	mv	a0, s3
+               	mv	a1, a0
+               	lhu	a0, 0x0(a1)
+               	addiw	a2, a0, 0x1
+               	sh	a2, 0x0(a1)
+               	lhu	a0, 0x0(a1)
+               	slli	a1, a0, 0x30
+               	srli	a1, a1, 0x30
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x984 <corpus.cases.mem.ptr_arith.checksum+0x838>
+               	j	0x9b8 <corpus.cases.mem.ptr_arith.checksum+0x86c>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x984 <corpus.cases.mem.ptr_arith.checksum+0x838>
+               	mv	a0, s2
+               	li	t0, 0x7
+               	and	a1, a0, t0
+               	bnez	a1, 0x9e8 <corpus.cases.mem.ptr_arith.checksum+0x89c>
+               	mv	a1, a0
+               	li	a2, 0x20
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x9d0 <corpus.cases.mem.ptr_arith.checksum+0x884>
+               	j	0xa04 <corpus.cases.mem.ptr_arith.checksum+0x8b8>
+               	mv	a1, a0
+               	li	a0, 0x20
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x9f0 <corpus.cases.mem.ptr_arith.checksum+0x8a4>
+               	sext.w	a0, s1
+               	lui	t1, 0x12345
+               	addiw	t1, t1, 0x678
+               	addw	a1, t1, a0
+               	lui	t1, 0x9abce
+               	addiw	t1, t1, -0x110
+               	addw	a2, t1, a0
+               	sext.w	a0, s1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa34 <corpus.cases.mem.ptr_arith.checksum+0x8e8>
+               	j	0xa60 <corpus.cases.mem.ptr_arith.checksum+0x914>
+               	sext.w	a4, a3
+               	li	t0, 0x7
+               	mulw	a5, a4, t0
+               	addiw	a4, a5, 0x3
+               	addw	a5, a4, a0
+               	slli	t0, a3, 0x2
+               	add	a4, s2, t0
+               	sw	a5, 0x0(a4)
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa34 <corpus.cases.mem.ptr_arith.checksum+0x8e8>
+               	addi	a0, s2, 0xc
+               	li	a3, -0x3
+               	li	t0, 0x5
+               	blt	a3, t0, 0xa74 <corpus.cases.mem.ptr_arith.checksum+0x928>
+               	j	0xae0 <corpus.cases.mem.ptr_arith.checksum+0x994>
+               	slli	t0, a3, 0x2
+               	add	a4, a0, t0
+               	lw	a5, 0x0(a4)
+               	slli	a4, a5, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a5, s5
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0xa9c <corpus.cases.mem.ptr_arith.checksum+0x950>
+               	j	0xad0 <corpus.cases.mem.ptr_arith.checksum+0x984>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0xa9c <corpus.cases.mem.ptr_arith.checksum+0x950>
+               	addi	a3, a3, 0x1
+               	mv	s5, a5
+               	li	t0, 0x5
+               	blt	a3, t0, 0xa74 <corpus.cases.mem.ptr_arith.checksum+0x928>
+               	mv	a0, s2
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xaf4 <corpus.cases.mem.ptr_arith.checksum+0x9a8>
+               	j	0xb1c <corpus.cases.mem.ptr_arith.checksum+0x9d0>
+               	slli	t0, a3, 0x2
+               	add	a4, a0, t0
+               	lw	a5, 0x0(a4)
+               	sext.w	a6, a3
+               	addw	a7, a5, a6
+               	addiw	a5, a7, 0x1
+               	sw	a5, 0x0(a4)
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xaf4 <corpus.cases.mem.ptr_arith.checksum+0x9a8>
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb34 <corpus.cases.mem.ptr_arith.checksum+0x9e8>
+               	j	0xb68 <corpus.cases.mem.ptr_arith.checksum+0xa1c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, s5, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb34 <corpus.cases.mem.ptr_arith.checksum+0x9e8>
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb78 <corpus.cases.mem.ptr_arith.checksum+0xa2c>
+               	j	0xbe4 <corpus.cases.mem.ptr_arith.checksum+0xa98>
+               	slli	t0, a0, 0x2
+               	add	a1, s2, t0
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	mv	a3, s5
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xba0 <corpus.cases.mem.ptr_arith.checksum+0xa54>
+               	j	0xbd4 <corpus.cases.mem.ptr_arith.checksum+0xa88>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a3, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xba0 <corpus.cases.mem.ptr_arith.checksum+0xa54>
+               	addi	a0, a0, 0x1
+               	mv	s5, a3
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xb78 <corpus.cases.mem.ptr_arith.checksum+0xa2c>
+               	slli	a0, a2, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbfc <corpus.cases.mem.ptr_arith.checksum+0xab0>
+               	j	0xc30 <corpus.cases.mem.ptr_arith.checksum+0xae4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbfc <corpus.cases.mem.ptr_arith.checksum+0xab0>
                	mv	a0, s5
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x5d0>
-               	mv	s1, a0
-               	li	s3, 0x0
-               	li	t0, 0x8
-               	bltu	s3, t0, 0x6ac <corpus.cases.mem.ptr_arith.checksum+0x5ec>
-               	j	0x6d4 <corpus.cases.mem.ptr_arith.checksum+0x614>
-               	slli	t0, s3, 0x2
-               	add	a0, s2, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x5fc>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	li	t0, 0x8
-               	bltu	s3, t0, 0x6ac <corpus.cases.mem.ptr_arith.checksum+0x5ec>
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.ptr_arith.checksum+0x61c>
-               	ld	s1, 0xf8(sp)
-               	ld	s2, 0xf0(sp)
-               	ld	s3, 0xe8(sp)
-               	ld	s4, 0xe0(sp)
-               	ld	s5, 0xd8(sp)
-               	ld	s6, 0xd0(sp)
-               	ld	s7, 0xc8(sp)
-               	ld	s8, 0xc0(sp)
-               	ld	ra, 0x108(sp)
-               	ld	s0, 0x100(sp)
-               	addi	sp, sp, 0x110
+               	ld	s1, 0x108(sp)
+               	ld	s2, 0x100(sp)
+               	ld	s3, 0xf8(sp)
+               	ld	s4, 0xf0(sp)
+               	ld	s5, 0xe8(sp)
+               	ld	s6, 0xe0(sp)
+               	ld	ra, 0x118(sp)
+               	ld	s0, 0x110(sp)
+               	addi	sp, sp, 0x120
                	ret

--- a/test/golden/riscv64-linux/mem/rec_layout.dis
+++ b/test/golden/riscv64-linux/mem/rec_layout.dis
@@ -3,86 +3,182 @@ mem/rec_layout.o:
 Disassembly of section .text:
 
 <corpus.cases.mem.rec_layout.fold_tiny>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a3, a0
-               	sd	a1, -0x30(s0)
-               	sd	a2, -0x28(s0)
-               	addi	a1, s0, -0x30
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x20(s0)
+               	sd	a2, -0x18(s0)
+               	addi	a1, s0, -0x20
                	lbu	a2, 0x0(a1)
-               	addi	a1, s0, -0x2c
-               	lw	s1, 0x0(a1)
-               	addi	a1, s0, -0x28
-               	lbu	s2, 0x0(a1)
-               	mv	a0, a3
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_tiny+0x44>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_tiny+0x58>
-               	mv	a1, a0
-               	mv	a0, a1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_tiny+0x6c>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	addi	a1, s0, -0x1c
+               	lw	a3, 0x0(a1)
+               	addi	a1, s0, -0x18
+               	lbu	a4, 0x0(a1)
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.mem.rec_layout.fold_tiny+0x44>
+               	j	0x78 <corpus.cases.mem.rec_layout.fold_tiny+0x78>
+               	li	t0, 0x8
+               	mul	a5, a2, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.mem.rec_layout.fold_tiny+0x44>
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.rec_layout.fold_tiny+0x90>
+               	j	0xc4 <corpus.cases.mem.rec_layout.fold_tiny+0xc4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a5, a1, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x90 <corpus.cases.mem.rec_layout.fold_tiny+0x90>
+               	zext.b	a1, a4
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd8 <corpus.cases.mem.rec_layout.fold_tiny+0xd8>
+               	j	0x10c <corpus.cases.mem.rec_layout.fold_tiny+0x10c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xd8 <corpus.cases.mem.rec_layout.fold_tiny+0xd8>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.rec_layout.fold_mid>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	a2, a0
-               	mv	a3, a1
-               	lhu	a4, 0x0(a3)
-               	addi	a3, a1, 0x4
-               	mv	a5, a3
-               	lbu	s1, 0x0(a5)
-               	addi	a5, a3, 0x4
-               	lw	s2, 0x0(a5)
-               	addi	a5, a3, 0x8
-               	lbu	s3, 0x0(a5)
-               	addi	a3, a1, 0x10
-               	lbu	s4, 0x0(a3)
-               	mv	a0, a2
-               	mv	a1, a4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_mid+0x58>
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_mid+0x64>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_mid+0x70>
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_mid+0x7c>
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_mid+0x88>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mv	a2, a1
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	mv	a4, a2
+               	lbu	a5, 0x0(a4)
+               	addi	a4, a2, 0x4
+               	lw	a6, 0x0(a4)
+               	addi	a4, a2, 0x8
+               	lbu	a2, 0x0(a4)
+               	addi	a4, a1, 0x10
+               	lbu	a1, 0x0(a4)
+               	slli	a4, a3, 0x30
+               	srli	a4, a4, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x160 <corpus.cases.mem.rec_layout.fold_mid+0x44>
+               	j	0x194 <corpus.cases.mem.rec_layout.fold_mid+0x78>
+               	li	t0, 0x8
+               	mul	a7, a3, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a0, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, t5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x160 <corpus.cases.mem.rec_layout.fold_mid+0x44>
+               	zext.b	a3, a5
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1a8 <corpus.cases.mem.rec_layout.fold_mid+0x8c>
+               	j	0x1dc <corpus.cases.mem.rec_layout.fold_mid+0xc0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a7, a3, a5
+               	li	t0, 0xff
+               	and	a5, a7, t0
+               	xor	a7, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1a8 <corpus.cases.mem.rec_layout.fold_mid+0x8c>
+               	slli	a3, a6, 0x20
+               	srli	a3, a3, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f4 <corpus.cases.mem.rec_layout.fold_mid+0xd8>
+               	j	0x228 <corpus.cases.mem.rec_layout.fold_mid+0x10c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a3, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a0, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f4 <corpus.cases.mem.rec_layout.fold_mid+0xd8>
+               	zext.b	a3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23c <corpus.cases.mem.rec_layout.fold_mid+0x120>
+               	j	0x270 <corpus.cases.mem.rec_layout.fold_mid+0x154>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x23c <corpus.cases.mem.rec_layout.fold_mid+0x120>
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x284 <corpus.cases.mem.rec_layout.fold_mid+0x168>
+               	j	0x2b8 <corpus.cases.mem.rec_layout.fold_mid+0x19c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x284 <corpus.cases.mem.rec_layout.fold_mid+0x168>
                	ret
 
 <corpus.cases.mem.rec_layout.fold_wide>:
@@ -91,15 +187,14 @@ Disassembly of section .text:
                	sd	s0, 0x70(sp)
                	addi	s0, sp, 0x80
                	sd	s1, 0x68(sp)
-               	sd	s2, 0x60(sp)
-               	addi	s1, s0, -0x48
+               	addi	s1, s0, -0x40
                	mv	a2, s1
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1cc <corpus.cases.mem.rec_layout.fold_wide+0x90>
-               	bnez	a1, 0x1a0 <corpus.cases.mem.rec_layout.fold_wide+0x64>
+               	bltu	a2, a3, 0x348 <corpus.cases.mem.rec_layout.fold_wide+0x8c>
+               	bnez	a1, 0x31c <corpus.cases.mem.rec_layout.fold_wide+0x60>
                	addi	a4, a2, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -109,8 +204,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x180 <corpus.cases.mem.rec_layout.fold_wide+0x44>
-               	j	0x224 <corpus.cases.mem.rec_layout.fold_wide+0xe8>
+               	bne	a6, t0, 0x2fc <corpus.cases.mem.rec_layout.fold_wide+0x40>
+               	j	0x3a0 <corpus.cases.mem.rec_layout.fold_wide+0xe4>
                	addi	a4, a2, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -120,9 +215,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1ac <corpus.cases.mem.rec_layout.fold_wide+0x70>
-               	j	0x224 <corpus.cases.mem.rec_layout.fold_wide+0xe8>
-               	bnez	a1, 0x1fc <corpus.cases.mem.rec_layout.fold_wide+0xc0>
+               	bne	a6, t0, 0x328 <corpus.cases.mem.rec_layout.fold_wide+0x6c>
+               	j	0x3a0 <corpus.cases.mem.rec_layout.fold_wide+0xe4>
+               	bnez	a1, 0x378 <corpus.cases.mem.rec_layout.fold_wide+0xbc>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x28
@@ -132,8 +227,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1dc <corpus.cases.mem.rec_layout.fold_wide+0xa0>
-               	j	0x224 <corpus.cases.mem.rec_layout.fold_wide+0xe8>
+               	bne	a5, t0, 0x358 <corpus.cases.mem.rec_layout.fold_wide+0x9c>
+               	j	0x3a0 <corpus.cases.mem.rec_layout.fold_wide+0xe4>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x28
@@ -143,16 +238,16 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x208 <corpus.cases.mem.rec_layout.fold_wide+0xcc>
+               	bne	a3, t0, 0x384 <corpus.cases.mem.rec_layout.fold_wide+0xc8>
                	mv	a1, s1
-               	addi	a2, s0, -0x5c
+               	addi	a2, s0, -0x54
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x2a8 <corpus.cases.mem.rec_layout.fold_wide+0x16c>
-               	bnez	a1, 0x27c <corpus.cases.mem.rec_layout.fold_wide+0x140>
+               	bltu	a3, a4, 0x424 <corpus.cases.mem.rec_layout.fold_wide+0x168>
+               	bnez	a1, 0x3f8 <corpus.cases.mem.rec_layout.fold_wide+0x13c>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lw	a7, 0x0(a6)
@@ -164,8 +259,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x25c <corpus.cases.mem.rec_layout.fold_wide+0x120>
-               	j	0x308 <corpus.cases.mem.rec_layout.fold_wide+0x1cc>
+               	bne	a7, t0, 0x3d8 <corpus.cases.mem.rec_layout.fold_wide+0x11c>
+               	j	0x484 <corpus.cases.mem.rec_layout.fold_wide+0x1c8>
                	addi	a5, a3, 0x14
                	addi	a6, a4, 0x14
                	li	a7, 0x14
@@ -175,9 +270,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x288 <corpus.cases.mem.rec_layout.fold_wide+0x14c>
-               	j	0x308 <corpus.cases.mem.rec_layout.fold_wide+0x1cc>
-               	bnez	a1, 0x2e0 <corpus.cases.mem.rec_layout.fold_wide+0x1a4>
+               	bne	a7, t0, 0x404 <corpus.cases.mem.rec_layout.fold_wide+0x148>
+               	j	0x484 <corpus.cases.mem.rec_layout.fold_wide+0x1c8>
+               	bnez	a1, 0x45c <corpus.cases.mem.rec_layout.fold_wide+0x1a0>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -187,10 +282,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2b8 <corpus.cases.mem.rec_layout.fold_wide+0x17c>
+               	bne	a6, t0, 0x434 <corpus.cases.mem.rec_layout.fold_wide+0x178>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a1)
-               	j	0x308 <corpus.cases.mem.rec_layout.fold_wide+0x1cc>
+               	j	0x484 <corpus.cases.mem.rec_layout.fold_wide+0x1c8>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x14
@@ -200,14 +295,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x2ec <corpus.cases.mem.rec_layout.fold_wide+0x1b0>
-               	addi	a1, s0, -0x74
+               	bne	a4, t0, 0x468 <corpus.cases.mem.rec_layout.fold_wide+0x1ac>
+               	addi	a1, s0, -0x6c
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x384 <corpus.cases.mem.rec_layout.fold_wide+0x248>
-               	bnez	a2, 0x358 <corpus.cases.mem.rec_layout.fold_wide+0x21c>
+               	bltu	a1, a3, 0x500 <corpus.cases.mem.rec_layout.fold_wide+0x244>
+               	bnez	a2, 0x4d4 <corpus.cases.mem.rec_layout.fold_wide+0x218>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -219,8 +314,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x338 <corpus.cases.mem.rec_layout.fold_wide+0x1fc>
-               	j	0x3e4 <corpus.cases.mem.rec_layout.fold_wide+0x2a8>
+               	bne	a6, t0, 0x4b4 <corpus.cases.mem.rec_layout.fold_wide+0x1f8>
+               	j	0x560 <corpus.cases.mem.rec_layout.fold_wide+0x2a4>
                	addi	a4, a1, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -230,9 +325,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x364 <corpus.cases.mem.rec_layout.fold_wide+0x228>
-               	j	0x3e4 <corpus.cases.mem.rec_layout.fold_wide+0x2a8>
-               	bnez	a2, 0x3bc <corpus.cases.mem.rec_layout.fold_wide+0x280>
+               	bne	a6, t0, 0x4e0 <corpus.cases.mem.rec_layout.fold_wide+0x224>
+               	j	0x560 <corpus.cases.mem.rec_layout.fold_wide+0x2a4>
+               	bnez	a2, 0x538 <corpus.cases.mem.rec_layout.fold_wide+0x27c>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -242,10 +337,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x394 <corpus.cases.mem.rec_layout.fold_wide+0x258>
+               	bne	a5, t0, 0x510 <corpus.cases.mem.rec_layout.fold_wide+0x254>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0x3e4 <corpus.cases.mem.rec_layout.fold_wide+0x2a8>
+               	j	0x560 <corpus.cases.mem.rec_layout.fold_wide+0x2a4>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x14
@@ -255,59 +350,136 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x3c8 <corpus.cases.mem.rec_layout.fold_wide+0x28c>
-               	addi	a1, s0, -0x74
+               	bne	a3, t0, 0x544 <corpus.cases.mem.rec_layout.fold_wide+0x288>
+               	addi	a1, s0, -0x6c
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x2ac>
+               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x2a8>
                	addi	a1, s1, 0x18
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x2c0>
-               	addi	s2, s1, 0x20
-               	mv	a1, s2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x2d8>
-               	addi	a1, s2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x2ec>
-               	addi	a1, s2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x300>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x584 <corpus.cases.mem.rec_layout.fold_wide+0x2c8>
+               	j	0x5b8 <corpus.cases.mem.rec_layout.fold_wide+0x2fc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x584 <corpus.cases.mem.rec_layout.fold_wide+0x2c8>
+               	addi	a1, s1, 0x20
+               	mv	a2, a1
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5dc <corpus.cases.mem.rec_layout.fold_wide+0x320>
+               	j	0x610 <corpus.cases.mem.rec_layout.fold_wide+0x354>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x5dc <corpus.cases.mem.rec_layout.fold_wide+0x320>
+               	addi	a1, s1, 0x20
+               	addi	a2, a1, 0x2
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x634 <corpus.cases.mem.rec_layout.fold_wide+0x378>
+               	j	0x668 <corpus.cases.mem.rec_layout.fold_wide+0x3ac>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x634 <corpus.cases.mem.rec_layout.fold_wide+0x378>
+               	addi	a1, s1, 0x20
+               	addi	a2, a1, 0x4
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x68c <corpus.cases.mem.rec_layout.fold_wide+0x3d0>
+               	j	0x6c0 <corpus.cases.mem.rec_layout.fold_wide+0x404>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x68c <corpus.cases.mem.rec_layout.fold_wide+0x3d0>
                	addi	a1, s1, 0x26
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_wide+0x314>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6dc <corpus.cases.mem.rec_layout.fold_wide+0x420>
+               	j	0x710 <corpus.cases.mem.rec_layout.fold_wide+0x454>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x6dc <corpus.cases.mem.rec_layout.fold_wide+0x420>
                	ld	s1, 0x68(sp)
-               	ld	s2, 0x60(sp)
                	ld	ra, 0x78(sp)
                	ld	s0, 0x70(sp)
                	addi	sp, sp, 0x80
                	ret
 
 <corpus.cases.mem.rec_layout.fold_nest>:
-               	addi	sp, sp, -0x160
-               	sd	ra, 0x158(sp)
-               	sd	s0, 0x150(sp)
-               	addi	s0, sp, 0x160
-               	sd	s1, 0x148(sp)
-               	sd	s2, 0x140(sp)
-               	sd	s3, 0x138(sp)
-               	addi	s1, s0, -0x80
+               	addi	sp, sp, -0x150
+               	sd	ra, 0x148(sp)
+               	sd	s0, 0x140(sp)
+               	addi	s0, sp, 0x150
+               	sd	s1, 0x138(sp)
+               	sd	s2, 0x130(sp)
+               	addi	s1, s0, -0x78
                	mv	a2, s1
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x504 <corpus.cases.mem.rec_layout.fold_nest+0x94>
-               	bnez	a1, 0x4d8 <corpus.cases.mem.rec_layout.fold_nest+0x68>
+               	bltu	a2, a3, 0x7b4 <corpus.cases.mem.rec_layout.fold_nest+0x90>
+               	bnez	a1, 0x788 <corpus.cases.mem.rec_layout.fold_nest+0x64>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -317,8 +489,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x4b8 <corpus.cases.mem.rec_layout.fold_nest+0x48>
-               	j	0x55c <corpus.cases.mem.rec_layout.fold_nest+0xec>
+               	bne	a6, t0, 0x768 <corpus.cases.mem.rec_layout.fold_nest+0x44>
+               	j	0x80c <corpus.cases.mem.rec_layout.fold_nest+0xe8>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -328,9 +500,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x4e4 <corpus.cases.mem.rec_layout.fold_nest+0x74>
-               	j	0x55c <corpus.cases.mem.rec_layout.fold_nest+0xec>
-               	bnez	a1, 0x534 <corpus.cases.mem.rec_layout.fold_nest+0xc4>
+               	bne	a6, t0, 0x794 <corpus.cases.mem.rec_layout.fold_nest+0x70>
+               	j	0x80c <corpus.cases.mem.rec_layout.fold_nest+0xe8>
+               	bnez	a1, 0x7e4 <corpus.cases.mem.rec_layout.fold_nest+0xc0>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -340,8 +512,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x514 <corpus.cases.mem.rec_layout.fold_nest+0xa4>
-               	j	0x55c <corpus.cases.mem.rec_layout.fold_nest+0xec>
+               	bne	a5, t0, 0x7c4 <corpus.cases.mem.rec_layout.fold_nest+0xa0>
+               	j	0x80c <corpus.cases.mem.rec_layout.fold_nest+0xe8>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -351,16 +523,16 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x540 <corpus.cases.mem.rec_layout.fold_nest+0xd0>
+               	bne	a3, t0, 0x7f0 <corpus.cases.mem.rec_layout.fold_nest+0xcc>
                	mv	a1, s1
-               	addi	a2, s0, -0xa8
+               	addi	a2, s0, -0xa0
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x5d8 <corpus.cases.mem.rec_layout.fold_nest+0x168>
-               	bnez	a1, 0x5ac <corpus.cases.mem.rec_layout.fold_nest+0x13c>
+               	bltu	a3, a4, 0x888 <corpus.cases.mem.rec_layout.fold_nest+0x164>
+               	bnez	a1, 0x85c <corpus.cases.mem.rec_layout.fold_nest+0x138>
                	addi	a5, a3, 0x28
                	addi	a6, a4, 0x28
                	li	a7, 0x28
@@ -370,8 +542,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x58c <corpus.cases.mem.rec_layout.fold_nest+0x11c>
-               	j	0x630 <corpus.cases.mem.rec_layout.fold_nest+0x1c0>
+               	bne	a7, t0, 0x83c <corpus.cases.mem.rec_layout.fold_nest+0x118>
+               	j	0x8e0 <corpus.cases.mem.rec_layout.fold_nest+0x1bc>
                	addi	a5, a3, 0x28
                	addi	a6, a4, 0x28
                	li	a7, 0x28
@@ -381,9 +553,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x5b8 <corpus.cases.mem.rec_layout.fold_nest+0x148>
-               	j	0x630 <corpus.cases.mem.rec_layout.fold_nest+0x1c0>
-               	bnez	a1, 0x608 <corpus.cases.mem.rec_layout.fold_nest+0x198>
+               	bne	a7, t0, 0x868 <corpus.cases.mem.rec_layout.fold_nest+0x144>
+               	j	0x8e0 <corpus.cases.mem.rec_layout.fold_nest+0x1bc>
+               	bnez	a1, 0x8b8 <corpus.cases.mem.rec_layout.fold_nest+0x194>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x28
@@ -393,8 +565,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x5e8 <corpus.cases.mem.rec_layout.fold_nest+0x178>
-               	j	0x630 <corpus.cases.mem.rec_layout.fold_nest+0x1c0>
+               	bne	a6, t0, 0x898 <corpus.cases.mem.rec_layout.fold_nest+0x174>
+               	j	0x8e0 <corpus.cases.mem.rec_layout.fold_nest+0x1bc>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x28
@@ -404,15 +576,15 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x614 <corpus.cases.mem.rec_layout.fold_nest+0x1a4>
-               	addi	s2, s0, -0xd0
+               	bne	a4, t0, 0x8c4 <corpus.cases.mem.rec_layout.fold_nest+0x1a0>
+               	addi	s2, s0, -0xc8
                	mv	a1, s2
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x6a8 <corpus.cases.mem.rec_layout.fold_nest+0x238>
-               	bnez	a2, 0x67c <corpus.cases.mem.rec_layout.fold_nest+0x20c>
+               	bltu	a1, a3, 0x958 <corpus.cases.mem.rec_layout.fold_nest+0x234>
+               	bnez	a2, 0x92c <corpus.cases.mem.rec_layout.fold_nest+0x208>
                	addi	a4, a1, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -422,8 +594,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x65c <corpus.cases.mem.rec_layout.fold_nest+0x1ec>
-               	j	0x700 <corpus.cases.mem.rec_layout.fold_nest+0x290>
+               	bne	a6, t0, 0x90c <corpus.cases.mem.rec_layout.fold_nest+0x1e8>
+               	j	0x9b0 <corpus.cases.mem.rec_layout.fold_nest+0x28c>
                	addi	a4, a1, 0x28
                	addi	a5, a3, 0x28
                	li	a6, 0x28
@@ -433,9 +605,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x688 <corpus.cases.mem.rec_layout.fold_nest+0x218>
-               	j	0x700 <corpus.cases.mem.rec_layout.fold_nest+0x290>
-               	bnez	a2, 0x6d8 <corpus.cases.mem.rec_layout.fold_nest+0x268>
+               	bne	a6, t0, 0x938 <corpus.cases.mem.rec_layout.fold_nest+0x214>
+               	j	0x9b0 <corpus.cases.mem.rec_layout.fold_nest+0x28c>
+               	bnez	a2, 0x988 <corpus.cases.mem.rec_layout.fold_nest+0x264>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x28
@@ -445,8 +617,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x6b8 <corpus.cases.mem.rec_layout.fold_nest+0x248>
-               	j	0x700 <corpus.cases.mem.rec_layout.fold_nest+0x290>
+               	bne	a5, t0, 0x968 <corpus.cases.mem.rec_layout.fold_nest+0x244>
+               	j	0x9b0 <corpus.cases.mem.rec_layout.fold_nest+0x28c>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x28
@@ -456,16 +628,16 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x6e4 <corpus.cases.mem.rec_layout.fold_nest+0x274>
+               	bne	a3, t0, 0x994 <corpus.cases.mem.rec_layout.fold_nest+0x270>
                	mv	a1, s2
-               	addi	a2, s0, -0xe4
+               	addi	a2, s0, -0xdc
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x784 <corpus.cases.mem.rec_layout.fold_nest+0x314>
-               	bnez	a1, 0x758 <corpus.cases.mem.rec_layout.fold_nest+0x2e8>
+               	bltu	a3, a4, 0xa34 <corpus.cases.mem.rec_layout.fold_nest+0x310>
+               	bnez	a1, 0xa08 <corpus.cases.mem.rec_layout.fold_nest+0x2e4>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lw	a7, 0x0(a6)
@@ -477,8 +649,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x738 <corpus.cases.mem.rec_layout.fold_nest+0x2c8>
-               	j	0x7e4 <corpus.cases.mem.rec_layout.fold_nest+0x374>
+               	bne	a7, t0, 0x9e8 <corpus.cases.mem.rec_layout.fold_nest+0x2c4>
+               	j	0xa94 <corpus.cases.mem.rec_layout.fold_nest+0x370>
                	addi	a5, a3, 0x14
                	addi	a6, a4, 0x14
                	li	a7, 0x14
@@ -488,9 +660,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x764 <corpus.cases.mem.rec_layout.fold_nest+0x2f4>
-               	j	0x7e4 <corpus.cases.mem.rec_layout.fold_nest+0x374>
-               	bnez	a1, 0x7bc <corpus.cases.mem.rec_layout.fold_nest+0x34c>
+               	bne	a7, t0, 0xa14 <corpus.cases.mem.rec_layout.fold_nest+0x2f0>
+               	j	0xa94 <corpus.cases.mem.rec_layout.fold_nest+0x370>
+               	bnez	a1, 0xa6c <corpus.cases.mem.rec_layout.fold_nest+0x348>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -500,10 +672,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x794 <corpus.cases.mem.rec_layout.fold_nest+0x324>
+               	bne	a6, t0, 0xa44 <corpus.cases.mem.rec_layout.fold_nest+0x320>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a1)
-               	j	0x7e4 <corpus.cases.mem.rec_layout.fold_nest+0x374>
+               	j	0xa94 <corpus.cases.mem.rec_layout.fold_nest+0x370>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x14
@@ -513,14 +685,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0x7c8 <corpus.cases.mem.rec_layout.fold_nest+0x358>
-               	addi	a1, s0, -0xfc
+               	bne	a4, t0, 0xa78 <corpus.cases.mem.rec_layout.fold_nest+0x354>
+               	addi	a1, s0, -0xf4
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0x860 <corpus.cases.mem.rec_layout.fold_nest+0x3f0>
-               	bnez	a2, 0x834 <corpus.cases.mem.rec_layout.fold_nest+0x3c4>
+               	bltu	a1, a3, 0xb10 <corpus.cases.mem.rec_layout.fold_nest+0x3ec>
+               	bnez	a2, 0xae4 <corpus.cases.mem.rec_layout.fold_nest+0x3c0>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -532,8 +704,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x814 <corpus.cases.mem.rec_layout.fold_nest+0x3a4>
-               	j	0x8c0 <corpus.cases.mem.rec_layout.fold_nest+0x450>
+               	bne	a6, t0, 0xac4 <corpus.cases.mem.rec_layout.fold_nest+0x3a0>
+               	j	0xb70 <corpus.cases.mem.rec_layout.fold_nest+0x44c>
                	addi	a4, a1, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -543,9 +715,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x840 <corpus.cases.mem.rec_layout.fold_nest+0x3d0>
-               	j	0x8c0 <corpus.cases.mem.rec_layout.fold_nest+0x450>
-               	bnez	a2, 0x898 <corpus.cases.mem.rec_layout.fold_nest+0x428>
+               	bne	a6, t0, 0xaf0 <corpus.cases.mem.rec_layout.fold_nest+0x3cc>
+               	j	0xb70 <corpus.cases.mem.rec_layout.fold_nest+0x44c>
+               	bnez	a2, 0xb48 <corpus.cases.mem.rec_layout.fold_nest+0x424>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -555,10 +727,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x870 <corpus.cases.mem.rec_layout.fold_nest+0x400>
+               	bne	a5, t0, 0xb20 <corpus.cases.mem.rec_layout.fold_nest+0x3fc>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0x8c0 <corpus.cases.mem.rec_layout.fold_nest+0x450>
+               	j	0xb70 <corpus.cases.mem.rec_layout.fold_nest+0x44c>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x14
@@ -568,46 +740,125 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x8a4 <corpus.cases.mem.rec_layout.fold_nest+0x434>
-               	addi	a1, s0, -0xfc
+               	bne	a3, t0, 0xb54 <corpus.cases.mem.rec_layout.fold_nest+0x430>
+               	addi	a1, s0, -0xf4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x454>
+               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x450>
                	addi	a1, s2, 0x18
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x468>
-               	addi	s3, s2, 0x20
-               	mv	a1, s3
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x480>
-               	addi	a1, s3, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x494>
-               	addi	a1, s3, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x4a8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb94 <corpus.cases.mem.rec_layout.fold_nest+0x470>
+               	j	0xbc8 <corpus.cases.mem.rec_layout.fold_nest+0x4a4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xb94 <corpus.cases.mem.rec_layout.fold_nest+0x470>
+               	addi	a1, s2, 0x20
+               	mv	a2, a1
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbec <corpus.cases.mem.rec_layout.fold_nest+0x4c8>
+               	j	0xc20 <corpus.cases.mem.rec_layout.fold_nest+0x4fc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbec <corpus.cases.mem.rec_layout.fold_nest+0x4c8>
+               	addi	a1, s2, 0x20
+               	addi	a2, a1, 0x2
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc44 <corpus.cases.mem.rec_layout.fold_nest+0x520>
+               	j	0xc78 <corpus.cases.mem.rec_layout.fold_nest+0x554>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc44 <corpus.cases.mem.rec_layout.fold_nest+0x520>
+               	addi	a1, s2, 0x20
+               	addi	a2, a1, 0x4
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc9c <corpus.cases.mem.rec_layout.fold_nest+0x578>
+               	j	0xcd0 <corpus.cases.mem.rec_layout.fold_nest+0x5ac>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xc9c <corpus.cases.mem.rec_layout.fold_nest+0x578>
                	addi	a1, s2, 0x26
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x4bc>
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcec <corpus.cases.mem.rec_layout.fold_nest+0x5c8>
+               	j	0xd20 <corpus.cases.mem.rec_layout.fold_nest+0x5fc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xcec <corpus.cases.mem.rec_layout.fold_nest+0x5c8>
                	addi	s2, s1, 0x28
                	mv	a1, s2
-               	addi	a2, s0, -0x110
+               	addi	a2, s0, -0x108
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0x9bc <corpus.cases.mem.rec_layout.fold_nest+0x54c>
-               	bnez	a1, 0x990 <corpus.cases.mem.rec_layout.fold_nest+0x520>
+               	bltu	a3, a4, 0xda8 <corpus.cases.mem.rec_layout.fold_nest+0x684>
+               	bnez	a1, 0xd7c <corpus.cases.mem.rec_layout.fold_nest+0x658>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lw	a7, 0x0(a6)
@@ -619,8 +870,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x970 <corpus.cases.mem.rec_layout.fold_nest+0x500>
-               	j	0xa1c <corpus.cases.mem.rec_layout.fold_nest+0x5ac>
+               	bne	a7, t0, 0xd5c <corpus.cases.mem.rec_layout.fold_nest+0x638>
+               	j	0xe08 <corpus.cases.mem.rec_layout.fold_nest+0x6e4>
                	addi	a5, a3, 0x14
                	addi	a6, a4, 0x14
                	li	a7, 0x14
@@ -630,9 +881,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x99c <corpus.cases.mem.rec_layout.fold_nest+0x52c>
-               	j	0xa1c <corpus.cases.mem.rec_layout.fold_nest+0x5ac>
-               	bnez	a1, 0x9f4 <corpus.cases.mem.rec_layout.fold_nest+0x584>
+               	bne	a7, t0, 0xd88 <corpus.cases.mem.rec_layout.fold_nest+0x664>
+               	j	0xe08 <corpus.cases.mem.rec_layout.fold_nest+0x6e4>
+               	bnez	a1, 0xde0 <corpus.cases.mem.rec_layout.fold_nest+0x6bc>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -642,10 +893,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x9cc <corpus.cases.mem.rec_layout.fold_nest+0x55c>
+               	bne	a6, t0, 0xdb8 <corpus.cases.mem.rec_layout.fold_nest+0x694>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a1)
-               	j	0xa1c <corpus.cases.mem.rec_layout.fold_nest+0x5ac>
+               	j	0xe08 <corpus.cases.mem.rec_layout.fold_nest+0x6e4>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x14
@@ -655,14 +906,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0xa00 <corpus.cases.mem.rec_layout.fold_nest+0x590>
-               	addi	a1, s0, -0x128
+               	bne	a4, t0, 0xdec <corpus.cases.mem.rec_layout.fold_nest+0x6c8>
+               	addi	a1, s0, -0x120
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xa98 <corpus.cases.mem.rec_layout.fold_nest+0x628>
-               	bnez	a2, 0xa6c <corpus.cases.mem.rec_layout.fold_nest+0x5fc>
+               	bltu	a1, a3, 0xe84 <corpus.cases.mem.rec_layout.fold_nest+0x760>
+               	bnez	a2, 0xe58 <corpus.cases.mem.rec_layout.fold_nest+0x734>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -674,8 +925,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xa4c <corpus.cases.mem.rec_layout.fold_nest+0x5dc>
-               	j	0xaf8 <corpus.cases.mem.rec_layout.fold_nest+0x688>
+               	bne	a6, t0, 0xe38 <corpus.cases.mem.rec_layout.fold_nest+0x714>
+               	j	0xee4 <corpus.cases.mem.rec_layout.fold_nest+0x7c0>
                	addi	a4, a1, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -685,9 +936,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xa78 <corpus.cases.mem.rec_layout.fold_nest+0x608>
-               	j	0xaf8 <corpus.cases.mem.rec_layout.fold_nest+0x688>
-               	bnez	a2, 0xad0 <corpus.cases.mem.rec_layout.fold_nest+0x660>
+               	bne	a6, t0, 0xe64 <corpus.cases.mem.rec_layout.fold_nest+0x740>
+               	j	0xee4 <corpus.cases.mem.rec_layout.fold_nest+0x7c0>
+               	bnez	a2, 0xebc <corpus.cases.mem.rec_layout.fold_nest+0x798>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -697,10 +948,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xaa8 <corpus.cases.mem.rec_layout.fold_nest+0x638>
+               	bne	a5, t0, 0xe94 <corpus.cases.mem.rec_layout.fold_nest+0x770>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0xaf8 <corpus.cases.mem.rec_layout.fold_nest+0x688>
+               	j	0xee4 <corpus.cases.mem.rec_layout.fold_nest+0x7c0>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x14
@@ -710,19 +961,19 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xadc <corpus.cases.mem.rec_layout.fold_nest+0x66c>
-               	addi	a1, s0, -0x128
+               	bne	a3, t0, 0xec8 <corpus.cases.mem.rec_layout.fold_nest+0x7a4>
+               	addi	a1, s0, -0x120
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x68c>
+               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x7c4>
                	addi	a1, s2, 0x14
-               	addi	a2, s0, -0x13c
+               	addi	a2, s0, -0x134
                	mv	a3, a2
                	mv	a4, a1
                	or	a1, a3, a4
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a3, a4, 0xb88 <corpus.cases.mem.rec_layout.fold_nest+0x718>
-               	bnez	a1, 0xb5c <corpus.cases.mem.rec_layout.fold_nest+0x6ec>
+               	bltu	a3, a4, 0xf74 <corpus.cases.mem.rec_layout.fold_nest+0x850>
+               	bnez	a1, 0xf48 <corpus.cases.mem.rec_layout.fold_nest+0x824>
                	addi	a5, a3, 0x10
                	addi	a6, a4, 0x10
                	lw	a7, 0x0(a6)
@@ -734,8 +985,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xb3c <corpus.cases.mem.rec_layout.fold_nest+0x6cc>
-               	j	0xbe8 <corpus.cases.mem.rec_layout.fold_nest+0x778>
+               	bne	a7, t0, 0xf28 <corpus.cases.mem.rec_layout.fold_nest+0x804>
+               	j	0xfd4 <corpus.cases.mem.rec_layout.fold_nest+0x8b0>
                	addi	a5, a3, 0x14
                	addi	a6, a4, 0x14
                	li	a7, 0x14
@@ -745,9 +996,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0xb68 <corpus.cases.mem.rec_layout.fold_nest+0x6f8>
-               	j	0xbe8 <corpus.cases.mem.rec_layout.fold_nest+0x778>
-               	bnez	a1, 0xbc0 <corpus.cases.mem.rec_layout.fold_nest+0x750>
+               	bne	a7, t0, 0xf54 <corpus.cases.mem.rec_layout.fold_nest+0x830>
+               	j	0xfd4 <corpus.cases.mem.rec_layout.fold_nest+0x8b0>
+               	bnez	a1, 0xfac <corpus.cases.mem.rec_layout.fold_nest+0x888>
                	mv	a1, a3
                	mv	a5, a4
                	li	a6, 0x10
@@ -757,10 +1008,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xb98 <corpus.cases.mem.rec_layout.fold_nest+0x728>
+               	bne	a6, t0, 0xf84 <corpus.cases.mem.rec_layout.fold_nest+0x860>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a1)
-               	j	0xbe8 <corpus.cases.mem.rec_layout.fold_nest+0x778>
+               	j	0xfd4 <corpus.cases.mem.rec_layout.fold_nest+0x8b0>
                	mv	a1, a3
                	mv	a3, a4
                	li	a4, 0x14
@@ -770,14 +1021,14 @@ Disassembly of section .text:
                	addi	a3, a3, 0x1
                	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a4, t0, 0xbcc <corpus.cases.mem.rec_layout.fold_nest+0x75c>
-               	addi	a1, s0, -0x154
+               	bne	a4, t0, 0xfb8 <corpus.cases.mem.rec_layout.fold_nest+0x894>
+               	addi	a1, s0, -0x14c
                	mv	a3, a2
                	or	a2, a1, a3
                	li	t0, 0x7
                	and	a2, a2, t0
-               	bltu	a1, a3, 0xc64 <corpus.cases.mem.rec_layout.fold_nest+0x7f4>
-               	bnez	a2, 0xc38 <corpus.cases.mem.rec_layout.fold_nest+0x7c8>
+               	bltu	a1, a3, 0x1050 <corpus.cases.mem.rec_layout.fold_nest+0x92c>
+               	bnez	a2, 0x1024 <corpus.cases.mem.rec_layout.fold_nest+0x900>
                	addi	a4, a1, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -789,8 +1040,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xc18 <corpus.cases.mem.rec_layout.fold_nest+0x7a8>
-               	j	0xcc4 <corpus.cases.mem.rec_layout.fold_nest+0x854>
+               	bne	a6, t0, 0x1004 <corpus.cases.mem.rec_layout.fold_nest+0x8e0>
+               	j	0x10b0 <corpus.cases.mem.rec_layout.fold_nest+0x98c>
                	addi	a4, a1, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -800,9 +1051,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0xc44 <corpus.cases.mem.rec_layout.fold_nest+0x7d4>
-               	j	0xcc4 <corpus.cases.mem.rec_layout.fold_nest+0x854>
-               	bnez	a2, 0xc9c <corpus.cases.mem.rec_layout.fold_nest+0x82c>
+               	bne	a6, t0, 0x1030 <corpus.cases.mem.rec_layout.fold_nest+0x90c>
+               	j	0x10b0 <corpus.cases.mem.rec_layout.fold_nest+0x98c>
+               	bnez	a2, 0x1088 <corpus.cases.mem.rec_layout.fold_nest+0x964>
                	mv	a2, a1
                	mv	a4, a3
                	li	a5, 0x10
@@ -812,10 +1063,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0xc74 <corpus.cases.mem.rec_layout.fold_nest+0x804>
+               	bne	a5, t0, 0x1060 <corpus.cases.mem.rec_layout.fold_nest+0x93c>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a2)
-               	j	0xcc4 <corpus.cases.mem.rec_layout.fold_nest+0x854>
+               	j	0x10b0 <corpus.cases.mem.rec_layout.fold_nest+0x98c>
                	mv	a2, a1
                	mv	a1, a3
                	li	a3, 0x14
@@ -825,21 +1076,36 @@ Disassembly of section .text:
                	addi	a1, a1, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xca8 <corpus.cases.mem.rec_layout.fold_nest+0x838>
-               	addi	a1, s0, -0x154
+               	bne	a3, t0, 0x1094 <corpus.cases.mem.rec_layout.fold_nest+0x970>
+               	addi	a1, s0, -0x14c
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x858>
+               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x990>
                	addi	a1, s1, 0x50
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.fold_nest+0x86c>
-               	ld	s1, 0x148(sp)
-               	ld	s2, 0x140(sp)
-               	ld	s3, 0x138(sp)
-               	ld	ra, 0x158(sp)
-               	ld	s0, 0x150(sp)
-               	addi	sp, sp, 0x160
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x10dc <corpus.cases.mem.rec_layout.fold_nest+0x9b8>
+               	j	0x1110 <corpus.cases.mem.rec_layout.fold_nest+0x9ec>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x10dc <corpus.cases.mem.rec_layout.fold_nest+0x9b8>
+               	ld	s1, 0x138(sp)
+               	ld	s2, 0x130(sp)
+               	ld	ra, 0x148(sp)
+               	ld	s0, 0x140(sp)
+               	addi	sp, sp, 0x150
                	ret
 
 <corpus.cases.mem.rec_layout.fill_mid>:
@@ -874,122 +1140,169 @@ Disassembly of section .text:
                	sd	s3, 0x5c8(sp)
                	sd	s4, 0x5c0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x24>
-               	mv	a1, a0
                	sext.w	s2, s1
-               	mv	a0, a1
-               	li	a1, 0xc
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x3c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x14
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x50>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x28
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x64>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x58
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x78>
-               	mv	a1, a0
-               	mv	a0, a1
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x11d0 <corpus.cases.mem.rec_layout.checksum+0x58>
+               	j	0x1208 <corpus.cases.mem.rec_layout.checksum+0x90>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0xc
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x11d0 <corpus.cases.mem.rec_layout.checksum+0x58>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1218 <corpus.cases.mem.rec_layout.checksum+0xa0>
+               	j	0x1250 <corpus.cases.mem.rec_layout.checksum+0xd8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x14
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1218 <corpus.cases.mem.rec_layout.checksum+0xa0>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1260 <corpus.cases.mem.rec_layout.checksum+0xe8>
+               	j	0x1298 <corpus.cases.mem.rec_layout.checksum+0x120>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x28
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1260 <corpus.cases.mem.rec_layout.checksum+0xe8>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12a8 <corpus.cases.mem.rec_layout.checksum+0x130>
+               	j	0x12e0 <corpus.cases.mem.rec_layout.checksum+0x168>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x58
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12a8 <corpus.cases.mem.rec_layout.checksum+0x130>
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12f0 <corpus.cases.mem.rec_layout.checksum+0x178>
+               	j	0x1328 <corpus.cases.mem.rec_layout.checksum+0x1b0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	li	t1, 0x4
+               	srl	a3, t1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a0, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12f0 <corpus.cases.mem.rec_layout.checksum+0x178>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x8c>
-               	mv	a1, a0
-               	mv	a0, a1
-               	li	a1, 0x4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xa0>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1b4>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xb4>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1c0>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xc8>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1cc>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xdc>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1d8>
                	li	a1, 0x8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xf0>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1e4>
                	li	a1, 0x4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x104>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1f0>
                	li	a1, 0x10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x118>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1fc>
                	li	a1, 0x18
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x12c>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x208>
                	li	a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x140>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x214>
                	li	a1, 0x26
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x154>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x220>
                	li	a1, 0x28
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x168>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x22c>
                	li	a1, 0x50
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x17c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x238>
                	addi	s3, s0, -0x88
                	mv	a1, s3
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0xf08 <corpus.cases.mem.rec_layout.checksum+0x1b8>
+               	bnez	a2, 0x13ec <corpus.cases.mem.rec_layout.checksum+0x274>
                	mv	a2, a1
                	li	a3, 0x58
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0xef0 <corpus.cases.mem.rec_layout.checksum+0x1a0>
-               	j	0xf24 <corpus.cases.mem.rec_layout.checksum+0x1d4>
+               	bne	a3, t0, 0x13d4 <corpus.cases.mem.rec_layout.checksum+0x25c>
+               	j	0x1408 <corpus.cases.mem.rec_layout.checksum+0x290>
                	mv	a2, a1
                	li	a1, 0x58
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0xf10 <corpus.cases.mem.rec_layout.checksum+0x1c0>
+               	bne	a1, t0, 0x13f4 <corpus.cases.mem.rec_layout.checksum+0x27c>
                	addi	a1, s0, -0xe0
                	mv	a2, a1
                	mv	a3, s3
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0xf9c <corpus.cases.mem.rec_layout.checksum+0x24c>
-               	bnez	a4, 0xf70 <corpus.cases.mem.rec_layout.checksum+0x220>
+               	bltu	a2, a3, 0x1480 <corpus.cases.mem.rec_layout.checksum+0x308>
+               	bnez	a4, 0x1454 <corpus.cases.mem.rec_layout.checksum+0x2dc>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -999,8 +1312,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0xf50 <corpus.cases.mem.rec_layout.checksum+0x200>
-               	j	0xff4 <corpus.cases.mem.rec_layout.checksum+0x2a4>
+               	bne	a7, t0, 0x1434 <corpus.cases.mem.rec_layout.checksum+0x2bc>
+               	j	0x14d8 <corpus.cases.mem.rec_layout.checksum+0x360>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1010,9 +1323,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0xf7c <corpus.cases.mem.rec_layout.checksum+0x22c>
-               	j	0xff4 <corpus.cases.mem.rec_layout.checksum+0x2a4>
-               	bnez	a4, 0xfcc <corpus.cases.mem.rec_layout.checksum+0x27c>
+               	bne	a7, t0, 0x1460 <corpus.cases.mem.rec_layout.checksum+0x2e8>
+               	j	0x14d8 <corpus.cases.mem.rec_layout.checksum+0x360>
+               	bnez	a4, 0x14b0 <corpus.cases.mem.rec_layout.checksum+0x338>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1022,8 +1335,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0xfac <corpus.cases.mem.rec_layout.checksum+0x25c>
-               	j	0xff4 <corpus.cases.mem.rec_layout.checksum+0x2a4>
+               	bne	a6, t0, 0x1490 <corpus.cases.mem.rec_layout.checksum+0x318>
+               	j	0x14d8 <corpus.cases.mem.rec_layout.checksum+0x360>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1033,14 +1346,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0xfd8 <corpus.cases.mem.rec_layout.checksum+0x288>
+               	bne	a3, t0, 0x14bc <corpus.cases.mem.rec_layout.checksum+0x344>
                	addi	a2, s0, -0x138
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1068 <corpus.cases.mem.rec_layout.checksum+0x318>
-               	bnez	a1, 0x103c <corpus.cases.mem.rec_layout.checksum+0x2ec>
+               	bltu	a2, a3, 0x154c <corpus.cases.mem.rec_layout.checksum+0x3d4>
+               	bnez	a1, 0x1520 <corpus.cases.mem.rec_layout.checksum+0x3a8>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1050,8 +1363,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x101c <corpus.cases.mem.rec_layout.checksum+0x2cc>
-               	j	0x10c0 <corpus.cases.mem.rec_layout.checksum+0x370>
+               	bne	a6, t0, 0x1500 <corpus.cases.mem.rec_layout.checksum+0x388>
+               	j	0x15a4 <corpus.cases.mem.rec_layout.checksum+0x42c>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1061,9 +1374,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1048 <corpus.cases.mem.rec_layout.checksum+0x2f8>
-               	j	0x10c0 <corpus.cases.mem.rec_layout.checksum+0x370>
-               	bnez	a1, 0x1098 <corpus.cases.mem.rec_layout.checksum+0x348>
+               	bne	a6, t0, 0x152c <corpus.cases.mem.rec_layout.checksum+0x3b4>
+               	j	0x15a4 <corpus.cases.mem.rec_layout.checksum+0x42c>
+               	bnez	a1, 0x157c <corpus.cases.mem.rec_layout.checksum+0x404>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1073,8 +1386,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1078 <corpus.cases.mem.rec_layout.checksum+0x328>
-               	j	0x10c0 <corpus.cases.mem.rec_layout.checksum+0x370>
+               	bne	a5, t0, 0x155c <corpus.cases.mem.rec_layout.checksum+0x3e4>
+               	j	0x15a4 <corpus.cases.mem.rec_layout.checksum+0x42c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1084,10 +1397,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x10a4 <corpus.cases.mem.rec_layout.checksum+0x354>
+               	bne	a3, t0, 0x1588 <corpus.cases.mem.rec_layout.checksum+0x410>
                	addi	a1, s0, -0x138
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x374>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x430>
                	mv	a1, s3
                	mv	a2, a1
                	li	t1, 0xa
@@ -1200,8 +1513,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x12ec <corpus.cases.mem.rec_layout.checksum+0x59c>
-               	bnez	a4, 0x12c0 <corpus.cases.mem.rec_layout.checksum+0x570>
+               	bltu	a2, a3, 0x17d0 <corpus.cases.mem.rec_layout.checksum+0x658>
+               	bnez	a4, 0x17a4 <corpus.cases.mem.rec_layout.checksum+0x62c>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1211,8 +1524,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x12a0 <corpus.cases.mem.rec_layout.checksum+0x550>
-               	j	0x1344 <corpus.cases.mem.rec_layout.checksum+0x5f4>
+               	bne	a7, t0, 0x1784 <corpus.cases.mem.rec_layout.checksum+0x60c>
+               	j	0x1828 <corpus.cases.mem.rec_layout.checksum+0x6b0>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1222,9 +1535,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x12cc <corpus.cases.mem.rec_layout.checksum+0x57c>
-               	j	0x1344 <corpus.cases.mem.rec_layout.checksum+0x5f4>
-               	bnez	a4, 0x131c <corpus.cases.mem.rec_layout.checksum+0x5cc>
+               	bne	a7, t0, 0x17b0 <corpus.cases.mem.rec_layout.checksum+0x638>
+               	j	0x1828 <corpus.cases.mem.rec_layout.checksum+0x6b0>
+               	bnez	a4, 0x1800 <corpus.cases.mem.rec_layout.checksum+0x688>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1234,8 +1547,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x12fc <corpus.cases.mem.rec_layout.checksum+0x5ac>
-               	j	0x1344 <corpus.cases.mem.rec_layout.checksum+0x5f4>
+               	bne	a6, t0, 0x17e0 <corpus.cases.mem.rec_layout.checksum+0x668>
+               	j	0x1828 <corpus.cases.mem.rec_layout.checksum+0x6b0>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1245,14 +1558,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1328 <corpus.cases.mem.rec_layout.checksum+0x5d8>
+               	bne	a3, t0, 0x180c <corpus.cases.mem.rec_layout.checksum+0x694>
                	addi	a2, s0, -0x1e8
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x13b8 <corpus.cases.mem.rec_layout.checksum+0x668>
-               	bnez	a1, 0x138c <corpus.cases.mem.rec_layout.checksum+0x63c>
+               	bltu	a2, a3, 0x189c <corpus.cases.mem.rec_layout.checksum+0x724>
+               	bnez	a1, 0x1870 <corpus.cases.mem.rec_layout.checksum+0x6f8>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1262,8 +1575,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x136c <corpus.cases.mem.rec_layout.checksum+0x61c>
-               	j	0x1410 <corpus.cases.mem.rec_layout.checksum+0x6c0>
+               	bne	a6, t0, 0x1850 <corpus.cases.mem.rec_layout.checksum+0x6d8>
+               	j	0x18f4 <corpus.cases.mem.rec_layout.checksum+0x77c>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1273,9 +1586,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1398 <corpus.cases.mem.rec_layout.checksum+0x648>
-               	j	0x1410 <corpus.cases.mem.rec_layout.checksum+0x6c0>
-               	bnez	a1, 0x13e8 <corpus.cases.mem.rec_layout.checksum+0x698>
+               	bne	a6, t0, 0x187c <corpus.cases.mem.rec_layout.checksum+0x704>
+               	j	0x18f4 <corpus.cases.mem.rec_layout.checksum+0x77c>
+               	bnez	a1, 0x18cc <corpus.cases.mem.rec_layout.checksum+0x754>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1285,8 +1598,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x13c8 <corpus.cases.mem.rec_layout.checksum+0x678>
-               	j	0x1410 <corpus.cases.mem.rec_layout.checksum+0x6c0>
+               	bne	a5, t0, 0x18ac <corpus.cases.mem.rec_layout.checksum+0x734>
+               	j	0x18f4 <corpus.cases.mem.rec_layout.checksum+0x77c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1296,10 +1609,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x13f4 <corpus.cases.mem.rec_layout.checksum+0x6a4>
+               	bne	a3, t0, 0x18d8 <corpus.cases.mem.rec_layout.checksum+0x760>
                	addi	a1, s0, -0x1e8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x6c4>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x780>
                	mv	s2, s3
                	mv	a1, s2
                	addi	a2, a1, 0x4
@@ -1315,8 +1628,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x14b8 <corpus.cases.mem.rec_layout.checksum+0x768>
-               	bnez	a4, 0x148c <corpus.cases.mem.rec_layout.checksum+0x73c>
+               	bltu	a2, a3, 0x199c <corpus.cases.mem.rec_layout.checksum+0x824>
+               	bnez	a4, 0x1970 <corpus.cases.mem.rec_layout.checksum+0x7f8>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1326,8 +1639,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x146c <corpus.cases.mem.rec_layout.checksum+0x71c>
-               	j	0x1510 <corpus.cases.mem.rec_layout.checksum+0x7c0>
+               	bne	a7, t0, 0x1950 <corpus.cases.mem.rec_layout.checksum+0x7d8>
+               	j	0x19f4 <corpus.cases.mem.rec_layout.checksum+0x87c>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1337,9 +1650,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1498 <corpus.cases.mem.rec_layout.checksum+0x748>
-               	j	0x1510 <corpus.cases.mem.rec_layout.checksum+0x7c0>
-               	bnez	a4, 0x14e8 <corpus.cases.mem.rec_layout.checksum+0x798>
+               	bne	a7, t0, 0x197c <corpus.cases.mem.rec_layout.checksum+0x804>
+               	j	0x19f4 <corpus.cases.mem.rec_layout.checksum+0x87c>
+               	bnez	a4, 0x19cc <corpus.cases.mem.rec_layout.checksum+0x854>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1349,8 +1662,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x14c8 <corpus.cases.mem.rec_layout.checksum+0x778>
-               	j	0x1510 <corpus.cases.mem.rec_layout.checksum+0x7c0>
+               	bne	a6, t0, 0x19ac <corpus.cases.mem.rec_layout.checksum+0x834>
+               	j	0x19f4 <corpus.cases.mem.rec_layout.checksum+0x87c>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1360,14 +1673,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x14f4 <corpus.cases.mem.rec_layout.checksum+0x7a4>
+               	bne	a3, t0, 0x19d8 <corpus.cases.mem.rec_layout.checksum+0x860>
                	addi	a2, s0, -0x298
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1584 <corpus.cases.mem.rec_layout.checksum+0x834>
-               	bnez	a1, 0x1558 <corpus.cases.mem.rec_layout.checksum+0x808>
+               	bltu	a2, a3, 0x1a68 <corpus.cases.mem.rec_layout.checksum+0x8f0>
+               	bnez	a1, 0x1a3c <corpus.cases.mem.rec_layout.checksum+0x8c4>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1377,8 +1690,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1538 <corpus.cases.mem.rec_layout.checksum+0x7e8>
-               	j	0x15dc <corpus.cases.mem.rec_layout.checksum+0x88c>
+               	bne	a6, t0, 0x1a1c <corpus.cases.mem.rec_layout.checksum+0x8a4>
+               	j	0x1ac0 <corpus.cases.mem.rec_layout.checksum+0x948>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1388,9 +1701,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1564 <corpus.cases.mem.rec_layout.checksum+0x814>
-               	j	0x15dc <corpus.cases.mem.rec_layout.checksum+0x88c>
-               	bnez	a1, 0x15b4 <corpus.cases.mem.rec_layout.checksum+0x864>
+               	bne	a6, t0, 0x1a48 <corpus.cases.mem.rec_layout.checksum+0x8d0>
+               	j	0x1ac0 <corpus.cases.mem.rec_layout.checksum+0x948>
+               	bnez	a1, 0x1a98 <corpus.cases.mem.rec_layout.checksum+0x920>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1400,8 +1713,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1594 <corpus.cases.mem.rec_layout.checksum+0x844>
-               	j	0x15dc <corpus.cases.mem.rec_layout.checksum+0x88c>
+               	bne	a5, t0, 0x1a78 <corpus.cases.mem.rec_layout.checksum+0x900>
+               	j	0x1ac0 <corpus.cases.mem.rec_layout.checksum+0x948>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1411,10 +1724,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x15c0 <corpus.cases.mem.rec_layout.checksum+0x870>
+               	bne	a3, t0, 0x1aa4 <corpus.cases.mem.rec_layout.checksum+0x92c>
                	addi	a1, s0, -0x298
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x890>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x94c>
                	addi	s4, s3, 0x28
                	addi	a1, s4, 0x14
                	addi	a2, a1, 0x4
@@ -1428,8 +1741,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x167c <corpus.cases.mem.rec_layout.checksum+0x92c>
-               	bnez	a4, 0x1650 <corpus.cases.mem.rec_layout.checksum+0x900>
+               	bltu	a2, a3, 0x1b60 <corpus.cases.mem.rec_layout.checksum+0x9e8>
+               	bnez	a4, 0x1b34 <corpus.cases.mem.rec_layout.checksum+0x9bc>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1439,8 +1752,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1630 <corpus.cases.mem.rec_layout.checksum+0x8e0>
-               	j	0x16d4 <corpus.cases.mem.rec_layout.checksum+0x984>
+               	bne	a7, t0, 0x1b14 <corpus.cases.mem.rec_layout.checksum+0x99c>
+               	j	0x1bb8 <corpus.cases.mem.rec_layout.checksum+0xa40>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1450,9 +1763,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x165c <corpus.cases.mem.rec_layout.checksum+0x90c>
-               	j	0x16d4 <corpus.cases.mem.rec_layout.checksum+0x984>
-               	bnez	a4, 0x16ac <corpus.cases.mem.rec_layout.checksum+0x95c>
+               	bne	a7, t0, 0x1b40 <corpus.cases.mem.rec_layout.checksum+0x9c8>
+               	j	0x1bb8 <corpus.cases.mem.rec_layout.checksum+0xa40>
+               	bnez	a4, 0x1b90 <corpus.cases.mem.rec_layout.checksum+0xa18>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1462,8 +1775,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x168c <corpus.cases.mem.rec_layout.checksum+0x93c>
-               	j	0x16d4 <corpus.cases.mem.rec_layout.checksum+0x984>
+               	bne	a6, t0, 0x1b70 <corpus.cases.mem.rec_layout.checksum+0x9f8>
+               	j	0x1bb8 <corpus.cases.mem.rec_layout.checksum+0xa40>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1473,14 +1786,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x16b8 <corpus.cases.mem.rec_layout.checksum+0x968>
+               	bne	a3, t0, 0x1b9c <corpus.cases.mem.rec_layout.checksum+0xa24>
                	addi	a2, s0, -0x348
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1748 <corpus.cases.mem.rec_layout.checksum+0x9f8>
-               	bnez	a1, 0x171c <corpus.cases.mem.rec_layout.checksum+0x9cc>
+               	bltu	a2, a3, 0x1c2c <corpus.cases.mem.rec_layout.checksum+0xab4>
+               	bnez	a1, 0x1c00 <corpus.cases.mem.rec_layout.checksum+0xa88>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1490,8 +1803,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x16fc <corpus.cases.mem.rec_layout.checksum+0x9ac>
-               	j	0x17a0 <corpus.cases.mem.rec_layout.checksum+0xa50>
+               	bne	a6, t0, 0x1be0 <corpus.cases.mem.rec_layout.checksum+0xa68>
+               	j	0x1c84 <corpus.cases.mem.rec_layout.checksum+0xb0c>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1501,9 +1814,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1728 <corpus.cases.mem.rec_layout.checksum+0x9d8>
-               	j	0x17a0 <corpus.cases.mem.rec_layout.checksum+0xa50>
-               	bnez	a1, 0x1778 <corpus.cases.mem.rec_layout.checksum+0xa28>
+               	bne	a6, t0, 0x1c0c <corpus.cases.mem.rec_layout.checksum+0xa94>
+               	j	0x1c84 <corpus.cases.mem.rec_layout.checksum+0xb0c>
+               	bnez	a1, 0x1c5c <corpus.cases.mem.rec_layout.checksum+0xae4>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1513,8 +1826,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1758 <corpus.cases.mem.rec_layout.checksum+0xa08>
-               	j	0x17a0 <corpus.cases.mem.rec_layout.checksum+0xa50>
+               	bne	a5, t0, 0x1c3c <corpus.cases.mem.rec_layout.checksum+0xac4>
+               	j	0x1c84 <corpus.cases.mem.rec_layout.checksum+0xb0c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1524,10 +1837,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1784 <corpus.cases.mem.rec_layout.checksum+0xa34>
+               	bne	a3, t0, 0x1c68 <corpus.cases.mem.rec_layout.checksum+0xaf0>
                	addi	a1, s0, -0x348
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xa54>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xb10>
                	addi	a1, s2, 0x18
                	ld	a2, 0x0(a1)
                	srli	a3, a2, 0x3
@@ -1538,8 +1851,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x1834 <corpus.cases.mem.rec_layout.checksum+0xae4>
-               	bnez	a4, 0x1808 <corpus.cases.mem.rec_layout.checksum+0xab8>
+               	bltu	a2, a3, 0x1d18 <corpus.cases.mem.rec_layout.checksum+0xba0>
+               	bnez	a4, 0x1cec <corpus.cases.mem.rec_layout.checksum+0xb74>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1549,8 +1862,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x17e8 <corpus.cases.mem.rec_layout.checksum+0xa98>
-               	j	0x188c <corpus.cases.mem.rec_layout.checksum+0xb3c>
+               	bne	a7, t0, 0x1ccc <corpus.cases.mem.rec_layout.checksum+0xb54>
+               	j	0x1d70 <corpus.cases.mem.rec_layout.checksum+0xbf8>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1560,9 +1873,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1814 <corpus.cases.mem.rec_layout.checksum+0xac4>
-               	j	0x188c <corpus.cases.mem.rec_layout.checksum+0xb3c>
-               	bnez	a4, 0x1864 <corpus.cases.mem.rec_layout.checksum+0xb14>
+               	bne	a7, t0, 0x1cf8 <corpus.cases.mem.rec_layout.checksum+0xb80>
+               	j	0x1d70 <corpus.cases.mem.rec_layout.checksum+0xbf8>
+               	bnez	a4, 0x1d48 <corpus.cases.mem.rec_layout.checksum+0xbd0>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1572,8 +1885,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1844 <corpus.cases.mem.rec_layout.checksum+0xaf4>
-               	j	0x188c <corpus.cases.mem.rec_layout.checksum+0xb3c>
+               	bne	a6, t0, 0x1d28 <corpus.cases.mem.rec_layout.checksum+0xbb0>
+               	j	0x1d70 <corpus.cases.mem.rec_layout.checksum+0xbf8>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1583,14 +1896,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1870 <corpus.cases.mem.rec_layout.checksum+0xb20>
+               	bne	a3, t0, 0x1d54 <corpus.cases.mem.rec_layout.checksum+0xbdc>
                	addi	a2, s0, -0x3f8
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1900 <corpus.cases.mem.rec_layout.checksum+0xbb0>
-               	bnez	a1, 0x18d4 <corpus.cases.mem.rec_layout.checksum+0xb84>
+               	bltu	a2, a3, 0x1de4 <corpus.cases.mem.rec_layout.checksum+0xc6c>
+               	bnez	a1, 0x1db8 <corpus.cases.mem.rec_layout.checksum+0xc40>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1600,8 +1913,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x18b4 <corpus.cases.mem.rec_layout.checksum+0xb64>
-               	j	0x1958 <corpus.cases.mem.rec_layout.checksum+0xc08>
+               	bne	a6, t0, 0x1d98 <corpus.cases.mem.rec_layout.checksum+0xc20>
+               	j	0x1e3c <corpus.cases.mem.rec_layout.checksum+0xcc4>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1611,9 +1924,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x18e0 <corpus.cases.mem.rec_layout.checksum+0xb90>
-               	j	0x1958 <corpus.cases.mem.rec_layout.checksum+0xc08>
-               	bnez	a1, 0x1930 <corpus.cases.mem.rec_layout.checksum+0xbe0>
+               	bne	a6, t0, 0x1dc4 <corpus.cases.mem.rec_layout.checksum+0xc4c>
+               	j	0x1e3c <corpus.cases.mem.rec_layout.checksum+0xcc4>
+               	bnez	a1, 0x1e14 <corpus.cases.mem.rec_layout.checksum+0xc9c>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1623,8 +1936,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1910 <corpus.cases.mem.rec_layout.checksum+0xbc0>
-               	j	0x1958 <corpus.cases.mem.rec_layout.checksum+0xc08>
+               	bne	a5, t0, 0x1df4 <corpus.cases.mem.rec_layout.checksum+0xc7c>
+               	j	0x1e3c <corpus.cases.mem.rec_layout.checksum+0xcc4>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1634,10 +1947,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x193c <corpus.cases.mem.rec_layout.checksum+0xbec>
+               	bne	a3, t0, 0x1e20 <corpus.cases.mem.rec_layout.checksum+0xca8>
                	addi	a1, s0, -0x3f8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xc0c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xcc8>
                	lw	a1, 0x0(s1)
                	li	t0, 0x3
                	mulw	a2, a1, t0
@@ -1648,8 +1961,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x19ec <corpus.cases.mem.rec_layout.checksum+0xc9c>
-               	bnez	a4, 0x19c0 <corpus.cases.mem.rec_layout.checksum+0xc70>
+               	bltu	a2, a3, 0x1ed0 <corpus.cases.mem.rec_layout.checksum+0xd58>
+               	bnez	a4, 0x1ea4 <corpus.cases.mem.rec_layout.checksum+0xd2c>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1659,8 +1972,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x19a0 <corpus.cases.mem.rec_layout.checksum+0xc50>
-               	j	0x1a44 <corpus.cases.mem.rec_layout.checksum+0xcf4>
+               	bne	a7, t0, 0x1e84 <corpus.cases.mem.rec_layout.checksum+0xd0c>
+               	j	0x1f28 <corpus.cases.mem.rec_layout.checksum+0xdb0>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -1670,9 +1983,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x19cc <corpus.cases.mem.rec_layout.checksum+0xc7c>
-               	j	0x1a44 <corpus.cases.mem.rec_layout.checksum+0xcf4>
-               	bnez	a4, 0x1a1c <corpus.cases.mem.rec_layout.checksum+0xccc>
+               	bne	a7, t0, 0x1eb0 <corpus.cases.mem.rec_layout.checksum+0xd38>
+               	j	0x1f28 <corpus.cases.mem.rec_layout.checksum+0xdb0>
+               	bnez	a4, 0x1f00 <corpus.cases.mem.rec_layout.checksum+0xd88>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -1682,8 +1995,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x19fc <corpus.cases.mem.rec_layout.checksum+0xcac>
-               	j	0x1a44 <corpus.cases.mem.rec_layout.checksum+0xcf4>
+               	bne	a6, t0, 0x1ee0 <corpus.cases.mem.rec_layout.checksum+0xd68>
+               	j	0x1f28 <corpus.cases.mem.rec_layout.checksum+0xdb0>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1693,14 +2006,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1a28 <corpus.cases.mem.rec_layout.checksum+0xcd8>
+               	bne	a3, t0, 0x1f0c <corpus.cases.mem.rec_layout.checksum+0xd94>
                	addi	a2, s0, -0x4a8
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1ab8 <corpus.cases.mem.rec_layout.checksum+0xd68>
-               	bnez	a1, 0x1a8c <corpus.cases.mem.rec_layout.checksum+0xd3c>
+               	bltu	a2, a3, 0x1f9c <corpus.cases.mem.rec_layout.checksum+0xe24>
+               	bnez	a1, 0x1f70 <corpus.cases.mem.rec_layout.checksum+0xdf8>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1710,8 +2023,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1a6c <corpus.cases.mem.rec_layout.checksum+0xd1c>
-               	j	0x1b10 <corpus.cases.mem.rec_layout.checksum+0xdc0>
+               	bne	a6, t0, 0x1f50 <corpus.cases.mem.rec_layout.checksum+0xdd8>
+               	j	0x1ff4 <corpus.cases.mem.rec_layout.checksum+0xe7c>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -1721,9 +2034,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1a98 <corpus.cases.mem.rec_layout.checksum+0xd48>
-               	j	0x1b10 <corpus.cases.mem.rec_layout.checksum+0xdc0>
-               	bnez	a1, 0x1ae8 <corpus.cases.mem.rec_layout.checksum+0xd98>
+               	bne	a6, t0, 0x1f7c <corpus.cases.mem.rec_layout.checksum+0xe04>
+               	j	0x1ff4 <corpus.cases.mem.rec_layout.checksum+0xe7c>
+               	bnez	a1, 0x1fcc <corpus.cases.mem.rec_layout.checksum+0xe54>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -1733,8 +2046,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1ac8 <corpus.cases.mem.rec_layout.checksum+0xd78>
-               	j	0x1b10 <corpus.cases.mem.rec_layout.checksum+0xdc0>
+               	bne	a5, t0, 0x1fac <corpus.cases.mem.rec_layout.checksum+0xe34>
+               	j	0x1ff4 <corpus.cases.mem.rec_layout.checksum+0xe7c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -1744,10 +2057,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1af4 <corpus.cases.mem.rec_layout.checksum+0xda4>
+               	bne	a3, t0, 0x1fd8 <corpus.cases.mem.rec_layout.checksum+0xe60>
                	addi	a1, s0, -0x4a8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xdc4>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0xe80>
                	addi	s1, s0, -0x4bc
                	mv	s2, s4
                	addi	a1, s0, -0x4d0
@@ -1756,8 +2069,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x1ba4 <corpus.cases.mem.rec_layout.checksum+0xe54>
-               	bnez	a4, 0x1b78 <corpus.cases.mem.rec_layout.checksum+0xe28>
+               	bltu	a2, a3, 0x2088 <corpus.cases.mem.rec_layout.checksum+0xf10>
+               	bnez	a4, 0x205c <corpus.cases.mem.rec_layout.checksum+0xee4>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	lw	a7, 0x0(a6)
@@ -1769,8 +2082,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1b58 <corpus.cases.mem.rec_layout.checksum+0xe08>
-               	j	0x1c04 <corpus.cases.mem.rec_layout.checksum+0xeb4>
+               	bne	a7, t0, 0x203c <corpus.cases.mem.rec_layout.checksum+0xec4>
+               	j	0x20e8 <corpus.cases.mem.rec_layout.checksum+0xf70>
                	addi	a5, a2, 0x14
                	addi	a6, a3, 0x14
                	li	a7, 0x14
@@ -1780,9 +2093,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1b84 <corpus.cases.mem.rec_layout.checksum+0xe34>
-               	j	0x1c04 <corpus.cases.mem.rec_layout.checksum+0xeb4>
-               	bnez	a4, 0x1bdc <corpus.cases.mem.rec_layout.checksum+0xe8c>
+               	bne	a7, t0, 0x2068 <corpus.cases.mem.rec_layout.checksum+0xef0>
+               	j	0x20e8 <corpus.cases.mem.rec_layout.checksum+0xf70>
+               	bnez	a4, 0x20c0 <corpus.cases.mem.rec_layout.checksum+0xf48>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -1792,10 +2105,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1bb4 <corpus.cases.mem.rec_layout.checksum+0xe64>
+               	bne	a6, t0, 0x2098 <corpus.cases.mem.rec_layout.checksum+0xf20>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a4)
-               	j	0x1c04 <corpus.cases.mem.rec_layout.checksum+0xeb4>
+               	j	0x20e8 <corpus.cases.mem.rec_layout.checksum+0xf70>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -1805,14 +2118,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1be8 <corpus.cases.mem.rec_layout.checksum+0xe98>
+               	bne	a3, t0, 0x20cc <corpus.cases.mem.rec_layout.checksum+0xf54>
                	mv	a2, s1
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1c80 <corpus.cases.mem.rec_layout.checksum+0xf30>
-               	bnez	a1, 0x1c54 <corpus.cases.mem.rec_layout.checksum+0xf04>
+               	bltu	a2, a3, 0x2164 <corpus.cases.mem.rec_layout.checksum+0xfec>
+               	bnez	a1, 0x2138 <corpus.cases.mem.rec_layout.checksum+0xfc0>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -1824,8 +2137,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1c34 <corpus.cases.mem.rec_layout.checksum+0xee4>
-               	j	0x1ce0 <corpus.cases.mem.rec_layout.checksum+0xf90>
+               	bne	a6, t0, 0x2118 <corpus.cases.mem.rec_layout.checksum+0xfa0>
+               	j	0x21c4 <corpus.cases.mem.rec_layout.checksum+0x104c>
                	addi	a4, a2, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -1835,9 +2148,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1c60 <corpus.cases.mem.rec_layout.checksum+0xf10>
-               	j	0x1ce0 <corpus.cases.mem.rec_layout.checksum+0xf90>
-               	bnez	a1, 0x1cb8 <corpus.cases.mem.rec_layout.checksum+0xf68>
+               	bne	a6, t0, 0x2144 <corpus.cases.mem.rec_layout.checksum+0xfcc>
+               	j	0x21c4 <corpus.cases.mem.rec_layout.checksum+0x104c>
+               	bnez	a1, 0x219c <corpus.cases.mem.rec_layout.checksum+0x1024>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -1847,10 +2160,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1c90 <corpus.cases.mem.rec_layout.checksum+0xf40>
+               	bne	a5, t0, 0x2174 <corpus.cases.mem.rec_layout.checksum+0xffc>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a1)
-               	j	0x1ce0 <corpus.cases.mem.rec_layout.checksum+0xf90>
+               	j	0x21c4 <corpus.cases.mem.rec_layout.checksum+0x104c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -1860,7 +2173,7 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1cc4 <corpus.cases.mem.rec_layout.checksum+0xf74>
+               	bne	a3, t0, 0x21a8 <corpus.cases.mem.rec_layout.checksum+0x1030>
                	addi	a1, s1, 0x4
                	addi	a2, a1, 0x4
                	lw	a1, 0x0(a2)
@@ -1872,8 +2185,8 @@ Disassembly of section .text:
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x1d74 <corpus.cases.mem.rec_layout.checksum+0x1024>
-               	bnez	a4, 0x1d48 <corpus.cases.mem.rec_layout.checksum+0xff8>
+               	bltu	a2, a3, 0x2258 <corpus.cases.mem.rec_layout.checksum+0x10e0>
+               	bnez	a4, 0x222c <corpus.cases.mem.rec_layout.checksum+0x10b4>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	lw	a7, 0x0(a6)
@@ -1885,8 +2198,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1d28 <corpus.cases.mem.rec_layout.checksum+0xfd8>
-               	j	0x1dd4 <corpus.cases.mem.rec_layout.checksum+0x1084>
+               	bne	a7, t0, 0x220c <corpus.cases.mem.rec_layout.checksum+0x1094>
+               	j	0x22b8 <corpus.cases.mem.rec_layout.checksum+0x1140>
                	addi	a5, a2, 0x14
                	addi	a6, a3, 0x14
                	li	a7, 0x14
@@ -1896,9 +2209,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1d54 <corpus.cases.mem.rec_layout.checksum+0x1004>
-               	j	0x1dd4 <corpus.cases.mem.rec_layout.checksum+0x1084>
-               	bnez	a4, 0x1dac <corpus.cases.mem.rec_layout.checksum+0x105c>
+               	bne	a7, t0, 0x2238 <corpus.cases.mem.rec_layout.checksum+0x10c0>
+               	j	0x22b8 <corpus.cases.mem.rec_layout.checksum+0x1140>
+               	bnez	a4, 0x2290 <corpus.cases.mem.rec_layout.checksum+0x1118>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -1908,10 +2221,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1d84 <corpus.cases.mem.rec_layout.checksum+0x1034>
+               	bne	a6, t0, 0x2268 <corpus.cases.mem.rec_layout.checksum+0x10f0>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a4)
-               	j	0x1dd4 <corpus.cases.mem.rec_layout.checksum+0x1084>
+               	j	0x22b8 <corpus.cases.mem.rec_layout.checksum+0x1140>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -1921,14 +2234,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1db8 <corpus.cases.mem.rec_layout.checksum+0x1068>
+               	bne	a3, t0, 0x229c <corpus.cases.mem.rec_layout.checksum+0x1124>
                	addi	a2, s0, -0x4fc
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1e50 <corpus.cases.mem.rec_layout.checksum+0x1100>
-               	bnez	a1, 0x1e24 <corpus.cases.mem.rec_layout.checksum+0x10d4>
+               	bltu	a2, a3, 0x2334 <corpus.cases.mem.rec_layout.checksum+0x11bc>
+               	bnez	a1, 0x2308 <corpus.cases.mem.rec_layout.checksum+0x1190>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -1940,8 +2253,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1e04 <corpus.cases.mem.rec_layout.checksum+0x10b4>
-               	j	0x1eb0 <corpus.cases.mem.rec_layout.checksum+0x1160>
+               	bne	a6, t0, 0x22e8 <corpus.cases.mem.rec_layout.checksum+0x1170>
+               	j	0x2394 <corpus.cases.mem.rec_layout.checksum+0x121c>
                	addi	a4, a2, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -1951,9 +2264,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1e30 <corpus.cases.mem.rec_layout.checksum+0x10e0>
-               	j	0x1eb0 <corpus.cases.mem.rec_layout.checksum+0x1160>
-               	bnez	a1, 0x1e88 <corpus.cases.mem.rec_layout.checksum+0x1138>
+               	bne	a6, t0, 0x2314 <corpus.cases.mem.rec_layout.checksum+0x119c>
+               	j	0x2394 <corpus.cases.mem.rec_layout.checksum+0x121c>
+               	bnez	a1, 0x236c <corpus.cases.mem.rec_layout.checksum+0x11f4>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -1963,10 +2276,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x1e60 <corpus.cases.mem.rec_layout.checksum+0x1110>
+               	bne	a5, t0, 0x2344 <corpus.cases.mem.rec_layout.checksum+0x11cc>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a1)
-               	j	0x1eb0 <corpus.cases.mem.rec_layout.checksum+0x1160>
+               	j	0x2394 <corpus.cases.mem.rec_layout.checksum+0x121c>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -1976,18 +2289,18 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1e94 <corpus.cases.mem.rec_layout.checksum+0x1144>
+               	bne	a3, t0, 0x2378 <corpus.cases.mem.rec_layout.checksum+0x1200>
                	addi	a1, s0, -0x4fc
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1164>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1220>
                	addi	a1, s0, -0x510
                	mv	a2, a1
                	mv	a3, s2
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x1f3c <corpus.cases.mem.rec_layout.checksum+0x11ec>
-               	bnez	a4, 0x1f10 <corpus.cases.mem.rec_layout.checksum+0x11c0>
+               	bltu	a2, a3, 0x2420 <corpus.cases.mem.rec_layout.checksum+0x12a8>
+               	bnez	a4, 0x23f4 <corpus.cases.mem.rec_layout.checksum+0x127c>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	lw	a7, 0x0(a6)
@@ -1999,8 +2312,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x1ef0 <corpus.cases.mem.rec_layout.checksum+0x11a0>
-               	j	0x1f9c <corpus.cases.mem.rec_layout.checksum+0x124c>
+               	bne	a7, t0, 0x23d4 <corpus.cases.mem.rec_layout.checksum+0x125c>
+               	j	0x2480 <corpus.cases.mem.rec_layout.checksum+0x1308>
                	addi	a5, a2, 0x14
                	addi	a6, a3, 0x14
                	li	a7, 0x14
@@ -2010,9 +2323,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x1f1c <corpus.cases.mem.rec_layout.checksum+0x11cc>
-               	j	0x1f9c <corpus.cases.mem.rec_layout.checksum+0x124c>
-               	bnez	a4, 0x1f74 <corpus.cases.mem.rec_layout.checksum+0x1224>
+               	bne	a7, t0, 0x2400 <corpus.cases.mem.rec_layout.checksum+0x1288>
+               	j	0x2480 <corpus.cases.mem.rec_layout.checksum+0x1308>
+               	bnez	a4, 0x2458 <corpus.cases.mem.rec_layout.checksum+0x12e0>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -2022,10 +2335,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1f4c <corpus.cases.mem.rec_layout.checksum+0x11fc>
+               	bne	a6, t0, 0x2430 <corpus.cases.mem.rec_layout.checksum+0x12b8>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a4)
-               	j	0x1f9c <corpus.cases.mem.rec_layout.checksum+0x124c>
+               	j	0x2480 <corpus.cases.mem.rec_layout.checksum+0x1308>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -2035,14 +2348,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x1f80 <corpus.cases.mem.rec_layout.checksum+0x1230>
+               	bne	a3, t0, 0x2464 <corpus.cases.mem.rec_layout.checksum+0x12ec>
                	addi	a2, s0, -0x528
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x2018 <corpus.cases.mem.rec_layout.checksum+0x12c8>
-               	bnez	a1, 0x1fec <corpus.cases.mem.rec_layout.checksum+0x129c>
+               	bltu	a2, a3, 0x24fc <corpus.cases.mem.rec_layout.checksum+0x1384>
+               	bnez	a1, 0x24d0 <corpus.cases.mem.rec_layout.checksum+0x1358>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -2054,8 +2367,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x1fcc <corpus.cases.mem.rec_layout.checksum+0x127c>
-               	j	0x2078 <corpus.cases.mem.rec_layout.checksum+0x1328>
+               	bne	a6, t0, 0x24b0 <corpus.cases.mem.rec_layout.checksum+0x1338>
+               	j	0x255c <corpus.cases.mem.rec_layout.checksum+0x13e4>
                	addi	a4, a2, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -2065,9 +2378,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x1ff8 <corpus.cases.mem.rec_layout.checksum+0x12a8>
-               	j	0x2078 <corpus.cases.mem.rec_layout.checksum+0x1328>
-               	bnez	a1, 0x2050 <corpus.cases.mem.rec_layout.checksum+0x1300>
+               	bne	a6, t0, 0x24dc <corpus.cases.mem.rec_layout.checksum+0x1364>
+               	j	0x255c <corpus.cases.mem.rec_layout.checksum+0x13e4>
+               	bnez	a1, 0x2534 <corpus.cases.mem.rec_layout.checksum+0x13bc>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -2077,10 +2390,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2028 <corpus.cases.mem.rec_layout.checksum+0x12d8>
+               	bne	a5, t0, 0x250c <corpus.cases.mem.rec_layout.checksum+0x1394>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a1)
-               	j	0x2078 <corpus.cases.mem.rec_layout.checksum+0x1328>
+               	j	0x255c <corpus.cases.mem.rec_layout.checksum+0x13e4>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -2090,18 +2403,18 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x205c <corpus.cases.mem.rec_layout.checksum+0x130c>
+               	bne	a3, t0, 0x2540 <corpus.cases.mem.rec_layout.checksum+0x13c8>
                	addi	a1, s0, -0x528
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x132c>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x13e8>
                	addi	a1, s0, -0x53c
                	mv	a2, a1
                	mv	a3, s1
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x2104 <corpus.cases.mem.rec_layout.checksum+0x13b4>
-               	bnez	a4, 0x20d8 <corpus.cases.mem.rec_layout.checksum+0x1388>
+               	bltu	a2, a3, 0x25e8 <corpus.cases.mem.rec_layout.checksum+0x1470>
+               	bnez	a4, 0x25bc <corpus.cases.mem.rec_layout.checksum+0x1444>
                	addi	a5, a2, 0x10
                	addi	a6, a3, 0x10
                	lw	a7, 0x0(a6)
@@ -2113,8 +2426,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x20b8 <corpus.cases.mem.rec_layout.checksum+0x1368>
-               	j	0x2164 <corpus.cases.mem.rec_layout.checksum+0x1414>
+               	bne	a7, t0, 0x259c <corpus.cases.mem.rec_layout.checksum+0x1424>
+               	j	0x2648 <corpus.cases.mem.rec_layout.checksum+0x14d0>
                	addi	a5, a2, 0x14
                	addi	a6, a3, 0x14
                	li	a7, 0x14
@@ -2124,9 +2437,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x20e4 <corpus.cases.mem.rec_layout.checksum+0x1394>
-               	j	0x2164 <corpus.cases.mem.rec_layout.checksum+0x1414>
-               	bnez	a4, 0x213c <corpus.cases.mem.rec_layout.checksum+0x13ec>
+               	bne	a7, t0, 0x25c8 <corpus.cases.mem.rec_layout.checksum+0x1450>
+               	j	0x2648 <corpus.cases.mem.rec_layout.checksum+0x14d0>
+               	bnez	a4, 0x2620 <corpus.cases.mem.rec_layout.checksum+0x14a8>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x10
@@ -2136,10 +2449,10 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2114 <corpus.cases.mem.rec_layout.checksum+0x13c4>
+               	bne	a6, t0, 0x25f8 <corpus.cases.mem.rec_layout.checksum+0x1480>
                	lw	a6, 0x0(a5)
                	sw	a6, 0x0(a4)
-               	j	0x2164 <corpus.cases.mem.rec_layout.checksum+0x1414>
+               	j	0x2648 <corpus.cases.mem.rec_layout.checksum+0x14d0>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -2149,14 +2462,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2148 <corpus.cases.mem.rec_layout.checksum+0x13f8>
+               	bne	a3, t0, 0x262c <corpus.cases.mem.rec_layout.checksum+0x14b4>
                	mv	a2, s2
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x21e0 <corpus.cases.mem.rec_layout.checksum+0x1490>
-               	bnez	a1, 0x21b4 <corpus.cases.mem.rec_layout.checksum+0x1464>
+               	bltu	a2, a3, 0x26c4 <corpus.cases.mem.rec_layout.checksum+0x154c>
+               	bnez	a1, 0x2698 <corpus.cases.mem.rec_layout.checksum+0x1520>
                	addi	a4, a2, 0x10
                	addi	a5, a3, 0x10
                	lw	a6, 0x0(a5)
@@ -2168,8 +2481,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2194 <corpus.cases.mem.rec_layout.checksum+0x1444>
-               	j	0x2240 <corpus.cases.mem.rec_layout.checksum+0x14f0>
+               	bne	a6, t0, 0x2678 <corpus.cases.mem.rec_layout.checksum+0x1500>
+               	j	0x2724 <corpus.cases.mem.rec_layout.checksum+0x15ac>
                	addi	a4, a2, 0x14
                	addi	a5, a3, 0x14
                	li	a6, 0x14
@@ -2179,9 +2492,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x21c0 <corpus.cases.mem.rec_layout.checksum+0x1470>
-               	j	0x2240 <corpus.cases.mem.rec_layout.checksum+0x14f0>
-               	bnez	a1, 0x2218 <corpus.cases.mem.rec_layout.checksum+0x14c8>
+               	bne	a6, t0, 0x26a4 <corpus.cases.mem.rec_layout.checksum+0x152c>
+               	j	0x2724 <corpus.cases.mem.rec_layout.checksum+0x15ac>
+               	bnez	a1, 0x26fc <corpus.cases.mem.rec_layout.checksum+0x1584>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x10
@@ -2191,10 +2504,10 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x21f0 <corpus.cases.mem.rec_layout.checksum+0x14a0>
+               	bne	a5, t0, 0x26d4 <corpus.cases.mem.rec_layout.checksum+0x155c>
                	lw	a5, 0x0(a4)
                	sw	a5, 0x0(a1)
-               	j	0x2240 <corpus.cases.mem.rec_layout.checksum+0x14f0>
+               	j	0x2724 <corpus.cases.mem.rec_layout.checksum+0x15ac>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x14
@@ -2204,15 +2517,15 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2224 <corpus.cases.mem.rec_layout.checksum+0x14d4>
+               	bne	a3, t0, 0x2708 <corpus.cases.mem.rec_layout.checksum+0x1590>
                	addi	a1, s0, -0x598
                	mv	a2, a1
                	mv	a3, s3
                	or	a4, a2, a3
                	li	t0, 0x7
                	and	a4, a4, t0
-               	bltu	a2, a3, 0x22b8 <corpus.cases.mem.rec_layout.checksum+0x1568>
-               	bnez	a4, 0x228c <corpus.cases.mem.rec_layout.checksum+0x153c>
+               	bltu	a2, a3, 0x279c <corpus.cases.mem.rec_layout.checksum+0x1624>
+               	bnez	a4, 0x2770 <corpus.cases.mem.rec_layout.checksum+0x15f8>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -2222,8 +2535,8 @@ Disassembly of section .text:
                	sd	t5, 0x0(a5)
                	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x226c <corpus.cases.mem.rec_layout.checksum+0x151c>
-               	j	0x2310 <corpus.cases.mem.rec_layout.checksum+0x15c0>
+               	bne	a7, t0, 0x2750 <corpus.cases.mem.rec_layout.checksum+0x15d8>
+               	j	0x27f4 <corpus.cases.mem.rec_layout.checksum+0x167c>
                	addi	a5, a2, 0x58
                	addi	a6, a3, 0x58
                	li	a7, 0x58
@@ -2233,9 +2546,9 @@ Disassembly of section .text:
                	sb	t5, 0x0(a5)
                	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	a7, t0, 0x2298 <corpus.cases.mem.rec_layout.checksum+0x1548>
-               	j	0x2310 <corpus.cases.mem.rec_layout.checksum+0x15c0>
-               	bnez	a4, 0x22e8 <corpus.cases.mem.rec_layout.checksum+0x1598>
+               	bne	a7, t0, 0x277c <corpus.cases.mem.rec_layout.checksum+0x1604>
+               	j	0x27f4 <corpus.cases.mem.rec_layout.checksum+0x167c>
+               	bnez	a4, 0x27cc <corpus.cases.mem.rec_layout.checksum+0x1654>
                	mv	a4, a2
                	mv	a5, a3
                	li	a6, 0x58
@@ -2245,8 +2558,8 @@ Disassembly of section .text:
                	addi	a5, a5, 0x8
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x22c8 <corpus.cases.mem.rec_layout.checksum+0x1578>
-               	j	0x2310 <corpus.cases.mem.rec_layout.checksum+0x15c0>
+               	bne	a6, t0, 0x27ac <corpus.cases.mem.rec_layout.checksum+0x1634>
+               	j	0x27f4 <corpus.cases.mem.rec_layout.checksum+0x167c>
                	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -2256,14 +2569,14 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x22f4 <corpus.cases.mem.rec_layout.checksum+0x15a4>
+               	bne	a3, t0, 0x27d8 <corpus.cases.mem.rec_layout.checksum+0x1660>
                	addi	a2, s0, -0x5f0
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x2384 <corpus.cases.mem.rec_layout.checksum+0x1634>
-               	bnez	a1, 0x2358 <corpus.cases.mem.rec_layout.checksum+0x1608>
+               	bltu	a2, a3, 0x2868 <corpus.cases.mem.rec_layout.checksum+0x16f0>
+               	bnez	a1, 0x283c <corpus.cases.mem.rec_layout.checksum+0x16c4>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -2273,8 +2586,8 @@ Disassembly of section .text:
                	sd	a7, 0x0(a4)
                	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a6, t0, 0x2338 <corpus.cases.mem.rec_layout.checksum+0x15e8>
-               	j	0x23dc <corpus.cases.mem.rec_layout.checksum+0x168c>
+               	bne	a6, t0, 0x281c <corpus.cases.mem.rec_layout.checksum+0x16a4>
+               	j	0x28c0 <corpus.cases.mem.rec_layout.checksum+0x1748>
                	addi	a4, a2, 0x58
                	addi	a5, a3, 0x58
                	li	a6, 0x58
@@ -2284,9 +2597,9 @@ Disassembly of section .text:
                	sb	a7, 0x0(a4)
                	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a6, t0, 0x2364 <corpus.cases.mem.rec_layout.checksum+0x1614>
-               	j	0x23dc <corpus.cases.mem.rec_layout.checksum+0x168c>
-               	bnez	a1, 0x23b4 <corpus.cases.mem.rec_layout.checksum+0x1664>
+               	bne	a6, t0, 0x2848 <corpus.cases.mem.rec_layout.checksum+0x16d0>
+               	j	0x28c0 <corpus.cases.mem.rec_layout.checksum+0x1748>
+               	bnez	a1, 0x2898 <corpus.cases.mem.rec_layout.checksum+0x1720>
                	mv	a1, a2
                	mv	a4, a3
                	li	a5, 0x58
@@ -2296,8 +2609,8 @@ Disassembly of section .text:
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x2394 <corpus.cases.mem.rec_layout.checksum+0x1644>
-               	j	0x23dc <corpus.cases.mem.rec_layout.checksum+0x168c>
+               	bne	a5, t0, 0x2878 <corpus.cases.mem.rec_layout.checksum+0x1700>
+               	j	0x28c0 <corpus.cases.mem.rec_layout.checksum+0x1748>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x58
@@ -2307,10 +2620,10 @@ Disassembly of section .text:
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x23c0 <corpus.cases.mem.rec_layout.checksum+0x1670>
+               	bne	a3, t0, 0x28a4 <corpus.cases.mem.rec_layout.checksum+0x172c>
                	addi	a1, s0, -0x5f0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x1690>
+               	jalr	ra <corpus.cases.mem.rec_layout.checksum+0x174c>
                	ld	s1, 0x5d8(sp)
                	ld	s2, 0x5d0(sp)
                	ld	s3, 0x5c8(sp)

--- a/test/golden/riscv64-linux/mem/uni_layout.dis
+++ b/test/golden/riscv64-linux/mem/uni_layout.dis
@@ -31,187 +31,356 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.mem.uni_layout.fold_w4>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	mv	a2, a0
-               	sd	a1, -0x28(s0)
-               	addi	s1, s0, -0x2c
-               	lbu	a1, -0x28(s0)
-               	lbu	a3, -0x27(s0)
-               	lbu	a4, -0x26(s0)
-               	lbu	a5, -0x25(s0)
-               	sb	a1, 0x0(s1)
-               	sb	a3, 0x1(s1)
-               	sb	a4, 0x2(s1)
-               	sb	a5, 0x3(s1)
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0x54>
-               	mv	a1, a0
-               	mv	a2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x1c
+               	lbu	a2, -0x18(s0)
+               	lbu	a3, -0x17(s0)
+               	lbu	a4, -0x16(s0)
+               	lbu	a5, -0x15(s0)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0x70>
-               	mv	a1, a0
-               	mv	a2, s1
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb8 <corpus.cases.mem.uni_layout.fold_w4+0x58>
+               	j	0xec <corpus.cases.mem.uni_layout.fold_w4+0x8c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xb8 <corpus.cases.mem.uni_layout.fold_w4+0x58>
+               	mv	a2, a1
+               	lw	a3, 0x0(a2)
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x108 <corpus.cases.mem.uni_layout.fold_w4+0xa8>
+               	j	0x13c <corpus.cases.mem.uni_layout.fold_w4+0xdc>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x108 <corpus.cases.mem.uni_layout.fold_w4+0xa8>
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0x8c>
-               	mv	a1, a0
-               	mv	s2, s1
-               	mv	a2, s2
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0xac>
-               	mv	a1, a0
-               	addi	a2, s2, 0x1
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0xc8>
-               	mv	a1, a0
-               	addi	a2, s2, 0x2
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0xe4>
-               	mv	a1, a0
-               	addi	a2, s2, 0x3
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w4+0x100>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x160 <corpus.cases.mem.uni_layout.fold_w4+0x100>
+               	j	0x194 <corpus.cases.mem.uni_layout.fold_w4+0x134>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x160 <corpus.cases.mem.uni_layout.fold_w4+0x100>
+               	mv	a2, a1
+               	mv	a3, a2
+               	lbu	a2, 0x0(a3)
+               	zext.b	a3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b4 <corpus.cases.mem.uni_layout.fold_w4+0x154>
+               	j	0x1e8 <corpus.cases.mem.uni_layout.fold_w4+0x188>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b4 <corpus.cases.mem.uni_layout.fold_w4+0x154>
+               	mv	a2, a1
+               	addi	a3, a2, 0x1
+               	lbu	a2, 0x0(a3)
+               	zext.b	a3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.mem.uni_layout.fold_w4+0x1a8>
+               	j	0x23c <corpus.cases.mem.uni_layout.fold_w4+0x1dc>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x208 <corpus.cases.mem.uni_layout.fold_w4+0x1a8>
+               	mv	a2, a1
+               	addi	a3, a2, 0x2
+               	lbu	a2, 0x0(a3)
+               	zext.b	a3, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x25c <corpus.cases.mem.uni_layout.fold_w4+0x1fc>
+               	j	0x290 <corpus.cases.mem.uni_layout.fold_w4+0x230>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x25c <corpus.cases.mem.uni_layout.fold_w4+0x1fc>
+               	mv	a2, a1
+               	addi	a1, a2, 0x3
+               	lbu	a2, 0x0(a1)
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2b0 <corpus.cases.mem.uni_layout.fold_w4+0x250>
+               	j	0x2e4 <corpus.cases.mem.uni_layout.fold_w4+0x284>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2b0 <corpus.cases.mem.uni_layout.fold_w4+0x250>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.uni_layout.fold_w8>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	mv	a2, a0
-               	sd	a1, -0x30(s0)
-               	addi	s1, s0, -0x38
-               	lbu	a1, -0x30(s0)
-               	lbu	a3, -0x2f(s0)
-               	lbu	a4, -0x2e(s0)
-               	lbu	a5, -0x2d(s0)
-               	lbu	a6, -0x2c(s0)
-               	lbu	a7, -0x2b(s0)
-               	lbu	t5, -0x2a(s0)
-               	lbu	t6, -0x29(s0)
-               	sb	a1, 0x0(s1)
-               	sb	a3, 0x1(s1)
-               	sb	a4, 0x2(s1)
-               	sb	a5, 0x3(s1)
-               	sb	a6, 0x4(s1)
-               	sb	a7, 0x5(s1)
-               	sb	t5, 0x6(s1)
-               	sb	t6, 0x7(s1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0x78>
-               	mv	a1, a0
-               	mv	a2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	a1, -0x18(s0)
+               	addi	a1, s0, -0x20
+               	lbu	a2, -0x18(s0)
+               	lbu	a3, -0x17(s0)
+               	lbu	a4, -0x16(s0)
+               	lbu	a5, -0x15(s0)
+               	lbu	a6, -0x14(s0)
+               	lbu	a7, -0x13(s0)
+               	lbu	t5, -0x12(s0)
+               	lbu	t6, -0x11(s0)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0x94>
-               	mv	a1, a0
-               	mv	a2, s1
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0xac>
-               	mv	a1, a0
-               	mv	s2, s1
-               	mv	a2, s2
-               	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0xcc>
-               	mv	a1, a0
-               	addi	a2, s2, 0x4
-               	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0xe8>
-               	mv	s2, a0
-               	li	s3, 0x0
+               	li	a2, 0x0
                	li	t0, 0x8
-               	bltu	s3, t0, 0x284 <corpus.cases.mem.uni_layout.fold_w8+0x104>
-               	j	0x2b0 <corpus.cases.mem.uni_layout.fold_w8+0x130>
-               	mv	a0, s1
-               	add	a1, a0, s3
-               	lbu	a2, 0x0(a1)
-               	mv	a0, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.fold_w8+0x118>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	bltu	a2, t0, 0x364 <corpus.cases.mem.uni_layout.fold_w8+0x70>
+               	j	0x398 <corpus.cases.mem.uni_layout.fold_w8+0xa4>
                	li	t0, 0x8
-               	bltu	s3, t0, 0x284 <corpus.cases.mem.uni_layout.fold_w8+0x104>
-               	mv	a0, s2
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x364 <corpus.cases.mem.uni_layout.fold_w8+0x70>
+               	mv	a2, a1
+               	ld	a3, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3b0 <corpus.cases.mem.uni_layout.fold_w8+0xbc>
+               	j	0x3e4 <corpus.cases.mem.uni_layout.fold_w8+0xf0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3b0 <corpus.cases.mem.uni_layout.fold_w8+0xbc>
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x400 <corpus.cases.mem.uni_layout.fold_w8+0x10c>
+               	j	0x434 <corpus.cases.mem.uni_layout.fold_w8+0x140>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x400 <corpus.cases.mem.uni_layout.fold_w8+0x10c>
+               	mv	a2, a1
+               	mv	a3, a2
+               	lw	a2, 0x0(a3)
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x458 <corpus.cases.mem.uni_layout.fold_w8+0x164>
+               	j	0x48c <corpus.cases.mem.uni_layout.fold_w8+0x198>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x458 <corpus.cases.mem.uni_layout.fold_w8+0x164>
+               	mv	a2, a1
+               	addi	a3, a2, 0x4
+               	lw	a2, 0x0(a3)
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4b0 <corpus.cases.mem.uni_layout.fold_w8+0x1bc>
+               	j	0x4e4 <corpus.cases.mem.uni_layout.fold_w8+0x1f0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4b0 <corpus.cases.mem.uni_layout.fold_w8+0x1bc>
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f4 <corpus.cases.mem.uni_layout.fold_w8+0x200>
+               	j	0x55c <corpus.cases.mem.uni_layout.fold_w8+0x268>
+               	mv	a3, a1
+               	add	a4, a3, a2
+               	lbu	a3, 0x0(a4)
+               	zext.b	a4, a3
+               	mv	a3, a0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x518 <corpus.cases.mem.uni_layout.fold_w8+0x224>
+               	j	0x54c <corpus.cases.mem.uni_layout.fold_w8+0x258>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a3, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a3, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x518 <corpus.cases.mem.uni_layout.fold_w8+0x224>
+               	addi	a2, a2, 0x1
+               	mv	a0, a3
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f4 <corpus.cases.mem.uni_layout.fold_w8+0x200>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.mem.uni_layout.checksum>:
-               	addi	sp, sp, -0x110
-               	sd	ra, 0x108(sp)
-               	sd	s0, 0x100(sp)
-               	addi	s0, sp, 0x110
-               	sd	s1, 0xf8(sp)
-               	sd	s2, 0xf0(sp)
-               	sd	s3, 0xe8(sp)
-               	sd	s4, 0xe0(sp)
-               	sd	s5, 0xd8(sp)
-               	sd	s6, 0xd0(sp)
-               	sd	s7, 0xc8(sp)
-               	sd	s8, 0xc0(sp)
-               	sd	s9, 0xb8(sp)
+               	addi	sp, sp, -0xf0
+               	sd	ra, 0xe8(sp)
+               	sd	s0, 0xe0(sp)
+               	addi	s0, sp, 0xf0
+               	sd	s1, 0xd8(sp)
+               	sd	s2, 0xd0(sp)
+               	sd	s3, 0xc8(sp)
+               	sd	s4, 0xc0(sp)
+               	sd	s5, 0xb8(sp)
+               	sd	s6, 0xb0(sp)
                	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x38>
-               	mv	s2, a0
+               	lui	s2, 0xfcbf3
+               	addiw	s2, s2, -0x632
+               	slli	s2, s2, 0xc
+               	addi	s2, s2, 0x484
+               	slli	s2, s2, 0xc
+               	addi	s2, s2, 0x222
+               	slli	s2, s2, 0xc
+               	addi	s2, s2, 0x325
                	li	s3, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x324 <corpus.cases.mem.uni_layout.checksum+0x54>
-               	j	0x6b0 <.Lpcrel_hi.1+0x74>
+               	bltu	s3, t0, 0x5c8 <corpus.cases.mem.uni_layout.checksum+0x5c>
+               	j	0x954 <.Lpcrel_hi.1+0x74>
                	addi	a0, s3, 0x1
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
@@ -223,7 +392,7 @@ Disassembly of section .text:
                	addi	t1, t1, -0x3eb
                	mul	a1, t1, a0
                	add	s4, a1, s1
-               	addi	s5, s0, -0x5c
+               	addi	s5, s0, -0x44
                	sb	zero, 0x0(s5)
                	sb	zero, 0x1(s5)
                	sb	zero, 0x2(s5)
@@ -236,7 +405,7 @@ Disassembly of section .text:
                	or	a0, a1, t0
                	mv	a1, s5
                	sw	a0, 0x0(a1)
-               	addi	a0, s0, -0xac
+               	addi	a0, s0, -0x8c
                	lbu	a1, 0x0(s5)
                	lbu	a2, 0x1(s5)
                	lbu	a3, 0x2(s5)
@@ -245,19 +414,19 @@ Disassembly of section .text:
                	sb	a2, 0x1(a0)
                	sb	a3, 0x2(a0)
                	sb	a4, 0x3(a0)
-               	sd	zero, -0xb8(s0)
+               	sd	zero, -0x98(s0)
                	lbu	a1, 0x0(a0)
                	lbu	a2, 0x1(a0)
                	lbu	a3, 0x2(a0)
                	lbu	a4, 0x3(a0)
-               	sb	a1, -0xb8(s0)
-               	sb	a2, -0xb7(s0)
-               	sb	a3, -0xb6(s0)
-               	sb	a4, -0xb5(s0)
-               	ld	a1, -0xb8(s0)
+               	sb	a1, -0x98(s0)
+               	sb	a2, -0x97(s0)
+               	sb	a3, -0x96(s0)
+               	sb	a4, -0x95(s0)
+               	ld	a1, -0x98(s0)
                	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x104>
+               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x10c>
                	srli	a1, s4, 0x7
                	sext.w	a2, a1
                	lui	t0, 0x80800
@@ -267,7 +436,7 @@ Disassembly of section .text:
                	or	a2, a1, t0
                	mv	a1, s5
                	sw	a2, 0x0(a1)
-               	addi	a1, s0, -0xcc
+               	addi	a1, s0, -0x9c
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -276,25 +445,25 @@ Disassembly of section .text:
                	sb	a3, 0x1(a1)
                	sb	a4, 0x2(a1)
                	sb	a5, 0x3(a1)
-               	sd	zero, -0xd8(s0)
+               	sd	zero, -0xa8(s0)
                	lbu	a2, 0x0(a1)
                	lbu	a3, 0x1(a1)
                	lbu	a4, 0x2(a1)
                	lbu	a5, 0x3(a1)
-               	sb	a2, -0xd8(s0)
-               	sb	a3, -0xd7(s0)
-               	sb	a4, -0xd6(s0)
-               	sb	a5, -0xd5(s0)
-               	ld	a1, -0xd8(s0)
+               	sb	a2, -0xa8(s0)
+               	sb	a3, -0xa7(s0)
+               	sb	a4, -0xa6(s0)
+               	sb	a5, -0xa5(s0)
+               	ld	a1, -0xa8(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x17c>
+               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x184>
                	mv	a1, s5
                	flw	ft0, 0x0(a1)
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
                	fsw	ft1, 0x0(a1)
-               	addi	a1, s0, -0xdc
+               	addi	a1, s0, -0xac
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -303,19 +472,19 @@ Disassembly of section .text:
                	sb	a3, 0x1(a1)
                	sb	a4, 0x2(a1)
                	sb	a5, 0x3(a1)
-               	sd	zero, -0xe8(s0)
+               	sd	zero, -0xb8(s0)
                	lbu	a2, 0x0(a1)
                	lbu	a3, 0x1(a1)
                	lbu	a4, 0x2(a1)
                	lbu	a5, 0x3(a1)
-               	sb	a2, -0xe8(s0)
-               	sb	a3, -0xe7(s0)
-               	sb	a4, -0xe6(s0)
-               	sb	a5, -0xe5(s0)
-               	ld	a1, -0xe8(s0)
+               	sb	a2, -0xb8(s0)
+               	sb	a3, -0xb7(s0)
+               	sb	a4, -0xb6(s0)
+               	sb	a5, -0xb5(s0)
+               	ld	a1, -0xb8(s0)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x1e8>
-               	addi	s5, s0, -0xf0
+               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x1f0>
+               	addi	s5, s0, -0xc0
                	sb	zero, 0x0(s5)
                	sb	zero, 0x1(s5)
                	sb	zero, 0x2(s5)
@@ -343,7 +512,7 @@ Disassembly of section .text:
                	or	a2, a1, t0
                	mv	a1, s5
                	sd	a2, 0x0(a1)
-               	addi	a1, s0, -0xf8
+               	addi	a1, s0, -0xd0
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -363,7 +532,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x2ac>
+               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x2b4>
                	srli	a1, s4, 0x9
                	lui	t0, 0xf8000
                	addiw	t0, t0, 0x40
@@ -384,7 +553,7 @@ Disassembly of section .text:
                	or	a1, a2, t0
                	mv	a2, s5
                	sd	a1, 0x0(a2)
-               	addi	a1, s0, -0x100
+               	addi	a1, s0, -0xe0
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -404,7 +573,7 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x350>
+               	jalr	ra <corpus.cases.mem.uni_layout.checksum+0x358>
                	mv	a1, s5
                	fld	ft0, 0x0(a1)
 
@@ -418,7 +587,7 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fadd.d	ft0, ft1, ft10
                	fsd	ft0, 0x0(a1)
-               	addi	a1, s0, -0x108
+               	addi	a1, s0, -0xe8
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -442,8 +611,8 @@ Disassembly of section .text:
                	addi	s3, s3, 0x1
                	mv	s2, a0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x324 <corpus.cases.mem.uni_layout.checksum+0x54>
-               	addi	s3, s0, -0x64
+               	bltu	s3, t0, 0x5c8 <corpus.cases.mem.uni_layout.checksum+0x5c>
+               	addi	s3, s0, -0x4c
                	sb	zero, 0x0(s3)
                	sb	zero, 0x1(s3)
                	sb	zero, 0x2(s3)
@@ -455,15 +624,15 @@ Disassembly of section .text:
                	sext.w	s4, s1
                	li	s5, 0x0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x6e8 <.Lpcrel_hi.1+0xac>
-               	j	0x85c <.Lpcrel_hi.1+0x220>
+               	bltu	s5, t0, 0x98c <.Lpcrel_hi.1+0xac>
+               	j	0xbdc <.Lpcrel_hi.1+0x2fc>
                	sext.w	a0, s5
                	addiw	a1, a0, 0x1
                	lui	t1, 0x9e378
                	addiw	t1, t1, -0x64f
                	mulw	a0, t1, a1
                	addw	s6, a0, s4
-               	addi	a0, s0, -0x6c
+               	addi	a0, s0, -0x54
                	mv	a1, a0
                	sw	s6, 0x0(a1)
                	lui	t0, 0xf0f0f
@@ -471,49 +640,93 @@ Disassembly of section .text:
                	xor	a1, s6, t0
                	addi	a2, a0, 0x4
                	sw	a1, 0x0(a2)
-               	mv	s7, s3
-               	lbu	a1, 0x0(a0)
-               	lbu	a2, 0x1(a0)
-               	lbu	a3, 0x2(a0)
-               	lbu	a4, 0x3(a0)
-               	lbu	a5, 0x4(a0)
-               	lbu	a6, 0x5(a0)
-               	lbu	a7, 0x6(a0)
-               	lbu	t5, 0x7(a0)
-               	sb	a1, 0x0(s7)
-               	sb	a2, 0x1(s7)
-               	sb	a3, 0x2(s7)
-               	sb	a4, 0x3(s7)
-               	sb	a5, 0x4(s7)
-               	sb	a6, 0x5(s7)
-               	sb	a7, 0x6(s7)
-               	sb	t5, 0x7(s7)
-               	mv	s8, s7
-               	lw	a1, 0x0(s8)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x134>
-               	addi	s9, s7, 0x4
-               	lw	a1, 0x0(s9)
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x144>
-               	mv	s7, s3
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lbu	a2, 0x0(a0)
+               	lbu	a3, 0x1(a0)
+               	lbu	a4, 0x2(a0)
+               	lbu	a5, 0x3(a0)
+               	lbu	a6, 0x4(a0)
+               	lbu	a7, 0x5(a0)
+               	lbu	t5, 0x6(a0)
+               	lbu	t6, 0x7(a0)
+               	sb	a2, 0x0(a1)
+               	sb	a3, 0x1(a1)
+               	sb	a4, 0x2(a1)
+               	sb	a5, 0x3(a1)
+               	sb	a6, 0x4(a1)
+               	sb	a7, 0x5(a1)
+               	sb	t5, 0x6(a1)
+               	sb	t6, 0x7(a1)
+               	mv	a0, a1
+               	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	mv	a1, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa2c <.Lpcrel_hi.1+0x14c>
+               	j	0xa60 <.Lpcrel_hi.1+0x180>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa2c <.Lpcrel_hi.1+0x14c>
+               	mv	a0, s3
+               	addi	a2, a0, 0x4
+               	lw	a0, 0x0(a2)
+               	slli	a2, a0, 0x20
+               	srli	a2, a2, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa84 <.Lpcrel_hi.1+0x1a4>
+               	j	0xab8 <.Lpcrel_hi.1+0x1d8>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa84 <.Lpcrel_hi.1+0x1a4>
+               	mv	a0, s3
+               	mv	a2, a0
+               	lhu	a0, 0x0(a2)
+               	slli	a2, a0, 0x30
+               	srli	a2, a2, 0x30
+               	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x15c>
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
+               	jalr	ra <.Lpcrel_hi.1+0x1f4>
+               	mv	a1, s3
+               	addi	a2, a1, 0x2
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x170>
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
+               	jalr	ra <.Lpcrel_hi.1+0x214>
+               	mv	a1, s3
+               	addi	a2, a1, 0x4
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x184>
-               	addi	a1, s0, -0x74
+               	jalr	ra <.Lpcrel_hi.1+0x234>
+               	addi	a1, s0, -0xf0
                	sext.w	a2, s6
                	mv	a3, a1
                	sh	a2, 0x0(a3)
@@ -524,56 +737,67 @@ Disassembly of section .text:
                	addiw	a2, s6, 0x1
                	addi	a3, a1, 0x4
                	sw	a2, 0x0(a3)
-               	lbu	a2, 0x0(a1)
-               	lbu	a3, 0x1(a1)
-               	lbu	a4, 0x2(a1)
-               	lbu	a5, 0x3(a1)
-               	lbu	a6, 0x4(a1)
-               	lbu	a7, 0x5(a1)
-               	lbu	t5, 0x6(a1)
-               	lbu	t6, 0x7(a1)
-               	sb	a2, 0x0(s7)
-               	sb	a3, 0x1(s7)
-               	sb	a4, 0x2(s7)
-               	sb	a5, 0x3(s7)
-               	sb	a6, 0x4(s7)
-               	sb	a7, 0x5(s7)
-               	sb	t5, 0x6(s7)
-               	sb	t6, 0x7(s7)
-               	lw	a1, 0x0(s8)
+               	mv	a2, s3
+               	lbu	a3, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s6, 0x7(a1)
+               	sb	a3, 0x0(a2)
+               	sb	a4, 0x1(a2)
+               	sb	a5, 0x2(a2)
+               	sb	a6, 0x3(a2)
+               	sb	a7, 0x4(a2)
+               	sb	t5, 0x5(a2)
+               	sb	t6, 0x6(a2)
+               	sb	s6, 0x7(a2)
+               	mv	a1, s3
+               	mv	a2, a1
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1fc>
-               	lw	a1, 0x0(s9)
+               	jalr	ra <.Lpcrel_hi.1+0x2c4>
+               	mv	a1, s3
+               	addi	a2, a1, 0x4
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x208>
+               	jalr	ra <.Lpcrel_hi.1+0x2e4>
                	addi	s5, s5, 0x1
                	mv	s2, a0
                	li	t0, 0x4
-               	bltu	s5, t0, 0x6e8 <.Lpcrel_hi.1+0xac>
-               	addi	s3, s0, -0x88
+               	bltu	s5, t0, 0x98c <.Lpcrel_hi.1+0xac>
+               	addi	s3, s0, -0x68
                	mv	a0, s3
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x890 <.Lpcrel_hi.1+0x254>
+               	bnez	a1, 0xc10 <.Lpcrel_hi.1+0x330>
                	mv	a1, a0
                	li	a2, 0x10
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x878 <.Lpcrel_hi.1+0x23c>
-               	j	0x8ac <.Lpcrel_hi.1+0x270>
+               	bne	a2, t0, 0xbf8 <.Lpcrel_hi.1+0x318>
+               	j	0xc2c <.Lpcrel_hi.1+0x34c>
                	mv	a1, a0
                	li	a0, 0x10
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x898 <.Lpcrel_hi.1+0x25c>
+               	bne	a0, t0, 0xc18 <.Lpcrel_hi.1+0x338>
                	li	s4, 0x0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x8bc <.Lpcrel_hi.1+0x280>
-               	j	0xa34 <.Lpcrel_hi.2+0x80>
+               	bltu	s4, t0, 0xc3c <.Lpcrel_hi.1+0x35c>
+               	j	0xe04 <.Lpcrel_hi.2+0x88>
                	addi	a0, s4, 0x1
                	sext.w	a1, a0
                	mv	a2, s3
@@ -605,15 +829,32 @@ Disassembly of section .text:
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x600
                	or	a0, a1, t0
+               	addi	a1, s3, 0x8
+               	mv	a2, a1
+               	sd	a0, 0x0(a2)
+               	mv	a0, s3
+               	lbu	a1, 0x0(a0)
+               	zext.b	a0, a1
+               	mv	a1, s2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xce4 <.Lpcrel_hi.1+0x404>
+               	j	0xd18 <.Lpcrel_hi.1+0x438>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a1, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xce4 <.Lpcrel_hi.1+0x404>
                	addi	s5, s3, 0x8
-               	mv	a1, s5
-               	sd	a0, 0x0(a1)
-               	mv	s6, s3
-               	lbu	a1, 0x0(s6)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x314>
-               	addi	a1, s0, -0xc0
+               	addi	a0, s0, -0xc8
                	lbu	a2, 0x0(s5)
                	lbu	a3, 0x1(s5)
                	lbu	a4, 0x2(s5)
@@ -622,18 +863,19 @@ Disassembly of section .text:
                	lbu	a7, 0x5(s5)
                	lbu	t5, 0x6(s5)
                	lbu	t6, 0x7(s5)
-               	sb	a2, 0x0(a1)
-               	sb	a3, 0x1(a1)
-               	sb	a4, 0x2(a1)
-               	sb	a5, 0x3(a1)
-               	sb	a6, 0x4(a1)
-               	sb	a7, 0x5(a1)
-               	sb	t5, 0x6(a1)
-               	sb	t6, 0x7(a1)
-               	ld	a2, 0x0(a1)
+               	sb	a2, 0x0(a0)
+               	sb	a3, 0x1(a0)
+               	sb	a4, 0x2(a0)
+               	sb	a5, 0x3(a0)
+               	sb	a6, 0x4(a0)
+               	sb	a7, 0x5(a0)
+               	sb	t5, 0x6(a0)
+               	sb	t6, 0x7(a0)
+               	ld	a2, 0x0(a0)
+               	mv	a0, a1
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x368>
+               	jalr	ra <.Lpcrel_hi.1+0x48c>
                	mv	a1, s5
                	fld	ft0, 0x0(a1)
 
@@ -642,58 +884,60 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fadd.d	ft1, ft0, ft10
                	fsd	ft1, 0x0(a1)
-               	lbu	a1, 0x0(s6)
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	zext.b	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x14>
-               	addi	a1, s0, -0xc8
-               	lbu	a2, 0x0(s5)
-               	lbu	a3, 0x1(s5)
-               	lbu	a4, 0x2(s5)
-               	lbu	a5, 0x3(s5)
-               	lbu	a6, 0x4(s5)
-               	lbu	a7, 0x5(s5)
-               	lbu	t5, 0x6(s5)
-               	lbu	t6, 0x7(s5)
-               	sb	a2, 0x0(a1)
-               	sb	a3, 0x1(a1)
-               	sb	a4, 0x2(a1)
-               	sb	a5, 0x3(a1)
-               	sb	a6, 0x4(a1)
-               	sb	a7, 0x5(a1)
-               	sb	t5, 0x6(a1)
-               	sb	t6, 0x7(a1)
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
+               	jalr	ra <.Lpcrel_hi.2+0x1c>
+               	addi	a1, s3, 0x8
+               	addi	a2, s0, -0xd8
+               	lbu	a3, 0x0(a1)
+               	lbu	a4, 0x1(a1)
+               	lbu	a5, 0x2(a1)
+               	lbu	a6, 0x3(a1)
+               	lbu	a7, 0x4(a1)
+               	lbu	t5, 0x5(a1)
+               	lbu	t6, 0x6(a1)
+               	lbu	s5, 0x7(a1)
+               	sb	a3, 0x0(a2)
+               	sb	a4, 0x1(a2)
+               	sb	a5, 0x2(a2)
+               	sb	a6, 0x3(a2)
+               	sb	a7, 0x4(a2)
+               	sb	t5, 0x5(a2)
+               	sb	t6, 0x6(a2)
+               	sb	s5, 0x7(a2)
+               	ld	a1, 0x0(a2)
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x68>
+               	jalr	ra <.Lpcrel_hi.2+0x70>
                	addi	s4, s4, 0x1
                	mv	s2, a0
                	li	t0, 0x4
-               	bltu	s4, t0, 0x8bc <.Lpcrel_hi.1+0x280>
-               	addi	s3, s0, -0xa0
+               	bltu	s4, t0, 0xc3c <.Lpcrel_hi.1+0x35c>
+               	addi	s3, s0, -0x80
                	mv	a0, s3
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xa68 <.Lpcrel_hi.2+0xb4>
+               	bnez	a1, 0xe38 <.Lpcrel_hi.2+0xbc>
                	mv	a1, a0
                	li	a2, 0x18
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0xa50 <.Lpcrel_hi.2+0x9c>
-               	j	0xa84 <.Lpcrel_hi.2+0xd0>
+               	bne	a2, t0, 0xe20 <.Lpcrel_hi.2+0xa4>
+               	j	0xe54 <.Lpcrel_hi.2+0xd8>
                	mv	a1, a0
                	li	a0, 0x18
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xa70 <.Lpcrel_hi.2+0xbc>
+               	bne	a0, t0, 0xe40 <.Lpcrel_hi.2+0xc4>
                	li	a0, 0x0
                	li	t0, 0x3
-               	bltu	a0, t0, 0xa94 <.Lpcrel_hi.2+0xe0>
-               	j	0xb0c <.Lpcrel_hi.2+0x158>
+               	bltu	a0, t0, 0xe64 <.Lpcrel_hi.2+0xe8>
+               	j	0xedc <.Lpcrel_hi.2+0x160>
                	addi	a1, a0, 0x1
                	lui	t1, 0x10000
                	slli	t1, t1, 0xc
@@ -723,14 +967,14 @@ Disassembly of section .text:
                	sd	a1, 0x0(a3)
                	addi	a0, a0, 0x1
                	li	t0, 0x3
-               	bltu	a0, t0, 0xa94 <.Lpcrel_hi.2+0xe0>
+               	bltu	a0, t0, 0xe64 <.Lpcrel_hi.2+0xe8>
                	li	s1, 0x0
                	li	t0, 0x3
-               	bltu	s1, t0, 0xb1c <.Lpcrel_hi.2+0x168>
-               	j	0xb8c <.Lpcrel_hi.2+0x1d8>
+               	bltu	s1, t0, 0xeec <.Lpcrel_hi.2+0x170>
+               	j	0xf5c <.Lpcrel_hi.2+0x1e0>
                	slli	t0, s1, 0x3
                	add	a0, s3, t0
-               	addi	a1, s0, -0xa8
+               	addi	a1, s0, -0x88
                	lbu	a2, 0x0(a0)
                	lbu	a3, 0x1(a0)
                	lbu	a4, 0x2(a0)
@@ -751,22 +995,19 @@ Disassembly of section .text:
                	mv	a0, s2
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x1c0>
+               	jalr	ra <.Lpcrel_hi.2+0x1c8>
                	addi	s1, s1, 0x1
                	mv	s2, a0
                	li	t0, 0x3
-               	bltu	s1, t0, 0xb1c <.Lpcrel_hi.2+0x168>
+               	bltu	s1, t0, 0xeec <.Lpcrel_hi.2+0x170>
                	mv	a0, s2
-               	ld	s1, 0xf8(sp)
-               	ld	s2, 0xf0(sp)
-               	ld	s3, 0xe8(sp)
-               	ld	s4, 0xe0(sp)
-               	ld	s5, 0xd8(sp)
-               	ld	s6, 0xd0(sp)
-               	ld	s7, 0xc8(sp)
-               	ld	s8, 0xc0(sp)
-               	ld	s9, 0xb8(sp)
-               	ld	ra, 0x108(sp)
-               	ld	s0, 0x100(sp)
-               	addi	sp, sp, 0x110
+               	ld	s1, 0xd8(sp)
+               	ld	s2, 0xd0(sp)
+               	ld	s3, 0xc8(sp)
+               	ld	s4, 0xc0(sp)
+               	ld	s5, 0xb8(sp)
+               	ld	s6, 0xb0(sp)
+               	ld	ra, 0xe8(sp)
+               	ld	s0, 0xe0(sp)
+               	addi	sp, sp, 0xf0
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_i16.dis
+++ b/test/golden/riscv64-linux/scalar/arith_i16.dis
@@ -3,124 +3,321 @@ scalar/arith_i16.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i16.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	lui	t1, 0x10
                	addiw	t1, t1, -0x10
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	slli	t1, s4, 0x30
+               	slli	t1, a3, 0x30
                	srai	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srai	t0, t0, 0x30
-               	blt	t1, t0, 0x68 <corpus.cases.scalar.arith_i16.checksum+0x68>
-               	j	0xc4 <corpus.cases.scalar.arith_i16.checksum+0xc4>
+               	blt	t1, t0, 0x64 <corpus.cases.scalar.arith_i16.checksum+0x64>
+               	j	0x144 <corpus.cases.scalar.arith_i16.checksum+0x144>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x80>
-               	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x9c>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
-               	li	t0, 0x20
-               	slli	t1, s4, 0x30
-               	srai	t1, t1, 0x30
-               	slli	t0, t0, 0x30
-               	srai	t0, t0, 0x30
-               	blt	t1, t0, 0x68 <corpus.cases.scalar.arith_i16.checksum+0x68>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	slli	a5, a4, 0x30
+               	srai	a5, a5, 0x30
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x30
+               	bltu	a7, t0, 0x90 <corpus.cases.scalar.arith_i16.checksum+0x90>
+               	j	0xc4 <corpus.cases.scalar.arith_i16.checksum+0xc4>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x90 <corpus.cases.scalar.arith_i16.checksum+0x90>
+               	li	t0, 0x3
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	slli	a4, a5, 0x30
+               	srai	a4, a4, 0x30
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xec <corpus.cases.scalar.arith_i16.checksum+0xec>
+               	j	0x120 <corpus.cases.scalar.arith_i16.checksum+0x120>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xec <corpus.cases.scalar.arith_i16.checksum+0xec>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
+               	li	t0, 0x20
+               	slli	t1, a3, 0x30
                	srai	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srai	t0, t0, 0x30
-               	blt	t1, t0, 0xe8 <corpus.cases.scalar.arith_i16.checksum+0xe8>
-               	j	0x12c <corpus.cases.scalar.arith_i16.checksum+0x12c>
+               	blt	t1, t0, 0x64 <corpus.cases.scalar.arith_i16.checksum+0x64>
+               	mv	a3, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	slli	t1, a4, 0x30
+               	srai	t1, t1, 0x30
+               	slli	t0, t0, 0x30
+               	srai	t0, t0, 0x30
+               	blt	t1, t0, 0x168 <corpus.cases.scalar.arith_i16.checksum+0x168>
+               	j	0x1f0 <corpus.cases.scalar.arith_i16.checksum+0x1f0>
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x104>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	slli	a6, a5, 0x30
+               	srai	a6, a6, 0x30
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x30
+               	bltu	t5, t0, 0x198 <corpus.cases.scalar.arith_i16.checksum+0x198>
+               	j	0x1cc <corpus.cases.scalar.arith_i16.checksum+0x1cc>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x198 <corpus.cases.scalar.arith_i16.checksum+0x198>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	slli	t1, a4, 0x30
                	srai	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srai	t0, t0, 0x30
-               	blt	t1, t0, 0xe8 <corpus.cases.scalar.arith_i16.checksum+0xe8>
+               	blt	t1, t0, 0x168 <corpus.cases.scalar.arith_i16.checksum+0x168>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x13c>
+               	subw	a4, t1, a0
+               	slli	a5, a4, 0x30
+               	srai	a5, a5, 0x30
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x210 <corpus.cases.scalar.arith_i16.checksum+0x210>
+               	j	0x244 <corpus.cases.scalar.arith_i16.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x210 <corpus.cases.scalar.arith_i16.checksum+0x210>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x14c>
+               	subw	a5, t1, a4
+               	slli	a4, a5, 0x30
+               	srai	a4, a4, 0x30
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x264 <corpus.cases.scalar.arith_i16.checksum+0x264>
+               	j	0x298 <corpus.cases.scalar.arith_i16.checksum+0x298>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x264 <corpus.cases.scalar.arith_i16.checksum+0x264>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x15c>
+               	subw	a4, t1, a1
+               	slli	a1, a4, 0x30
+               	srai	a1, a1, 0x30
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b8 <corpus.cases.scalar.arith_i16.checksum+0x2b8>
+               	j	0x2ec <corpus.cases.scalar.arith_i16.checksum+0x2ec>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b8 <corpus.cases.scalar.arith_i16.checksum+0x2b8>
                	lui	t1, 0x8
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x170>
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srai	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x310 <corpus.cases.scalar.arith_i16.checksum+0x310>
+               	j	0x344 <corpus.cases.scalar.arith_i16.checksum+0x344>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x310 <corpus.cases.scalar.arith_i16.checksum+0x310>
                	lui	t1, 0x8
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x180>
+               	subw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srai	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x364 <corpus.cases.scalar.arith_i16.checksum+0x364>
+               	j	0x398 <corpus.cases.scalar.arith_i16.checksum+0x398>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x364 <corpus.cases.scalar.arith_i16.checksum+0x364>
                	lui	t1, 0x10
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x194>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x1a0>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x1ac>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i16.checksum+0x1b8>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srai	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.scalar.arith_i16.checksum+0x3bc>
+               	j	0x3f0 <corpus.cases.scalar.arith_i16.checksum+0x3f0>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.scalar.arith_i16.checksum+0x3bc>
+               	addw	a1, a0, a3
+               	slli	a4, a1, 0x30
+               	srai	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x40c <corpus.cases.scalar.arith_i16.checksum+0x40c>
+               	j	0x440 <corpus.cases.scalar.arith_i16.checksum+0x440>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x40c <corpus.cases.scalar.arith_i16.checksum+0x40c>
+               	subw	a1, a0, a3
+               	slli	a4, a1, 0x30
+               	srai	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <corpus.cases.scalar.arith_i16.checksum+0x45c>
+               	j	0x490 <corpus.cases.scalar.arith_i16.checksum+0x490>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <corpus.cases.scalar.arith_i16.checksum+0x45c>
+               	subw	a1, a3, a0
+               	slli	a0, a1, 0x30
+               	srai	a0, a0, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ac <corpus.cases.scalar.arith_i16.checksum+0x4ac>
+               	j	0x4e0 <corpus.cases.scalar.arith_i16.checksum+0x4e0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ac <corpus.cases.scalar.arith_i16.checksum+0x4ac>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_i32.dis
+++ b/test/golden/riscv64-linux/scalar/arith_i32.dis
@@ -3,106 +3,291 @@ scalar/arith_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i32.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t1, -0x10
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	blt	s4, t0, 0x54 <corpus.cases.scalar.arith_i32.checksum+0x54>
-               	j	0xa0 <corpus.cases.scalar.arith_i32.checksum+0xa0>
+               	blt	a3, t0, 0x50 <corpus.cases.scalar.arith_i32.checksum+0x50>
+               	j	0x118 <corpus.cases.scalar.arith_i32.checksum+0x118>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x6c>
-               	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x88>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
-               	li	t0, 0x20
-               	blt	s4, t0, 0x54 <corpus.cases.scalar.arith_i32.checksum+0x54>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	sext.w	a5, a4
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	blt	s5, t0, 0xb4 <corpus.cases.scalar.arith_i32.checksum+0xb4>
-               	j	0xe8 <corpus.cases.scalar.arith_i32.checksum+0xe8>
+               	bltu	a7, t0, 0x78 <corpus.cases.scalar.arith_i32.checksum+0x78>
+               	j	0xac <corpus.cases.scalar.arith_i32.checksum+0xac>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x78 <corpus.cases.scalar.arith_i32.checksum+0x78>
+               	li	t0, 0x3
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	sext.w	a4, a5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd0 <corpus.cases.scalar.arith_i32.checksum+0xd0>
+               	j	0x104 <corpus.cases.scalar.arith_i32.checksum+0x104>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd0 <corpus.cases.scalar.arith_i32.checksum+0xd0>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
+               	li	t0, 0x20
+               	blt	a3, t0, 0x50 <corpus.cases.scalar.arith_i32.checksum+0x50>
+               	mv	a3, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	blt	a4, t0, 0x12c <corpus.cases.scalar.arith_i32.checksum+0x12c>
+               	j	0x1a0 <corpus.cases.scalar.arith_i32.checksum+0x1a0>
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0xd0>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	sext.w	a6, a5
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	blt	s5, t0, 0xb4 <corpus.cases.scalar.arith_i32.checksum+0xb4>
+               	bltu	t5, t0, 0x158 <corpus.cases.scalar.arith_i32.checksum+0x158>
+               	j	0x18c <corpus.cases.scalar.arith_i32.checksum+0x18c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x158 <corpus.cases.scalar.arith_i32.checksum+0x158>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	blt	a4, t0, 0x12c <corpus.cases.scalar.arith_i32.checksum+0x12c>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0xf8>
+               	subw	a4, t1, a0
+               	sext.w	a5, a4
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1bc <corpus.cases.scalar.arith_i32.checksum+0x1bc>
+               	j	0x1f0 <corpus.cases.scalar.arith_i32.checksum+0x1f0>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1bc <corpus.cases.scalar.arith_i32.checksum+0x1bc>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x108>
+               	subw	a5, t1, a4
+               	sext.w	a4, a5
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x20c <corpus.cases.scalar.arith_i32.checksum+0x20c>
+               	j	0x240 <corpus.cases.scalar.arith_i32.checksum+0x240>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x20c <corpus.cases.scalar.arith_i32.checksum+0x20c>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x118>
+               	subw	a4, t1, a1
+               	sext.w	a1, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x25c <corpus.cases.scalar.arith_i32.checksum+0x25c>
+               	j	0x290 <corpus.cases.scalar.arith_i32.checksum+0x290>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x25c <corpus.cases.scalar.arith_i32.checksum+0x25c>
                	lui	t1, 0x80000
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x12c>
+               	addw	a1, t1, a0
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2b0 <corpus.cases.scalar.arith_i32.checksum+0x2b0>
+               	j	0x2e4 <corpus.cases.scalar.arith_i32.checksum+0x2e4>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2b0 <corpus.cases.scalar.arith_i32.checksum+0x2b0>
                	lui	t1, 0x80000
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x13c>
+               	subw	a1, t1, a0
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x300 <corpus.cases.scalar.arith_i32.checksum+0x300>
+               	j	0x334 <corpus.cases.scalar.arith_i32.checksum+0x334>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x300 <corpus.cases.scalar.arith_i32.checksum+0x300>
                	li	t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x14c>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x158>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x164>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i32.checksum+0x170>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x350 <corpus.cases.scalar.arith_i32.checksum+0x350>
+               	j	0x384 <corpus.cases.scalar.arith_i32.checksum+0x384>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x350 <corpus.cases.scalar.arith_i32.checksum+0x350>
+               	addw	a1, a0, a3
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x39c <corpus.cases.scalar.arith_i32.checksum+0x39c>
+               	j	0x3d0 <corpus.cases.scalar.arith_i32.checksum+0x3d0>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x39c <corpus.cases.scalar.arith_i32.checksum+0x39c>
+               	subw	a1, a0, a3
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e8 <corpus.cases.scalar.arith_i32.checksum+0x3e8>
+               	j	0x41c <corpus.cases.scalar.arith_i32.checksum+0x41c>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3e8 <corpus.cases.scalar.arith_i32.checksum+0x3e8>
+               	subw	a1, a3, a0
+               	sext.w	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x434 <corpus.cases.scalar.arith_i32.checksum+0x434>
+               	j	0x468 <corpus.cases.scalar.arith_i32.checksum+0x468>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x434 <corpus.cases.scalar.arith_i32.checksum+0x434>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_i64.dis
+++ b/test/golden/riscv64-linux/scalar/arith_i64.dis
@@ -3,50 +3,73 @@ scalar/arith_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i64.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x28>
                	li	t1, -0x10
-               	add	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	add	a1, t1, a0
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	blt	s4, t0, 0x50 <corpus.cases.scalar.arith_i64.checksum+0x50>
-               	j	0x9c <corpus.cases.scalar.arith_i64.checksum+0x9c>
+               	blt	a3, t0, 0x38 <corpus.cases.scalar.arith_i64.checksum+0x38>
+               	j	0xf8 <corpus.cases.scalar.arith_i64.checksum+0xf8>
                	li	t0, 0x7
-               	mul	a0, s4, t0
-               	addi	a1, a0, 0x1
-               	add	s5, s3, a1
-               	mv	a0, s2
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x68>
-               	li	t0, 0x3
-               	mul	a1, s4, t0
-               	addi	a2, a1, 0x2
-               	sub	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x84>
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
-               	li	t0, 0x20
-               	blt	s4, t0, 0x50 <corpus.cases.scalar.arith_i64.checksum+0x50>
-               	mv	s4, s1
-               	li	s5, 0x0
+               	mul	a4, a3, t0
+               	addi	a5, a4, 0x1
+               	add	a4, a1, a5
+               	mv	a5, a2
+               	li	a6, 0x0
                	li	t0, 0x8
-               	blt	s5, t0, 0xb0 <corpus.cases.scalar.arith_i64.checksum+0xb0>
-               	j	0xfc <corpus.cases.scalar.arith_i64.checksum+0xfc>
+               	bltu	a6, t0, 0x5c <corpus.cases.scalar.arith_i64.checksum+0x5c>
+               	j	0x90 <corpus.cases.scalar.arith_i64.checksum+0x90>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x5c <corpus.cases.scalar.arith_i64.checksum+0x5c>
+               	li	t0, 0x3
+               	mul	a6, a3, t0
+               	addi	a7, a6, 0x2
+               	sub	a6, a4, a7
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xb0 <corpus.cases.scalar.arith_i64.checksum+0xb0>
+               	j	0xe4 <corpus.cases.scalar.arith_i64.checksum+0xe4>
+               	li	t0, 0x8
+               	mul	a7, a4, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xb0 <corpus.cases.scalar.arith_i64.checksum+0xb0>
+               	addi	a3, a3, 0x1
+               	mv	a2, a5
+               	mv	a1, a6
+               	li	t0, 0x20
+               	blt	a3, t0, 0x38 <corpus.cases.scalar.arith_i64.checksum+0x38>
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	blt	a4, t0, 0x10c <corpus.cases.scalar.arith_i64.checksum+0x10c>
+               	j	0x194 <corpus.cases.scalar.arith_i64.checksum+0x194>
                	lui	t0, 0x1234
                	addiw	t0, t0, 0x568
                	slli	t0, t0, 0xc
@@ -55,65 +78,206 @@ Disassembly of section .text:
                	addi	t0, t0, -0x543
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x211
-               	mul	a0, s5, t0
-               	addi	a1, a0, 0x1
-               	sub	s4, s4, a1
-               	mv	a0, s2
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0xe4>
-               	addi	s5, s5, 0x1
-               	mv	s2, a0
+               	mul	a5, a4, t0
+               	addi	a6, a5, 0x1
+               	sub	a5, a3, a6
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	blt	s5, t0, 0xb0 <corpus.cases.scalar.arith_i64.checksum+0xb0>
+               	bltu	a7, t0, 0x14c <corpus.cases.scalar.arith_i64.checksum+0x14c>
+               	j	0x180 <corpus.cases.scalar.arith_i64.checksum+0x180>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x14c <corpus.cases.scalar.arith_i64.checksum+0x14c>
+               	addi	a4, a4, 0x1
+               	mv	a2, a6
+               	mv	a3, a5
+               	li	t0, 0x8
+               	blt	a4, t0, 0x10c <corpus.cases.scalar.arith_i64.checksum+0x10c>
                	li	t1, 0x0
-               	sub	s5, t1, s3
-               	mv	a0, s2
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x10c>
+               	sub	a4, t1, a1
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ac <corpus.cases.scalar.arith_i64.checksum+0x1ac>
+               	j	0x1e0 <corpus.cases.scalar.arith_i64.checksum+0x1e0>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ac <corpus.cases.scalar.arith_i64.checksum+0x1ac>
                	li	t1, 0x0
-               	sub	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x11c>
+               	sub	a5, t1, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f8 <corpus.cases.scalar.arith_i64.checksum+0x1f8>
+               	j	0x22c <corpus.cases.scalar.arith_i64.checksum+0x22c>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f8 <corpus.cases.scalar.arith_i64.checksum+0x1f8>
                	li	t1, 0x0
-               	sub	a1, t1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x12c>
+               	sub	a4, t1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.scalar.arith_i64.checksum+0x244>
+               	j	0x278 <corpus.cases.scalar.arith_i64.checksum+0x278>
+               	li	t0, 0x8
+               	mul	a5, a0, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.scalar.arith_i64.checksum+0x244>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x1
-               	add	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x14c>
+               	add	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2a0 <corpus.cases.scalar.arith_i64.checksum+0x2a0>
+               	j	0x2d4 <corpus.cases.scalar.arith_i64.checksum+0x2d4>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2a0 <corpus.cases.scalar.arith_i64.checksum+0x2a0>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	sub	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x168>
+               	sub	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2f8 <corpus.cases.scalar.arith_i64.checksum+0x2f8>
+               	j	0x32c <corpus.cases.scalar.arith_i64.checksum+0x32c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2f8 <corpus.cases.scalar.arith_i64.checksum+0x2f8>
                	li	t1, -0x1
-               	add	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x178>
-               	add	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x184>
-               	sub	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x190>
-               	sub	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i64.checksum+0x19c>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	add	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x344 <corpus.cases.scalar.arith_i64.checksum+0x344>
+               	j	0x378 <corpus.cases.scalar.arith_i64.checksum+0x378>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x344 <corpus.cases.scalar.arith_i64.checksum+0x344>
+               	add	a0, a1, a3
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x38c <corpus.cases.scalar.arith_i64.checksum+0x38c>
+               	j	0x3c0 <corpus.cases.scalar.arith_i64.checksum+0x3c0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x38c <corpus.cases.scalar.arith_i64.checksum+0x38c>
+               	sub	a0, a1, a3
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3d4 <corpus.cases.scalar.arith_i64.checksum+0x3d4>
+               	j	0x408 <corpus.cases.scalar.arith_i64.checksum+0x408>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3d4 <corpus.cases.scalar.arith_i64.checksum+0x3d4>
+               	sub	a0, a3, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x41c <corpus.cases.scalar.arith_i64.checksum+0x41c>
+               	j	0x450 <corpus.cases.scalar.arith_i64.checksum+0x450>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x41c <corpus.cases.scalar.arith_i64.checksum+0x41c>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_i8.dis
+++ b/test/golden/riscv64-linux/scalar/arith_i8.dis
@@ -3,120 +3,317 @@ scalar/arith_i8.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_i8.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t1, 0xf0
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	slli	t1, s4, 0x38
+               	slli	t1, a3, 0x38
                	srai	t1, t1, 0x38
                	slli	t0, t0, 0x38
                	srai	t0, t0, 0x38
-               	blt	t1, t0, 0x64 <corpus.cases.scalar.arith_i8.checksum+0x64>
-               	j	0xc0 <corpus.cases.scalar.arith_i8.checksum+0xc0>
+               	blt	t1, t0, 0x60 <corpus.cases.scalar.arith_i8.checksum+0x60>
+               	j	0x140 <corpus.cases.scalar.arith_i8.checksum+0x140>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x7c>
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	slli	a5, a4, 0x38
+               	srai	a5, a5, 0x38
+               	mv	a6, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x8c <corpus.cases.scalar.arith_i8.checksum+0x8c>
+               	j	0xc0 <corpus.cases.scalar.arith_i8.checksum+0xc0>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x8c <corpus.cases.scalar.arith_i8.checksum+0x8c>
                	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x98>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	slli	a4, a5, 0x38
+               	srai	a4, a4, 0x38
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xe8 <corpus.cases.scalar.arith_i8.checksum+0xe8>
+               	j	0x11c <corpus.cases.scalar.arith_i8.checksum+0x11c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xe8 <corpus.cases.scalar.arith_i8.checksum+0xe8>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
                	li	t0, 0x20
-               	slli	t1, s4, 0x38
+               	slli	t1, a3, 0x38
                	srai	t1, t1, 0x38
                	slli	t0, t0, 0x38
                	srai	t0, t0, 0x38
-               	blt	t1, t0, 0x64 <corpus.cases.scalar.arith_i8.checksum+0x64>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	blt	t1, t0, 0x60 <corpus.cases.scalar.arith_i8.checksum+0x60>
+               	mv	a3, a1
+               	li	a4, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x38
+               	slli	t1, a4, 0x38
                	srai	t1, t1, 0x38
                	slli	t0, t0, 0x38
                	srai	t0, t0, 0x38
-               	blt	t1, t0, 0xe4 <corpus.cases.scalar.arith_i8.checksum+0xe4>
-               	j	0x124 <corpus.cases.scalar.arith_i8.checksum+0x124>
+               	blt	t1, t0, 0x164 <corpus.cases.scalar.arith_i8.checksum+0x164>
+               	j	0x1e8 <corpus.cases.scalar.arith_i8.checksum+0x1e8>
                	li	t0, 0x35
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0xfc>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	slli	a6, a5, 0x38
+               	srai	a6, a6, 0x38
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x38
+               	bltu	t5, t0, 0x190 <corpus.cases.scalar.arith_i8.checksum+0x190>
+               	j	0x1c4 <corpus.cases.scalar.arith_i8.checksum+0x1c4>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x190 <corpus.cases.scalar.arith_i8.checksum+0x190>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	slli	t1, a4, 0x38
                	srai	t1, t1, 0x38
                	slli	t0, t0, 0x38
                	srai	t0, t0, 0x38
-               	blt	t1, t0, 0xe4 <corpus.cases.scalar.arith_i8.checksum+0xe4>
+               	blt	t1, t0, 0x164 <corpus.cases.scalar.arith_i8.checksum+0x164>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x134>
+               	subw	a4, t1, a0
+               	slli	a5, a4, 0x38
+               	srai	a5, a5, 0x38
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x208 <corpus.cases.scalar.arith_i8.checksum+0x208>
+               	j	0x23c <corpus.cases.scalar.arith_i8.checksum+0x23c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x208 <corpus.cases.scalar.arith_i8.checksum+0x208>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x144>
+               	subw	a5, t1, a4
+               	slli	a4, a5, 0x38
+               	srai	a4, a4, 0x38
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x25c <corpus.cases.scalar.arith_i8.checksum+0x25c>
+               	j	0x290 <corpus.cases.scalar.arith_i8.checksum+0x290>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x25c <corpus.cases.scalar.arith_i8.checksum+0x25c>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x154>
+               	subw	a4, t1, a1
+               	slli	a1, a4, 0x38
+               	srai	a1, a1, 0x38
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b0 <corpus.cases.scalar.arith_i8.checksum+0x2b0>
+               	j	0x2e4 <corpus.cases.scalar.arith_i8.checksum+0x2e4>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b0 <corpus.cases.scalar.arith_i8.checksum+0x2b0>
                	li	t1, 0x7f
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x164>
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x38
+               	srai	a4, a4, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x304 <corpus.cases.scalar.arith_i8.checksum+0x304>
+               	j	0x338 <corpus.cases.scalar.arith_i8.checksum+0x338>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x304 <corpus.cases.scalar.arith_i8.checksum+0x304>
                	li	t1, 0x80
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x174>
+               	subw	a1, t1, a0
+               	slli	a4, a1, 0x38
+               	srai	a4, a4, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x358 <corpus.cases.scalar.arith_i8.checksum+0x358>
+               	j	0x38c <corpus.cases.scalar.arith_i8.checksum+0x38c>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x358 <corpus.cases.scalar.arith_i8.checksum+0x358>
                	li	t1, 0xff
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x184>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x190>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x19c>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_i8.checksum+0x1a8>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x38
+               	srai	a4, a4, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3ac <corpus.cases.scalar.arith_i8.checksum+0x3ac>
+               	j	0x3e0 <corpus.cases.scalar.arith_i8.checksum+0x3e0>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3ac <corpus.cases.scalar.arith_i8.checksum+0x3ac>
+               	addw	a1, a0, a3
+               	slli	a4, a1, 0x38
+               	srai	a4, a4, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3fc <corpus.cases.scalar.arith_i8.checksum+0x3fc>
+               	j	0x430 <corpus.cases.scalar.arith_i8.checksum+0x430>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3fc <corpus.cases.scalar.arith_i8.checksum+0x3fc>
+               	subw	a1, a0, a3
+               	slli	a4, a1, 0x38
+               	srai	a4, a4, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x44c <corpus.cases.scalar.arith_i8.checksum+0x44c>
+               	j	0x480 <corpus.cases.scalar.arith_i8.checksum+0x480>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x44c <corpus.cases.scalar.arith_i8.checksum+0x44c>
+               	subw	a1, a3, a0
+               	slli	a0, a1, 0x38
+               	srai	a0, a0, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x49c <corpus.cases.scalar.arith_i8.checksum+0x49c>
+               	j	0x4d0 <corpus.cases.scalar.arith_i8.checksum+0x4d0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x49c <corpus.cases.scalar.arith_i8.checksum+0x49c>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_u16.dis
+++ b/test/golden/riscv64-linux/scalar/arith_u16.dis
@@ -3,124 +3,321 @@ scalar/arith_u16.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u16.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	lui	t1, 0x10
                	addiw	t1, t1, -0x10
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	slli	t1, s4, 0x30
+               	slli	t1, a3, 0x30
                	srli	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srli	t0, t0, 0x30
-               	bltu	t1, t0, 0x68 <corpus.cases.scalar.arith_u16.checksum+0x68>
-               	j	0xc4 <corpus.cases.scalar.arith_u16.checksum+0xc4>
+               	bltu	t1, t0, 0x64 <corpus.cases.scalar.arith_u16.checksum+0x64>
+               	j	0x144 <corpus.cases.scalar.arith_u16.checksum+0x144>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x80>
-               	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x9c>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
-               	li	t0, 0x20
-               	slli	t1, s4, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, t0, 0x30
-               	srli	t0, t0, 0x30
-               	bltu	t1, t0, 0x68 <corpus.cases.scalar.arith_u16.checksum+0x68>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	slli	a5, a4, 0x30
+               	srli	a5, a5, 0x30
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x30
+               	bltu	a7, t0, 0x90 <corpus.cases.scalar.arith_u16.checksum+0x90>
+               	j	0xc4 <corpus.cases.scalar.arith_u16.checksum+0xc4>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x90 <corpus.cases.scalar.arith_u16.checksum+0x90>
+               	li	t0, 0x3
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	slli	a4, a5, 0x30
+               	srli	a4, a4, 0x30
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xec <corpus.cases.scalar.arith_u16.checksum+0xec>
+               	j	0x120 <corpus.cases.scalar.arith_u16.checksum+0x120>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xec <corpus.cases.scalar.arith_u16.checksum+0xec>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
+               	li	t0, 0x20
+               	slli	t1, a3, 0x30
                	srli	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srli	t0, t0, 0x30
-               	bltu	t1, t0, 0xe8 <corpus.cases.scalar.arith_u16.checksum+0xe8>
-               	j	0x12c <corpus.cases.scalar.arith_u16.checksum+0x12c>
+               	bltu	t1, t0, 0x64 <corpus.cases.scalar.arith_u16.checksum+0x64>
+               	mv	a3, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	slli	t1, a4, 0x30
+               	srli	t1, t1, 0x30
+               	slli	t0, t0, 0x30
+               	srli	t0, t0, 0x30
+               	bltu	t1, t0, 0x168 <corpus.cases.scalar.arith_u16.checksum+0x168>
+               	j	0x1f0 <corpus.cases.scalar.arith_u16.checksum+0x1f0>
                	lui	t0, 0xb
                	addiw	t0, t0, -0x433
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x104>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	slli	a6, a5, 0x30
+               	srli	a6, a6, 0x30
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	slli	t1, s5, 0x30
+               	bltu	t5, t0, 0x198 <corpus.cases.scalar.arith_u16.checksum+0x198>
+               	j	0x1cc <corpus.cases.scalar.arith_u16.checksum+0x1cc>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x198 <corpus.cases.scalar.arith_u16.checksum+0x198>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	slli	t1, a4, 0x30
                	srli	t1, t1, 0x30
                	slli	t0, t0, 0x30
                	srli	t0, t0, 0x30
-               	bltu	t1, t0, 0xe8 <corpus.cases.scalar.arith_u16.checksum+0xe8>
+               	bltu	t1, t0, 0x168 <corpus.cases.scalar.arith_u16.checksum+0x168>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x13c>
+               	subw	a4, t1, a0
+               	slli	a5, a4, 0x30
+               	srli	a5, a5, 0x30
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x210 <corpus.cases.scalar.arith_u16.checksum+0x210>
+               	j	0x244 <corpus.cases.scalar.arith_u16.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x210 <corpus.cases.scalar.arith_u16.checksum+0x210>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x14c>
+               	subw	a5, t1, a4
+               	slli	a4, a5, 0x30
+               	srli	a4, a4, 0x30
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x264 <corpus.cases.scalar.arith_u16.checksum+0x264>
+               	j	0x298 <corpus.cases.scalar.arith_u16.checksum+0x298>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x264 <corpus.cases.scalar.arith_u16.checksum+0x264>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x15c>
+               	subw	a4, t1, a1
+               	slli	a1, a4, 0x30
+               	srli	a1, a1, 0x30
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b8 <corpus.cases.scalar.arith_u16.checksum+0x2b8>
+               	j	0x2ec <corpus.cases.scalar.arith_u16.checksum+0x2ec>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2b8 <corpus.cases.scalar.arith_u16.checksum+0x2b8>
                	lui	t1, 0x8
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x170>
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srli	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x310 <corpus.cases.scalar.arith_u16.checksum+0x310>
+               	j	0x344 <corpus.cases.scalar.arith_u16.checksum+0x344>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x310 <corpus.cases.scalar.arith_u16.checksum+0x310>
                	lui	t1, 0x8
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x180>
+               	subw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srli	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x364 <corpus.cases.scalar.arith_u16.checksum+0x364>
+               	j	0x398 <corpus.cases.scalar.arith_u16.checksum+0x398>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x364 <corpus.cases.scalar.arith_u16.checksum+0x364>
                	lui	t1, 0x10
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x194>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x1a0>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x1ac>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u16.checksum+0x1b8>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x30
+               	srli	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.scalar.arith_u16.checksum+0x3bc>
+               	j	0x3f0 <corpus.cases.scalar.arith_u16.checksum+0x3f0>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3bc <corpus.cases.scalar.arith_u16.checksum+0x3bc>
+               	addw	a1, a0, a3
+               	slli	a4, a1, 0x30
+               	srli	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x40c <corpus.cases.scalar.arith_u16.checksum+0x40c>
+               	j	0x440 <corpus.cases.scalar.arith_u16.checksum+0x440>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x40c <corpus.cases.scalar.arith_u16.checksum+0x40c>
+               	subw	a1, a0, a3
+               	slli	a4, a1, 0x30
+               	srli	a4, a4, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <corpus.cases.scalar.arith_u16.checksum+0x45c>
+               	j	0x490 <corpus.cases.scalar.arith_u16.checksum+0x490>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x45c <corpus.cases.scalar.arith_u16.checksum+0x45c>
+               	subw	a1, a3, a0
+               	slli	a0, a1, 0x30
+               	srli	a0, a0, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ac <corpus.cases.scalar.arith_u16.checksum+0x4ac>
+               	j	0x4e0 <corpus.cases.scalar.arith_u16.checksum+0x4e0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x4ac <corpus.cases.scalar.arith_u16.checksum+0x4ac>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_u32.dis
+++ b/test/golden/riscv64-linux/scalar/arith_u32.dis
@@ -3,106 +3,303 @@ scalar/arith_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u32.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t1, -0x10
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	bltu	s4, t0, 0x54 <corpus.cases.scalar.arith_u32.checksum+0x54>
-               	j	0xa0 <corpus.cases.scalar.arith_u32.checksum+0xa0>
+               	bltu	a3, t0, 0x50 <corpus.cases.scalar.arith_u32.checksum+0x50>
+               	j	0x120 <corpus.cases.scalar.arith_u32.checksum+0x120>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x6c>
-               	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x88>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
-               	li	t0, 0x20
-               	bltu	s4, t0, 0x54 <corpus.cases.scalar.arith_u32.checksum+0x54>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0xb4 <corpus.cases.scalar.arith_u32.checksum+0xb4>
-               	j	0xe8 <corpus.cases.scalar.arith_u32.checksum+0xe8>
+               	bltu	a7, t0, 0x7c <corpus.cases.scalar.arith_u32.checksum+0x7c>
+               	j	0xb0 <corpus.cases.scalar.arith_u32.checksum+0xb0>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x7c <corpus.cases.scalar.arith_u32.checksum+0x7c>
+               	li	t0, 0x3
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	slli	a4, a5, 0x20
+               	srli	a4, a4, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.scalar.arith_u32.checksum+0xd8>
+               	j	0x10c <corpus.cases.scalar.arith_u32.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.scalar.arith_u32.checksum+0xd8>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
+               	li	t0, 0x20
+               	bltu	a3, t0, 0x50 <corpus.cases.scalar.arith_u32.checksum+0x50>
+               	mv	a3, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x134 <corpus.cases.scalar.arith_u32.checksum+0x134>
+               	j	0x1ac <corpus.cases.scalar.arith_u32.checksum+0x1ac>
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0xd0>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	slli	a6, a5, 0x20
+               	srli	a6, a6, 0x20
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0xb4 <corpus.cases.scalar.arith_u32.checksum+0xb4>
+               	bltu	t5, t0, 0x164 <corpus.cases.scalar.arith_u32.checksum+0x164>
+               	j	0x198 <corpus.cases.scalar.arith_u32.checksum+0x198>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x164 <corpus.cases.scalar.arith_u32.checksum+0x164>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x134 <corpus.cases.scalar.arith_u32.checksum+0x134>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0xf8>
+               	subw	a4, t1, a0
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1cc <corpus.cases.scalar.arith_u32.checksum+0x1cc>
+               	j	0x200 <corpus.cases.scalar.arith_u32.checksum+0x200>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1cc <corpus.cases.scalar.arith_u32.checksum+0x1cc>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x108>
+               	subw	a5, t1, a4
+               	slli	a4, a5, 0x20
+               	srli	a4, a4, 0x20
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x220 <corpus.cases.scalar.arith_u32.checksum+0x220>
+               	j	0x254 <corpus.cases.scalar.arith_u32.checksum+0x254>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x220 <corpus.cases.scalar.arith_u32.checksum+0x220>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x118>
+               	subw	a4, t1, a1
+               	slli	a1, a4, 0x20
+               	srli	a1, a1, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x274 <corpus.cases.scalar.arith_u32.checksum+0x274>
+               	j	0x2a8 <corpus.cases.scalar.arith_u32.checksum+0x2a8>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x274 <corpus.cases.scalar.arith_u32.checksum+0x274>
                	lui	t1, 0x80000
                	addiw	t1, t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x12c>
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2cc <corpus.cases.scalar.arith_u32.checksum+0x2cc>
+               	j	0x300 <corpus.cases.scalar.arith_u32.checksum+0x300>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2cc <corpus.cases.scalar.arith_u32.checksum+0x2cc>
                	lui	t1, 0x80000
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x13c>
+               	subw	a1, t1, a0
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x320 <corpus.cases.scalar.arith_u32.checksum+0x320>
+               	j	0x354 <corpus.cases.scalar.arith_u32.checksum+0x354>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x320 <corpus.cases.scalar.arith_u32.checksum+0x320>
                	li	t1, -0x1
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x14c>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x158>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x164>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u32.checksum+0x170>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x374 <corpus.cases.scalar.arith_u32.checksum+0x374>
+               	j	0x3a8 <corpus.cases.scalar.arith_u32.checksum+0x3a8>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x374 <corpus.cases.scalar.arith_u32.checksum+0x374>
+               	addw	a1, a0, a3
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3c4 <corpus.cases.scalar.arith_u32.checksum+0x3c4>
+               	j	0x3f8 <corpus.cases.scalar.arith_u32.checksum+0x3f8>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3c4 <corpus.cases.scalar.arith_u32.checksum+0x3c4>
+               	subw	a1, a0, a3
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x414 <corpus.cases.scalar.arith_u32.checksum+0x414>
+               	j	0x448 <corpus.cases.scalar.arith_u32.checksum+0x448>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x414 <corpus.cases.scalar.arith_u32.checksum+0x414>
+               	subw	a1, a3, a0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x464 <corpus.cases.scalar.arith_u32.checksum+0x464>
+               	j	0x498 <corpus.cases.scalar.arith_u32.checksum+0x498>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x464 <corpus.cases.scalar.arith_u32.checksum+0x464>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_u64.dis
+++ b/test/golden/riscv64-linux/scalar/arith_u64.dis
@@ -3,50 +3,73 @@ scalar/arith_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u64.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x28>
                	li	t1, -0x10
-               	add	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	add	a1, t1, a0
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	bltu	s4, t0, 0x50 <corpus.cases.scalar.arith_u64.checksum+0x50>
-               	j	0x9c <corpus.cases.scalar.arith_u64.checksum+0x9c>
+               	bltu	a3, t0, 0x38 <corpus.cases.scalar.arith_u64.checksum+0x38>
+               	j	0xf8 <corpus.cases.scalar.arith_u64.checksum+0xf8>
                	li	t0, 0x7
-               	mul	a0, s4, t0
-               	addi	a1, a0, 0x1
-               	add	s5, s3, a1
-               	mv	a0, s2
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x68>
-               	li	t0, 0x3
-               	mul	a1, s4, t0
-               	addi	a2, a1, 0x2
-               	sub	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x84>
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
-               	li	t0, 0x20
-               	bltu	s4, t0, 0x50 <corpus.cases.scalar.arith_u64.checksum+0x50>
-               	mv	s4, s1
-               	li	s5, 0x0
+               	mul	a4, a3, t0
+               	addi	a5, a4, 0x1
+               	add	a4, a1, a5
+               	mv	a5, a2
+               	li	a6, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0xb0 <corpus.cases.scalar.arith_u64.checksum+0xb0>
-               	j	0xfc <corpus.cases.scalar.arith_u64.checksum+0xfc>
+               	bltu	a6, t0, 0x5c <corpus.cases.scalar.arith_u64.checksum+0x5c>
+               	j	0x90 <corpus.cases.scalar.arith_u64.checksum+0x90>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x5c <corpus.cases.scalar.arith_u64.checksum+0x5c>
+               	li	t0, 0x3
+               	mul	a6, a3, t0
+               	addi	a7, a6, 0x2
+               	sub	a6, a4, a7
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xb0 <corpus.cases.scalar.arith_u64.checksum+0xb0>
+               	j	0xe4 <corpus.cases.scalar.arith_u64.checksum+0xe4>
+               	li	t0, 0x8
+               	mul	a7, a4, t0
+               	srl	t5, a6, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xb0 <corpus.cases.scalar.arith_u64.checksum+0xb0>
+               	addi	a3, a3, 0x1
+               	mv	a2, a5
+               	mv	a1, a6
+               	li	t0, 0x20
+               	bltu	a3, t0, 0x38 <corpus.cases.scalar.arith_u64.checksum+0x38>
+               	mv	a3, a0
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x10c <corpus.cases.scalar.arith_u64.checksum+0x10c>
+               	j	0x194 <corpus.cases.scalar.arith_u64.checksum+0x194>
                	lui	t0, 0x1234
                	addiw	t0, t0, 0x568
                	slli	t0, t0, 0xc
@@ -55,65 +78,206 @@ Disassembly of section .text:
                	addi	t0, t0, -0x543
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x211
-               	mul	a0, s5, t0
-               	addi	a1, a0, 0x1
-               	sub	s4, s4, a1
-               	mv	a0, s2
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0xe4>
-               	addi	s5, s5, 0x1
-               	mv	s2, a0
+               	mul	a5, a4, t0
+               	addi	a6, a5, 0x1
+               	sub	a5, a3, a6
+               	mv	a6, a2
+               	li	a7, 0x0
                	li	t0, 0x8
-               	bltu	s5, t0, 0xb0 <corpus.cases.scalar.arith_u64.checksum+0xb0>
+               	bltu	a7, t0, 0x14c <corpus.cases.scalar.arith_u64.checksum+0x14c>
+               	j	0x180 <corpus.cases.scalar.arith_u64.checksum+0x180>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x14c <corpus.cases.scalar.arith_u64.checksum+0x14c>
+               	addi	a4, a4, 0x1
+               	mv	a2, a6
+               	mv	a3, a5
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x10c <corpus.cases.scalar.arith_u64.checksum+0x10c>
                	li	t1, 0x0
-               	sub	s5, t1, s3
-               	mv	a0, s2
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x10c>
+               	sub	a4, t1, a1
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ac <corpus.cases.scalar.arith_u64.checksum+0x1ac>
+               	j	0x1e0 <corpus.cases.scalar.arith_u64.checksum+0x1e0>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1ac <corpus.cases.scalar.arith_u64.checksum+0x1ac>
                	li	t1, 0x0
-               	sub	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x11c>
+               	sub	a5, t1, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f8 <corpus.cases.scalar.arith_u64.checksum+0x1f8>
+               	j	0x22c <corpus.cases.scalar.arith_u64.checksum+0x22c>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x1f8 <corpus.cases.scalar.arith_u64.checksum+0x1f8>
                	li	t1, 0x0
-               	sub	a1, t1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x12c>
+               	sub	a4, t1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.scalar.arith_u64.checksum+0x244>
+               	j	0x278 <corpus.cases.scalar.arith_u64.checksum+0x278>
+               	li	t0, 0x8
+               	mul	a5, a0, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x244 <corpus.cases.scalar.arith_u64.checksum+0x244>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x1
-               	add	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x14c>
+               	add	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2a0 <corpus.cases.scalar.arith_u64.checksum+0x2a0>
+               	j	0x2d4 <corpus.cases.scalar.arith_u64.checksum+0x2d4>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2a0 <corpus.cases.scalar.arith_u64.checksum+0x2a0>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
-               	sub	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x168>
+               	sub	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2f8 <corpus.cases.scalar.arith_u64.checksum+0x2f8>
+               	j	0x32c <corpus.cases.scalar.arith_u64.checksum+0x32c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x2f8 <corpus.cases.scalar.arith_u64.checksum+0x2f8>
                	li	t1, -0x1
-               	add	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x178>
-               	add	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x184>
-               	sub	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x190>
-               	sub	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u64.checksum+0x19c>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	add	a0, t1, a1
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x344 <corpus.cases.scalar.arith_u64.checksum+0x344>
+               	j	0x378 <corpus.cases.scalar.arith_u64.checksum+0x378>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x344 <corpus.cases.scalar.arith_u64.checksum+0x344>
+               	add	a0, a1, a3
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x38c <corpus.cases.scalar.arith_u64.checksum+0x38c>
+               	j	0x3c0 <corpus.cases.scalar.arith_u64.checksum+0x3c0>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x38c <corpus.cases.scalar.arith_u64.checksum+0x38c>
+               	sub	a0, a1, a3
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3d4 <corpus.cases.scalar.arith_u64.checksum+0x3d4>
+               	j	0x408 <corpus.cases.scalar.arith_u64.checksum+0x408>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x3d4 <corpus.cases.scalar.arith_u64.checksum+0x3d4>
+               	sub	a0, a3, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x41c <corpus.cases.scalar.arith_u64.checksum+0x41c>
+               	j	0x450 <corpus.cases.scalar.arith_u64.checksum+0x450>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x41c <corpus.cases.scalar.arith_u64.checksum+0x41c>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/scalar/arith_u8.dis
+++ b/test/golden/riscv64-linux/scalar/arith_u8.dis
@@ -3,112 +3,297 @@ scalar/arith_u8.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.arith_u8.checksum>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	sd	s2, 0x20(sp)
-               	sd	s3, 0x18(sp)
-               	sd	s4, 0x10(sp)
-               	sd	s5, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x28>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sext.w	a1, a0
                	li	t1, 0xf0
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x20
-               	zext.b	t1, s4
+               	zext.b	t1, a3
                	zext.b	t0, t0
-               	bltu	t1, t0, 0x5c <corpus.cases.scalar.arith_u8.checksum+0x5c>
-               	j	0xb0 <corpus.cases.scalar.arith_u8.checksum+0xb0>
+               	bltu	t1, t0, 0x58 <corpus.cases.scalar.arith_u8.checksum+0x58>
+               	j	0x128 <corpus.cases.scalar.arith_u8.checksum+0x128>
                	li	t0, 0x7
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x1
-               	addw	s5, s3, a1
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x74>
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x1
+               	addw	a4, a0, a5
+               	zext.b	a5, a4
+               	mv	a6, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x80 <corpus.cases.scalar.arith_u8.checksum+0x80>
+               	j	0xb4 <corpus.cases.scalar.arith_u8.checksum+0xb4>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x80 <corpus.cases.scalar.arith_u8.checksum+0x80>
                	li	t0, 0x3
-               	mulw	a1, s4, t0
-               	addiw	a2, a1, 0x2
-               	subw	s3, s5, a2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x90>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	mulw	a5, a3, t0
+               	addiw	a7, a5, 0x2
+               	subw	a5, a4, a7
+               	zext.b	a4, a5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.scalar.arith_u8.checksum+0xd8>
+               	j	0x10c <corpus.cases.scalar.arith_u8.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0xd8 <corpus.cases.scalar.arith_u8.checksum+0xd8>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a5
                	li	t0, 0x20
-               	zext.b	t1, s4
+               	zext.b	t1, a3
                	zext.b	t0, t0
-               	bltu	t1, t0, 0x5c <corpus.cases.scalar.arith_u8.checksum+0x5c>
-               	mv	s4, s2
-               	li	s5, 0x0
+               	bltu	t1, t0, 0x58 <corpus.cases.scalar.arith_u8.checksum+0x58>
+               	mv	a3, a1
+               	li	a4, 0x0
                	li	t0, 0x8
-               	zext.b	t1, s5
+               	zext.b	t1, a4
                	zext.b	t0, t0
-               	bltu	t1, t0, 0xcc <corpus.cases.scalar.arith_u8.checksum+0xcc>
-               	j	0x104 <corpus.cases.scalar.arith_u8.checksum+0x104>
+               	bltu	t1, t0, 0x144 <corpus.cases.scalar.arith_u8.checksum+0x144>
+               	j	0x1bc <corpus.cases.scalar.arith_u8.checksum+0x1bc>
                	li	t0, 0xb5
-               	mulw	a0, s5, t0
-               	addiw	a1, a0, 0x1
-               	subw	s4, s4, a1
-               	mv	a0, s1
-               	mv	a1, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0xe4>
-               	addiw	s5, s5, 0x1
-               	mv	s1, a0
+               	mulw	a5, a4, t0
+               	addiw	a6, a5, 0x1
+               	subw	a5, a3, a6
+               	zext.b	a6, a5
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	zext.b	t1, s5
+               	bltu	t5, t0, 0x16c <corpus.cases.scalar.arith_u8.checksum+0x16c>
+               	j	0x1a0 <corpus.cases.scalar.arith_u8.checksum+0x1a0>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x16c <corpus.cases.scalar.arith_u8.checksum+0x16c>
+               	addiw	a4, a4, 0x1
+               	mv	a2, a7
+               	mv	a3, a5
+               	li	t0, 0x8
+               	zext.b	t1, a4
                	zext.b	t0, t0
-               	bltu	t1, t0, 0xcc <corpus.cases.scalar.arith_u8.checksum+0xcc>
+               	bltu	t1, t0, 0x144 <corpus.cases.scalar.arith_u8.checksum+0x144>
                	li	t1, 0x0
-               	subw	s5, t1, s3
-               	mv	a0, s1
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x114>
+               	subw	a4, t1, a0
+               	zext.b	a5, a4
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1d8 <corpus.cases.scalar.arith_u8.checksum+0x1d8>
+               	j	0x20c <corpus.cases.scalar.arith_u8.checksum+0x20c>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1d8 <corpus.cases.scalar.arith_u8.checksum+0x1d8>
                	li	t1, 0x0
-               	subw	a1, t1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x124>
+               	subw	a5, t1, a4
+               	zext.b	a4, a5
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x228 <corpus.cases.scalar.arith_u8.checksum+0x228>
+               	j	0x25c <corpus.cases.scalar.arith_u8.checksum+0x25c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x228 <corpus.cases.scalar.arith_u8.checksum+0x228>
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x134>
+               	subw	a4, t1, a1
+               	zext.b	a1, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x278 <corpus.cases.scalar.arith_u8.checksum+0x278>
+               	j	0x2ac <corpus.cases.scalar.arith_u8.checksum+0x2ac>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a1, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x278 <corpus.cases.scalar.arith_u8.checksum+0x278>
                	li	t1, 0x7f
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x144>
+               	addw	a1, t1, a0
+               	zext.b	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2c8 <corpus.cases.scalar.arith_u8.checksum+0x2c8>
+               	j	0x2fc <corpus.cases.scalar.arith_u8.checksum+0x2fc>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2c8 <corpus.cases.scalar.arith_u8.checksum+0x2c8>
                	li	t1, 0x80
-               	subw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x154>
+               	subw	a1, t1, a0
+               	zext.b	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x318 <corpus.cases.scalar.arith_u8.checksum+0x318>
+               	j	0x34c <corpus.cases.scalar.arith_u8.checksum+0x34c>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x318 <corpus.cases.scalar.arith_u8.checksum+0x318>
                	li	t1, 0xff
-               	addw	a1, t1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x164>
-               	addw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x170>
-               	subw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x17c>
-               	subw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.arith_u8.checksum+0x188>
-               	ld	s1, 0x28(sp)
-               	ld	s2, 0x20(sp)
-               	ld	s3, 0x18(sp)
-               	ld	s4, 0x10(sp)
-               	ld	s5, 0x8(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addw	a1, t1, a0
+               	zext.b	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x368 <corpus.cases.scalar.arith_u8.checksum+0x368>
+               	j	0x39c <corpus.cases.scalar.arith_u8.checksum+0x39c>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x368 <corpus.cases.scalar.arith_u8.checksum+0x368>
+               	addw	a1, a0, a3
+               	zext.b	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b4 <corpus.cases.scalar.arith_u8.checksum+0x3b4>
+               	j	0x3e8 <corpus.cases.scalar.arith_u8.checksum+0x3e8>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x3b4 <corpus.cases.scalar.arith_u8.checksum+0x3b4>
+               	subw	a1, a0, a3
+               	zext.b	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x400 <corpus.cases.scalar.arith_u8.checksum+0x400>
+               	j	0x434 <corpus.cases.scalar.arith_u8.checksum+0x434>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x400 <corpus.cases.scalar.arith_u8.checksum+0x400>
+               	subw	a1, a3, a0
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x44c <corpus.cases.scalar.arith_u8.checksum+0x44c>
+               	j	0x480 <corpus.cases.scalar.arith_u8.checksum+0x480>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x44c <corpus.cases.scalar.arith_u8.checksum+0x44c>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/divrem_i32.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_i32.dis
@@ -3,198 +3,370 @@ scalar/divrem_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_i32.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x30>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	sext.w	a1, a0
                	lui	t1, 0x77359
                	addiw	t1, t1, 0x400
-               	subw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	subw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	blt	s4, t0, 0x60 <corpus.cases.scalar.divrem_i32.checksum+0x60>
-               	j	0x104 <corpus.cases.scalar.divrem_i32.checksum+0x104>
+               	blt	a3, t0, 0x58 <corpus.cases.scalar.divrem_i32.checksum+0x58>
+               	j	0x1b0 <corpus.cases.scalar.divrem_i32.checksum+0x1b0>
                	li	t0, 0x83
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x3
-               	addw	s5, a1, s2
-               	sext.w	t0, s5
-               	bnez	t0, 0x7c <corpus.cases.scalar.divrem_i32.checksum+0x7c>
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x3
+               	addw	a4, a5, a1
+               	sext.w	t0, a4
+               	bnez	t0, 0x74 <corpus.cases.scalar.divrem_i32.checksum+0x74>
                	ebreak
-               	addiw	t0, s5, 0x1
-               	bnez	t0, 0x94 <corpus.cases.scalar.divrem_i32.checksum+0x94>
+               	addiw	t0, a4, 0x1
+               	bnez	t0, 0x8c <corpus.cases.scalar.divrem_i32.checksum+0x8c>
                	lui	t0, 0x80000
-               	subw	t0, s3, t0
-               	bnez	t0, 0x94 <corpus.cases.scalar.divrem_i32.checksum+0x94>
+               	subw	t0, a0, t0
+               	bnez	t0, 0x8c <corpus.cases.scalar.divrem_i32.checksum+0x8c>
                	ebreak
-               	divw	s6, s3, s5
-               	sext.w	t0, s5
-               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i32.checksum+0xa4>
+               	divw	a5, a0, a4
+               	sext.w	t0, a4
+               	bnez	t0, 0x9c <corpus.cases.scalar.divrem_i32.checksum+0x9c>
                	ebreak
-               	addiw	t0, s5, 0x1
-               	bnez	t0, 0xbc <corpus.cases.scalar.divrem_i32.checksum+0xbc>
+               	addiw	t0, a4, 0x1
+               	bnez	t0, 0xb4 <corpus.cases.scalar.divrem_i32.checksum+0xb4>
                	lui	t0, 0x80000
-               	subw	t0, s3, t0
-               	bnez	t0, 0xbc <corpus.cases.scalar.divrem_i32.checksum+0xbc>
+               	subw	t0, a0, t0
+               	bnez	t0, 0xb4 <corpus.cases.scalar.divrem_i32.checksum+0xb4>
                	ebreak
-               	remw	s7, s3, s5
-               	mv	a0, s1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xc8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xd4>
-               	mulw	a1, s5, s6
-               	addw	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0xe8>
-               	subw	s3, s3, s5
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	remw	a6, a0, a4
+               	sext.w	a7, a5
+               	mv	t5, a2
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xd0 <corpus.cases.scalar.divrem_i32.checksum+0xd0>
+               	j	0x104 <corpus.cases.scalar.divrem_i32.checksum+0x104>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xd0 <corpus.cases.scalar.divrem_i32.checksum+0xd0>
+               	sext.w	a7, a6
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x118 <corpus.cases.scalar.divrem_i32.checksum+0x118>
+               	j	0x14c <corpus.cases.scalar.divrem_i32.checksum+0x14c>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x118 <corpus.cases.scalar.divrem_i32.checksum+0x118>
+               	mulw	a7, a4, a5
+               	addw	a5, a7, a6
+               	sext.w	a6, a5
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x168 <corpus.cases.scalar.divrem_i32.checksum+0x168>
+               	j	0x19c <corpus.cases.scalar.divrem_i32.checksum+0x19c>
+               	li	t0, 0x8
+               	mul	a7, a5, t0
+               	srl	t6, a6, a7
+               	li	t0, 0xff
+               	and	a7, t6, t0
+               	xor	t6, t5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, t6, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x168 <corpus.cases.scalar.divrem_i32.checksum+0x168>
+               	subw	a0, a0, a4
+               	addiw	a3, a3, 0x1
+               	mv	a2, t5
                	li	t0, 0x10
-               	blt	s4, t0, 0x60 <corpus.cases.scalar.divrem_i32.checksum+0x60>
+               	blt	a3, t0, 0x58 <corpus.cases.scalar.divrem_i32.checksum+0x58>
                	lui	t1, 0x77359
                	addiw	t1, t1, 0x400
-               	addw	a0, t1, s2
+               	addw	a0, t1, a1
                	li	t1, 0x0
-               	subw	a1, t1, a0
-               	li	s3, 0x0
-               	mv	s4, a1
+               	subw	a3, t1, a0
+               	li	a0, 0x0
                	li	t0, 0x8
-               	blt	s3, t0, 0x12c <corpus.cases.scalar.divrem_i32.checksum+0x12c>
-               	j	0x1d0 <corpus.cases.scalar.divrem_i32.checksum+0x1d0>
+               	blt	a0, t0, 0x1d4 <corpus.cases.scalar.divrem_i32.checksum+0x1d4>
+               	j	0x32c <corpus.cases.scalar.divrem_i32.checksum+0x32c>
                	li	t0, 0xc5
-               	mulw	a0, s3, t0
-               	addiw	a1, a0, 0x5
-               	addw	s5, a1, s2
-               	sext.w	t0, s5
-               	bnez	t0, 0x148 <corpus.cases.scalar.divrem_i32.checksum+0x148>
-               	ebreak
-               	addiw	t0, s5, 0x1
-               	bnez	t0, 0x160 <corpus.cases.scalar.divrem_i32.checksum+0x160>
-               	lui	t0, 0x80000
-               	subw	t0, s4, t0
-               	bnez	t0, 0x160 <corpus.cases.scalar.divrem_i32.checksum+0x160>
-               	ebreak
-               	divw	s6, s4, s5
-               	sext.w	t0, s5
-               	bnez	t0, 0x170 <corpus.cases.scalar.divrem_i32.checksum+0x170>
-               	ebreak
-               	addiw	t0, s5, 0x1
-               	bnez	t0, 0x188 <corpus.cases.scalar.divrem_i32.checksum+0x188>
-               	lui	t0, 0x80000
-               	subw	t0, s4, t0
-               	bnez	t0, 0x188 <corpus.cases.scalar.divrem_i32.checksum+0x188>
-               	ebreak
-               	remw	s7, s4, s5
-               	mv	a0, s1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x194>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1a0>
-               	mulw	a1, s5, s6
-               	addw	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x1b4>
-               	addw	s4, s4, s5
-               	addiw	s3, s3, 0x1
-               	mv	s1, a0
-               	li	t0, 0x8
-               	blt	s3, t0, 0x12c <corpus.cases.scalar.divrem_i32.checksum+0x12c>
-               	lui	t1, 0x80000
-               	addiw	t1, t1, -0x4
-               	addw	s3, t1, s2
-               	li	t1, 0x3
-               	addw	s4, t1, s2
-               	sext.w	t0, s4
+               	mulw	a4, a0, t0
+               	addiw	a5, a4, 0x5
+               	addw	a4, a5, a1
+               	sext.w	t0, a4
                	bnez	t0, 0x1f0 <corpus.cases.scalar.divrem_i32.checksum+0x1f0>
                	ebreak
-               	addiw	t0, s4, 0x1
+               	addiw	t0, a4, 0x1
                	bnez	t0, 0x208 <corpus.cases.scalar.divrem_i32.checksum+0x208>
                	lui	t0, 0x80000
-               	subw	t0, s3, t0
+               	subw	t0, a3, t0
                	bnez	t0, 0x208 <corpus.cases.scalar.divrem_i32.checksum+0x208>
                	ebreak
-               	divw	s2, s3, s4
-               	sext.w	t0, s4
+               	divw	a5, a3, a4
+               	sext.w	t0, a4
                	bnez	t0, 0x218 <corpus.cases.scalar.divrem_i32.checksum+0x218>
                	ebreak
-               	addiw	t0, s4, 0x1
+               	addiw	t0, a4, 0x1
                	bnez	t0, 0x230 <corpus.cases.scalar.divrem_i32.checksum+0x230>
                	lui	t0, 0x80000
-               	subw	t0, s3, t0
+               	subw	t0, a3, t0
                	bnez	t0, 0x230 <corpus.cases.scalar.divrem_i32.checksum+0x230>
                	ebreak
-               	remw	s5, s3, s4
-               	mv	a0, s1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x23c>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x248>
-               	mulw	a1, s4, s2
-               	addw	a2, a1, s5
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x25c>
-               	sext.w	t0, s3
-               	bnez	t0, 0x270 <corpus.cases.scalar.divrem_i32.checksum+0x270>
+               	remw	a6, a3, a4
+               	sext.w	a7, a5
+               	mv	t5, a2
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x24c <corpus.cases.scalar.divrem_i32.checksum+0x24c>
+               	j	0x280 <corpus.cases.scalar.divrem_i32.checksum+0x280>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x24c <corpus.cases.scalar.divrem_i32.checksum+0x24c>
+               	sext.w	a7, a6
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x294 <corpus.cases.scalar.divrem_i32.checksum+0x294>
+               	j	0x2c8 <corpus.cases.scalar.divrem_i32.checksum+0x2c8>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x294 <corpus.cases.scalar.divrem_i32.checksum+0x294>
+               	mulw	a7, a4, a5
+               	addw	a5, a7, a6
+               	sext.w	a6, a5
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x2e4 <corpus.cases.scalar.divrem_i32.checksum+0x2e4>
+               	j	0x318 <corpus.cases.scalar.divrem_i32.checksum+0x318>
+               	li	t0, 0x8
+               	mul	a7, a5, t0
+               	srl	t6, a6, a7
+               	li	t0, 0xff
+               	and	a7, t6, t0
+               	xor	t6, t5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, t6, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x2e4 <corpus.cases.scalar.divrem_i32.checksum+0x2e4>
+               	addw	a3, a3, a4
+               	addiw	a0, a0, 0x1
+               	mv	a2, t5
+               	li	t0, 0x8
+               	blt	a0, t0, 0x1d4 <corpus.cases.scalar.divrem_i32.checksum+0x1d4>
+               	lui	t1, 0x80000
+               	addiw	t1, t1, -0x4
+               	addw	a0, t1, a1
+               	li	t1, 0x3
+               	addw	a3, t1, a1
+               	sext.w	t0, a3
+               	bnez	t0, 0x34c <corpus.cases.scalar.divrem_i32.checksum+0x34c>
                	ebreak
-               	addiw	t0, s3, 0x1
-               	bnez	t0, 0x288 <corpus.cases.scalar.divrem_i32.checksum+0x288>
+               	addiw	t0, a3, 0x1
+               	bnez	t0, 0x364 <corpus.cases.scalar.divrem_i32.checksum+0x364>
                	lui	t0, 0x80000
-               	subw	t0, s4, t0
-               	bnez	t0, 0x288 <corpus.cases.scalar.divrem_i32.checksum+0x288>
+               	subw	t0, a0, t0
+               	bnez	t0, 0x364 <corpus.cases.scalar.divrem_i32.checksum+0x364>
                	ebreak
-               	divw	s1, s4, s3
-               	sext.w	t0, s3
-               	bnez	t0, 0x298 <corpus.cases.scalar.divrem_i32.checksum+0x298>
+               	divw	a1, a0, a3
+               	sext.w	t0, a3
+               	bnez	t0, 0x374 <corpus.cases.scalar.divrem_i32.checksum+0x374>
                	ebreak
-               	addiw	t0, s3, 0x1
-               	bnez	t0, 0x2b0 <corpus.cases.scalar.divrem_i32.checksum+0x2b0>
+               	addiw	t0, a3, 0x1
+               	bnez	t0, 0x38c <corpus.cases.scalar.divrem_i32.checksum+0x38c>
                	lui	t0, 0x80000
-               	subw	t0, s4, t0
-               	bnez	t0, 0x2b0 <corpus.cases.scalar.divrem_i32.checksum+0x2b0>
+               	subw	t0, a0, t0
+               	bnez	t0, 0x38c <corpus.cases.scalar.divrem_i32.checksum+0x38c>
                	ebreak
-               	remw	s2, s4, s3
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2b8>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2c4>
-               	mulw	a1, s3, s1
-               	addw	a2, a1, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i32.checksum+0x2d8>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	remw	a4, a0, a3
+               	sext.w	a5, a1
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3a4 <corpus.cases.scalar.divrem_i32.checksum+0x3a4>
+               	j	0x3d8 <corpus.cases.scalar.divrem_i32.checksum+0x3d8>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3a4 <corpus.cases.scalar.divrem_i32.checksum+0x3a4>
+               	sext.w	a5, a4
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3ec <corpus.cases.scalar.divrem_i32.checksum+0x3ec>
+               	j	0x420 <corpus.cases.scalar.divrem_i32.checksum+0x420>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x3ec <corpus.cases.scalar.divrem_i32.checksum+0x3ec>
+               	mulw	a5, a3, a1
+               	addw	a1, a5, a4
+               	sext.w	a4, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x43c <corpus.cases.scalar.divrem_i32.checksum+0x43c>
+               	j	0x470 <corpus.cases.scalar.divrem_i32.checksum+0x470>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x43c <corpus.cases.scalar.divrem_i32.checksum+0x43c>
+               	sext.w	t0, a0
+               	bnez	t0, 0x47c <corpus.cases.scalar.divrem_i32.checksum+0x47c>
+               	ebreak
+               	addiw	t0, a0, 0x1
+               	bnez	t0, 0x494 <corpus.cases.scalar.divrem_i32.checksum+0x494>
+               	lui	t0, 0x80000
+               	subw	t0, a3, t0
+               	bnez	t0, 0x494 <corpus.cases.scalar.divrem_i32.checksum+0x494>
+               	ebreak
+               	divw	a1, a3, a0
+               	sext.w	t0, a0
+               	bnez	t0, 0x4a4 <corpus.cases.scalar.divrem_i32.checksum+0x4a4>
+               	ebreak
+               	addiw	t0, a0, 0x1
+               	bnez	t0, 0x4bc <corpus.cases.scalar.divrem_i32.checksum+0x4bc>
+               	lui	t0, 0x80000
+               	subw	t0, a3, t0
+               	bnez	t0, 0x4bc <corpus.cases.scalar.divrem_i32.checksum+0x4bc>
+               	ebreak
+               	remw	a4, a3, a0
+               	sext.w	a3, a1
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x4d4 <corpus.cases.scalar.divrem_i32.checksum+0x4d4>
+               	j	0x508 <corpus.cases.scalar.divrem_i32.checksum+0x508>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x4d4 <corpus.cases.scalar.divrem_i32.checksum+0x4d4>
+               	sext.w	a3, a4
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x51c <corpus.cases.scalar.divrem_i32.checksum+0x51c>
+               	j	0x550 <corpus.cases.scalar.divrem_i32.checksum+0x550>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x51c <corpus.cases.scalar.divrem_i32.checksum+0x51c>
+               	mulw	a3, a0, a1
+               	addw	a0, a3, a4
+               	sext.w	a1, a0
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x56c <corpus.cases.scalar.divrem_i32.checksum+0x56c>
+               	j	0x5a0 <corpus.cases.scalar.divrem_i32.checksum+0x5a0>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x56c <corpus.cases.scalar.divrem_i32.checksum+0x56c>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/divrem_i64.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_i64.dis
@@ -3,20 +3,11 @@ scalar/divrem_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_i64.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x30>
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
                	lui	t1, 0x7ce6
                	addiw	t1, t1, 0x6c5
                	slli	t1, t1, 0xc
@@ -24,189 +15,356 @@ Disassembly of section .text:
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x7c0
                	slli	t1, t1, 0xc
-               	sub	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
-               	li	t0, 0x10
-               	blt	s4, t0, 0x70 <corpus.cases.scalar.divrem_i64.checksum+0x70>
-               	j	0x114 <corpus.cases.scalar.divrem_i64.checksum+0x114>
-               	li	t0, 0x83
-               	mul	a0, s4, t0
-               	addi	a1, a0, 0x3
-               	add	s5, a1, s1
-               	bnez	s5, 0x88 <corpus.cases.scalar.divrem_i64.checksum+0x88>
-               	ebreak
-               	addi	t0, s5, 0x1
-               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i64.checksum+0xa4>
-               	li	t0, 0x1
-               	slli	t0, t0, 0x3f
-               	sub	t0, s3, t0
-               	bnez	t0, 0xa4 <corpus.cases.scalar.divrem_i64.checksum+0xa4>
-               	ebreak
-               	div	s6, s3, s5
-               	bnez	s5, 0xb0 <corpus.cases.scalar.divrem_i64.checksum+0xb0>
-               	ebreak
-               	addi	t0, s5, 0x1
-               	bnez	t0, 0xcc <corpus.cases.scalar.divrem_i64.checksum+0xcc>
-               	li	t0, 0x1
-               	slli	t0, t0, 0x3f
-               	sub	t0, s3, t0
-               	bnez	t0, 0xcc <corpus.cases.scalar.divrem_i64.checksum+0xcc>
-               	ebreak
-               	rem	s7, s3, s5
-               	mv	a0, s2
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xd8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xe4>
-               	mul	a1, s5, s6
-               	add	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0xf8>
-               	sub	s3, s3, s5
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
-               	li	t0, 0x10
-               	blt	s4, t0, 0x70 <corpus.cases.scalar.divrem_i64.checksum+0x70>
-               	lui	t1, 0x7ce6
-               	addiw	t1, t1, 0x6c5
-               	slli	t1, t1, 0xc
-               	addi	t1, t1, 0xe3
-               	slli	t1, t1, 0xc
-               	addi	t1, t1, -0x7c0
-               	slli	t1, t1, 0xc
-               	add	a0, t1, s1
-               	li	t1, 0x0
                	sub	a1, t1, a0
-               	li	s3, 0x0
-               	mv	s4, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
+               	li	t0, 0x10
+               	blt	a3, t0, 0x64 <corpus.cases.scalar.divrem_i64.checksum+0x64>
+               	j	0x1b0 <corpus.cases.scalar.divrem_i64.checksum+0x1b0>
+               	li	t0, 0x83
+               	mul	a4, a3, t0
+               	addi	a5, a4, 0x3
+               	add	a4, a5, a0
+               	bnez	a4, 0x7c <corpus.cases.scalar.divrem_i64.checksum+0x7c>
+               	ebreak
+               	addi	t0, a4, 0x1
+               	bnez	t0, 0x98 <corpus.cases.scalar.divrem_i64.checksum+0x98>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, a1, t0
+               	bnez	t0, 0x98 <corpus.cases.scalar.divrem_i64.checksum+0x98>
+               	ebreak
+               	div	a5, a1, a4
+               	bnez	a4, 0xa4 <corpus.cases.scalar.divrem_i64.checksum+0xa4>
+               	ebreak
+               	addi	t0, a4, 0x1
+               	bnez	t0, 0xc0 <corpus.cases.scalar.divrem_i64.checksum+0xc0>
+               	li	t0, 0x1
+               	slli	t0, t0, 0x3f
+               	sub	t0, a1, t0
+               	bnez	t0, 0xc0 <corpus.cases.scalar.divrem_i64.checksum+0xc0>
+               	ebreak
+               	rem	a6, a1, a4
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	blt	s3, t0, 0x150 <corpus.cases.scalar.divrem_i64.checksum+0x150>
-               	j	0x1f4 <corpus.cases.scalar.divrem_i64.checksum+0x1f4>
+               	bltu	t5, t0, 0xd8 <corpus.cases.scalar.divrem_i64.checksum+0xd8>
+               	j	0x10c <corpus.cases.scalar.divrem_i64.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0xd8 <corpus.cases.scalar.divrem_i64.checksum+0xd8>
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x11c <corpus.cases.scalar.divrem_i64.checksum+0x11c>
+               	j	0x150 <corpus.cases.scalar.divrem_i64.checksum+0x150>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x11c <corpus.cases.scalar.divrem_i64.checksum+0x11c>
+               	mul	t5, a4, a5
+               	add	a5, t5, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x168 <corpus.cases.scalar.divrem_i64.checksum+0x168>
+               	j	0x19c <corpus.cases.scalar.divrem_i64.checksum+0x19c>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a7, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x168 <corpus.cases.scalar.divrem_i64.checksum+0x168>
+               	sub	a1, a1, a4
+               	addi	a3, a3, 0x1
+               	mv	a2, a7
+               	li	t0, 0x10
+               	blt	a3, t0, 0x64 <corpus.cases.scalar.divrem_i64.checksum+0x64>
+               	lui	t1, 0x7ce6
+               	addiw	t1, t1, 0x6c5
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, 0xe3
+               	slli	t1, t1, 0xc
+               	addi	t1, t1, -0x7c0
+               	slli	t1, t1, 0xc
+               	add	a1, t1, a0
+               	li	t1, 0x0
+               	sub	a3, t1, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	blt	a1, t0, 0x1e8 <corpus.cases.scalar.divrem_i64.checksum+0x1e8>
+               	j	0x334 <corpus.cases.scalar.divrem_i64.checksum+0x334>
                	li	t0, 0xc5
-               	mul	a0, s3, t0
-               	addi	a1, a0, 0x5
-               	add	s5, a1, s1
-               	bnez	s5, 0x168 <corpus.cases.scalar.divrem_i64.checksum+0x168>
+               	mul	a4, a1, t0
+               	addi	a5, a4, 0x5
+               	add	a4, a5, a0
+               	bnez	a4, 0x200 <corpus.cases.scalar.divrem_i64.checksum+0x200>
                	ebreak
-               	addi	t0, s5, 0x1
-               	bnez	t0, 0x184 <corpus.cases.scalar.divrem_i64.checksum+0x184>
+               	addi	t0, a4, 0x1
+               	bnez	t0, 0x21c <corpus.cases.scalar.divrem_i64.checksum+0x21c>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s4, t0
-               	bnez	t0, 0x184 <corpus.cases.scalar.divrem_i64.checksum+0x184>
+               	sub	t0, a3, t0
+               	bnez	t0, 0x21c <corpus.cases.scalar.divrem_i64.checksum+0x21c>
                	ebreak
-               	div	s6, s4, s5
-               	bnez	s5, 0x190 <corpus.cases.scalar.divrem_i64.checksum+0x190>
+               	div	a5, a3, a4
+               	bnez	a4, 0x228 <corpus.cases.scalar.divrem_i64.checksum+0x228>
                	ebreak
-               	addi	t0, s5, 0x1
-               	bnez	t0, 0x1ac <corpus.cases.scalar.divrem_i64.checksum+0x1ac>
+               	addi	t0, a4, 0x1
+               	bnez	t0, 0x244 <corpus.cases.scalar.divrem_i64.checksum+0x244>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s4, t0
-               	bnez	t0, 0x1ac <corpus.cases.scalar.divrem_i64.checksum+0x1ac>
+               	sub	t0, a3, t0
+               	bnez	t0, 0x244 <corpus.cases.scalar.divrem_i64.checksum+0x244>
                	ebreak
-               	rem	s7, s4, s5
-               	mv	a0, s2
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1b8>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1c4>
-               	mul	a1, s5, s6
-               	add	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x1d8>
-               	add	s4, s4, s5
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	rem	a6, a3, a4
+               	mv	a7, a2
+               	li	t5, 0x0
                	li	t0, 0x8
-               	blt	s3, t0, 0x150 <corpus.cases.scalar.divrem_i64.checksum+0x150>
+               	bltu	t5, t0, 0x25c <corpus.cases.scalar.divrem_i64.checksum+0x25c>
+               	j	0x290 <corpus.cases.scalar.divrem_i64.checksum+0x290>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x25c <corpus.cases.scalar.divrem_i64.checksum+0x25c>
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x2a0 <corpus.cases.scalar.divrem_i64.checksum+0x2a0>
+               	j	0x2d4 <corpus.cases.scalar.divrem_i64.checksum+0x2d4>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x2a0 <corpus.cases.scalar.divrem_i64.checksum+0x2a0>
+               	mul	t5, a4, a5
+               	add	a5, t5, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2ec <corpus.cases.scalar.divrem_i64.checksum+0x2ec>
+               	j	0x320 <corpus.cases.scalar.divrem_i64.checksum+0x320>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a7, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x2ec <corpus.cases.scalar.divrem_i64.checksum+0x2ec>
+               	add	a3, a3, a4
+               	addi	a1, a1, 0x1
+               	mv	a2, a7
+               	li	t0, 0x8
+               	blt	a1, t0, 0x1e8 <corpus.cases.scalar.divrem_i64.checksum+0x1e8>
                	lui	t1, 0xf8000
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x4
-               	add	s3, t1, s1
+               	add	a1, t1, a0
                	li	t1, 0x3
-               	add	s4, t1, s1
-               	bnez	s4, 0x21c <corpus.cases.scalar.divrem_i64.checksum+0x21c>
+               	add	a3, t1, a0
+               	bnez	a3, 0x35c <corpus.cases.scalar.divrem_i64.checksum+0x35c>
                	ebreak
-               	addi	t0, s4, 0x1
-               	bnez	t0, 0x238 <corpus.cases.scalar.divrem_i64.checksum+0x238>
+               	addi	t0, a3, 0x1
+               	bnez	t0, 0x378 <corpus.cases.scalar.divrem_i64.checksum+0x378>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s3, t0
-               	bnez	t0, 0x238 <corpus.cases.scalar.divrem_i64.checksum+0x238>
+               	sub	t0, a1, t0
+               	bnez	t0, 0x378 <corpus.cases.scalar.divrem_i64.checksum+0x378>
                	ebreak
-               	div	s1, s3, s4
-               	bnez	s4, 0x244 <corpus.cases.scalar.divrem_i64.checksum+0x244>
+               	div	a0, a1, a3
+               	bnez	a3, 0x384 <corpus.cases.scalar.divrem_i64.checksum+0x384>
                	ebreak
-               	addi	t0, s4, 0x1
-               	bnez	t0, 0x260 <corpus.cases.scalar.divrem_i64.checksum+0x260>
+               	addi	t0, a3, 0x1
+               	bnez	t0, 0x3a0 <corpus.cases.scalar.divrem_i64.checksum+0x3a0>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s3, t0
-               	bnez	t0, 0x260 <corpus.cases.scalar.divrem_i64.checksum+0x260>
+               	sub	t0, a1, t0
+               	bnez	t0, 0x3a0 <corpus.cases.scalar.divrem_i64.checksum+0x3a0>
                	ebreak
-               	rem	s5, s3, s4
-               	mv	a0, s2
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x26c>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x278>
-               	mul	a1, s4, s1
-               	add	a2, a1, s5
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x28c>
-               	bnez	s3, 0x29c <corpus.cases.scalar.divrem_i64.checksum+0x29c>
+               	rem	a4, a1, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x3b4 <corpus.cases.scalar.divrem_i64.checksum+0x3b4>
+               	j	0x3e8 <corpus.cases.scalar.divrem_i64.checksum+0x3e8>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a0, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x3b4 <corpus.cases.scalar.divrem_i64.checksum+0x3b4>
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x3f8 <corpus.cases.scalar.divrem_i64.checksum+0x3f8>
+               	j	0x42c <corpus.cases.scalar.divrem_i64.checksum+0x42c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x3f8 <corpus.cases.scalar.divrem_i64.checksum+0x3f8>
+               	mul	a5, a3, a0
+               	add	a0, a5, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x444 <corpus.cases.scalar.divrem_i64.checksum+0x444>
+               	j	0x478 <corpus.cases.scalar.divrem_i64.checksum+0x478>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x444 <corpus.cases.scalar.divrem_i64.checksum+0x444>
+               	bnez	a1, 0x480 <corpus.cases.scalar.divrem_i64.checksum+0x480>
                	ebreak
-               	addi	t0, s3, 0x1
-               	bnez	t0, 0x2b8 <corpus.cases.scalar.divrem_i64.checksum+0x2b8>
+               	addi	t0, a1, 0x1
+               	bnez	t0, 0x49c <corpus.cases.scalar.divrem_i64.checksum+0x49c>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s4, t0
-               	bnez	t0, 0x2b8 <corpus.cases.scalar.divrem_i64.checksum+0x2b8>
+               	sub	t0, a3, t0
+               	bnez	t0, 0x49c <corpus.cases.scalar.divrem_i64.checksum+0x49c>
                	ebreak
-               	div	s1, s4, s3
-               	bnez	s3, 0x2c4 <corpus.cases.scalar.divrem_i64.checksum+0x2c4>
+               	div	a0, a3, a1
+               	bnez	a1, 0x4a8 <corpus.cases.scalar.divrem_i64.checksum+0x4a8>
                	ebreak
-               	addi	t0, s3, 0x1
-               	bnez	t0, 0x2e0 <corpus.cases.scalar.divrem_i64.checksum+0x2e0>
+               	addi	t0, a1, 0x1
+               	bnez	t0, 0x4c4 <corpus.cases.scalar.divrem_i64.checksum+0x4c4>
                	li	t0, 0x1
                	slli	t0, t0, 0x3f
-               	sub	t0, s4, t0
-               	bnez	t0, 0x2e0 <corpus.cases.scalar.divrem_i64.checksum+0x2e0>
+               	sub	t0, a3, t0
+               	bnez	t0, 0x4c4 <corpus.cases.scalar.divrem_i64.checksum+0x4c4>
                	ebreak
-               	rem	s2, s4, s3
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x2e8>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x2f4>
-               	mul	a1, s3, s1
-               	add	a2, a1, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_i64.checksum+0x308>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	rem	a4, a3, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4d8 <corpus.cases.scalar.divrem_i64.checksum+0x4d8>
+               	j	0x50c <corpus.cases.scalar.divrem_i64.checksum+0x50c>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4d8 <corpus.cases.scalar.divrem_i64.checksum+0x4d8>
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x51c <corpus.cases.scalar.divrem_i64.checksum+0x51c>
+               	j	0x550 <corpus.cases.scalar.divrem_i64.checksum+0x550>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x51c <corpus.cases.scalar.divrem_i64.checksum+0x51c>
+               	mul	a3, a1, a0
+               	add	a0, a3, a4
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x568 <corpus.cases.scalar.divrem_i64.checksum+0x568>
+               	j	0x59c <corpus.cases.scalar.divrem_i64.checksum+0x59c>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x568 <corpus.cases.scalar.divrem_i64.checksum+0x568>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/divrem_u32.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_u32.dis
@@ -3,109 +3,246 @@ scalar/divrem_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_u32.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x30>
-               	sext.w	s2, s1
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
+               	sd	s2, 0x0(sp)
+               	sext.w	a1, a0
                	li	t1, -0x1
-               	subw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	subw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	bltu	s4, t0, 0x5c <corpus.cases.scalar.divrem_u32.checksum+0x5c>
-               	j	0xd0 <corpus.cases.scalar.divrem_u32.checksum+0xd0>
+               	bltu	a3, t0, 0x54 <corpus.cases.scalar.divrem_u32.checksum+0x54>
+               	j	0x188 <corpus.cases.scalar.divrem_u32.checksum+0x188>
                	li	t0, 0x83
-               	mulw	a0, s4, t0
-               	addiw	a1, a0, 0x3
-               	addw	s5, a1, s2
-               	sext.w	t0, s5
-               	bnez	t0, 0x78 <corpus.cases.scalar.divrem_u32.checksum+0x78>
+               	mulw	a4, a3, t0
+               	addiw	a5, a4, 0x3
+               	addw	a4, a5, a1
+               	sext.w	t0, a4
+               	bnez	t0, 0x70 <corpus.cases.scalar.divrem_u32.checksum+0x70>
                	ebreak
-               	divuw	s6, s3, s5
-               	sext.w	t0, s5
-               	bnez	t0, 0x88 <corpus.cases.scalar.divrem_u32.checksum+0x88>
+               	divuw	a5, a0, a4
+               	sext.w	t0, a4
+               	bnez	t0, 0x80 <corpus.cases.scalar.divrem_u32.checksum+0x80>
                	ebreak
-               	remuw	s7, s3, s5
-               	mv	a0, s1
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x94>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xa0>
-               	mulw	a1, s5, s6
-               	addw	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0xb4>
-               	subw	s3, s3, s5
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	remuw	a6, a0, a4
+               	slli	a7, a5, 0x20
+               	srli	a7, a7, 0x20
+               	mv	t5, a2
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xa0 <corpus.cases.scalar.divrem_u32.checksum+0xa0>
+               	j	0xd4 <corpus.cases.scalar.divrem_u32.checksum+0xd4>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xa0 <corpus.cases.scalar.divrem_u32.checksum+0xa0>
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xec <corpus.cases.scalar.divrem_u32.checksum+0xec>
+               	j	0x120 <corpus.cases.scalar.divrem_u32.checksum+0x120>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0xec <corpus.cases.scalar.divrem_u32.checksum+0xec>
+               	mulw	a7, a4, a5
+               	addw	a5, a7, a6
+               	slli	a6, a5, 0x20
+               	srli	a6, a6, 0x20
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x140 <corpus.cases.scalar.divrem_u32.checksum+0x140>
+               	j	0x174 <corpus.cases.scalar.divrem_u32.checksum+0x174>
+               	li	t0, 0x8
+               	mul	a7, a5, t0
+               	srl	t6, a6, a7
+               	li	t0, 0xff
+               	and	a7, t6, t0
+               	xor	t6, t5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, t6, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x140 <corpus.cases.scalar.divrem_u32.checksum+0x140>
+               	subw	a0, a0, a4
+               	addiw	a3, a3, 0x1
+               	mv	a2, t5
                	li	t0, 0x10
-               	bltu	s4, t0, 0x5c <corpus.cases.scalar.divrem_u32.checksum+0x5c>
+               	bltu	a3, t0, 0x54 <corpus.cases.scalar.divrem_u32.checksum+0x54>
                	li	t1, -0x3
-               	addw	s3, t1, s2
+               	addw	a0, t1, a1
                	li	t1, 0x3
-               	addw	s4, t1, s2
-               	sext.w	t0, s4
-               	bnez	t0, 0xec <corpus.cases.scalar.divrem_u32.checksum+0xec>
+               	addw	a3, t1, a1
+               	sext.w	t0, a3
+               	bnez	t0, 0x1a4 <corpus.cases.scalar.divrem_u32.checksum+0x1a4>
                	ebreak
-               	divuw	s2, s3, s4
-               	sext.w	t0, s4
-               	bnez	t0, 0xfc <corpus.cases.scalar.divrem_u32.checksum+0xfc>
+               	divuw	a1, a0, a3
+               	sext.w	t0, a3
+               	bnez	t0, 0x1b4 <corpus.cases.scalar.divrem_u32.checksum+0x1b4>
                	ebreak
-               	remuw	s5, s3, s4
-               	mv	a0, s1
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x108>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x114>
-               	mulw	a1, s4, s2
-               	addw	a2, a1, s5
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x128>
-               	sext.w	t0, s3
-               	bnez	t0, 0x13c <corpus.cases.scalar.divrem_u32.checksum+0x13c>
+               	remuw	a4, a0, a3
+               	slli	a5, a1, 0x20
+               	srli	a5, a5, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1d0 <corpus.cases.scalar.divrem_u32.checksum+0x1d0>
+               	j	0x204 <corpus.cases.scalar.divrem_u32.checksum+0x204>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x1d0 <corpus.cases.scalar.divrem_u32.checksum+0x1d0>
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x21c <corpus.cases.scalar.divrem_u32.checksum+0x21c>
+               	j	0x250 <corpus.cases.scalar.divrem_u32.checksum+0x250>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a5, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a2, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x21c <corpus.cases.scalar.divrem_u32.checksum+0x21c>
+               	mulw	a5, a3, a1
+               	addw	a1, a5, a4
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x270 <corpus.cases.scalar.divrem_u32.checksum+0x270>
+               	j	0x2a4 <corpus.cases.scalar.divrem_u32.checksum+0x2a4>
+               	li	t0, 0x8
+               	mul	a5, a1, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x270 <corpus.cases.scalar.divrem_u32.checksum+0x270>
+               	sext.w	t0, a0
+               	bnez	t0, 0x2b0 <corpus.cases.scalar.divrem_u32.checksum+0x2b0>
                	ebreak
-               	divuw	s1, s4, s3
-               	sext.w	t0, s3
-               	bnez	t0, 0x14c <corpus.cases.scalar.divrem_u32.checksum+0x14c>
+               	divuw	a1, a3, a0
+               	sext.w	t0, a0
+               	bnez	t0, 0x2c0 <corpus.cases.scalar.divrem_u32.checksum+0x2c0>
                	ebreak
-               	remuw	s2, s4, s3
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x154>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x160>
-               	mulw	a1, s3, s1
-               	addw	a2, a1, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u32.checksum+0x174>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	remuw	a4, a3, a0
+               	slli	a3, a1, 0x20
+               	srli	a3, a3, 0x20
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x2dc <corpus.cases.scalar.divrem_u32.checksum+0x2dc>
+               	j	0x310 <corpus.cases.scalar.divrem_u32.checksum+0x310>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x2dc <corpus.cases.scalar.divrem_u32.checksum+0x2dc>
+               	slli	a3, a4, 0x20
+               	srli	a3, a3, 0x20
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x328 <corpus.cases.scalar.divrem_u32.checksum+0x328>
+               	j	0x35c <corpus.cases.scalar.divrem_u32.checksum+0x35c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a3, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x328 <corpus.cases.scalar.divrem_u32.checksum+0x328>
+               	mulw	a3, a0, a1
+               	addw	a0, a3, a4
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x37c <corpus.cases.scalar.divrem_u32.checksum+0x37c>
+               	j	0x3b0 <corpus.cases.scalar.divrem_u32.checksum+0x3b0>
+               	li	t0, 0x8
+               	mul	a3, a0, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0x37c <corpus.cases.scalar.divrem_u32.checksum+0x37c>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	s2, 0x0(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/divrem_u64.dis
+++ b/test/golden/riscv64-linux/scalar/divrem_u64.dis
@@ -3,102 +3,219 @@ scalar/divrem_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.divrem_u64.checksum>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	sd	s2, 0x30(sp)
-               	sd	s3, 0x28(sp)
-               	sd	s4, 0x20(sp)
-               	sd	s5, 0x18(sp)
-               	sd	s6, 0x10(sp)
-               	sd	s7, 0x8(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x30>
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	sd	s1, 0x8(sp)
                	li	t1, -0x1
-               	sub	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	sub	a1, t1, a0
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	bltu	s4, t0, 0x58 <corpus.cases.scalar.divrem_u64.checksum+0x58>
-               	j	0xc4 <corpus.cases.scalar.divrem_u64.checksum+0xc4>
+               	bltu	a3, t0, 0x4c <corpus.cases.scalar.divrem_u64.checksum+0x4c>
+               	j	0x160 <corpus.cases.scalar.divrem_u64.checksum+0x160>
                	li	t0, 0x83
-               	mul	a0, s4, t0
-               	addi	a1, a0, 0x3
-               	add	s5, a1, s1
-               	bnez	s5, 0x70 <corpus.cases.scalar.divrem_u64.checksum+0x70>
+               	mul	a4, a3, t0
+               	addi	a5, a4, 0x3
+               	add	a4, a5, a0
+               	bnez	a4, 0x64 <corpus.cases.scalar.divrem_u64.checksum+0x64>
                	ebreak
-               	divu	s6, s3, s5
-               	bnez	s5, 0x7c <corpus.cases.scalar.divrem_u64.checksum+0x7c>
+               	divu	a5, a1, a4
+               	bnez	a4, 0x70 <corpus.cases.scalar.divrem_u64.checksum+0x70>
                	ebreak
-               	remu	s7, s3, s5
-               	mv	a0, s2
-               	mv	a1, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x88>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x94>
-               	mul	a1, s5, s6
-               	add	a2, a1, s7
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xa8>
-               	sub	s3, s3, s5
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
+               	remu	a6, a1, a4
+               	mv	a7, a2
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x88 <corpus.cases.scalar.divrem_u64.checksum+0x88>
+               	j	0xbc <corpus.cases.scalar.divrem_u64.checksum+0xbc>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a5, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x88 <corpus.cases.scalar.divrem_u64.checksum+0x88>
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0xcc <corpus.cases.scalar.divrem_u64.checksum+0xcc>
+               	j	0x100 <corpus.cases.scalar.divrem_u64.checksum+0x100>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0xcc <corpus.cases.scalar.divrem_u64.checksum+0xcc>
+               	mul	t5, a4, a5
+               	add	a5, t5, a6
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x118 <corpus.cases.scalar.divrem_u64.checksum+0x118>
+               	j	0x14c <corpus.cases.scalar.divrem_u64.checksum+0x14c>
+               	li	t0, 0x8
+               	mul	t5, a6, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a7, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, t6, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x118 <corpus.cases.scalar.divrem_u64.checksum+0x118>
+               	sub	a1, a1, a4
+               	addi	a3, a3, 0x1
+               	mv	a2, a7
                	li	t0, 0x10
-               	bltu	s4, t0, 0x58 <corpus.cases.scalar.divrem_u64.checksum+0x58>
+               	bltu	a3, t0, 0x4c <corpus.cases.scalar.divrem_u64.checksum+0x4c>
                	li	t1, -0x3
-               	add	s3, t1, s1
+               	add	a1, t1, a0
                	li	t1, 0x3
-               	add	s4, t1, s1
-               	bnez	s4, 0xdc <corpus.cases.scalar.divrem_u64.checksum+0xdc>
+               	add	a3, t1, a0
+               	bnez	a3, 0x178 <corpus.cases.scalar.divrem_u64.checksum+0x178>
                	ebreak
-               	divu	s1, s3, s4
-               	bnez	s4, 0xe8 <corpus.cases.scalar.divrem_u64.checksum+0xe8>
+               	divu	a0, a1, a3
+               	bnez	a3, 0x184 <corpus.cases.scalar.divrem_u64.checksum+0x184>
                	ebreak
-               	remu	s5, s3, s4
-               	mv	a0, s2
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0xf4>
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x100>
-               	mul	a1, s4, s1
-               	add	a2, a1, s5
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x114>
-               	bnez	s3, 0x124 <corpus.cases.scalar.divrem_u64.checksum+0x124>
+               	remu	a4, a1, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x198 <corpus.cases.scalar.divrem_u64.checksum+0x198>
+               	j	0x1cc <corpus.cases.scalar.divrem_u64.checksum+0x1cc>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a0, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x198 <corpus.cases.scalar.divrem_u64.checksum+0x198>
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1dc <corpus.cases.scalar.divrem_u64.checksum+0x1dc>
+               	j	0x210 <corpus.cases.scalar.divrem_u64.checksum+0x210>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x1dc <corpus.cases.scalar.divrem_u64.checksum+0x1dc>
+               	mul	a5, a3, a0
+               	add	a0, a5, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x228 <corpus.cases.scalar.divrem_u64.checksum+0x228>
+               	j	0x25c <corpus.cases.scalar.divrem_u64.checksum+0x25c>
+               	li	t0, 0x8
+               	mul	a5, a4, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x228 <corpus.cases.scalar.divrem_u64.checksum+0x228>
+               	bnez	a1, 0x264 <corpus.cases.scalar.divrem_u64.checksum+0x264>
                	ebreak
-               	divu	s1, s4, s3
-               	bnez	s3, 0x130 <corpus.cases.scalar.divrem_u64.checksum+0x130>
+               	divu	a0, a3, a1
+               	bnez	a1, 0x270 <corpus.cases.scalar.divrem_u64.checksum+0x270>
                	ebreak
-               	remu	s2, s4, s3
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x138>
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x144>
-               	mul	a1, s3, s1
-               	add	a2, a1, s2
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.divrem_u64.checksum+0x158>
-               	ld	s1, 0x38(sp)
-               	ld	s2, 0x30(sp)
-               	ld	s3, 0x28(sp)
-               	ld	s4, 0x20(sp)
-               	ld	s5, 0x18(sp)
-               	ld	s6, 0x10(sp)
-               	ld	s7, 0x8(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	remu	a4, a3, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x284 <corpus.cases.scalar.divrem_u64.checksum+0x284>
+               	j	0x2b8 <corpus.cases.scalar.divrem_u64.checksum+0x2b8>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a0, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x284 <corpus.cases.scalar.divrem_u64.checksum+0x284>
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2c8 <corpus.cases.scalar.divrem_u64.checksum+0x2c8>
+               	j	0x2fc <corpus.cases.scalar.divrem_u64.checksum+0x2fc>
+               	li	t0, 0x8
+               	mul	a5, a3, t0
+               	srl	a6, a4, a5
+               	li	t0, 0xff
+               	and	a5, a6, t0
+               	xor	a6, a2, a5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a6, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2c8 <corpus.cases.scalar.divrem_u64.checksum+0x2c8>
+               	mul	a3, a1, a0
+               	add	a0, a3, a4
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x314 <corpus.cases.scalar.divrem_u64.checksum+0x314>
+               	j	0x348 <corpus.cases.scalar.divrem_u64.checksum+0x348>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x314 <corpus.cases.scalar.divrem_u64.checksum+0x314>
+               	mv	a0, a2
+               	ld	s1, 0x8(sp)
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret

--- a/test/golden/riscv64-linux/scalar/mul_i32.dis
+++ b/test/golden/riscv64-linux/scalar/mul_i32.dis
@@ -3,70 +3,170 @@ scalar/mul_i32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_i32.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0x24>
-               	sext.w	s2, s1
+               	sext.w	a1, a0
                	lui	t1, 0x9e378
                	addiw	t1, t1, -0x647
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	blt	s4, t0, 0x54 <corpus.cases.scalar.mul_i32.checksum+0x54>
-               	j	0x84 <corpus.cases.scalar.mul_i32.checksum+0x84>
+               	blt	a3, t0, 0x40 <corpus.cases.scalar.mul_i32.checksum+0x40>
+               	j	0xb0 <corpus.cases.scalar.mul_i32.checksum+0xb0>
                	li	t1, 0x2
-               	mulw	a0, t1, s4
-               	addiw	a1, a0, 0x3
-               	mulw	s3, s3, a1
-               	mv	a0, s1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0x6c>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	mulw	a4, t1, a3
+               	addiw	a5, a4, 0x3
+               	mulw	a4, a0, a5
+               	sext.w	a5, a4
+               	mv	a6, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x68 <corpus.cases.scalar.mul_i32.checksum+0x68>
+               	j	0x9c <corpus.cases.scalar.mul_i32.checksum+0x9c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x68 <corpus.cases.scalar.mul_i32.checksum+0x68>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a4
                	li	t0, 0x10
-               	blt	s4, t0, 0x54 <corpus.cases.scalar.mul_i32.checksum+0x54>
+               	blt	a3, t0, 0x40 <corpus.cases.scalar.mul_i32.checksum+0x40>
                	li	t1, -0x41
-               	addw	s4, t1, s2
-               	mulw	a1, s4, s4
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0x94>
+               	addw	a3, t1, a1
+               	mulw	a4, a3, a3
+               	sext.w	a5, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xd0 <corpus.cases.scalar.mul_i32.checksum+0xd0>
+               	j	0x104 <corpus.cases.scalar.mul_i32.checksum+0x104>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xd0 <corpus.cases.scalar.mul_i32.checksum+0xd0>
                	li	t0, -0x1
-               	mulw	a1, s4, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0xa4>
-               	mulw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0xb0>
-               	mulw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0xbc>
+               	mulw	a4, a3, t0
+               	sext.w	a5, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x120 <corpus.cases.scalar.mul_i32.checksum+0x120>
+               	j	0x154 <corpus.cases.scalar.mul_i32.checksum+0x154>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x120 <corpus.cases.scalar.mul_i32.checksum+0x120>
+               	mulw	a4, a0, a3
+               	sext.w	a5, a4
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x16c <corpus.cases.scalar.mul_i32.checksum+0x16c>
+               	j	0x1a0 <corpus.cases.scalar.mul_i32.checksum+0x1a0>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x16c <corpus.cases.scalar.mul_i32.checksum+0x16c>
+               	mulw	a4, a3, a0
+               	sext.w	a0, a4
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1b8 <corpus.cases.scalar.mul_i32.checksum+0x1b8>
+               	j	0x1ec <corpus.cases.scalar.mul_i32.checksum+0x1ec>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1b8 <corpus.cases.scalar.mul_i32.checksum+0x1b8>
                	lui	t1, 0x10
                	addiw	t1, t1, 0x1
-               	addw	s1, t1, s2
-               	mulw	a1, s1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0xd4>
+               	addw	a0, t1, a1
+               	mulw	a1, a0, a0
+               	sext.w	a3, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x210 <corpus.cases.scalar.mul_i32.checksum+0x210>
+               	j	0x244 <corpus.cases.scalar.mul_i32.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x210 <corpus.cases.scalar.mul_i32.checksum+0x210>
                	li	t0, -0x1
-               	mulw	a1, s1, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i32.checksum+0xe4>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mulw	a1, a0, t0
+               	sext.w	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x260 <corpus.cases.scalar.mul_i32.checksum+0x260>
+               	j	0x294 <corpus.cases.scalar.mul_i32.checksum+0x294>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x260 <corpus.cases.scalar.mul_i32.checksum+0x260>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/scalar/mul_i64.dis
+++ b/test/golden/riscv64-linux/scalar/mul_i64.dis
@@ -3,17 +3,6 @@ scalar/mul_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_i64.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0x24>
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -22,57 +11,161 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	add	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	add	a1, t1, a0
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	blt	s4, t0, 0x68 <corpus.cases.scalar.mul_i64.checksum+0x68>
-               	j	0x98 <corpus.cases.scalar.mul_i64.checksum+0x98>
+               	blt	a3, t0, 0x54 <corpus.cases.scalar.mul_i64.checksum+0x54>
+               	j	0xc0 <corpus.cases.scalar.mul_i64.checksum+0xc0>
                	li	t1, 0x2
-               	mul	a0, t1, s4
-               	addi	a1, a0, 0x3
-               	mul	s3, s3, a1
-               	mv	a0, s2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0x80>
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
+               	mul	a4, t1, a3
+               	addi	a5, a4, 0x3
+               	mul	a4, a1, a5
+               	mv	a5, a2
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x78 <corpus.cases.scalar.mul_i64.checksum+0x78>
+               	j	0xac <corpus.cases.scalar.mul_i64.checksum+0xac>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x78 <corpus.cases.scalar.mul_i64.checksum+0x78>
+               	addi	a3, a3, 0x1
+               	mv	a2, a5
+               	mv	a1, a4
                	li	t0, 0x10
-               	blt	s4, t0, 0x68 <corpus.cases.scalar.mul_i64.checksum+0x68>
+               	blt	a3, t0, 0x54 <corpus.cases.scalar.mul_i64.checksum+0x54>
                	li	t1, -0x3f
-               	add	s4, t1, s1
-               	mul	a1, s4, s4
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xa8>
+               	add	a3, t1, a0
+               	mul	a4, a3, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xdc <corpus.cases.scalar.mul_i64.checksum+0xdc>
+               	j	0x110 <corpus.cases.scalar.mul_i64.checksum+0x110>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xdc <corpus.cases.scalar.mul_i64.checksum+0xdc>
                	li	t0, -0x1
-               	mul	a1, s4, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xb8>
-               	mul	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xc4>
-               	mul	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xd0>
+               	mul	a4, a3, t0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x128 <corpus.cases.scalar.mul_i64.checksum+0x128>
+               	j	0x15c <corpus.cases.scalar.mul_i64.checksum+0x15c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x128 <corpus.cases.scalar.mul_i64.checksum+0x128>
+               	mul	a4, a1, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x170 <corpus.cases.scalar.mul_i64.checksum+0x170>
+               	j	0x1a4 <corpus.cases.scalar.mul_i64.checksum+0x1a4>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x170 <corpus.cases.scalar.mul_i64.checksum+0x170>
+               	mul	a4, a3, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1b8 <corpus.cases.scalar.mul_i64.checksum+0x1b8>
+               	j	0x1ec <corpus.cases.scalar.mul_i64.checksum+0x1ec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a5, a4, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1b8 <corpus.cases.scalar.mul_i64.checksum+0x1b8>
                	lui	t1, 0x100
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0xf
-               	add	s2, t1, s1
-               	mul	a1, s2, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xec>
+               	add	a1, t1, a0
+               	mul	a0, a1, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.scalar.mul_i64.checksum+0x210>
+               	j	0x244 <corpus.cases.scalar.mul_i64.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.scalar.mul_i64.checksum+0x210>
                	li	t0, -0x1
-               	mul	a1, s2, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_i64.checksum+0xfc>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mul	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x25c <corpus.cases.scalar.mul_i64.checksum+0x25c>
+               	j	0x290 <corpus.cases.scalar.mul_i64.checksum+0x290>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x25c <corpus.cases.scalar.mul_i64.checksum+0x25c>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/scalar/mul_u32.dis
+++ b/test/golden/riscv64-linux/scalar/mul_u32.dis
@@ -3,71 +3,178 @@ scalar/mul_u32.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_u32.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0x24>
-               	sext.w	s2, s1
+               	sext.w	a1, a0
                	lui	t1, 0x9e378
                	addiw	t1, t1, -0x64f
-               	addw	a1, t1, s2
-               	mv	s1, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	addw	a0, t1, a1
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	bltu	s4, t0, 0x54 <corpus.cases.scalar.mul_u32.checksum+0x54>
-               	j	0x84 <corpus.cases.scalar.mul_u32.checksum+0x84>
+               	bltu	a3, t0, 0x40 <corpus.cases.scalar.mul_u32.checksum+0x40>
+               	j	0xb4 <corpus.cases.scalar.mul_u32.checksum+0xb4>
                	li	t1, 0x2
-               	mulw	a0, t1, s4
-               	addiw	a1, a0, 0x3
-               	mulw	s3, s3, a1
-               	mv	a0, s1
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0x6c>
-               	addiw	s4, s4, 0x1
-               	mv	s1, a0
+               	mulw	a4, t1, a3
+               	addiw	a5, a4, 0x3
+               	mulw	a4, a0, a5
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	mv	a6, a2
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6c <corpus.cases.scalar.mul_u32.checksum+0x6c>
+               	j	0xa0 <corpus.cases.scalar.mul_u32.checksum+0xa0>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a5, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6c <corpus.cases.scalar.mul_u32.checksum+0x6c>
+               	addiw	a3, a3, 0x1
+               	mv	a2, a6
+               	mv	a0, a4
                	li	t0, 0x10
-               	bltu	s4, t0, 0x54 <corpus.cases.scalar.mul_u32.checksum+0x54>
+               	bltu	a3, t0, 0x40 <corpus.cases.scalar.mul_u32.checksum+0x40>
                	li	t1, -0x41
-               	addw	s4, t1, s2
-               	mulw	a1, s4, s4
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0x94>
+               	addw	a3, t1, a1
+               	mulw	a4, a3, a3
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xd8 <corpus.cases.scalar.mul_u32.checksum+0xd8>
+               	j	0x10c <corpus.cases.scalar.mul_u32.checksum+0x10c>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0xd8 <corpus.cases.scalar.mul_u32.checksum+0xd8>
                	li	t0, -0x1
-               	mulw	a1, s4, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0xa4>
-               	mulw	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0xb0>
-               	mulw	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0xbc>
+               	mulw	a4, a3, t0
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x12c <corpus.cases.scalar.mul_u32.checksum+0x12c>
+               	j	0x160 <corpus.cases.scalar.mul_u32.checksum+0x160>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x12c <corpus.cases.scalar.mul_u32.checksum+0x12c>
+               	mulw	a4, a0, a3
+               	slli	a5, a4, 0x20
+               	srli	a5, a5, 0x20
+               	li	a4, 0x0
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x17c <corpus.cases.scalar.mul_u32.checksum+0x17c>
+               	j	0x1b0 <corpus.cases.scalar.mul_u32.checksum+0x1b0>
+               	li	t0, 0x8
+               	mul	a6, a4, t0
+               	srl	a7, a5, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a4, a4, 0x1
+               	li	t0, 0x8
+               	bltu	a4, t0, 0x17c <corpus.cases.scalar.mul_u32.checksum+0x17c>
+               	mulw	a4, a3, a0
+               	slli	a0, a4, 0x20
+               	srli	a0, a0, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1cc <corpus.cases.scalar.mul_u32.checksum+0x1cc>
+               	j	0x200 <corpus.cases.scalar.mul_u32.checksum+0x200>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1cc <corpus.cases.scalar.mul_u32.checksum+0x1cc>
                	lui	t1, 0x10
                	addiw	t1, t1, 0x1
-               	addw	s1, t1, s2
-               	mulw	a1, s1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0xd4>
+               	addw	a0, t1, a1
+               	mulw	a1, a0, a0
+               	slli	a3, a1, 0x20
+               	srli	a3, a3, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x228 <corpus.cases.scalar.mul_u32.checksum+0x228>
+               	j	0x25c <corpus.cases.scalar.mul_u32.checksum+0x25c>
+               	li	t0, 0x8
+               	mul	a4, a1, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x228 <corpus.cases.scalar.mul_u32.checksum+0x228>
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	mulw	a1, s1, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u32.checksum+0xe8>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mulw	a1, a0, t0
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x280 <corpus.cases.scalar.mul_u32.checksum+0x280>
+               	j	0x2b4 <corpus.cases.scalar.mul_u32.checksum+0x2b4>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x280 <corpus.cases.scalar.mul_u32.checksum+0x280>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/scalar/mul_u64.dis
+++ b/test/golden/riscv64-linux/scalar/mul_u64.dis
@@ -3,17 +3,6 @@ scalar/mul_u64.o:
 Disassembly of section .text:
 
 <corpus.cases.scalar.mul_u64.checksum>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	sd	s2, 0x10(sp)
-               	sd	s3, 0x8(sp)
-               	sd	s4, 0x0(sp)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0x24>
                	lui	t1, 0xf9e37
                	addiw	t1, t1, 0x79c
                	slli	t1, t1, 0xc
@@ -22,59 +11,163 @@ Disassembly of section .text:
                	addi	t1, t1, 0x4a8
                	slli	t1, t1, 0xc
                	addi	t1, t1, -0x3eb
-               	add	a1, t1, s1
-               	mv	s2, a0
-               	mv	s3, a1
-               	li	s4, 0x0
+               	add	a1, t1, a0
+               	lui	a2, 0xfcbf3
+               	addiw	a2, a2, -0x632
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x484
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x222
+               	slli	a2, a2, 0xc
+               	addi	a2, a2, 0x325
+               	li	a3, 0x0
                	li	t0, 0x10
-               	bltu	s4, t0, 0x68 <corpus.cases.scalar.mul_u64.checksum+0x68>
-               	j	0x98 <corpus.cases.scalar.mul_u64.checksum+0x98>
+               	bltu	a3, t0, 0x54 <corpus.cases.scalar.mul_u64.checksum+0x54>
+               	j	0xc0 <corpus.cases.scalar.mul_u64.checksum+0xc0>
                	li	t1, 0x2
-               	mul	a0, t1, s4
-               	addi	a1, a0, 0x3
-               	mul	s3, s3, a1
-               	mv	a0, s2
-               	mv	a1, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0x80>
-               	addi	s4, s4, 0x1
-               	mv	s2, a0
+               	mul	a4, t1, a3
+               	addi	a5, a4, 0x3
+               	mul	a4, a1, a5
+               	mv	a5, a2
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x78 <corpus.cases.scalar.mul_u64.checksum+0x78>
+               	j	0xac <corpus.cases.scalar.mul_u64.checksum+0xac>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a5, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x78 <corpus.cases.scalar.mul_u64.checksum+0x78>
+               	addi	a3, a3, 0x1
+               	mv	a2, a5
+               	mv	a1, a4
                	li	t0, 0x10
-               	bltu	s4, t0, 0x68 <corpus.cases.scalar.mul_u64.checksum+0x68>
+               	bltu	a3, t0, 0x54 <corpus.cases.scalar.mul_u64.checksum+0x54>
                	li	t1, -0x3f
-               	add	s4, t1, s1
-               	mul	a1, s4, s4
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0xa8>
+               	add	a3, t1, a0
+               	mul	a4, a3, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xdc <corpus.cases.scalar.mul_u64.checksum+0xdc>
+               	j	0x110 <corpus.cases.scalar.mul_u64.checksum+0x110>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0xdc <corpus.cases.scalar.mul_u64.checksum+0xdc>
                	li	t0, -0x1
-               	mul	a1, s4, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0xb8>
-               	mul	a1, s3, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0xc4>
-               	mul	a1, s4, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0xd0>
+               	mul	a4, a3, t0
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x128 <corpus.cases.scalar.mul_u64.checksum+0x128>
+               	j	0x15c <corpus.cases.scalar.mul_u64.checksum+0x15c>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x128 <corpus.cases.scalar.mul_u64.checksum+0x128>
+               	mul	a4, a1, a3
+               	li	a5, 0x0
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x170 <corpus.cases.scalar.mul_u64.checksum+0x170>
+               	j	0x1a4 <corpus.cases.scalar.mul_u64.checksum+0x1a4>
+               	li	t0, 0x8
+               	mul	a6, a5, t0
+               	srl	a7, a4, a6
+               	li	t0, 0xff
+               	and	a6, a7, t0
+               	xor	a7, a2, a6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a7, t0
+               	addi	a5, a5, 0x1
+               	li	t0, 0x8
+               	bltu	a5, t0, 0x170 <corpus.cases.scalar.mul_u64.checksum+0x170>
+               	mul	a4, a3, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1b8 <corpus.cases.scalar.mul_u64.checksum+0x1b8>
+               	j	0x1ec <corpus.cases.scalar.mul_u64.checksum+0x1ec>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a5, a4, a3
+               	li	t0, 0xff
+               	and	a3, a5, t0
+               	xor	a5, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1b8 <corpus.cases.scalar.mul_u64.checksum+0x1b8>
                	lui	t1, 0x100
                	slli	t1, t1, 0xc
                	addi	t1, t1, 0xf
-               	add	s2, t1, s1
-               	mul	a1, s2, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0xec>
+               	add	a1, t1, a0
+               	mul	a0, a1, a1
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.scalar.mul_u64.checksum+0x210>
+               	j	0x244 <corpus.cases.scalar.mul_u64.checksum+0x244>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a0, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a2, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x210 <corpus.cases.scalar.mul_u64.checksum+0x210>
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	mul	a1, s2, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.scalar.mul_u64.checksum+0x104>
-               	ld	s1, 0x18(sp)
-               	ld	s2, 0x10(sp)
-               	ld	s3, 0x8(sp)
-               	ld	s4, 0x0(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	mul	a0, a1, t0
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.scalar.mul_u64.checksum+0x264>
+               	j	0x298 <corpus.cases.scalar.mul_u64.checksum+0x298>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a0, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a2, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a2, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x264 <corpus.cases.scalar.mul_u64.checksum+0x264>
+               	mv	a0, a2
                	ret

--- a/test/golden/riscv64-linux/vec/autovec_loop.dis
+++ b/test/golden/riscv64-linux/vec/autovec_loop.dis
@@ -4,602 +4,706 @@ Disassembly of section .text:
 
 <corpus.cases.vec.autovec_loop.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x710
+               	addiw	t0, t0, -0x740
                	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x718
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x720
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x710
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x728
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x730
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x738
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x740
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x748
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
+               	sd	ra, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x750
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x740
+               	add	s0, sp, t0
                	lui	t1, 0x1
                	addiw	t1, t1, -0x758
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
+               	sd	s1, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x760
                	add	t1, sp, t1
-               	fsd	fs0, 0x0(t1)
-               	mv	s1, a0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0xbc>
+               	sd	s2, 0x0(t1)
                	li	t0, 0x1
-               	and	a1, s1, t0
+               	and	a1, a0, t0
                	li	t1, 0x43
-               	sub	s2, t1, a1
+               	sub	a2, t1, a1
                	li	t1, 0x25
-               	sub	s3, t1, a1
-               	sext.w	a1, s1
-               	fcvt.s.lu	fs0, s1
-               	addi	s1, s0, -0x15c
-               	mv	a2, s1
+               	sub	a3, t1, a1
+               	sext.w	a1, a0
+               	fcvt.s.lu	ft0, a0
+               	addi	a0, s0, -0x6a0
+               	mv	a4, a0
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x11c <corpus.cases.vec.autovec_loop.checksum+0x11c>
-               	mv	a3, a2
-               	li	a4, 0x108
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a5, a4, t0
+               	bnez	a5, 0xb0 <corpus.cases.vec.autovec_loop.checksum+0xb0>
+               	mv	a5, a4
+               	li	a6, 0x108
+               	sd	zero, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x100 <corpus.cases.vec.autovec_loop.checksum+0x100>
-               	sw	zero, 0x0(a3)
-               	j	0x138 <corpus.cases.vec.autovec_loop.checksum+0x138>
-               	mv	a3, a2
-               	li	a2, 0x10c
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a6, t0, 0x94 <corpus.cases.vec.autovec_loop.checksum+0x94>
+               	sw	zero, 0x0(a5)
+               	j	0xcc <corpus.cases.vec.autovec_loop.checksum+0xcc>
+               	mv	a5, a4
+               	li	a4, 0x10c
+               	sb	zero, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a4, a4, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x124 <corpus.cases.vec.autovec_loop.checksum+0x124>
-               	addi	s4, s0, -0x268
-               	mv	a2, s4
+               	bne	a4, t0, 0xb8 <corpus.cases.vec.autovec_loop.checksum+0xb8>
+               	addi	a4, s0, -0x7ac
+               	mv	a5, a4
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x170 <corpus.cases.vec.autovec_loop.checksum+0x170>
-               	mv	a3, a2
-               	li	a4, 0x108
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a6, a5, t0
+               	bnez	a6, 0x104 <corpus.cases.vec.autovec_loop.checksum+0x104>
+               	mv	a6, a5
+               	li	a7, 0x108
+               	sd	zero, 0x0(a6)
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x154 <corpus.cases.vec.autovec_loop.checksum+0x154>
-               	sw	zero, 0x0(a3)
-               	j	0x18c <corpus.cases.vec.autovec_loop.checksum+0x18c>
-               	mv	a3, a2
-               	li	a2, 0x10c
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a7, t0, 0xe8 <corpus.cases.vec.autovec_loop.checksum+0xe8>
+               	sw	zero, 0x0(a6)
+               	j	0x120 <corpus.cases.vec.autovec_loop.checksum+0x120>
+               	mv	a6, a5
+               	li	a5, 0x10c
+               	sb	zero, 0x0(a6)
+               	addi	a6, a6, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x178 <corpus.cases.vec.autovec_loop.checksum+0x178>
-               	li	a2, 0x0
-               	bltu	a2, s2, 0x198 <corpus.cases.vec.autovec_loop.checksum+0x198>
-               	j	0x1e8 <corpus.cases.vec.autovec_loop.checksum+0x1e8>
-               	sext.w	a3, a2
+               	bne	a5, t0, 0x10c <corpus.cases.vec.autovec_loop.checksum+0x10c>
+               	li	a5, 0x0
+               	bltu	a5, a2, 0x12c <corpus.cases.vec.autovec_loop.checksum+0x12c>
+               	j	0x17c <corpus.cases.vec.autovec_loop.checksum+0x17c>
+               	sext.w	a6, a5
                	lui	t0, 0x9e378
                	addiw	t0, t0, -0x64f
-               	mulw	a4, a3, t0
+               	mulw	a7, a6, t0
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
-               	addw	a5, a4, t0
-               	slli	t0, a2, 0x2
-               	add	a4, s1, t0
-               	sw	a5, 0x0(a4)
+               	addw	t5, a7, t0
+               	slli	t0, a5, 0x2
+               	add	a7, a0, t0
+               	sw	t5, 0x0(a7)
                	lui	t0, 0xa
                	addiw	t0, t0, -0x1c9
-               	mulw	a4, a3, t0
+               	mulw	a7, a6, t0
                	li	t1, -0x1
-               	subw	a3, t1, a4
-               	slli	t0, a2, 0x2
-               	add	a4, s4, t0
-               	sw	a3, 0x0(a4)
-               	addi	a2, a2, 0x1
-               	bltu	a2, s2, 0x198 <corpus.cases.vec.autovec_loop.checksum+0x198>
-               	mv	a2, s1
-               	lw	a3, 0x0(a2)
-               	addw	a4, a3, a1
-               	sw	a4, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lw	a3, 0x0(a2)
-               	addw	a4, a3, a1
-               	sw	a4, 0x0(a2)
-               	addi	s5, s0, -0x374
-               	mv	a1, s5
+               	subw	a6, t1, a7
+               	slli	t0, a5, 0x2
+               	add	a7, a4, t0
+               	sw	a6, 0x0(a7)
+               	addi	a5, a5, 0x1
+               	bltu	a5, a2, 0x12c <corpus.cases.vec.autovec_loop.checksum+0x12c>
+               	mv	a5, a0
+               	lw	a6, 0x0(a5)
+               	addw	a7, a6, a1
+               	sw	a7, 0x0(a5)
+               	addi	a5, a4, 0x4
+               	lw	a6, 0x0(a5)
+               	addw	a7, a6, a1
+               	sw	a7, 0x0(a5)
+               	addi	a1, s0, -0x12c
+               	mv	a5, a1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x240 <corpus.cases.vec.autovec_loop.checksum+0x240>
-               	mv	a2, a1
-               	li	a3, 0x108
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	a6, a5, t0
+               	bnez	a6, 0x1d4 <corpus.cases.vec.autovec_loop.checksum+0x1d4>
+               	mv	a6, a5
+               	li	a7, 0x108
+               	sd	zero, 0x0(a6)
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x224 <corpus.cases.vec.autovec_loop.checksum+0x224>
-               	sw	zero, 0x0(a2)
-               	j	0x25c <corpus.cases.vec.autovec_loop.checksum+0x25c>
-               	mv	a2, a1
-               	li	a1, 0x10c
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
+               	bne	a7, t0, 0x1b8 <corpus.cases.vec.autovec_loop.checksum+0x1b8>
+               	sw	zero, 0x0(a6)
+               	j	0x1f0 <corpus.cases.vec.autovec_loop.checksum+0x1f0>
+               	mv	a6, a5
+               	li	a5, 0x10c
+               	sb	zero, 0x0(a6)
+               	addi	a6, a6, 0x1
+               	addi	a5, a5, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x248 <corpus.cases.vec.autovec_loop.checksum+0x248>
-               	li	a1, 0x0
-               	bltu	a1, s2, 0x268 <corpus.cases.vec.autovec_loop.checksum+0x268>
-               	j	0x2a0 <corpus.cases.vec.autovec_loop.checksum+0x2a0>
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	lw	a3, 0x0(a2)
+               	bne	a5, t0, 0x1dc <corpus.cases.vec.autovec_loop.checksum+0x1dc>
+               	li	a5, 0x0
+               	bltu	a5, a2, 0x1fc <corpus.cases.vec.autovec_loop.checksum+0x1fc>
+               	j	0x234 <corpus.cases.vec.autovec_loop.checksum+0x234>
+               	slli	t0, a5, 0x2
+               	add	a6, a0, t0
+               	lw	a7, 0x0(a6)
                	li	t0, 0x3
-               	mulw	a2, a3, t0
-               	slli	t0, a1, 0x2
-               	add	a3, s4, t0
-               	lw	a4, 0x0(a3)
-               	addw	a3, a2, a4
-               	slli	t0, a1, 0x2
-               	add	a2, s5, t0
-               	sw	a3, 0x0(a2)
-               	addi	a1, a1, 0x1
-               	bltu	a1, s2, 0x268 <corpus.cases.vec.autovec_loop.checksum+0x268>
-               	mv	s6, a0
-               	li	s7, 0x0
-               	bltu	s7, s2, 0x2b0 <corpus.cases.vec.autovec_loop.checksum+0x2b0>
-               	j	0x2d4 <corpus.cases.vec.autovec_loop.checksum+0x2d4>
-               	slli	t0, s7, 0x2
-               	add	a0, s5, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x2c0>
-               	addi	s7, s7, 0x1
-               	mv	s6, a0
-               	bltu	s7, s2, 0x2b0 <corpus.cases.vec.autovec_loop.checksum+0x2b0>
-               	li	a0, 0x0
-               	li	a1, 0x0
-               	li	s7, 0x0
-               	bltu	a0, s2, 0x2e8 <corpus.cases.vec.autovec_loop.checksum+0x2e8>
-               	j	0x310 <corpus.cases.vec.autovec_loop.checksum+0x310>
-               	slli	t0, a0, 0x2
-               	add	a2, s5, t0
-               	lw	a3, 0x0(a2)
-               	addw	a1, a1, a3
-               	slli	t0, a0, 0x2
-               	add	a2, s1, t0
-               	lw	a3, 0x0(a2)
-               	xor	s7, s7, a3
-               	addi	a0, a0, 0x1
-               	bltu	a0, s2, 0x2e8 <corpus.cases.vec.autovec_loop.checksum+0x2e8>
-               	mv	a0, s6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x314>
-               	mv	a1, s7
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x320>
-               	addi	s6, s0, -0x480
-               	mv	a1, s6
+               	mulw	a6, a7, t0
+               	slli	t0, a5, 0x2
+               	add	a7, a4, t0
+               	lw	t5, 0x0(a7)
+               	addw	a7, a6, t5
+               	slli	t0, a5, 0x2
+               	add	a6, a1, t0
+               	sw	a7, 0x0(a6)
+               	addi	a5, a5, 0x1
+               	bltu	a5, a2, 0x1fc <corpus.cases.vec.autovec_loop.checksum+0x1fc>
+               	lui	a5, 0xfcbf3
+               	addiw	a5, a5, -0x632
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x484
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x222
+               	slli	a5, a5, 0xc
+               	addi	a5, a5, 0x325
+               	li	a6, 0x0
+               	bltu	a6, a2, 0x260 <corpus.cases.vec.autovec_loop.checksum+0x260>
+               	j	0x2c8 <corpus.cases.vec.autovec_loop.checksum+0x2c8>
+               	slli	t0, a6, 0x2
+               	add	a7, a1, t0
+               	lw	t5, 0x0(a7)
+               	slli	a7, t5, 0x20
+               	srli	a7, a7, 0x20
+               	mv	t5, a5
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x288 <corpus.cases.vec.autovec_loop.checksum+0x288>
+               	j	0x2bc <corpus.cases.vec.autovec_loop.checksum+0x2bc>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x288 <corpus.cases.vec.autovec_loop.checksum+0x288>
+               	addi	a6, a6, 0x1
+               	mv	a5, t5
+               	bltu	a6, a2, 0x260 <corpus.cases.vec.autovec_loop.checksum+0x260>
+               	li	a6, 0x0
+               	li	a7, 0x0
+               	li	t5, 0x0
+               	bltu	a6, a2, 0x2dc <corpus.cases.vec.autovec_loop.checksum+0x2dc>
+               	j	0x304 <corpus.cases.vec.autovec_loop.checksum+0x304>
+               	slli	t0, a6, 0x2
+               	add	t6, a1, t0
+               	lw	s1, 0x0(t6)
+               	addw	a7, a7, s1
+               	slli	t0, a6, 0x2
+               	add	t6, a0, t0
+               	lw	s1, 0x0(t6)
+               	xor	t5, t5, s1
+               	addi	a6, a6, 0x1
+               	bltu	a6, a2, 0x2dc <corpus.cases.vec.autovec_loop.checksum+0x2dc>
+               	slli	a6, a7, 0x20
+               	srli	a6, a6, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x31c <corpus.cases.vec.autovec_loop.checksum+0x31c>
+               	j	0x350 <corpus.cases.vec.autovec_loop.checksum+0x350>
+               	li	t0, 0x8
+               	mul	t6, a7, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a5, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, s1, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x31c <corpus.cases.vec.autovec_loop.checksum+0x31c>
+               	slli	a6, t5, 0x20
+               	srli	a6, a6, 0x20
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x368 <corpus.cases.vec.autovec_loop.checksum+0x368>
+               	j	0x39c <corpus.cases.vec.autovec_loop.checksum+0x39c>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a6, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a5, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x368 <corpus.cases.vec.autovec_loop.checksum+0x368>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x748
+               	add	a6, s0, t0
+               	mv	a7, a6
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x360 <corpus.cases.vec.autovec_loop.checksum+0x360>
-               	mv	a2, a1
-               	li	a3, 0x108
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	t5, a7, t0
+               	bnez	t5, 0x3dc <corpus.cases.vec.autovec_loop.checksum+0x3dc>
+               	mv	t5, a7
+               	li	t6, 0x108
+               	sd	zero, 0x0(t5)
+               	addi	t5, t5, 0x8
+               	addi	t6, t6, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x344 <corpus.cases.vec.autovec_loop.checksum+0x344>
-               	sw	zero, 0x0(a2)
-               	j	0x37c <corpus.cases.vec.autovec_loop.checksum+0x37c>
-               	mv	a2, a1
-               	li	a1, 0x10c
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x368 <corpus.cases.vec.autovec_loop.checksum+0x368>
-               	li	a1, 0x0
-               	bltu	a1, s2, 0x388 <corpus.cases.vec.autovec_loop.checksum+0x388>
-               	j	0x400 <corpus.cases.vec.autovec_loop.checksum+0x400>
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	lw	a3, 0x0(a2)
-               	slli	t0, a1, 0x2
-               	add	a2, s4, t0
-               	lw	a4, 0x0(a2)
-               	bltu	a4, a3, 0x3d0 <corpus.cases.vec.autovec_loop.checksum+0x3d0>
-               	slli	t0, a1, 0x2
-               	add	a2, s4, t0
-               	lw	a3, 0x0(a2)
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	lw	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	slli	t0, a1, 0x2
-               	add	a3, s6, t0
-               	sw	a2, 0x0(a3)
+               	bne	t6, t0, 0x3c0 <corpus.cases.vec.autovec_loop.checksum+0x3c0>
+               	sw	zero, 0x0(t5)
                	j	0x3f8 <corpus.cases.vec.autovec_loop.checksum+0x3f8>
-               	slli	t0, a1, 0x2
-               	add	a2, s1, t0
-               	lw	a3, 0x0(a2)
-               	slli	t0, a1, 0x2
-               	add	a2, s4, t0
-               	lw	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	slli	t0, a1, 0x2
-               	add	a3, s6, t0
-               	sw	a2, 0x0(a3)
-               	addi	a1, a1, 0x1
-               	bltu	a1, s2, 0x388 <corpus.cases.vec.autovec_loop.checksum+0x388>
-               	mv	s4, a0
-               	li	s7, 0x0
-               	bltu	s7, s2, 0x410 <corpus.cases.vec.autovec_loop.checksum+0x410>
-               	j	0x434 <corpus.cases.vec.autovec_loop.checksum+0x434>
-               	slli	t0, s7, 0x2
-               	add	a0, s6, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x420>
-               	addi	s7, s7, 0x1
-               	mv	s4, a0
-               	bltu	s7, s2, 0x410 <corpus.cases.vec.autovec_loop.checksum+0x410>
-               	addi	s6, s0, -0x58c
-               	mv	a0, s6
+               	mv	t5, a7
+               	li	a7, 0x10c
+               	sb	zero, 0x0(t5)
+               	addi	t5, t5, 0x1
+               	addi	a7, a7, -0x1
+               	li	t0, 0x0
+               	bne	a7, t0, 0x3e4 <corpus.cases.vec.autovec_loop.checksum+0x3e4>
+               	li	a7, 0x0
+               	bltu	a7, a2, 0x404 <corpus.cases.vec.autovec_loop.checksum+0x404>
+               	j	0x47c <corpus.cases.vec.autovec_loop.checksum+0x47c>
+               	slli	t0, a7, 0x2
+               	add	t5, a0, t0
+               	lw	t6, 0x0(t5)
+               	slli	t0, a7, 0x2
+               	add	t5, a4, t0
+               	lw	s1, 0x0(t5)
+               	bltu	s1, t6, 0x44c <corpus.cases.vec.autovec_loop.checksum+0x44c>
+               	slli	t0, a7, 0x2
+               	add	t5, a4, t0
+               	lw	t6, 0x0(t5)
+               	slli	t0, a7, 0x2
+               	add	t5, a0, t0
+               	lw	s1, 0x0(t5)
+               	subw	t5, t6, s1
+               	slli	t0, a7, 0x2
+               	add	t6, a6, t0
+               	sw	t5, 0x0(t6)
+               	j	0x474 <corpus.cases.vec.autovec_loop.checksum+0x474>
+               	slli	t0, a7, 0x2
+               	add	t5, a0, t0
+               	lw	t6, 0x0(t5)
+               	slli	t0, a7, 0x2
+               	add	t5, a4, t0
+               	lw	s1, 0x0(t5)
+               	subw	t5, t6, s1
+               	slli	t0, a7, 0x2
+               	add	t6, a6, t0
+               	sw	t5, 0x0(t6)
+               	addi	a7, a7, 0x1
+               	bltu	a7, a2, 0x404 <corpus.cases.vec.autovec_loop.checksum+0x404>
+               	li	a4, 0x0
+               	bltu	a4, a2, 0x488 <corpus.cases.vec.autovec_loop.checksum+0x488>
+               	j	0x4f0 <corpus.cases.vec.autovec_loop.checksum+0x4f0>
+               	slli	t0, a4, 0x2
+               	add	a7, a6, t0
+               	lw	t5, 0x0(a7)
+               	slli	a7, t5, 0x20
+               	srli	a7, a7, 0x20
+               	mv	t5, a5
+               	li	t6, 0x0
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x4b0 <corpus.cases.vec.autovec_loop.checksum+0x4b0>
+               	j	0x4e4 <corpus.cases.vec.autovec_loop.checksum+0x4e4>
+               	li	t0, 0x8
+               	mul	s1, t6, t0
+               	srl	s2, a7, s1
+               	li	t0, 0xff
+               	and	s1, s2, t0
+               	xor	s2, t5, s1
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	t5, s2, t0
+               	addi	t6, t6, 0x1
+               	li	t0, 0x8
+               	bltu	t6, t0, 0x4b0 <corpus.cases.vec.autovec_loop.checksum+0x4b0>
+               	addi	a4, a4, 0x1
+               	mv	a5, t5
+               	bltu	a4, a2, 0x488 <corpus.cases.vec.autovec_loop.checksum+0x488>
+               	addi	a4, s0, -0x238
+               	mv	a6, a4
                	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x46c <corpus.cases.vec.autovec_loop.checksum+0x46c>
-               	mv	a1, a0
-               	li	a2, 0x108
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
+               	and	a7, a6, t0
+               	bnez	a7, 0x528 <corpus.cases.vec.autovec_loop.checksum+0x528>
+               	mv	a7, a6
+               	li	t5, 0x108
+               	sd	zero, 0x0(a7)
+               	addi	a7, a7, 0x8
+               	addi	t5, t5, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x450 <corpus.cases.vec.autovec_loop.checksum+0x450>
-               	sw	zero, 0x0(a1)
-               	j	0x488 <corpus.cases.vec.autovec_loop.checksum+0x488>
-               	mv	a1, a0
-               	li	a0, 0x10c
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
+               	bne	t5, t0, 0x50c <corpus.cases.vec.autovec_loop.checksum+0x50c>
+               	sw	zero, 0x0(a7)
+               	j	0x544 <corpus.cases.vec.autovec_loop.checksum+0x544>
+               	mv	a7, a6
+               	li	a6, 0x10c
+               	sb	zero, 0x0(a7)
+               	addi	a7, a7, 0x1
+               	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x474 <corpus.cases.vec.autovec_loop.checksum+0x474>
-               	li	a0, 0x0
-               	bltu	a0, s2, 0x494 <corpus.cases.vec.autovec_loop.checksum+0x494>
-               	j	0x4b8 <corpus.cases.vec.autovec_loop.checksum+0x4b8>
-               	slli	t0, a0, 0x2
-               	add	a1, s6, t0
+               	bne	a6, t0, 0x530 <corpus.cases.vec.autovec_loop.checksum+0x530>
+               	li	a6, 0x0
+               	bltu	a6, a2, 0x550 <corpus.cases.vec.autovec_loop.checksum+0x550>
+               	j	0x574 <corpus.cases.vec.autovec_loop.checksum+0x574>
+               	slli	t0, a6, 0x2
+               	add	a7, a4, t0
                	lui	t0, 0xab
                	addiw	t0, t0, -0x555
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x556
-               	sw	t0, 0x0(a1)
-               	addi	a0, a0, 0x1
-               	bltu	a0, s2, 0x494 <corpus.cases.vec.autovec_loop.checksum+0x494>
-               	li	a0, 0x0
-               	bltu	a0, s2, 0x4c4 <corpus.cases.vec.autovec_loop.checksum+0x4c4>
-               	j	0x4ec <corpus.cases.vec.autovec_loop.checksum+0x4ec>
-               	slli	t0, a0, 0x2
-               	add	a1, s5, t0
-               	lw	a2, 0x0(a1)
+               	sw	t0, 0x0(a7)
+               	addi	a6, a6, 0x1
+               	bltu	a6, a2, 0x550 <corpus.cases.vec.autovec_loop.checksum+0x550>
+               	li	a6, 0x0
+               	bltu	a6, a2, 0x580 <corpus.cases.vec.autovec_loop.checksum+0x580>
+               	j	0x5a8 <corpus.cases.vec.autovec_loop.checksum+0x5a8>
+               	slli	t0, a6, 0x2
+               	add	a7, a1, t0
+               	lw	t5, 0x0(a7)
                	li	t0, 0x1
-               	xor	a1, a2, t0
-               	slli	t0, a0, 0x2
-               	add	a2, s6, t0
-               	sw	a1, 0x0(a2)
-               	addi	a0, a0, 0x2
-               	bltu	a0, s2, 0x4c4 <corpus.cases.vec.autovec_loop.checksum+0x4c4>
-               	li	s5, 0x0
-               	bltu	s5, s2, 0x4f8 <corpus.cases.vec.autovec_loop.checksum+0x4f8>
-               	j	0x51c <corpus.cases.vec.autovec_loop.checksum+0x51c>
-               	slli	t0, s5, 0x2
-               	add	a0, s6, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x508>
-               	addi	s5, s5, 0x1
-               	mv	s4, a0
-               	bltu	s5, s2, 0x4f8 <corpus.cases.vec.autovec_loop.checksum+0x4f8>
-               	addi	s5, s0, -0x698
-               	mv	a0, s5
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x554 <corpus.cases.vec.autovec_loop.checksum+0x554>
-               	mv	a1, a0
-               	li	a2, 0x108
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x538 <corpus.cases.vec.autovec_loop.checksum+0x538>
-               	sw	zero, 0x0(a1)
-               	j	0x570 <corpus.cases.vec.autovec_loop.checksum+0x570>
-               	mv	a1, a0
-               	li	a0, 0x10c
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x55c <corpus.cases.vec.autovec_loop.checksum+0x55c>
-               	mv	a0, s1
-               	lw	a1, 0x0(a0)
-               	mv	a0, s5
-               	sw	a1, 0x0(a0)
-               	li	a0, 0x1
-               	bltu	a0, s2, 0x58c <corpus.cases.vec.autovec_loop.checksum+0x58c>
-               	j	0x5c8 <corpus.cases.vec.autovec_loop.checksum+0x5c8>
-               	addi	a1, a0, -0x1
+               	xor	a7, t5, t0
+               	slli	t0, a6, 0x2
+               	add	t5, a4, t0
+               	sw	a7, 0x0(t5)
+               	addi	a6, a6, 0x2
+               	bltu	a6, a2, 0x580 <corpus.cases.vec.autovec_loop.checksum+0x580>
+               	li	a1, 0x0
+               	bltu	a1, a2, 0x5b4 <corpus.cases.vec.autovec_loop.checksum+0x5b4>
+               	j	0x61c <corpus.cases.vec.autovec_loop.checksum+0x61c>
                	slli	t0, a1, 0x2
-               	add	a2, s5, t0
-               	lw	a1, 0x0(a2)
+               	add	a6, a4, t0
+               	lw	a7, 0x0(a6)
+               	slli	a6, a7, 0x20
+               	srli	a6, a6, 0x20
+               	mv	a7, a5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x5dc <corpus.cases.vec.autovec_loop.checksum+0x5dc>
+               	j	0x610 <corpus.cases.vec.autovec_loop.checksum+0x610>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a6, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a7, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a7, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x5dc <corpus.cases.vec.autovec_loop.checksum+0x5dc>
+               	addi	a1, a1, 0x1
+               	mv	a5, a7
+               	bltu	a1, a2, 0x5b4 <corpus.cases.vec.autovec_loop.checksum+0x5b4>
+               	addi	a1, s0, -0x344
+               	mv	a4, a1
+               	li	t0, 0x7
+               	and	a6, a4, t0
+               	bnez	a6, 0x654 <corpus.cases.vec.autovec_loop.checksum+0x654>
+               	mv	a6, a4
+               	li	a7, 0x108
+               	sd	zero, 0x0(a6)
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x638 <corpus.cases.vec.autovec_loop.checksum+0x638>
+               	sw	zero, 0x0(a6)
+               	j	0x670 <corpus.cases.vec.autovec_loop.checksum+0x670>
+               	mv	a6, a4
+               	li	a4, 0x10c
+               	sb	zero, 0x0(a6)
+               	addi	a6, a6, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x65c <corpus.cases.vec.autovec_loop.checksum+0x65c>
+               	mv	a4, a0
+               	lw	a6, 0x0(a4)
+               	mv	a4, a1
+               	sw	a6, 0x0(a4)
+               	li	a4, 0x1
+               	bltu	a4, a2, 0x68c <corpus.cases.vec.autovec_loop.checksum+0x68c>
+               	j	0x6c8 <corpus.cases.vec.autovec_loop.checksum+0x6c8>
+               	addi	a6, a4, -0x1
+               	slli	t0, a6, 0x2
+               	add	a7, a1, t0
+               	lw	a6, 0x0(a7)
                	li	t0, 0x1f
-               	mulw	a2, a1, t0
-               	slli	t0, a0, 0x2
-               	add	a1, s1, t0
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	slli	t0, a0, 0x2
-               	add	a2, s5, t0
-               	sw	a1, 0x0(a2)
-               	addi	a0, a0, 0x1
-               	bltu	a0, s2, 0x58c <corpus.cases.vec.autovec_loop.checksum+0x58c>
-               	li	s1, 0x0
-               	bltu	s1, s2, 0x5d4 <corpus.cases.vec.autovec_loop.checksum+0x5d4>
-               	j	0x5f8 <corpus.cases.vec.autovec_loop.checksum+0x5f8>
-               	slli	t0, s1, 0x2
-               	add	a0, s5, t0
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x5e4>
-               	addi	s1, s1, 0x1
-               	mv	s4, a0
-               	bltu	s1, s2, 0x5d4 <corpus.cases.vec.autovec_loop.checksum+0x5d4>
-               	addi	s1, s0, -0x72c
-               	mv	a0, s1
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x630 <corpus.cases.vec.autovec_loop.checksum+0x630>
-               	mv	a1, a0
-               	li	a2, 0x90
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x614 <corpus.cases.vec.autovec_loop.checksum+0x614>
-               	sw	zero, 0x0(a1)
-               	j	0x64c <corpus.cases.vec.autovec_loop.checksum+0x64c>
-               	mv	a1, a0
-               	li	a0, 0x94
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x638 <corpus.cases.vec.autovec_loop.checksum+0x638>
-               	addi	s2, s0, -0x7c0
-               	mv	a0, s2
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x684 <corpus.cases.vec.autovec_loop.checksum+0x684>
-               	mv	a1, a0
-               	li	a2, 0x90
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x668 <corpus.cases.vec.autovec_loop.checksum+0x668>
-               	sw	zero, 0x0(a1)
-               	j	0x6a0 <corpus.cases.vec.autovec_loop.checksum+0x6a0>
-               	mv	a1, a0
-               	li	a0, 0x94
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x68c <corpus.cases.vec.autovec_loop.checksum+0x68c>
+               	mulw	a7, a6, t0
+               	slli	t0, a4, 0x2
+               	add	a6, a0, t0
+               	lw	t5, 0x0(a6)
+               	addw	a6, a7, t5
+               	slli	t0, a4, 0x2
+               	add	a7, a1, t0
+               	sw	a6, 0x0(a7)
+               	addi	a4, a4, 0x1
+               	bltu	a4, a2, 0x68c <corpus.cases.vec.autovec_loop.checksum+0x68c>
                	li	a0, 0x0
-               	bltu	a0, s3, 0x6ac <corpus.cases.vec.autovec_loop.checksum+0x6ac>
-               	j	0x6e0 <corpus.cases.vec.autovec_loop.checksum+0x6e0>
-               	fcvt.s.lu	ft0, a0
-               	fadd.s	ft1, ft0, fs0
-               	slli	t0, a0, 0x2
-               	add	a1, s1, t0
-               	fsw	ft1, 0x0(a1)
-               	lui	t0, 0x3fa00
-               	fmv.w.x	ft11, t0
-               	fsub.s	ft1, ft11, ft0
-               	slli	t0, a0, 0x2
-               	add	a1, s2, t0
-               	fsw	ft1, 0x0(a1)
-               	addi	a0, a0, 0x1
-               	bltu	a0, s3, 0x6ac <corpus.cases.vec.autovec_loop.checksum+0x6ac>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7ac
-               	add	s5, s0, t0
-               	mv	a0, s5
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x720 <corpus.cases.vec.autovec_loop.checksum+0x720>
-               	mv	a1, a0
-               	li	a2, 0x90
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x704 <corpus.cases.vec.autovec_loop.checksum+0x704>
-               	sw	zero, 0x0(a1)
+               	bltu	a0, a2, 0x6d4 <corpus.cases.vec.autovec_loop.checksum+0x6d4>
                	j	0x73c <corpus.cases.vec.autovec_loop.checksum+0x73c>
-               	mv	a1, a0
-               	li	a0, 0x94
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x728 <corpus.cases.vec.autovec_loop.checksum+0x728>
-               	li	a0, 0x0
-               	bltu	a0, s3, 0x748 <corpus.cases.vec.autovec_loop.checksum+0x748>
-               	j	0x778 <corpus.cases.vec.autovec_loop.checksum+0x778>
                	slli	t0, a0, 0x2
-               	add	a1, s1, t0
-               	flw	ft0, 0x0(a1)
-               	slli	t0, a0, 0x2
-               	add	a1, s2, t0
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	slli	t0, a0, 0x2
-               	add	a1, s5, t0
-               	fsw	ft2, 0x0(a1)
+               	add	a4, a1, t0
+               	lw	a6, 0x0(a4)
+               	slli	a4, a6, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a6, a5
+               	li	a7, 0x0
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6fc <corpus.cases.vec.autovec_loop.checksum+0x6fc>
+               	j	0x730 <corpus.cases.vec.autovec_loop.checksum+0x730>
+               	li	t0, 0x8
+               	mul	t5, a7, t0
+               	srl	t6, a4, t5
+               	li	t0, 0xff
+               	and	t5, t6, t0
+               	xor	t6, a6, t5
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, t6, t0
+               	addi	a7, a7, 0x1
+               	li	t0, 0x8
+               	bltu	a7, t0, 0x6fc <corpus.cases.vec.autovec_loop.checksum+0x6fc>
                	addi	a0, a0, 0x1
-               	bltu	a0, s3, 0x748 <corpus.cases.vec.autovec_loop.checksum+0x748>
-               	li	s6, 0x0
-               	bltu	s6, s3, 0x784 <corpus.cases.vec.autovec_loop.checksum+0x784>
-               	j	0x7ac <corpus.cases.vec.autovec_loop.checksum+0x7ac>
-               	slli	t0, s6, 0x2
-               	add	a0, s5, t0
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x798>
-               	addi	s6, s6, 0x1
-               	mv	s4, a0
-               	bltu	s6, s3, 0x784 <corpus.cases.vec.autovec_loop.checksum+0x784>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	s5, s0, t0
-               	mv	a0, s5
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x7ec <corpus.cases.vec.autovec_loop.checksum+0x7ec>
+               	mv	a5, a6
+               	bltu	a0, a2, 0x6d4 <corpus.cases.vec.autovec_loop.checksum+0x6d4>
+               	addi	a0, s0, -0x3d8
                	mv	a1, a0
-               	li	a2, 0x90
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
+               	li	t0, 0x7
+               	and	a2, a1, t0
+               	bnez	a2, 0x774 <corpus.cases.vec.autovec_loop.checksum+0x774>
+               	mv	a2, a1
+               	li	a4, 0x90
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a4, a4, -0x8
+               	li	t0, 0x0
+               	bne	a4, t0, 0x758 <corpus.cases.vec.autovec_loop.checksum+0x758>
+               	sw	zero, 0x0(a2)
+               	j	0x790 <corpus.cases.vec.autovec_loop.checksum+0x790>
+               	mv	a2, a1
+               	li	a1, 0x94
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x77c <corpus.cases.vec.autovec_loop.checksum+0x77c>
+               	addi	a1, s0, -0x46c
+               	mv	a2, a1
+               	li	t0, 0x7
+               	and	a4, a2, t0
+               	bnez	a4, 0x7c8 <corpus.cases.vec.autovec_loop.checksum+0x7c8>
+               	mv	a4, a2
+               	li	a6, 0x90
+               	sd	zero, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a6, a6, -0x8
+               	li	t0, 0x0
+               	bne	a6, t0, 0x7ac <corpus.cases.vec.autovec_loop.checksum+0x7ac>
+               	sw	zero, 0x0(a4)
+               	j	0x7e4 <corpus.cases.vec.autovec_loop.checksum+0x7e4>
+               	mv	a4, a2
+               	li	a2, 0x94
+               	sb	zero, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a2, a2, -0x1
                	li	t0, 0x0
                	bne	a2, t0, 0x7d0 <corpus.cases.vec.autovec_loop.checksum+0x7d0>
-               	sw	zero, 0x0(a1)
-               	j	0x808 <corpus.cases.vec.autovec_loop.checksum+0x808>
-               	mv	a1, a0
-               	li	a0, 0x94
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
+               	li	a2, 0x0
+               	bltu	a2, a3, 0x7f0 <corpus.cases.vec.autovec_loop.checksum+0x7f0>
+               	j	0x824 <corpus.cases.vec.autovec_loop.checksum+0x824>
+               	fcvt.s.lu	ft1, a2
+               	fadd.s	ft2, ft1, ft0
+               	slli	t0, a2, 0x2
+               	add	a4, a0, t0
+               	fsw	ft2, 0x0(a4)
+               	lui	t0, 0x3fa00
+               	fmv.w.x	ft11, t0
+               	fsub.s	ft2, ft11, ft1
+               	slli	t0, a2, 0x2
+               	add	a4, a1, t0
+               	fsw	ft2, 0x0(a4)
+               	addi	a2, a2, 0x1
+               	bltu	a2, a3, 0x7f0 <corpus.cases.vec.autovec_loop.checksum+0x7f0>
+               	addi	a2, s0, -0x500
+               	mv	a4, a2
+               	li	t0, 0x7
+               	and	a6, a4, t0
+               	bnez	a6, 0x85c <corpus.cases.vec.autovec_loop.checksum+0x85c>
+               	mv	a6, a4
+               	li	a7, 0x90
+               	sd	zero, 0x0(a6)
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	a0, t0, 0x7f4 <corpus.cases.vec.autovec_loop.checksum+0x7f4>
-               	li	a0, 0x0
-               	bltu	a0, s3, 0x814 <corpus.cases.vec.autovec_loop.checksum+0x814>
-               	j	0x844 <corpus.cases.vec.autovec_loop.checksum+0x844>
-               	slli	t0, a0, 0x2
-               	add	a1, s1, t0
-               	flw	ft0, 0x0(a1)
-               	slli	t0, a0, 0x2
-               	add	a1, s2, t0
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	slli	t0, a0, 0x2
-               	add	a1, s5, t0
-               	fsw	ft2, 0x0(a1)
-               	addi	a0, a0, 0x1
-               	bltu	a0, s3, 0x814 <corpus.cases.vec.autovec_loop.checksum+0x814>
-               	li	s1, 0x0
-               	bltu	s1, s3, 0x850 <corpus.cases.vec.autovec_loop.checksum+0x850>
+               	bne	a7, t0, 0x840 <corpus.cases.vec.autovec_loop.checksum+0x840>
+               	sw	zero, 0x0(a6)
                	j	0x878 <corpus.cases.vec.autovec_loop.checksum+0x878>
-               	slli	t0, s1, 0x2
-               	add	a0, s5, t0
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x864>
-               	addi	s1, s1, 0x1
-               	mv	s4, a0
-               	bltu	s1, s3, 0x850 <corpus.cases.vec.autovec_loop.checksum+0x850>
+               	mv	a6, a4
+               	li	a4, 0x94
+               	sb	zero, 0x0(a6)
+               	addi	a6, a6, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x864 <corpus.cases.vec.autovec_loop.checksum+0x864>
+               	li	a4, 0x0
+               	bltu	a4, a3, 0x884 <corpus.cases.vec.autovec_loop.checksum+0x884>
+               	j	0x8b4 <corpus.cases.vec.autovec_loop.checksum+0x8b4>
+               	slli	t0, a4, 0x2
+               	add	a6, a0, t0
+               	flw	ft0, 0x0(a6)
+               	slli	t0, a4, 0x2
+               	add	a6, a1, t0
+               	flw	ft1, 0x0(a6)
+               	fmul.s	ft2, ft0, ft1
+               	slli	t0, a4, 0x2
+               	add	a6, a2, t0
+               	fsw	ft2, 0x0(a6)
+               	addi	a4, a4, 0x1
+               	bltu	a4, a3, 0x884 <corpus.cases.vec.autovec_loop.checksum+0x884>
+               	li	a4, 0x0
+               	bltu	a4, a3, 0x8c0 <corpus.cases.vec.autovec_loop.checksum+0x8c0>
+               	j	0x92c <corpus.cases.vec.autovec_loop.checksum+0x92c>
+               	slli	t0, a4, 0x2
+               	add	a6, a2, t0
+               	flw	ft0, 0x0(a6)
+               	fmv.x.w	a6, ft0
+               	slli	a7, a6, 0x20
+               	srli	a7, a7, 0x20
+               	mv	a6, a5
+               	li	t5, 0x0
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x8ec <corpus.cases.vec.autovec_loop.checksum+0x8ec>
+               	j	0x920 <corpus.cases.vec.autovec_loop.checksum+0x920>
+               	li	t0, 0x8
+               	mul	t6, t5, t0
+               	srl	s1, a7, t6
+               	li	t0, 0xff
+               	and	t6, s1, t0
+               	xor	s1, a6, t6
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a6, s1, t0
+               	addi	t5, t5, 0x1
+               	li	t0, 0x8
+               	bltu	t5, t0, 0x8ec <corpus.cases.vec.autovec_loop.checksum+0x8ec>
+               	addi	a4, a4, 0x1
+               	mv	a5, a6
+               	bltu	a4, a3, 0x8c0 <corpus.cases.vec.autovec_loop.checksum+0x8c0>
+               	addi	a2, s0, -0x594
+               	mv	a4, a2
+               	li	t0, 0x7
+               	and	a6, a4, t0
+               	bnez	a6, 0x964 <corpus.cases.vec.autovec_loop.checksum+0x964>
+               	mv	a6, a4
+               	li	a7, 0x90
+               	sd	zero, 0x0(a6)
+               	addi	a6, a6, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x948 <corpus.cases.vec.autovec_loop.checksum+0x948>
+               	sw	zero, 0x0(a6)
+               	j	0x980 <corpus.cases.vec.autovec_loop.checksum+0x980>
+               	mv	a6, a4
+               	li	a4, 0x94
+               	sb	zero, 0x0(a6)
+               	addi	a6, a6, 0x1
+               	addi	a4, a4, -0x1
+               	li	t0, 0x0
+               	bne	a4, t0, 0x96c <corpus.cases.vec.autovec_loop.checksum+0x96c>
+               	li	a4, 0x0
+               	bltu	a4, a3, 0x98c <corpus.cases.vec.autovec_loop.checksum+0x98c>
+               	j	0x9bc <corpus.cases.vec.autovec_loop.checksum+0x9bc>
+               	slli	t0, a4, 0x2
+               	add	a6, a0, t0
+               	flw	ft0, 0x0(a6)
+               	slli	t0, a4, 0x2
+               	add	a6, a1, t0
+               	flw	ft1, 0x0(a6)
+               	fdiv.s	ft2, ft0, ft1
+               	slli	t0, a4, 0x2
+               	add	a6, a2, t0
+               	fsw	ft2, 0x0(a6)
+               	addi	a4, a4, 0x1
+               	bltu	a4, a3, 0x98c <corpus.cases.vec.autovec_loop.checksum+0x98c>
+               	li	a0, 0x0
+               	bltu	a0, a3, 0x9c8 <corpus.cases.vec.autovec_loop.checksum+0x9c8>
+               	j	0xa34 <corpus.cases.vec.autovec_loop.checksum+0xa34>
+               	slli	t0, a0, 0x2
+               	add	a1, a2, t0
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a4, a1, 0x20
+               	srli	a4, a4, 0x20
+               	mv	a1, a5
+               	li	a6, 0x0
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x9f4 <corpus.cases.vec.autovec_loop.checksum+0x9f4>
+               	j	0xa28 <corpus.cases.vec.autovec_loop.checksum+0xa28>
+               	li	t0, 0x8
+               	mul	a7, a6, t0
+               	srl	t5, a4, a7
+               	li	t0, 0xff
+               	and	a7, t5, t0
+               	xor	t5, a1, a7
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a1, t5, t0
+               	addi	a6, a6, 0x1
+               	li	t0, 0x8
+               	bltu	a6, t0, 0x9f4 <corpus.cases.vec.autovec_loop.checksum+0x9f4>
+               	addi	a0, a0, 0x1
+               	mv	a5, a1
+               	bltu	a0, a3, 0x9c8 <corpus.cases.vec.autovec_loop.checksum+0x9c8>
                	li	a0, 0x0
                	fmv.w.x	ft0, zero
-               	bltu	a0, s3, 0x888 <corpus.cases.vec.autovec_loop.checksum+0x888>
-               	j	0x8a0 <corpus.cases.vec.autovec_loop.checksum+0x8a0>
+               	bltu	a0, a3, 0xa44 <corpus.cases.vec.autovec_loop.checksum+0xa44>
+               	j	0xa5c <corpus.cases.vec.autovec_loop.checksum+0xa5c>
                	slli	t0, a0, 0x2
-               	add	a1, s5, t0
+               	add	a1, a2, t0
                	flw	ft1, 0x0(a1)
                	fadd.s	ft0, ft0, ft1
                	addi	a0, a0, 0x1
-               	bltu	a0, s3, 0x888 <corpus.cases.vec.autovec_loop.checksum+0x888>
-               	mv	a0, s4
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.autovec_loop.checksum+0x8a8>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x728
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x730
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x738
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x740
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x748
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x750
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
+               	bltu	a0, a3, 0xa44 <corpus.cases.vec.autovec_loop.checksum+0xa44>
+               	fmv.x.w	a0, ft0
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	li	a0, 0x0
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa78 <corpus.cases.vec.autovec_loop.checksum+0xa78>
+               	j	0xaac <corpus.cases.vec.autovec_loop.checksum+0xaac>
+               	li	t0, 0x8
+               	mul	a2, a0, t0
+               	srl	a3, a1, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, a5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a5, a3, t0
+               	addi	a0, a0, 0x1
+               	li	t0, 0x8
+               	bltu	a0, t0, 0xa78 <corpus.cases.vec.autovec_loop.checksum+0xa78>
+               	mv	a0, a5
                	lui	t1, 0x1
                	addiw	t1, t1, -0x758
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
+               	ld	s1, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x760
                	add	t1, sp, t1
-               	fld	fs0, 0x0(t1)
+               	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x748
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x750
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x710
+               	addiw	t0, t0, -0x740
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/riscv64-linux/vec/vec_cmp_i64.dis
@@ -3,1883 +3,2305 @@ vec/vec_cmp_i64.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x34>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x50>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x30>
+               	j	0x64 <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x64>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x30>
+               	addi	a2, a1, 0x8
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x7c>
+               	j	0xb0 <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x7c>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x34>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x50>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf0 <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x30>
+               	j	0x124 <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x64>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf0 <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x30>
+               	addi	a2, a1, 0x8
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x13c <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x7c>
+               	j	0x170 <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x13c <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x7c>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x330
+               	addiw	t0, t0, -0x360
                	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x338
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x340
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x330
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x348
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x350
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x358
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x360
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x368
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
+               	sd	ra, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x370
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x360
+               	add	s0, sp, t0
                	lui	t1, 0x1
                	addiw	t1, t1, -0x378
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
+               	sd	s1, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x380
                	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
+               	sd	s2, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x388
                	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
+               	sd	s3, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x390
                	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
+               	sd	s4, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x398
+               	add	t1, sp, t1
+               	sd	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3a0
+               	add	t1, sp, t1
+               	sd	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3a8
+               	add	t1, sp, t1
+               	sd	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3b0
+               	add	t1, sp, t1
+               	sd	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3b8
+               	add	t1, sp, t1
+               	sd	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3c0
+               	add	t1, sp, t1
+               	sd	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3c8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x500
+               	addiw	t1, t1, 0x4c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	s6, s0, -0xb8
-               	addi	s7, s0, -0xc8
-               	addi	s8, s0, -0xd8
-               	addi	s9, s0, -0xe8
-               	addi	s10, s0, -0xf8
-               	addi	s11, s0, -0x108
+               	addi	t2, s0, -0x78
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x88
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x98
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xa8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x600
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xb8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x608
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xc8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x610
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xd8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x670
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xe8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0xf8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x108
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x118
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x128
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x138
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x148
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a5, s0, -0x158
-               	addi	a5, s0, -0x168
-               	addi	t2, s0, -0x178
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x188
-               	addi	a6, s0, -0x198
-               	addi	t2, s0, -0x1a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x1b8
-               	addi	a7, s0, -0x1c8
-               	addi	t2, s0, -0x1d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x1e8
-               	addi	t5, s0, -0x1f8
+               	addi	s4, s0, -0x138
+               	addi	s5, s0, -0x148
+               	addi	s6, s0, -0x158
+               	addi	s6, s0, -0x168
+               	addi	s6, s0, -0x178
+               	addi	s7, s0, -0x188
+               	addi	s7, s0, -0x198
+               	addi	s7, s0, -0x1a8
+               	addi	s8, s0, -0x1b8
+               	addi	s8, s0, -0x1c8
+               	addi	s8, s0, -0x1d8
+               	addi	s9, s0, -0x1e8
+               	addi	s9, s0, -0x1f8
                	addi	t2, s0, -0x208
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x218
-               	addi	t6, s0, -0x228
-               	addi	t2, s0, -0x238
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x248
-               	addi	s1, s0, -0x258
-               	addi	t2, s0, -0x268
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x278
-               	addi	a7, s0, -0x288
-               	addi	t2, s0, -0x298
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x2a8
-               	addi	t5, s0, -0x2b8
-               	addi	t2, s0, -0x2c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	s10, s0, -0x218
+               	addi	s10, s0, -0x228
+               	addi	s10, s0, -0x238
+               	addi	s11, s0, -0x248
+               	addi	s11, s0, -0x258
+               	addi	s11, s0, -0x268
+               	addi	s3, s0, -0x278
+               	addi	s3, s0, -0x288
+               	addi	s3, s0, -0x298
+               	addi	s2, s0, -0x2a8
+               	addi	s2, s0, -0x2b8
+               	addi	s2, s0, -0x2c8
                	addi	t6, s0, -0x2d8
                	addi	t6, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x308
-               	addi	s1, s0, -0x318
+               	addi	t6, s0, -0x2f8
+               	addi	t6, s0, -0x308
+               	addi	t6, s0, -0x318
                	addi	t2, s0, -0x328
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
+               	addiw	t1, t1, 0x398
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x338
+               	addi	t5, s0, -0x338
                	addi	t2, s0, -0x348
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
+               	addiw	t1, t1, 0x390
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x358
+               	addi	a7, s0, -0x358
                	addi	t2, s0, -0x368
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
+               	addiw	t1, t1, 0x388
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x378
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x388
+               	addi	a6, s0, -0x388
                	addi	t2, s0, -0x398
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x380
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3a8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3b8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3e8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3f8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x408
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x418
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x428
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x438
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x448
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x458
-               	addi	t5, s0, -0x468
+               	addi	a5, s0, -0x458
+               	addi	a5, s0, -0x468
                	addi	t2, s0, -0x478
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x488
-               	addi	s1, s0, -0x498
-               	addi	s1, s0, -0x4a8
-               	addi	a7, s0, -0x4b8
-               	addi	a7, s0, -0x4c8
+               	addi	a4, s0, -0x488
+               	addi	a4, s0, -0x498
+               	addi	t2, s0, -0x4a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a3, s0, -0x4b8
+               	addi	a3, s0, -0x4c8
                	addi	t2, s0, -0x4d8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x4e8
-               	addi	a7, s0, -0x4f8
+               	addi	a2, s0, -0x4e8
+               	addi	a2, s0, -0x4f8
                	addi	t2, s0, -0x508
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x518
-               	addi	a7, s0, -0x528
+               	addi	a1, s0, -0x518
+               	addi	a1, s0, -0x528
                	addi	t2, s0, -0x538
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x5e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x548
-               	addi	a7, s0, -0x558
+               	addi	a1, s0, -0x548
+               	addi	a1, s0, -0x558
                	addi	t2, s0, -0x568
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x5e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x578
-               	addi	a7, s0, -0x588
+               	addi	a1, s0, -0x578
+               	addi	a1, s0, -0x588
                	addi	t2, s0, -0x598
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
+               	addiw	t1, t1, 0x5d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x5a8
-               	addi	a7, s0, -0x5b8
+               	addi	a1, s0, -0x5a8
+               	addi	a1, s0, -0x5b8
                	addi	t2, s0, -0x5c8
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
+               	addiw	t1, t1, 0x5d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x5d8
-               	addi	a7, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x608
-               	addi	a7, s0, -0x618
+               	addi	a1, s0, -0x5d8
+               	addi	a1, s0, -0x5e8
+               	addi	a1, s0, -0x5f8
+               	addi	a1, s0, -0x608
+               	addi	a1, s0, -0x618
                	addi	t2, s0, -0x628
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x638
+               	addi	a1, s0, -0x638
                	addi	t2, s0, -0x648
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x658
+               	addi	a1, s0, -0x658
                	addi	t2, s0, -0x668
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x678
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
+               	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x688
-               	addi	a7, s0, -0x698
-               	addi	a7, s0, -0x6a8
-               	addi	a7, s0, -0x6b8
-               	addi	a7, s0, -0x6c8
-               	addi	a7, s0, -0x6d8
-               	addi	a7, s0, -0x6e8
-               	addi	a7, s0, -0x6f8
-               	addi	a7, s0, -0x708
-               	addi	a7, s0, -0x718
-               	addi	a7, s0, -0x728
-               	addi	a7, s0, -0x738
-               	addi	a7, s0, -0x748
-               	addi	a7, s0, -0x758
-               	addi	a7, s0, -0x768
-               	addi	a7, s0, -0x778
-               	addi	a7, s0, -0x788
-               	addi	a7, s0, -0x798
-               	addi	a7, s0, -0x7a8
-               	addi	a7, s0, -0x7b8
-               	addi	a7, s0, -0x7c8
-               	addi	a7, s0, -0x7d8
-               	addi	a7, s0, -0x7e8
-               	addi	a7, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a7, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a7, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a7, s0, t0
+               	addi	a1, s0, -0x688
+               	addi	a1, s0, -0x698
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7c8
-               	add	a7, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x5a0>
-               	mv	t2, a0
+               	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
+               	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
+               	li	t0, 0x7
+               	and	a0, t2, t0
+               	bnez	a0, 0x724 <corpus.cases.vec.vec_cmp_i64.checksum+0x5a4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	li	a1, 0x60
+               	sd	zero, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a1, a1, -0x8
+               	li	t0, 0x0
+               	bne	a1, t0, 0x70c <corpus.cases.vec.vec_cmp_i64.checksum+0x58c>
+               	j	0x750 <corpus.cases.vec.vec_cmp_i64.checksum+0x5d0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	li	a1, 0x60
+               	sb	zero, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x73c <corpus.cases.vec.vec_cmp_i64.checksum+0x5bc>
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x768
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, 0x3a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, 0x3a0
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	mv	t2, t3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	li	t0, 0x7
-               	and	a0, t2, t0
-               	bnez	a0, 0x770 <corpus.cases.vec.vec_cmp_i64.checksum+0x698>
+               	and	a1, t2, t0
+               	bnez	a1, 0x7dc <corpus.cases.vec.vec_cmp_i64.checksum+0x65c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	mv	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	li	a0, 0x60
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sd	zero, 0x0(t2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t2, t2, 0x8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
                	addi	a0, a0, -0x8
                	li	t0, 0x0
-               	bne	a0, t0, 0x728 <corpus.cases.vec.vec_cmp_i64.checksum+0x650>
-               	j	0x7dc <corpus.cases.vec.vec_cmp_i64.checksum+0x704>
+               	bne	a0, t0, 0x7c4 <corpus.cases.vec.vec_cmp_i64.checksum+0x644>
+               	j	0x808 <corpus.cases.vec.vec_cmp_i64.checksum+0x688>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	li	a1, 0x60
+               	sb	zero, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x7f4 <corpus.cases.vec.vec_cmp_i64.checksum+0x674>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x758
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
                	mv	t2, t3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	li	a0, 0x60
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
+               	addiw	t1, t1, 0x5a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	sb	zero, 0x0(t2)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	t2, t2, 0x1
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x748
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x798 <corpus.cases.vec.vec_cmp_i64.checksum+0x6c0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x738
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x10
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x558
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x558
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x558
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x728
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x550
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x550
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x550
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x550
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x600
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x550
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x600
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x10
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x548
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x600
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x548
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x600
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x548
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x718
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x540
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x540
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x540
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x540
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x608
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x540
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x608
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x538
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x608
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x538
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x608
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x538
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x708
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, 0x530
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, 0x530
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x530
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x530
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x610
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x530
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x610
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
-               	mv	t2, t3
+               	addi	t2, t3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x528
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	li	t0, 0x7
-               	and	a0, t2, t0
-               	bnez	a0, 0x8a8 <corpus.cases.vec.vec_cmp_i64.checksum+0x7d0>
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	mv	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	li	a0, 0x60
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x528
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	sd	zero, 0x0(t2)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	t2, t2, 0x8
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a0, a0, -0x8
-               	li	t0, 0x0
-               	bne	a0, t0, 0x860 <corpus.cases.vec.vec_cmp_i64.checksum+0x788>
-               	j	0x914 <corpus.cases.vec.vec_cmp_i64.checksum+0x83c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	mv	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	li	a0, 0x60
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x528
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	sb	zero, 0x0(t2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t2, t2, 0x1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x8d0 <corpus.cases.vec.vec_cmp_i64.checksum+0x7f8>
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x6f8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x520
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x520
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lui	t0, 0x200
+               	mv	a1, t2
+               	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a0)
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x520
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0x1234
+               	addiw	t0, t0, 0x568
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x765
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x432
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x110
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x520
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x670
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x520
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
-               	lui	t0, 0x100
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1
-               	sd	t0, 0x0(a0)
+               	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	t2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	mv	a0, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sd	t2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
-               	ld	t2, 0x0(a0)
+               	sd	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a0, s2, 0x8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sd	t2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t3, 0x0(t1)
-               	mv	t2, t3
+               	addi	t2, t3, 0x30
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	mv	a0, s2
-               	ld	t2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x518
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a0, t2
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x518
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	sd	t2, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	ld	s2, 0x0(a0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
-               	sd	s2, 0x0(a0)
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x6e8
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x510
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	lui	t0, 0x100
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1
-               	sd	t0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	lui	t0, 0x200
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	ld	a0, 0x0(s2)
-               	mv	s2, s3
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	s2, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	sd	s2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	mv	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	mv	s2, s3
-               	ld	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sd	a0, 0x0(s2)
-               	addi	a0, s3, 0x8
-               	ld	s2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	sd	s2, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	li	t0, -0x1
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	lui	t0, 0xfff00
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s4
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s4, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	mv	s2, s4
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s4, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0xfff00
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	li	t0, -0x1
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s5
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s5, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	mv	s2, s5
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s5, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0xf8000
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	lui	t0, 0xf8000
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s6
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s6, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x20
-               	mv	s2, s6
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s6, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0xf8000
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	lui	t0, 0xf8000
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s7
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s7, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x20
-               	mv	s2, s7
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s7, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0xf8000
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	lui	t0, 0x1234
-               	addiw	t0, t0, 0x568
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x765
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x432
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x110
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s8
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s8, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x30
-               	mv	s2, s8
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s8, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	li	t0, -0x1
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	lui	t0, 0x1234
-               	addiw	t0, t0, 0x568
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x765
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x432
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x110
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s9
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s9, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x30
-               	mv	s2, s9
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s9, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0x200
-               	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	zero, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s10
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s10, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x40
-               	mv	s2, s10
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s10, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	lui	t0, 0x200
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	li	t0, -0x1
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	mv	s2, s11
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	addi	s2, s11, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x40
-               	mv	s2, s11
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	addi	s2, s11, 0x8
-               	ld	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	s3, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	a0, s0, t0
-               	mv	s2, a0
-               	li	t0, 0x10a
-               	sd	t0, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	li	t0, -0x1
-               	sd	t0, 0x0(s2)
-               	mv	s2, a0
-               	ld	s3, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sd	s3, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	ld	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	sd	a0, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x50
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	ld	s3, 0x0(s2)
-               	mv	s2, a0
-               	sd	s3, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	ld	a1, 0x0(s2)
-               	addi	s2, a0, 0x8
-               	sd	a1, 0x0(s2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	li	t0, 0xa
-               	sd	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	zero, 0x0(a1)
-               	mv	a1, a0
-               	ld	s2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	sd	s2, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lui	t0, 0x1234
+               	addiw	t0, t0, 0x568
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x765
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x432
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x110
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x30
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x508
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6d8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	zero, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x40
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6c8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x40
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6b8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	li	t0, 0x10a
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x50
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6a8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	li	t0, 0xa
+               	sd	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	zero, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addi	t2, t3, 0x50
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	s1, 0xfcbf3
+               	addiw	s1, s1, -0x632
+               	slli	s1, s1, 0xc
+               	addi	s1, s1, 0x484
+               	slli	s1, s1, 0xc
+               	addi	s1, s1, 0x222
+               	slli	s1, s1, 0xc
+               	addi	s1, s1, 0x325
+               	li	s9, 0x0
+               	li	t0, 0x6
+               	bltu	s9, t0, 0x1780 <corpus.cases.vec.vec_cmp_i64.checksum+0x1600>
+               	j	0x2338 <corpus.cases.vec.vec_cmp_i64.checksum+0x21b8>
+               	li	t0, 0x10
+               	mul	a0, s9, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	add	t2, t3, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	mv	a0, s4
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
+               	sd	a1, 0x0(a0)
+               	li	t0, 0x10
+               	mul	a0, s9, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	add	t2, t3, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	mv	a0, s5
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	sd	a1, 0x0(a0)
+               	mv	a0, s4
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	add	t2, a1, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s4
+               	ld	a0, 0x0(a1)
+               	mv	a1, s6
+               	sd	a0, 0x0(a1)
+               	addi	a0, s4, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	sd	a1, 0x0(a0)
+               	mv	a0, s6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	t2, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	add	t2, a1, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s5
+               	ld	a0, 0x0(a1)
+               	mv	a1, s7
+               	sd	a0, 0x0(a1)
+               	addi	a0, s5, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	sd	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	t2, 0x0(a0)
+               	mv	a0, s6
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a0, s7
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	mv	a1, s8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s6, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s7, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	addi	a1, s8, 0x8
+               	sd	a0, 0x0(a1)
+               	mv	a0, s1
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1838>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s7
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a1, a0, t2
+               	xori	a1, a1, 0x1
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s7, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a0, a1, t2
+               	xori	a0, a0, 0x1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, 0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x50
+               	mv	a0, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	s2, 0x0(a1)
-               	mv	a1, a0
-               	sd	s2, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1944>
+               	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s7
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a1, t2, a0
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a0
+               	mv	a0, s10
+               	sd	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s6, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	addi	a1, s10, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1a18>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s7
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a1, a0, t2
+               	xori	a1, a1, 0x1
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a0
+               	mv	a0, s11
+               	sd	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s6, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	slt	a0, a1, t2
+               	xori	a0, a0, 0x1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	addi	a1, s11, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1af4>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s7
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	seqz	a1, a1
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a0
+               	mv	a0, s3
+               	sd	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s7, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a0, t2, a1
+               	seqz	a0, a0
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	addi	a1, s3, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1bd0>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s7
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	snez	a1, a1
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a0
+               	mv	a0, s2
+               	sd	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s7, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a0, t2, a1
+               	snez	a0, a0
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	addi	a1, s2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a1, s2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1cac>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s8
+               	ld	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a1, s6
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	and	a1, t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a1, 0x0(a0)
+               	addi	a0, s8, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s6, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	and	a0, t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
+               	sd	a0, 0x0(a1)
+               	mv	a0, s8
+               	ld	a1, 0x0(a0)
+               	not	a0, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s8, 0x8
+               	ld	a1, 0x0(a0)
+               	not	a0, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a0, s7
+               	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
                	addiw	t1, t1, 0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	and	a0, t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s7, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	and	a0, t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	or	a0, t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x678
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	or	a0, t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x678
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x678
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	t2, 0x0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0x2144 <corpus.cases.vec.vec_cmp_i64.checksum+0x1fc4>
+               	j	0x21f0 <corpus.cases.vec.vec_cmp_i64.checksum+0x2070>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	mul	a0, t2, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0x2144 <corpus.cases.vec.vec_cmp_i64.checksum+0x1fc4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x678
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	t2, 0x0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0x226c <corpus.cases.vec.vec_cmp_i64.checksum+0x20ec>
+               	j	0x2318 <corpus.cases.vec.vec_cmp_i64.checksum+0x2198>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	mul	a0, t2, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0x226c <corpus.cases.vec.vec_cmp_i64.checksum+0x20ec>
+               	addi	s9, s9, 0x1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s1, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1160 <corpus.cases.vec.vec_cmp_i64.checksum+0x1088>
-               	j	0x1c88 <corpus.cases.vec.vec_cmp_i64.checksum+0x1bb0>
-               	li	t0, 0x10
-               	mul	a0, s3, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	add	a1, t2, a0
-               	mv	a0, a1
-               	ld	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	sd	a2, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	sd	a1, 0x0(a0)
-               	li	t0, 0x10
-               	mul	a0, s3, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	add	a1, t2, a0
-               	mv	a0, a1
-               	ld	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	sd	a2, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	add	a0, a1, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	add	a0, a1, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a2, 0x0(a0)
-               	slt	a0, a1, a2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	sub	a0, t1, a1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a2, 0x0(a0)
-               	slt	a0, a1, a2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	sub	a0, t1, a1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
+               	bltu	s9, t0, 0x1780 <corpus.cases.vec.vec_cmp_i64.checksum+0x1600>
+               	addi	s2, s0, -0x6e8
                	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1354>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1378>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	slt	a1, s4, a2
-               	xori	a1, a1, 0x1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	slt	a1, s4, a2
-               	xori	a1, a1, 0x1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1454>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1478>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	slt	a1, a2, s4
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	slt	a1, a2, s4
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x154c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1570>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	slt	a1, s4, a2
-               	xori	a1, a1, 0x1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	slt	a1, s4, a2
-               	xori	a1, a1, 0x1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x164c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1670>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	xor	a1, a2, s4
-               	seqz	a1, a1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	xor	a1, a2, s4
-               	seqz	a1, a1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x174c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1770>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	xor	a1, a2, s4
-               	snez	a1, a1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	xor	a1, a2, s4
-               	snez	a1, a1
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x184c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1870>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	slt	a1, a2, s4
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	slt	a1, a2, s4
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	and	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	and	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	and	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	and	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s4, 0x0(a1)
-               	or	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	s4, 0x0(a1)
-               	or	a1, a2, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1b74>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1b98>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x1160 <corpus.cases.vec.vec_cmp_i64.checksum+0x1088>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	s3, s0, t0
+               	li	t0, 0x7
+               	and	a1, a0, t0
+               	bnez	a1, 0x236c <corpus.cases.vec.vec_cmp_i64.checksum+0x21ec>
+               	mv	a1, a0
+               	li	a2, 0x50
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x2354 <corpus.cases.vec.vec_cmp_i64.checksum+0x21d4>
+               	j	0x2388 <corpus.cases.vec.vec_cmp_i64.checksum+0x2208>
+               	mv	a1, a0
+               	li	a0, 0x50
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x2374 <corpus.cases.vec.vec_cmp_i64.checksum+0x21f4>
+               	addi	s3, s0, -0x738
                	mv	a0, s3
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1cc4 <corpus.cases.vec.vec_cmp_i64.checksum+0x1bec>
+               	bnez	a1, 0x23bc <corpus.cases.vec.vec_cmp_i64.checksum+0x223c>
                	mv	a1, a0
                	li	a2, 0x50
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1cac <corpus.cases.vec.vec_cmp_i64.checksum+0x1bd4>
-               	j	0x1ce0 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c08>
+               	bne	a2, t0, 0x23a4 <corpus.cases.vec.vec_cmp_i64.checksum+0x2224>
+               	j	0x23d8 <corpus.cases.vec.vec_cmp_i64.checksum+0x2258>
                	mv	a1, a0
                	li	a0, 0x50
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1ccc <corpus.cases.vec.vec_cmp_i64.checksum+0x1bf4>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	s4, s0, t0
-               	mv	a0, s4
-               	li	t0, 0x7
-               	and	a1, a0, t0
-               	bnez	a1, 0x1d1c <corpus.cases.vec.vec_cmp_i64.checksum+0x1c44>
-               	mv	a1, a0
-               	li	a2, 0x50
-               	sd	zero, 0x0(a1)
-               	addi	a1, a1, 0x8
-               	addi	a2, a2, -0x8
-               	li	t0, 0x0
-               	bne	a2, t0, 0x1d04 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c2c>
-               	j	0x1d38 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c60>
-               	mv	a1, a0
-               	li	a0, 0x50
-               	sb	zero, 0x0(a1)
-               	addi	a1, a1, 0x1
-               	addi	a0, a0, -0x1
-               	li	t0, 0x0
-               	bne	a0, t0, 0x1d24 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c4c>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a0, s0, t0
+               	bne	a0, t0, 0x23c4 <corpus.cases.vec.vec_cmp_i64.checksum+0x2244>
+               	addi	a0, s0, -0x748
                	mv	a1, a0
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
@@ -1896,7 +2318,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1904,14 +2326,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	mv	a0, s3
+               	mv	a0, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1919,16 +2341,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x758
                	mv	a1, a0
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
@@ -1945,7 +2365,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1953,14 +2373,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	mv	a0, s4
+               	mv	a0, s3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1968,16 +2388,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x768
                	mv	a1, a0
                	lui	t0, 0x200
                	slli	t0, t0, 0xc
@@ -1991,7 +2409,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1999,14 +2417,58 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
+               	addiw	t1, t1, 0x660
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x10
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x660
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x660
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a0, s0, -0x778
+               	mv	a1, a0
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x658
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x10
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2014,62 +2476,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	lui	t0, 0x100
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, 0x1
-               	sd	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lui	t0, 0x200
-               	slli	t0, t0, 0xc
-               	addi	t0, t0, -0x1
-               	sd	t0, 0x0(a1)
-               	mv	a1, a0
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	ld	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s4, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x788
                	mv	a1, a0
                	li	t0, -0x1
                	sd	t0, 0x0(a1)
@@ -2078,7 +2492,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2086,14 +2500,53 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
+               	addiw	t1, t1, 0x650
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x650
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x650
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a0, s0, -0x798
+               	mv	a1, a0
+               	sd	zero, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x648
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
                	addi	a0, s3, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2101,57 +2554,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	sd	zero, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	li	t0, -0x1
-               	sd	t0, 0x0(a1)
-               	mv	a1, a0
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	ld	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s4, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x7a8
                	mv	a1, a0
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
@@ -2166,7 +2576,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2174,14 +2584,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x30
+               	addi	a0, s2, 0x30
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2189,16 +2599,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x7b8
                	mv	a1, a0
                	lui	t0, 0xf8000
                	slli	t0, t0, 0xc
@@ -2214,7 +2622,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2222,14 +2630,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s4, 0x30
+               	addi	a0, s3, 0x30
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2237,16 +2645,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x7c8
                	mv	a1, a0
                	li	t0, 0x10a
                	sd	t0, 0x0(a1)
@@ -2256,7 +2662,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2264,14 +2670,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x40
+               	addi	a0, s2, 0x40
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2279,16 +2685,14 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	a0, s0, t0
+               	addi	a0, s0, -0x7d8
                	mv	a1, a0
                	li	t0, 0xa
                	sd	t0, 0x0(a1)
@@ -2297,7 +2701,7 @@ Disassembly of section .text:
                	mv	a1, a0
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2305,14 +2709,14 @@ Disassembly of section .text:
                	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s4, 0x40
+               	addi	a0, s3, 0x40
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2320,24 +2724,43 @@ Disassembly of section .text:
                	mv	a1, a0
                	sd	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	li	s5, 0x0
+               	li	s4, 0x0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x2450 <corpus.cases.vec.vec_cmp_i64.checksum+0x2378>
-               	j	0x2e28 <corpus.cases.vec.vec_cmp_i64.checksum+0x2d50>
+               	bltu	s4, t0, 0x2aa0 <corpus.cases.vec.vec_cmp_i64.checksum+0x2920>
+               	j	0x33c8 <corpus.cases.vec.vec_cmp_i64.checksum+0x3248>
                	li	t0, 0x10
-               	mul	a0, s5, t0
+               	mul	a0, s4, t0
+               	add	a1, s2, a0
+               	mv	a0, a1
+               	ld	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	li	t0, 0x10
+               	mul	a0, s4, t0
                	add	a1, s3, a0
                	mv	a0, a1
                	ld	a2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
@@ -2345,676 +2768,613 @@ Disassembly of section .text:
                	addi	a0, a1, 0x8
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	sd	a1, 0x0(a0)
-               	li	t0, 0x10
-               	mul	a0, s5, t0
-               	add	a1, s4, a0
-               	mv	a0, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x618
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x618
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x618
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
                	ld	a2, 0x0(a0)
+               	sltu	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	sd	a2, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	add	a0, a1, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sd	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	ld	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x500
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	add	a0, a1, t2
+               	addi	a0, t2, 0x8
+               	ld	a2, 0x0(a0)
+               	sltu	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	sd	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
                	mv	a0, s1
-               	ld	a2, 0x0(a0)
-               	sltu	a0, a1, a2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	sub	a0, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
-               	ld	a2, 0x0(a0)
-               	sltu	a0, a1, a2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	sub	a0, t1, a1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x25d4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2bc8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x25f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a3, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a6, a2
                	xori	a1, a1, 0x1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a3, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a6, a2
                	xori	a1, a1, 0x1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2c9c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x26b4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x26d8>
-               	mv	a1, s1
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a2, a3
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a2, a6
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	addi	a1, s1, 0x8
-               	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a2, a3
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a2, a6
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2d68>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x278c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x27b0>
-               	mv	a1, s1
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a3, a2
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a6, a2
                	xori	a1, a1, 0x1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
-               	addi	a1, s1, 0x8
-               	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a3, a2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	sltu	a1, a6, a2
                	xori	a1, a1, 0x1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x5e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x5e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2e3c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x286c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2890>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	ld	a6, 0x0(a1)
+               	xor	a1, a2, a6
                	seqz	a1, a1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
+               	addiw	t1, t1, 0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	xor	a1, a2, a6
                	seqz	a1, a1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
+               	addiw	t1, t1, 0x5d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
+               	addiw	t1, t1, 0x5d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2f10>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x294c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2970>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	ld	a6, 0x0(a1)
+               	xor	a1, a2, a6
                	snez	a1, a1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
+               	addiw	t1, t1, 0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	xor	a1, a2, a6
                	snez	a1, a1
                	zext.b	a2, a1
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
+               	addiw	t1, t1, 0x5d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2fe4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2a2c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2a50>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a2, a3
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
+               	ld	a6, 0x0(a1)
+               	and	a1, a2, a6
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	ld	a3, 0x0(a1)
-               	sltu	a1, a2, a3
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	and	a1, a2, a6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
+               	addiw	t1, t1, 0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a6, 0x0(a1)
+               	and	a1, a2, a6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a6, 0x0(a1)
+               	and	a1, a2, a6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
+               	ld	a6, 0x0(a1)
+               	or	a1, a2, a6
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
+               	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
+               	ld	a6, 0x0(a1)
+               	or	a1, a2, a6
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
+               	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
+               	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2d14>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2d38>
-               	addi	s5, s5, 0x1
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x3230>
+               	addi	s4, s4, 0x1
+               	mv	s1, a0
                	li	t0, 0x5
-               	bltu	s5, t0, 0x2450 <corpus.cases.vec.vec_cmp_i64.checksum+0x2378>
-               	mv	a0, s2
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x348
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x350
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x358
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x360
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x368
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x370
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
+               	bltu	s4, t0, 0x2aa0 <corpus.cases.vec.vec_cmp_i64.checksum+0x2920>
+               	mv	a0, s1
                	lui	t1, 0x1
                	addiw	t1, t1, -0x378
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
+               	ld	s1, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x380
                	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
+               	ld	s2, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x388
                	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
+               	ld	s3, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x390
                	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
+               	ld	s4, 0x0(t1)
                	lui	t1, 0x1
                	addiw	t1, t1, -0x398
                	add	t1, sp, t1
+               	ld	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3a0
+               	add	t1, sp, t1
+               	ld	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3a8
+               	add	t1, sp, t1
+               	ld	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3b0
+               	add	t1, sp, t1
+               	ld	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3b8
+               	add	t1, sp, t1
+               	ld	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3c0
+               	add	t1, sp, t1
+               	ld	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x3c8
+               	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, -0x368
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, -0x370
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x330
+               	addiw	t0, t0, -0x360
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/riscv64-linux/vec/vec_cmp_select.dis
@@ -3,144 +3,349 @@ vec/vec_cmp_select.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_cmp_select.fold_u8x16>:
-               	addi	sp, sp, -0x120
-               	sd	ra, 0x118(sp)
-               	sd	s0, 0x110(sp)
-               	addi	s0, sp, 0x120
-               	sd	s1, 0x108(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	a1, s0, -0x118
-               	mv	a1, s1
-               	lbu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x6c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x1
+               	addi	sp, sp, -0x110
+               	sd	ra, 0x108(sp)
+               	sd	s0, 0x100(sp)
+               	addi	s0, sp, 0x110
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x80
+               	addi	a2, s0, -0x90
+               	addi	a2, s0, -0xa0
+               	addi	a2, s0, -0xb0
+               	addi	a2, s0, -0xc0
+               	addi	a2, s0, -0xd0
+               	addi	a2, s0, -0xe0
+               	addi	a2, s0, -0xf0
+               	addi	a2, s0, -0x100
+               	addi	a2, s0, -0x110
+               	mv	a2, a1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x88>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x6c>
+               	j	0xa0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xa0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x6c>
+               	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xa4>
-               	mv	a1, a0
-               	addi	a2, s1, 0x3
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xbc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xbc>
+               	j	0xf0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xf0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xbc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xbc>
+               	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xc0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x10c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x10c>
+               	j	0x140 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x140>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x10c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x10c>
+               	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xdc>
-               	mv	a1, a0
-               	addi	a2, s1, 0x5
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x15c>
+               	j	0x190 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x190>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x15c>
+               	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0xf8>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ac <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1ac>
+               	j	0x1e0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1e0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ac <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1ac>
+               	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x114>
-               	mv	a1, a0
-               	addi	a2, s1, 0x7
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1fc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1fc>
+               	j	0x230 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x230>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1fc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1fc>
+               	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x130>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x24c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x24c>
+               	j	0x280 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x280>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x24c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x24c>
+               	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x14c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x9
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x29c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x29c>
+               	j	0x2d0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x2d0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x29c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x29c>
+               	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x168>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x2ec>
+               	j	0x320 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x320>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x2ec>
+               	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x184>
-               	mv	a1, a0
-               	addi	a2, s1, 0xb
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x33c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x33c>
+               	j	0x370 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x370>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x33c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x33c>
+               	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1a0>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x38c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x38c>
+               	j	0x3c0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x3c0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x38c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x38c>
+               	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1bc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xd
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3dc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x3dc>
+               	j	0x410 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x410>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3dc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x3dc>
+               	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1d8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x42c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x42c>
+               	j	0x460 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x460>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x42c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x42c>
+               	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x1f4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xf
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x47c>
+               	j	0x4b0 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x4b0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x47c>
+               	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x210>
-               	ld	s1, 0x108(sp)
-               	ld	ra, 0x118(sp)
-               	ld	s0, 0x110(sp)
-               	addi	sp, sp, 0x120
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4cc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x4cc>
+               	j	0x500 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x500>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4cc <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x4cc>
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x51c>
+               	j	0x550 <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x550>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.vec.vec_cmp_select.fold_u8x16+0x51c>
+               	ld	ra, 0x108(sp)
+               	ld	s0, 0x100(sp)
+               	addi	sp, sp, 0x110
                	ret
 
 <corpus.cases.vec.vec_cmp_select.fold_u16x8>:
@@ -149,7 +354,6 @@ Disassembly of section .text:
                	sd	s0, 0x90(sp)
                	addi	s0, sp, 0xa0
                	sd	s1, 0x88(sp)
-               	mv	a2, a0
                	mv	s1, a1
                	addi	a1, s0, -0x28
                	addi	a1, s0, -0x38
@@ -160,60 +364,53 @@ Disassembly of section .text:
                	addi	a1, s0, -0x88
                	addi	a1, s0, -0x98
                	mv	a1, s1
-               	lhu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x4c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x48>
+               	addi	a1, s1, 0x2
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x68>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x60>
+               	addi	a1, s1, 0x4
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x84>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x78>
+               	addi	a1, s1, 0x6
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xa0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x90>
+               	addi	a1, s1, 0x8
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xbc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xa8>
+               	addi	a1, s1, 0xa
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xc0>
+               	addi	a1, s1, 0xc
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xd8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	addi	a1, s1, 0xe
+               	lhu	a2, 0x0(a1)
+               	slli	a1, a2, 0x30
+               	srli	a1, a1, 0x30
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xf4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
-               	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0x110>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u16x8+0xf0>
                	ld	s1, 0x88(sp)
                	ld	ra, 0x98(sp)
                	ld	s0, 0x90(sp)
@@ -226,39 +423,35 @@ Disassembly of section .text:
                	sd	s0, 0x50(sp)
                	addi	s0, sp, 0x60
                	sd	s1, 0x48(sp)
-               	mv	a2, a0
                	mv	s1, a1
                	addi	a1, s0, -0x28
                	addi	a1, s0, -0x38
                	addi	a1, s0, -0x48
                	addi	a1, s0, -0x58
                	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
-               	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x38>
+               	addi	a1, s1, 0x4
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x50>
+               	addi	a1, s1, 0x8
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
-               	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x68>
+               	addi	a1, s1, 0xc
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x90>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_u32x4+0x80>
                	ld	s1, 0x48(sp)
                	ld	ra, 0x58(sp)
                	ld	s0, 0x50(sp)
@@ -300,7 +493,6 @@ Disassembly of section .text:
                	sd	s0, 0x50(sp)
                	addi	s0, sp, 0x60
                	sd	s1, 0x48(sp)
-               	mv	a2, a0
                	mv	s1, a1
                	addi	a1, s0, -0x28
                	addi	a1, s0, -0x38
@@ -308,31 +500,36 @@ Disassembly of section .text:
                	addi	a1, s0, -0x58
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x40>
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x60>
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
-               	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x80>
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0x90>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.fold_f32x4+0xa0>
                	ld	s1, 0x48(sp)
                	ld	ra, 0x58(sp)
                	ld	s0, 0x50(sp)
@@ -340,262 +537,262 @@ Disassembly of section .text:
                	ret
 
 <corpus.cases.vec.vec_cmp_select.checksum>:
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x7e0
+               	lui	t0, 0x1
+               	addiw	t0, t0, 0x520
                	sub	sp, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7e8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x518
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7f0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x510
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x7e0
+               	lui	t0, 0x1
+               	addiw	t0, t0, 0x520
                	add	s0, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7f8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x508
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x800
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x500
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7f8
+               	addiw	t1, t1, 0x4f8
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7f0
+               	addiw	t1, t1, 0x4f0
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7e8
+               	addiw	t1, t1, 0x4e8
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7e0
+               	addiw	t1, t1, 0x4e0
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7d8
+               	addiw	t1, t1, 0x4d8
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7d0
+               	addiw	t1, t1, 0x4d0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7c8
+               	addiw	t1, t1, 0x4c8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7c0
+               	addiw	t1, t1, 0x4c0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7b8
+               	addiw	t1, t1, 0x4b8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7b0
+               	addiw	t1, t1, 0x4b0
                	add	t1, sp, t1
                	fsd	fs0, 0x0(t1)
-               	mv	t2, a0
+               	mv	s1, a0
+               	addi	t2, s0, -0x80
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x478
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s2, s0, -0x80
-               	addi	s3, s0, -0x90
-               	addi	a1, s0, -0xa0
-               	addi	a1, s0, -0xb0
-               	addi	s4, s0, -0xc0
-               	addi	a1, s0, -0xd0
-               	addi	a1, s0, -0xe0
-               	addi	s5, s0, -0xf0
-               	addi	a1, s0, -0x100
-               	addi	a1, s0, -0x110
-               	addi	s6, s0, -0x120
-               	addi	a1, s0, -0x130
-               	addi	a1, s0, -0x140
-               	addi	s7, s0, -0x150
-               	addi	a1, s0, -0x160
-               	addi	a1, s0, -0x170
-               	addi	s8, s0, -0x180
-               	addi	a1, s0, -0x190
-               	addi	a1, s0, -0x1a0
-               	addi	s9, s0, -0x1b0
-               	addi	a1, s0, -0x1c0
-               	addi	a1, s0, -0x1d0
-               	addi	s10, s0, -0x1e0
-               	addi	a1, s0, -0x1f0
-               	addi	a1, s0, -0x200
-               	addi	s11, s0, -0x210
-               	addi	a1, s0, -0x220
-               	addi	a1, s0, -0x230
-               	addi	t2, s0, -0x240
+               	addi	t2, s0, -0x90
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x250
-               	addi	a1, s0, -0x260
-               	addi	t2, s0, -0x270
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x280
+               	addi	a2, s0, -0xa0
+               	addi	a2, s0, -0xb0
+               	addi	s2, s0, -0xc0
+               	addi	a2, s0, -0xd0
+               	addi	a2, s0, -0xe0
+               	addi	s3, s0, -0xf0
+               	addi	a2, s0, -0x100
+               	addi	a2, s0, -0x110
+               	addi	s4, s0, -0x120
+               	addi	a2, s0, -0x130
+               	addi	a2, s0, -0x140
+               	addi	s5, s0, -0x150
+               	addi	a2, s0, -0x160
+               	addi	a2, s0, -0x170
+               	addi	s6, s0, -0x180
+               	addi	a2, s0, -0x190
+               	addi	a2, s0, -0x1a0
+               	addi	s7, s0, -0x1b0
+               	addi	a2, s0, -0x1c0
+               	addi	a2, s0, -0x1d0
+               	addi	s8, s0, -0x1e0
+               	addi	a2, s0, -0x1f0
+               	addi	a2, s0, -0x200
+               	addi	s9, s0, -0x210
+               	addi	a2, s0, -0x220
+               	addi	a2, s0, -0x230
+               	addi	s10, s0, -0x240
+               	addi	a2, s0, -0x250
+               	addi	a2, s0, -0x260
+               	addi	s11, s0, -0x270
+               	addi	a2, s0, -0x280
                	addi	t2, s0, -0x290
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
+               	addiw	t1, t1, -0x4e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2a0
+               	addi	a3, s0, -0x2a0
                	addi	t2, s0, -0x2b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
+               	addiw	t1, t1, -0x4e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x2c0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2d0
-               	addi	a1, s0, -0x2e0
+               	addi	a5, s0, -0x2d0
+               	addi	a5, s0, -0x2e0
                	addi	t2, s0, -0x2f0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x300
+               	addi	a6, s0, -0x300
                	addi	t2, s0, -0x310
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x320
+               	addi	a7, s0, -0x320
                	addi	t2, s0, -0x330
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x508
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x340
-               	addi	a1, s0, -0x350
-               	addi	a1, s0, -0x360
-               	addi	a1, s0, -0x370
+               	addi	t2, s0, -0x340
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x510
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t6, s0, -0x350
+               	addi	t6, s0, -0x360
+               	addi	t6, s0, -0x370
                	addi	t2, s0, -0x380
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x518
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x390
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3a0
                	addi	t2, s0, -0x3b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x3c0
                	addi	a1, s0, -0x3d0
                	addi	t2, s0, -0x3e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x3f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x400
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x410
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x420
                	addi	a1, s0, -0x430
                	addi	t2, s0, -0x440
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x450
                	addi	a1, s0, -0x460
                	addi	t2, s0, -0x470
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x480
                	addi	a1, s0, -0x490
                	addi	t2, s0, -0x4a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4b0
                	addi	a1, s0, -0x4c0
                	addi	t2, s0, -0x4d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x4e0
                	addi	a1, s0, -0x4f0
                	addi	t2, s0, -0x500
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x510
                	addi	a1, s0, -0x520
                	addi	t2, s0, -0x530
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x540
                	addi	a1, s0, -0x550
                	addi	t2, s0, -0x560
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x570
                	addi	a1, s0, -0x580
                	addi	t2, s0, -0x590
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x5b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5c0
                	addi	a1, s0, -0x5d0
                	addi	t2, s0, -0x5e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x5f0
@@ -604,42 +801,42 @@ Disassembly of section .text:
                	addi	a1, s0, -0x620
                	addi	t2, s0, -0x630
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x640
                	addi	a1, s0, -0x650
                	addi	t2, s0, -0x660
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x670
                	addi	a1, s0, -0x680
                	addi	t2, s0, -0x690
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x6a0
                	addi	a1, s0, -0x6b0
                	addi	t2, s0, -0x6c0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x6d0
                	addi	a1, s0, -0x6e0
                	addi	t2, s0, -0x6f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x700
                	addi	a1, s0, -0x710
                	addi	t2, s0, -0x720
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x730
@@ -649,31 +846,31 @@ Disassembly of section .text:
                	addi	a1, s0, -0x770
                	addi	t2, s0, -0x780
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x790
                	addi	t2, s0, -0x7a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x7b0
                	addi	t2, s0, -0x7c0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	t2, s0, -0x7d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	addi	a1, s0, -0x7e0
                	addi	a1, s0, -0x7f0
                	addi	t2, s0, -0x800
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -689,14 +886,14 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x7c0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7b0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -715,21 +912,21 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x760
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x750
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x740
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -742,7 +939,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x710
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -755,7 +952,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x6e0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x390
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -768,7 +965,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x6b0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x398
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -781,7 +978,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x680
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x3a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -794,21 +991,21 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x650
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x3a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x640
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x630
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -821,7 +1018,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x600
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -834,7 +1031,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x5d0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -847,7 +1044,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x5a0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -860,7 +1057,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x570
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -873,7 +1070,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x540
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -884,11 +1081,7 @@ Disassembly of section .text:
                	add	a1, s0, t0
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x510
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	add	a1, s0, t0
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x500
                	add	a1, s0, t0
@@ -899,7 +1092,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x4e0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -909,7 +1102,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x4c0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -919,28 +1112,28 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x4a0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x490
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x480
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x470
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -953,7 +1146,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x440
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -966,7 +1159,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x410
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -979,7 +1172,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x3e0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -992,7 +1185,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x3b0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1005,7 +1198,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x380
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1027,7 +1220,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x320
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1037,7 +1230,7 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x300
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1047,14 +1240,14 @@ Disassembly of section .text:
                	addiw	t0, t0, 0x2e0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x2d0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
@@ -1272,235 +1465,52 @@ Disassembly of section .text:
                	lui	t0, 0xfffff
                	addiw	t0, t0, -0x1b0
                	add	a1, s0, t0
+               	sext.w	t2, s1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x460
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	fcvt.s.lu	fs0, s1
+               	sext.w	t2, s1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x468
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	sext.w	t2, s1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x470
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, -0x1c0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1d0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1e0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1f0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x200
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x210
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x220
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x230
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x240
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x250
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x260
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x270
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x280
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x290
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2a0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2b0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2c0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2d0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2e0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2f0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x300
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x310
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x320
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x330
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x340
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x350
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x360
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x370
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x380
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x390
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3a0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3b0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3c0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3d0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3e0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3f0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x400
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x410
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x420
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x430
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x440
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x450
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x460
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x470
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x480
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x490
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4a0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4b0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4c0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4d0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4e0
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4f0
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1100>
-               	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	sext.w	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	fcvt.s.lu	fs0, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	sext.w	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	sext.w	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x500
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	li	t0, 0xa
                	sw	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	li	t0, 0x14
                	sw	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	li	t0, 0x1e
                	sw	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
@@ -1509,15 +1519,161 @@ Disassembly of section .text:
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	lw	a1, 0x0(a0)
-               	mv	a0, s2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, -0x1d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	li	t0, 0x14
+               	sw	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	li	t0, 0x14
+               	sw	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	li	t0, 0xa
+               	sw	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	li	t0, 0x1
+               	sw	t0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x460
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addw	t2, a1, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x490
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a0, 0x0(a1)
+               	mv	a1, s2
+               	sw	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -1525,7 +1681,7 @@ Disassembly of section .text:
                	addi	a0, s2, 0x4
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -1533,50 +1689,36 @@ Disassembly of section .text:
                	addi	a0, s2, 0x8
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d0
+               	addiw	t1, t1, -0x478
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0xc
                	sw	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x510
-               	add	t2, s0, t0
+               	mv	a0, s2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x460
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	addw	t2, a1, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x498
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	li	t0, 0x14
-               	sw	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	li	t0, 0x14
-               	sw	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	li	t0, 0xa
-               	sw	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	li	t0, 0x1
-               	sw	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1584,7 +1726,7 @@ Disassembly of section .text:
                	mv	a1, s3
                	sw	a0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
@@ -1592,7 +1734,7 @@ Disassembly of section .text:
                	addi	a0, s3, 0x4
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
@@ -1600,1409 +1742,1373 @@ Disassembly of section .text:
                	addi	a0, s3, 0x8
                	sw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7d8
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s3, 0xc
                	sw	a1, 0x0(a0)
-               	mv	a0, s2
-               	lw	a1, 0x0(a0)
+               	addi	a0, s3, 0xc
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	addw	t2, a1, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	mv	a1, s2
-               	lw	a0, 0x0(a1)
-               	mv	a1, s4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s2, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	sw	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	sw	a1, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	sw	a1, 0x0(a0)
-               	mv	a0, s4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e0
+               	addiw	t1, t1, -0x498
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	sw	t2, 0x0(a0)
+               	mv	a0, s2
+               	lw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a0, s3
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sltu	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	mv	a1, s4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s2, 0x4
+               	lw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s3, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sltu	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s4, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s2, 0x8
+               	lw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sltu	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s4, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s2, 0xc
+               	lw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
                	addi	a0, s3, 0xc
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x4b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	sw	s2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sw	s2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sw	s2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
+               	sltu	a0, t2, a1
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s4, 0xc
                	sw	a0, 0x0(a1)
                	mv	a0, s4
                	lw	a1, 0x0(a0)
-               	mv	a0, s5
-               	lw	s2, 0x0(a0)
-               	sltu	a0, a1, s2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	subw	a0, t1, a1
-               	mv	a1, s6
-               	sw	a0, 0x0(a1)
-               	addi	a0, s4, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	lw	s2, 0x0(a0)
-               	sltu	a0, a1, s2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	subw	a0, t1, a1
-               	addi	a1, s6, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s4, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	lw	s2, 0x0(a0)
-               	sltu	a0, a1, s2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	subw	a0, t1, a1
-               	addi	a1, s6, 0x8
-               	sw	a0, 0x0(a1)
-               	addi	a0, s4, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s5, 0xc
-               	lw	s2, 0x0(a0)
-               	sltu	a0, a1, s2
-               	zext.b	a1, a0
-               	li	t1, 0x0
-               	subw	a0, t1, a1
-               	addi	a1, s6, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s6
-               	lw	a1, 0x0(a0)
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c8
+               	addiw	t1, t1, -0x4c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x147c>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, s4, 0x4
+               	lw	a0, 0x0(a1)
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1570>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x14cc>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, s4, 0x8
+               	lw	a0, 0x0(a1)
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x151c>
+               	addi	a1, s4, 0xc
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1534>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, s3
+               	lw	s4, 0x0(a1)
+               	mv	a1, s2
+               	lw	a0, 0x0(a1)
+               	sltu	a1, s4, a0
+               	zext.b	a0, a1
+               	li	t1, 0x0
+               	subw	a1, t1, a0
+               	mv	a0, s5
+               	sw	a1, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	lw	s4, 0x0(a0)
+               	sltu	a0, a1, s4
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s5, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	lw	s4, 0x0(a0)
+               	sltu	a0, a1, s4
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s5, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	lw	s4, 0x0(a0)
+               	sltu	a0, a1, s4
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	subw	a0, t1, a1
+               	addi	a1, s5, 0xc
+               	sw	a0, 0x0(a1)
+               	mv	a0, s5
+               	lw	a1, 0x0(a0)
+               	slli	s4, a1, 0x20
+               	srli	s4, s4, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1628>
+               	addi	a1, s5, 0x4
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1640>
+               	addi	a1, s5, 0x8
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1658>
+               	addi	a1, s5, 0xc
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1670>
+               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	seqz	a1, a1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	mv	s4, s6
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	seqz	a1, a1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s6, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	seqz	a1, a1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s6, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0xc
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	seqz	a1, a1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s6, 0xc
+               	sw	a1, 0x0(s4)
+               	mv	a1, s6
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1738>
                	addi	a1, s6, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1584>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1750>
                	addi	a1, s6, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1598>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1768>
                	addi	a1, s6, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x15ac>
-               	mv	a1, s5
-               	lw	s2, 0x0(a1)
-               	mv	a1, s4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1780>
+               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	snez	a1, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	mv	s2, s7
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
+               	subw	a1, t1, s4
+               	mv	s4, s7
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	snez	a1, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s7, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
+               	subw	a1, t1, s4
+               	addi	s4, s7, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	snez	a1, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s7, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
+               	subw	a1, t1, s4
+               	addi	s4, s7, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0xc
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s5, 0x0(a1)
+               	xor	a1, s4, s5
+               	snez	a1, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s7, 0xc
-               	sw	a1, 0x0(s2)
+               	subw	a1, t1, s4
+               	addi	s4, s7, 0xc
+               	sw	a1, 0x0(s4)
                	mv	a1, s7
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1660>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1848>
                	addi	a1, s7, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1674>
-               	addi	a1, s7, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1688>
-               	addi	a1, s7, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x169c>
-               	mv	a1, s4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	seqz	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	mv	s2, s8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	seqz	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s8, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	seqz	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s8, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	seqz	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s8, 0xc
-               	sw	a1, 0x0(s2)
-               	mv	a1, s8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1760>
-               	addi	a1, s8, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1774>
-               	addi	a1, s8, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1788>
-               	addi	a1, s8, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x179c>
-               	mv	a1, s4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	snez	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	mv	s2, s9
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	snez	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s9, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	snez	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s9, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s3, 0x0(a1)
-               	xor	a1, s2, s3
-               	snez	a1, a1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s9, 0xc
-               	sw	a1, 0x0(s2)
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1860>
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	addi	a1, s7, 0x8
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1874>
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1878>
+               	addi	a1, s7, 0xc
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1888>
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1890>
                	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x189c>
-               	mv	a1, s4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
+               	lw	s4, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
                	xori	a1, a1, 0x1
-               	zext.b	s2, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	mv	s2, s10
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
+               	subw	a1, t1, s4
+               	mv	s4, s8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
                	xori	a1, a1, 0x1
-               	zext.b	s2, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s10, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
+               	subw	a1, t1, s4
+               	addi	s4, s8, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
                	xori	a1, a1, 0x1
-               	zext.b	s2, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s10, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
+               	subw	a1, t1, s4
+               	addi	s4, s8, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0xc
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
                	xori	a1, a1, 0x1
-               	zext.b	s2, a1
+               	zext.b	s4, a1
                	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s10, 0xc
-               	sw	a1, 0x0(s2)
-               	mv	a1, s10
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	subw	a1, t1, s4
+               	addi	s4, s8, 0xc
+               	sw	a1, 0x0(s4)
+               	mv	a1, s8
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1960>
-               	addi	a1, s10, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1958>
+               	addi	a1, s8, 0x4
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1974>
-               	addi	a1, s10, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1970>
+               	addi	a1, s8, 0x8
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1988>
+               	addi	a1, s8, 0xc
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x19a0>
+               	mv	a1, s3
+               	lw	s4, 0x0(a1)
+               	mv	a1, s2
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
+               	xori	a1, a1, 0x1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	mv	s4, s9
+               	sw	a1, 0x0(s4)
+               	addi	a1, s3, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
+               	xori	a1, a1, 0x1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s9, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s3, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
+               	xori	a1, a1, 0x1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s9, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s3, 0xc
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s5, s4
+               	xori	a1, a1, 0x1
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s9, 0xc
+               	sw	a1, 0x0(s4)
+               	mv	a1, s9
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a68>
+               	addi	a1, s9, 0x4
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a80>
+               	addi	a1, s9, 0x8
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a98>
+               	addi	a1, s9, 0xc
+               	lw	s4, 0x0(a1)
+               	slli	a1, s4, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1ab0>
+               	mv	a1, s2
+               	lw	s4, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s4, s5
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	mv	s4, s10
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s4, s5
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s10, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s4, s5
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s10, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s2, 0xc
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s5, 0x0(a1)
+               	sltu	a1, s4, s5
+               	zext.b	s4, a1
+               	li	t1, 0x0
+               	subw	a1, t1, s4
+               	addi	s4, s10, 0xc
+               	sw	a1, 0x0(s4)
+               	mv	a1, s10
+               	lw	s4, 0x0(a1)
+               	mv	a1, s2
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	mv	s4, s11
+               	sw	a1, 0x0(s4)
+               	addi	a1, s10, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	addi	s4, s11, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s10, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	addi	s4, s11, 0x8
+               	sw	a1, 0x0(s4)
                	addi	a1, s10, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x199c>
-               	mv	a1, s5
-               	lw	s2, 0x0(a1)
-               	mv	a1, s4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
-               	xori	a1, a1, 0x1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	mv	s2, s11
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
-               	xori	a1, a1, 0x1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s11, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
-               	xori	a1, a1, 0x1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s11, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s5, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s3, s2
-               	xori	a1, a1, 0x1
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	addi	s2, s11, 0xc
-               	sw	a1, 0x0(s2)
+               	lw	s4, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	addi	s4, s11, 0xc
+               	sw	a1, 0x0(s4)
+               	mv	a1, s10
+               	lw	s4, 0x0(a1)
+               	not	a1, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s4, t2
+               	sw	a1, 0x0(s4)
+               	addi	a1, s10, 0x4
+               	lw	s4, 0x0(a1)
+               	not	a1, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s4, t2, 0x4
+               	sw	a1, 0x0(s4)
+               	addi	a1, s10, 0x8
+               	lw	s4, 0x0(a1)
+               	not	a1, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s4, t2, 0x8
+               	sw	a1, 0x0(s4)
+               	addi	a1, s10, 0xc
+               	lw	s4, 0x0(a1)
+               	not	a1, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s4, t2, 0xc
+               	sw	a1, 0x0(s4)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	s4, 0x0(a1)
+               	mv	a1, s3
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s4, t2
+               	sw	a1, 0x0(s4)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s4, t2, 0x4
+               	sw	a1, 0x0(s4)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	s4, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	s5, 0x0(a1)
+               	and	a1, s4, s5
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s4, t2, 0x8
+               	sw	a1, 0x0(s4)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	s4, 0x0(a1)
+               	and	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s11
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a60>
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	s4, 0x0(a1)
+               	or	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
                	addi	a1, s11, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a74>
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	s4, 0x0(a1)
+               	or	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
                	addi	a1, s11, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a88>
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	s4, 0x0(a1)
+               	or	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
                	addi	a1, s11, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1a9c>
-               	mv	a1, s4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1e58>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	sw	a1, 0x0(s2)
-               	addi	a1, s4, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s3, 0x0(a1)
-               	sltu	a1, s2, s3
-               	zext.b	s2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0xc
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s2, 0x0(a1)
-               	mv	a1, s4
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0xc
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s2, 0x0(a1)
-               	not	a1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	not	a1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s2, 0x0(a1)
-               	not	a1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	s2, 0x0(a1)
-               	not	a1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0xc
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s2, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	and	a1, s2, s3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	sw	a1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s2, 0x0(a1)
-               	and	a1, a4, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a4, t2, 0xc
-               	sw	a1, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s2, 0x0(a1)
-               	or	a1, a4, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a4, t2
-               	sw	a1, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	or	a1, a4, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a4, t2, 0x4
-               	sw	a1, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s2, 0x0(a1)
-               	or	a1, a4, s2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a4, t2, 0x8
-               	sw	a1, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x800
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	or	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1f80>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fa4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1e80>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fc8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1ea8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1fec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x1ed0>
+               	mv	a1, s10
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
                	lw	a3, 0x0(a1)
-               	mv	a1, s5
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
                	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
                	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
                	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, s4
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	or	a1, a3, a4
-               	mv	a3, s1
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	or	a1, a3, a4
-               	addi	a3, s1, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	or	a1, a3, a4
-               	addi	a3, s1, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x7e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	or	a1, a3, a4
-               	addi	a3, s1, 0xc
-               	sw	a1, 0x0(a3)
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23a0>
-               	addi	a1, s1, 0x4
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23b4>
-               	addi	a1, s1, 0x8
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23c8>
-               	addi	a1, s1, 0xc
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x23dc>
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mv	a1, s5
-               	lw	a4, 0x0(a1)
-               	addw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	a4, 0x0(a1)
-               	addw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	a4, 0x0(a1)
-               	addw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	a4, 0x0(a1)
-               	addw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	and	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x25e0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2604>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2628>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x264c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	not	a1, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s10
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	mv	a1, s4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s5
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
-               	addi	a1, s4, 0x4
+               	addi	a1, s10, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
-               	addi	a1, s4, 0x8
+               	addi	a1, s10, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
-               	addi	a1, s4, 0xc
+               	addi	a1, s10, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s2
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x508
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s2, 0x4
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x508
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x500
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s2, 0x8
                	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x508
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x508
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x510
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x4f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x508
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2920>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2258>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2944>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2280>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2968>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x22a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x510
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x298c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x22d0>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s10
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x518
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2498>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x24c0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x24e8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2510>
+               	mv	a1, s10
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0x8
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s10, 0xc
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x27a8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x27d0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x27f8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2820>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x520
+               	addiw	t0, t0, -0x1e0
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x100
@@ -3024,7 +3130,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3032,7 +3138,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3040,7 +3146,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3048,13 +3154,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x530
+               	addiw	t0, t0, -0x1f0
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -3074,7 +3180,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3082,7 +3188,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3090,7 +3196,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3098,149 +3204,149 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b0
+               	addiw	t1, t1, -0x460
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3250,19 +3356,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3272,19 +3378,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3294,19 +3400,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3316,55 +3422,59 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2eb0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2d48>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2ed4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2d70>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2ef8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2d98>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2f1c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2dc0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3374,19 +3484,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3396,19 +3506,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3418,19 +3528,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3440,55 +3550,59 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2f48>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2f70>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x30e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2f98>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x310c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x2fc0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3499,19 +3613,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3522,19 +3636,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3545,19 +3659,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3568,55 +3682,59 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3158>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3180>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x32e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x31a8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x330c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x31d0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3627,19 +3745,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3650,19 +3768,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3673,19 +3791,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3696,55 +3814,59 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3368>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3390>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x34e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x33b8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x350c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x33e0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3755,19 +3877,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3778,19 +3900,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3801,19 +3923,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3824,55 +3946,59 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3578>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x35a0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x36e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x35c8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x2e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x370c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x35f0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -3883,19 +4009,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -3906,19 +4032,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -3929,19 +4055,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -3952,49 +4078,53 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3788>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x37b0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x38e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x37d8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x2e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x390c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3800>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x540
+               	addiw	t0, t0, -0x200
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3fc00
@@ -4014,7 +4144,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4022,7 +4152,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4030,7 +4160,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4038,13 +4168,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x550
+               	addiw	t0, t0, -0x210
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x40200
@@ -4062,7 +4192,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4070,7 +4200,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4078,7 +4208,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4086,152 +4216,94 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	fadd.s	ft1, ft0, fs0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x2f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bac>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3a98>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bd0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3bf4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c18>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c3c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3ab4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3ca8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4241,19 +4313,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4263,19 +4335,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4285,19 +4357,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4307,26 +4379,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3e24>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3c30>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4336,19 +4408,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4358,19 +4430,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4380,19 +4452,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4402,26 +4474,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3fa0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3dac>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4431,19 +4503,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4453,19 +4525,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4475,19 +4547,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4497,26 +4569,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x411c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x3f28>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4527,19 +4599,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4550,19 +4622,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4573,19 +4645,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4596,26 +4668,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x42a8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x40b4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4625,19 +4697,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4647,19 +4719,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4669,19 +4741,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4691,26 +4763,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4424>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4230>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -4720,19 +4792,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -4742,19 +4814,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -4764,19 +4836,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -4786,712 +4858,625 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x45a0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x43ac>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x348
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x308
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x2f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x358
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x360
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4db4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4bb8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4dd8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4dfc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e44>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4bd4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e68>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4e8c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4eb0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x368
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x350
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x370
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5004>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5028>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x504c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5070>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4d20>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x560
+               	addiw	t0, t0, -0x220
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3ff8
@@ -5508,7 +5493,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5516,13 +5501,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x570
+               	addiw	t0, t0, -0x230
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x4004
@@ -5535,7 +5520,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5543,61 +5528,57 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	fcvt.d.lu	ft1, t2
+               	fcvt.d.lu	ft1, s1
                	fadd.d	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x378
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5607,19 +5588,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x390
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5629,37 +5610,37 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x390
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x390
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x52d4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4f74>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x390
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x52f8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x4f98>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5669,19 +5650,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x398
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5691,37 +5672,37 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x398
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x398
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53cc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x506c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x398
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x53f0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5090>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5732,19 +5713,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x3a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5755,37 +5736,37 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x3a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x3a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x54cc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x516c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x3a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x54f0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5190>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5795,19 +5776,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x3a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x380
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x388
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5817,31 +5798,31 @@ Disassembly of section .text:
                	li	t1, 0x0
                	sub	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x3a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x3a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x55c4>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5264>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x3a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	ld	a2, 0x0(a1)
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x55e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5288>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x580
+               	addiw	t0, t0, -0x240
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -5871,7 +5852,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5879,7 +5860,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -5887,7 +5868,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -5895,7 +5876,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -5903,7 +5884,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -5911,7 +5892,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -5919,7 +5900,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -5927,13 +5908,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x590
+               	addiw	t0, t0, -0x250
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x2
@@ -5965,7 +5946,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -5973,7 +5954,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -5981,7 +5962,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -5989,7 +5970,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -5997,7 +5978,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -6005,7 +5986,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -6013,7 +5994,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -6021,245 +6002,245 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x3b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7b8
+               	addiw	t1, t1, -0x468
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x3b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lhu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6273,19 +6254,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -6299,19 +6280,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6325,19 +6306,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -6351,19 +6332,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6377,19 +6358,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -6403,19 +6384,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6429,19 +6410,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -6455,91 +6436,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5fbc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5c54>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5fe0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6004>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6028>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x604c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6070>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6094>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x60b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6554,19 +6470,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -6581,19 +6497,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6608,19 +6524,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -6635,19 +6551,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6662,19 +6578,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -6689,19 +6605,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6716,19 +6632,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -6743,91 +6659,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x3d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x643c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x5fd0>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6460>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6484>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x64f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6514>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6538>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6841,19 +6692,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -6867,19 +6718,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6893,19 +6744,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -6919,19 +6770,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6945,19 +6796,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -6971,19 +6822,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6997,19 +6848,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7023,925 +6874,587 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a1, t1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x3e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x689c>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x632c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x68c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x68e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6908>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x692c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6950>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6974>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6998>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
-               	slli	t1, a2, 0x30
-               	srli	t1, t1, 0x30
-               	slli	t0, a3, 0x30
-               	srli	t0, t0, 0x30
-               	sltu	a1, t1, t0
-               	zext.b	a2, a1
-               	li	t1, 0x0
-               	subw	a1, t1, a2
+               	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
+               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x2
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x6
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xa
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x3f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
-               	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xe
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x3e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x3f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
+               	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x400
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x75bc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x75e0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7604>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7628>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x764c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7670>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7694>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x76b8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x6c08>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5a0
+               	addiw	t0, t0, -0x260
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x1
@@ -7993,7 +7506,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -8001,7 +7514,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
@@ -8009,7 +7522,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -8017,7 +7530,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
@@ -8025,7 +7538,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -8033,7 +7546,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
@@ -8041,7 +7554,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -8049,7 +7562,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
@@ -8057,7 +7570,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -8065,7 +7578,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
@@ -8073,7 +7586,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -8081,7 +7594,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
@@ -8089,7 +7602,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -8097,7 +7610,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
@@ -8105,7 +7618,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
@@ -8113,13 +7626,13 @@ Disassembly of section .text:
                	addi	a2, a1, 0xf
                	lbu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5b0
+               	addiw	t0, t0, -0x270
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0x2
@@ -8172,7 +7685,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -8180,7 +7693,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
@@ -8188,7 +7701,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -8196,7 +7709,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
@@ -8204,7 +7717,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -8212,7 +7725,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
@@ -8220,7 +7733,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -8228,7 +7741,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
@@ -8236,7 +7749,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -8244,7 +7757,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
@@ -8252,7 +7765,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -8260,7 +7773,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
@@ -8268,7 +7781,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -8276,7 +7789,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
@@ -8284,7 +7797,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
@@ -8292,437 +7805,437 @@ Disassembly of section .text:
                	addi	a2, a1, 0xf
                	lbu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x408
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7c0
+               	addiw	t1, t1, -0x470
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x410
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -8733,19 +8246,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -8756,19 +8269,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -8779,19 +8292,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -8802,19 +8315,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8825,19 +8338,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8848,19 +8361,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8871,19 +8384,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8894,19 +8407,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8917,19 +8430,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8940,19 +8453,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8963,19 +8476,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8986,19 +8499,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9009,19 +8522,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9032,19 +8545,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9055,19 +8568,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9078,26 +8591,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x88b0>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x7e00>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9109,19 +8622,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9133,19 +8646,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9157,19 +8670,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9181,19 +8694,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9205,19 +8718,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9229,19 +8742,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9253,19 +8766,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9277,19 +8790,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9301,19 +8814,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9325,19 +8838,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9349,19 +8862,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9373,19 +8886,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9397,19 +8910,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9421,19 +8934,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9445,19 +8958,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9469,26 +8982,26 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x430
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x8ecc>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x841c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9500,19 +9013,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9524,19 +9037,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9548,19 +9061,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9572,19 +9085,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9596,19 +9109,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9620,19 +9133,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9644,19 +9157,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9668,19 +9181,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9692,19 +9205,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9716,19 +9229,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9740,19 +9253,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9764,19 +9277,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9788,19 +9301,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9812,19 +9325,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9836,19 +9349,19 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9860,1202 +9373,1202 @@ Disassembly of section .text:
                	li	t1, 0x0
                	subw	a2, t1, a1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x788
+               	addiw	t1, t1, -0x438
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x94e8>
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x8a38>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x418
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x428
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	not	a1, a2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x798
+               	addiw	t1, t1, -0x448
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x420
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	and	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x790
+               	addiw	t1, t1, -0x440
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a0
+               	addiw	t1, t1, -0x450
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	or	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x7a8
+               	addiw	t1, t1, -0x458
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0xa684>
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7f8
+               	jalr	ra <corpus.cases.vec.vec_cmp_select.checksum+0x9bd4>
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x508
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x800
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x500
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7f8
+               	addiw	t1, t1, 0x4f8
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7f0
+               	addiw	t1, t1, 0x4f0
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7e8
+               	addiw	t1, t1, 0x4e8
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7e0
+               	addiw	t1, t1, 0x4e0
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7d8
+               	addiw	t1, t1, 0x4d8
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7d0
+               	addiw	t1, t1, 0x4d0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7c8
+               	addiw	t1, t1, 0x4c8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7c0
+               	addiw	t1, t1, 0x4c0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7b8
+               	addiw	t1, t1, 0x4b8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x7b0
+               	addiw	t1, t1, 0x4b0
                	add	t1, sp, t1
                	fld	fs0, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7e8
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x518
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x7f0
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x510
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x7e0
+               	lui	t0, 0x1
+               	addiw	t0, t0, 0x520
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f32x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_f32x2.dis
@@ -3,692 +3,521 @@ vec/vec_f32x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x2.fold_vec>:
-               	addi	sp, sp, -0x30
-               	sd	ra, 0x28(sp)
-               	sd	s0, 0x20(sp)
-               	addi	s0, sp, 0x30
-               	sd	s1, 0x18(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x20
-               	addi	a1, s0, -0x28
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.fold_vec+0x34>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x20
+               	sd	ra, 0x18(sp)
+               	sd	s0, 0x10(sp)
+               	addi	s0, sp, 0x20
+               	addi	a2, s0, -0x18
+               	addi	a2, s0, -0x20
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.fold_vec+0x50>
-               	ld	s1, 0x18(sp)
-               	ld	ra, 0x28(sp)
-               	ld	s0, 0x20(sp)
-               	addi	sp, sp, 0x30
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c <corpus.cases.vec.vec_f32x2.fold_vec+0x3c>
+               	j	0x70 <corpus.cases.vec.vec_f32x2.fold_vec+0x70>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x3c <corpus.cases.vec.vec_f32x2.fold_vec+0x3c>
+               	addi	a2, a1, 0x4
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x94 <corpus.cases.vec.vec_f32x2.fold_vec+0x94>
+               	j	0xc8 <corpus.cases.vec.vec_f32x2.fold_vec+0xc8>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x94 <corpus.cases.vec.vec_f32x2.fold_vec+0x94>
+               	ld	ra, 0x18(sp)
+               	ld	s0, 0x10(sp)
+               	addi	sp, sp, 0x20
                	ret
 
 <corpus.cases.vec.vec_f32x2.checksum>:
-               	addi	sp, sp, -0x450
-               	sd	ra, 0x448(sp)
-               	sd	s0, 0x440(sp)
-               	addi	s0, sp, 0x450
-               	sd	s1, 0x438(sp)
-               	sd	s2, 0x430(sp)
-               	sd	s3, 0x428(sp)
-               	sd	s4, 0x420(sp)
-               	sd	s5, 0x418(sp)
-               	sd	s6, 0x410(sp)
-               	sd	s7, 0x408(sp)
-               	sd	s8, 0x400(sp)
-               	sd	s9, 0x3f8(sp)
-               	sd	s10, 0x3f0(sp)
-               	sd	s11, 0x3e8(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x70
-               	addi	s3, s0, -0x78
-               	addi	s4, s0, -0x80
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x90
-               	addi	s5, s0, -0x98
-               	addi	a1, s0, -0xa0
-               	addi	a1, s0, -0xa8
-               	addi	s6, s0, -0xb0
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc0
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd0
-               	addi	s7, s0, -0xd8
-               	addi	a1, s0, -0xe0
-               	addi	a1, s0, -0xe8
-               	addi	s8, s0, -0xf0
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x100
-               	addi	s9, s0, -0x108
-               	addi	a1, s0, -0x110
-               	addi	a1, s0, -0x118
-               	addi	s10, s0, -0x120
-               	addi	a1, s0, -0x128
-               	addi	a1, s0, -0x130
-               	addi	s11, s0, -0x138
-               	addi	a1, s0, -0x140
-               	addi	a1, s0, -0x148
-               	addi	t2, s0, -0x150
-               	sd	t2, -0x410(s0)
-               	addi	a2, s0, -0x158
-               	addi	a2, s0, -0x160
-               	addi	t2, s0, -0x168
-               	sd	t2, -0x418(s0)
+               	addi	sp, sp, -0x350
+               	sd	ra, 0x348(sp)
+               	sd	s0, 0x340(sp)
+               	addi	s0, sp, 0x350
+               	sd	s1, 0x338(sp)
+               	sd	s2, 0x330(sp)
+               	sd	s3, 0x328(sp)
+               	sd	s4, 0x320(sp)
+               	sd	s5, 0x318(sp)
+               	sd	s6, 0x310(sp)
+               	sd	s7, 0x308(sp)
+               	sd	s8, 0x300(sp)
+               	sd	s9, 0x2f8(sp)
+               	sd	s10, 0x2f0(sp)
+               	sd	s11, 0x2e8(sp)
+               	mv	t2, a0
+               	sd	t2, -0x2e0(s0)
+               	addi	a1, s0, -0x70
+               	addi	t2, s0, -0x78
+               	sd	t2, -0x308(s0)
+               	addi	s1, s0, -0x80
+               	addi	a3, s0, -0x88
+               	addi	a3, s0, -0x90
+               	addi	s2, s0, -0x98
+               	addi	a3, s0, -0xa0
+               	addi	a3, s0, -0xa8
+               	addi	s3, s0, -0xb0
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc0
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd0
+               	addi	s4, s0, -0xd8
+               	addi	a3, s0, -0xe0
+               	addi	a3, s0, -0xe8
+               	addi	s5, s0, -0xf0
+               	addi	a3, s0, -0xf8
+               	addi	a3, s0, -0x100
+               	addi	s6, s0, -0x108
+               	addi	a3, s0, -0x110
+               	addi	a3, s0, -0x118
+               	addi	s7, s0, -0x120
+               	addi	a3, s0, -0x128
+               	addi	a3, s0, -0x130
+               	addi	s8, s0, -0x138
+               	addi	a3, s0, -0x140
+               	addi	a3, s0, -0x148
+               	addi	s9, s0, -0x150
+               	addi	a3, s0, -0x158
+               	addi	a3, s0, -0x160
+               	addi	s10, s0, -0x168
                	addi	a3, s0, -0x170
                	addi	a3, s0, -0x178
-               	addi	t2, s0, -0x180
-               	sd	t2, -0x420(s0)
-               	addi	a4, s0, -0x188
-               	addi	a4, s0, -0x190
+               	addi	s11, s0, -0x180
+               	addi	a3, s0, -0x188
+               	addi	a3, s0, -0x190
                	addi	t2, s0, -0x198
-               	sd	t2, -0x428(s0)
+               	sd	t2, -0x310(s0)
                	addi	t2, s0, -0x1a0
-               	sd	t2, -0x3e0(s0)
-               	addi	a6, s0, -0x1a8
-               	addi	a6, s0, -0x1b0
+               	sd	t2, -0x318(s0)
+               	addi	a5, s0, -0x1a8
+               	addi	a5, s0, -0x1b0
                	addi	t2, s0, -0x1b8
-               	sd	t2, -0x430(s0)
-               	addi	a7, s0, -0x1c0
-               	addi	a7, s0, -0x1c8
-               	addi	a7, s0, -0x1d0
+               	sd	t2, -0x320(s0)
+               	addi	a6, s0, -0x1c0
+               	addi	a6, s0, -0x1c8
+               	addi	a6, s0, -0x1d0
                	addi	t2, s0, -0x1d8
-               	sd	t2, -0x438(s0)
-               	addi	t5, s0, -0x1e0
-               	addi	t5, s0, -0x1e8
-               	addi	t5, s0, -0x1f0
+               	sd	t2, -0x328(s0)
+               	addi	a7, s0, -0x1e0
+               	addi	a7, s0, -0x1e8
+               	addi	a7, s0, -0x1f0
                	addi	t2, s0, -0x1f8
-               	sd	t2, -0x440(s0)
-               	addi	t6, s0, -0x200
-               	addi	t6, s0, -0x208
-               	addi	t6, s0, -0x210
-               	addi	t6, s0, -0x218
+               	sd	t2, -0x330(s0)
+               	addi	t5, s0, -0x200
+               	addi	t5, s0, -0x208
+               	addi	t5, s0, -0x210
+               	addi	t5, s0, -0x218
                	addi	t2, s0, -0x220
-               	sd	t2, -0x3e8(s0)
-               	addi	a5, s0, -0x228
-               	addi	a5, s0, -0x230
+               	sd	t2, -0x338(s0)
+               	addi	t6, s0, -0x228
+               	addi	t6, s0, -0x230
                	addi	t2, s0, -0x238
-               	sd	t2, -0x448(s0)
-               	addi	t6, s0, -0x240
-               	addi	t6, s0, -0x248
-               	addi	t6, s0, -0x250
+               	sd	t2, -0x340(s0)
+               	addi	a0, s0, -0x240
+               	addi	a0, s0, -0x248
+               	addi	a0, s0, -0x250
                	addi	t2, s0, -0x258
-               	sd	t2, -0x3f0(s0)
-               	addi	t6, s0, -0x260
+               	sd	t2, -0x2e8(s0)
+               	addi	a0, s0, -0x260
                	addi	t2, s0, -0x268
-               	sd	t2, -0x408(s0)
+               	sd	t2, -0x2f0(s0)
                	addi	t2, s0, -0x270
-               	sd	t2, -0x3f8(s0)
+               	sd	t2, -0x2f8(s0)
                	addi	t2, s0, -0x278
-               	sd	t2, -0x400(s0)
-               	addi	t6, s0, -0x280
-               	addi	t6, s0, -0x288
-               	addi	t6, s0, -0x290
-               	addi	t6, s0, -0x298
-               	addi	t6, s0, -0x2a0
-               	addi	t6, s0, -0x2a8
-               	addi	t6, s0, -0x2b0
-               	addi	t6, s0, -0x2b8
-               	addi	t6, s0, -0x2c0
-               	addi	t6, s0, -0x2c8
-               	addi	t6, s0, -0x2d0
-               	addi	t6, s0, -0x2d8
-               	addi	t6, s0, -0x2e0
-               	addi	t6, s0, -0x2e8
-               	addi	t6, s0, -0x2f0
-               	addi	t6, s0, -0x2f8
-               	addi	t6, s0, -0x300
-               	addi	t6, s0, -0x308
-               	addi	t6, s0, -0x310
-               	addi	t6, s0, -0x318
-               	addi	t6, s0, -0x320
-               	addi	t6, s0, -0x328
-               	addi	t6, s0, -0x330
-               	addi	t6, s0, -0x338
-               	addi	t6, s0, -0x340
-               	addi	t6, s0, -0x348
-               	addi	t6, s0, -0x350
-               	addi	t6, s0, -0x358
-               	addi	t6, s0, -0x360
-               	addi	t6, s0, -0x368
-               	addi	t6, s0, -0x370
-               	addi	t6, s0, -0x378
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x200>
-               	fcvt.s.lu	ft0, s1
-               	addi	t6, s0, -0x380
-               	mv	s1, t6
+               	sd	t2, -0x300(s0)
+               	ld	t2, -0x2e0(s0)
+               	fcvt.s.lu	ft0, t2
+               	addi	a0, s0, -0x2c0
+               	mv	a2, a0
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x4
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s2, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s0, -0x388
-               	mv	s1, t6
+               	addi	a2, a0, 0x4
+               	fsw	ft1, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a0, a1, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x2c8
+               	mv	a2, a0
                	lui	t0, 0x3f000
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s3, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s0, -0x390
-               	mv	s1, t6
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x308(s0)
+               	mv	a2, t2
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x308(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x2d0
+               	mv	a2, a0
                	lui	t0, 0x3f800
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x41d80
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s4, 0x4
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, s1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a0, s1, 0x4
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s3, 0x4
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft2, 0x0(a0)
+               	ld	t2, -0x308(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s3
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s3, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s5
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	ld	t2, -0x308(s0)
+               	mv	a0, t2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x308(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x33c>
-               	addi	t6, s5, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x2e0>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x350>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x364>
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x378>
-               	mv	t6, s5
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x2ec>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	mv	t6, s7
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
+               	mv	a1, s4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	addi	t6, s7, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s7
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	addi	a1, s4, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x3c4>
-               	addi	t6, s7, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x330>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s5
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x3d8>
-               	mv	t6, s5
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x374>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	mv	t6, s8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
+               	mv	a1, s6
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	addi	t6, s8, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	addi	a1, s6, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x424>
-               	addi	t6, s8, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x3b8>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x438>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s5
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	t6, s9
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s9
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x3fc>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x440>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s9
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x4
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s9
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x484>
-               	addi	t6, s9, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x498>
-               	mv	t6, s5
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	mv	t6, s10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x4e4>
-               	addi	t6, s10, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x4f8>
-               	mv	t6, s5
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
-               	fdiv.s	ft2, ft0, ft1
-               	mv	t6, s11
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
-               	fdiv.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x4
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s11
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x544>
-               	addi	t6, s11, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x558>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s5
-               	flw	ft1, 0x0(t6)
-               	fdiv.s	ft2, ft0, ft1
-               	ld	t2, -0x410(s0)
-               	mv	t6, t2
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft1, 0x0(t6)
-               	fdiv.s	ft2, ft0, ft1
-               	ld	t2, -0x410(s0)
-               	addi	t6, t2, 0x4
-               	fsw	ft2, 0x0(t6)
-               	ld	t2, -0x410(s0)
-               	mv	t6, t2
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x5b0>
-               	ld	t2, -0x410(s0)
-               	addi	t6, t2, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x5c8>
-               	mv	a1, s5
+               	mv	a1, s2
                	flw	ft0, 0x0(a1)
-               	mv	a1, s4
+               	mv	a1, s1
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x418(s0)
-               	mv	a1, t2
+               	mv	a1, s10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s5, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x418(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s10, 0x4
                	fsw	ft2, 0x0(a1)
-               	ld	t2, -0x418(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x620>
-               	ld	t2, -0x418(s0)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x4c8>
+               	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x638>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s3
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x420(s0)
-               	mv	a1, t2
+               	mv	a1, s11
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x420(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s11, 0x4
                	fsw	ft2, 0x0(a1)
-               	ld	t2, -0x420(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x690>
-               	ld	t2, -0x420(s0)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x50c>
+               	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x6a8>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s5
+               	mv	a1, s2
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	ld	t2, -0x428(s0)
+               	ld	t2, -0x310(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s5, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	ld	t2, -0x428(s0)
+               	ld	t2, -0x310(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	ld	t2, -0x428(s0)
+               	ld	t2, -0x310(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x700>
-               	ld	t2, -0x428(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x718>
-               	addi	a1, s0, -0x3d8
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x55c>
+               	addi	a1, s0, -0x2d8
                	mv	a2, a1
                	sw	zero, 0x0(a2)
                	addi	a2, a1, 0x4
                	sw	zero, 0x0(a2)
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3e0(s0)
+               	ld	t2, -0x318(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3e0(s0)
+               	ld	t2, -0x318(s0)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
-               	mv	s1, a0
-               	ld	t2, -0x3e0(s0)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	mv	s4, a0
+               	ld	t2, -0x318(s0)
+               	mv	s5, t2
+               	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x7e4 <corpus.cases.vec.vec_f32x2.checksum+0x778>
-               	j	0x960 <corpus.cases.vec.vec_f32x2.checksum+0x8f4>
-               	mv	a0, s5
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x430(s0)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x430(s0)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	ld	t2, -0x430(s0)
-               	mv	a0, t2
+               	bltu	s6, t0, 0x694 <corpus.cases.vec.vec_f32x2.checksum+0x5bc>
+               	j	0x7b0 <corpus.cases.vec.vec_f32x2.checksum+0x6d8>
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
                	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x7cc>
-               	ld	t2, -0x430(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x7e4>
-               	mv	a1, s2
-               	flw	ft0, 0x0(a1)
-               	ld	t2, -0x430(s0)
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x320(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x320(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x320(s0)
                	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x438(s0)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	flw	ft0, 0x0(a1)
-               	ld	t2, -0x430(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x438(s0)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	ld	t2, -0x438(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x844>
-               	ld	t2, -0x438(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x85c>
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x608>
                	mv	a1, s5
                	flw	ft0, 0x0(a1)
-               	mv	a1, s6
+               	ld	t2, -0x320(s0)
+               	mv	a1, t2
                	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x440(s0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x328(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	addi	a1, s5, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	ld	t2, -0x320(s0)
+               	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x440(s0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x328(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	ld	t2, -0x440(s0)
+               	ld	t2, -0x328(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x8b4>
-               	ld	t2, -0x440(s0)
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x660>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x330(s0)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x330(s0)
                	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x330(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x8cc>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x440(s0)
-               	mv	s5, t2
-               	ld	t2, -0x438(s0)
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x6b0>
+               	addi	s6, s6, 0x1
+               	mv	s4, a0
+               	ld	t2, -0x330(s0)
                	mv	s2, t2
+               	ld	t2, -0x328(s0)
+               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x7e4 <corpus.cases.vec.vec_f32x2.checksum+0x778>
-               	addi	s3, s0, -0x3c0
-               	mv	a0, s3
+               	bltu	s6, t0, 0x694 <corpus.cases.vec.vec_f32x2.checksum+0x5bc>
+               	addi	s6, s0, -0x2a8
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x994 <corpus.cases.vec.vec_f32x2.checksum+0x928>
+               	bnez	a1, 0x7e4 <corpus.cases.vec.vec_f32x2.checksum+0x70c>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x97c <corpus.cases.vec.vec_f32x2.checksum+0x910>
-               	j	0x9b0 <corpus.cases.vec.vec_f32x2.checksum+0x944>
+               	bne	a2, t0, 0x7cc <corpus.cases.vec.vec_f32x2.checksum+0x6f4>
+               	j	0x800 <corpus.cases.vec.vec_f32x2.checksum+0x728>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x99c <corpus.cases.vec.vec_f32x2.checksum+0x930>
-               	mv	a0, s3
-               	mv	a1, s5
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	mv	a0, s5
-               	flw	ft0, 0x0(a0)
+               	bne	a0, t0, 0x7ec <corpus.cases.vec.vec_f32x2.checksum+0x714>
                	mv	a0, s6
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x3e8(s0)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	ld	t2, -0x3e8(s0)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	ld	t2, -0x3e8(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3e8(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	mv	a0, s5
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x448(s0)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x448(s0)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x10
-               	ld	t2, -0x448(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x448(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x18
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
@@ -697,169 +526,250 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	mv	a0, s6
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
-               	mv	a0, s5
+               	mv	a0, s3
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x3f0(s0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x338(s0)
                	mv	a0, t2
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
+               	addi	a0, s2, 0x4
                	flw	ft0, 0x0(a0)
-               	addi	a0, s5, 0x4
+               	addi	a0, s3, 0x4
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	ld	t2, -0x3f0(s0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x338(s0)
                	addi	a0, t2, 0x4
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x20
-               	ld	t2, -0x3f0(s0)
+               	addi	a0, s6, 0x8
+               	ld	t2, -0x338(s0)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3f0(s0)
+               	ld	t2, -0x338(s0)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x28
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	li	s2, 0x0
-               	li	t0, 0x6
-               	bltu	s2, t0, 0xb70 <corpus.cases.vec.vec_f32x2.checksum+0xb04>
-               	j	0xbe4 <corpus.cases.vec.vec_f32x2.checksum+0xb78>
-               	slli	t0, s2, 0x3
-               	add	a0, s3, t0
-               	mv	a1, a0
-               	flw	ft0, 0x0(a1)
-               	ld	t2, -0x408(s0)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	flw	ft0, 0x0(a1)
-               	ld	t2, -0x408(s0)
-               	addi	a0, t2, 0x4
-               	fsw	ft0, 0x0(a0)
-               	ld	t2, -0x408(s0)
-               	mv	a0, t2
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
                	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xb48>
-               	ld	t2, -0x408(s0)
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x340(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x340(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x10
+               	ld	t2, -0x340(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x340(s0)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xb60>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
-               	li	t0, 0x6
-               	bltu	s2, t0, 0xb70 <corpus.cases.vec.vec_f32x2.checksum+0xb04>
-               	addi	s2, s0, -0x3d0
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, s6, 0x18
+               	mv	a1, s5
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	mv	a0, s3
+               	flw	ft0, 0x0(a0)
                	mv	a0, s2
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x2e8(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x2e8(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x20
+               	ld	t2, -0x2e8(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x2e8(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, s6, 0x28
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	li	s1, 0x0
+               	li	t0, 0x6
+               	bltu	s1, t0, 0x9c0 <corpus.cases.vec.vec_f32x2.checksum+0x8e8>
+               	j	0xa14 <corpus.cases.vec.vec_f32x2.checksum+0x93c>
+               	slli	t0, s1, 0x3
+               	add	a0, s6, t0
+               	mv	a1, a0
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x2f0(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x2f0(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x2f0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0x924>
+               	addi	s1, s1, 0x1
+               	mv	s4, a0
+               	li	t0, 0x6
+               	bltu	s1, t0, 0x9c0 <corpus.cases.vec.vec_f32x2.checksum+0x8e8>
+               	addi	s1, s0, -0x2b8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xc18 <corpus.cases.vec.vec_f32x2.checksum+0xbac>
+               	bnez	a1, 0xa48 <corpus.cases.vec.vec_f32x2.checksum+0x970>
                	mv	a1, a0
                	li	a2, 0x10
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0xc00 <corpus.cases.vec.vec_f32x2.checksum+0xb94>
-               	j	0xc34 <corpus.cases.vec.vec_f32x2.checksum+0xbc8>
+               	bne	a2, t0, 0xa30 <corpus.cases.vec.vec_f32x2.checksum+0x958>
+               	j	0xa64 <corpus.cases.vec.vec_f32x2.checksum+0x98c>
                	mv	a1, a0
                	li	a0, 0x10
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xc20 <corpus.cases.vec.vec_f32x2.checksum+0xbb4>
-               	mv	a0, s2
+               	bne	a0, t0, 0xa50 <corpus.cases.vec.vec_f32x2.checksum+0x978>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x10
+               	addi	a1, s6, 0x10
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3f8(s0)
+               	ld	t2, -0x2f8(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3f8(s0)
+               	ld	t2, -0x2f8(s0)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	s3, s2, 0x4
-               	ld	t2, -0x3f8(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s3
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3f8(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	addi	a1, s1, 0x4
+               	ld	t2, -0x2f8(s0)
+               	mv	a2, t2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x2f8(s0)
+               	addi	a2, t2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s1, 0xc
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xc4c>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xafc <corpus.cases.vec.vec_f32x2.checksum+0xa24>
+               	j	0xb30 <corpus.cases.vec.vec_f32x2.checksum+0xa58>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xafc <corpus.cases.vec.vec_f32x2.checksum+0xa24>
+               	addi	a0, s1, 0x4
+               	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	ld	t2, -0x400(s0)
+               	ld	t2, -0x300(s0)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	ld	t2, -0x400(s0)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x400(s0)
+               	ld	t2, -0x300(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x300(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xc8c>
-               	ld	t2, -0x400(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xca4>
-               	addi	a1, s2, 0xc
+               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xa90>
+               	addi	a1, s1, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x2.checksum+0xcb8>
-               	ld	s1, 0x438(sp)
-               	ld	s2, 0x430(sp)
-               	ld	s3, 0x428(sp)
-               	ld	s4, 0x420(sp)
-               	ld	s5, 0x418(sp)
-               	ld	s6, 0x410(sp)
-               	ld	s7, 0x408(sp)
-               	ld	s8, 0x400(sp)
-               	ld	s9, 0x3f8(sp)
-               	ld	s10, 0x3f0(sp)
-               	ld	s11, 0x3e8(sp)
-               	ld	ra, 0x448(sp)
-               	ld	s0, 0x440(sp)
-               	addi	sp, sp, 0x450
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb90 <corpus.cases.vec.vec_f32x2.checksum+0xab8>
+               	j	0xbc4 <corpus.cases.vec.vec_f32x2.checksum+0xaec>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb90 <corpus.cases.vec.vec_f32x2.checksum+0xab8>
+               	ld	s1, 0x338(sp)
+               	ld	s2, 0x330(sp)
+               	ld	s3, 0x328(sp)
+               	ld	s4, 0x320(sp)
+               	ld	s5, 0x318(sp)
+               	ld	s6, 0x310(sp)
+               	ld	s7, 0x308(sp)
+               	ld	s8, 0x300(sp)
+               	ld	s9, 0x2f8(sp)
+               	ld	s10, 0x2f0(sp)
+               	ld	s11, 0x2e8(sp)
+               	ld	ra, 0x348(sp)
+               	ld	s0, 0x340(sp)
+               	addi	sp, sp, 0x350
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f32x3.dis
+++ b/test/golden/riscv64-linux/vec/vec_f32x3.dis
@@ -3,703 +3,577 @@ vec/vec_f32x3.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x3.fold_vec>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x24
-               	addi	a1, s0, -0x30
-               	addi	a1, s0, -0x3c
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.fold_vec+0x38>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	addi	a2, s0, -0x1c
+               	addi	a2, s0, -0x28
+               	addi	a2, s0, -0x34
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.fold_vec+0x54>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40 <corpus.cases.vec.vec_f32x3.fold_vec+0x40>
+               	j	0x74 <corpus.cases.vec.vec_f32x3.fold_vec+0x74>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40 <corpus.cases.vec.vec_f32x3.fold_vec+0x40>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.fold_vec+0x70>
-               	ld	s1, 0x38(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x98 <corpus.cases.vec.vec_f32x3.fold_vec+0x98>
+               	j	0xcc <corpus.cases.vec.vec_f32x3.fold_vec+0xcc>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x98 <corpus.cases.vec.vec_f32x3.fold_vec+0x98>
+               	addi	a2, a1, 0x8
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.vec.vec_f32x3.fold_vec+0xf0>
+               	j	0x124 <corpus.cases.vec.vec_f32x3.fold_vec+0x124>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.vec.vec_f32x3.fold_vec+0xf0>
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.vec.vec_f32x3.checksum>:
-               	addi	sp, sp, -0x3e0
-               	sd	ra, 0x3d8(sp)
-               	sd	s0, 0x3d0(sp)
-               	addi	s0, sp, 0x3e0
-               	sd	s1, 0x3c8(sp)
-               	sd	s2, 0x3c0(sp)
-               	sd	s3, 0x3b8(sp)
-               	sd	s4, 0x3b0(sp)
-               	sd	s5, 0x3a8(sp)
-               	sd	s6, 0x3a0(sp)
-               	sd	s7, 0x398(sp)
-               	sd	s8, 0x390(sp)
-               	sd	s9, 0x388(sp)
-               	sd	s10, 0x380(sp)
-               	sd	s11, 0x378(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x74
-               	addi	s3, s0, -0x80
-               	addi	a1, s0, -0x8c
-               	addi	a1, s0, -0x98
-               	addi	s4, s0, -0xa4
-               	addi	a1, s0, -0xb0
-               	addi	a1, s0, -0xbc
-               	addi	s5, s0, -0xc8
-               	addi	a1, s0, -0xd4
-               	addi	a1, s0, -0xe0
-               	addi	a1, s0, -0xec
-               	addi	a1, s0, -0xf8
-               	addi	s6, s0, -0x104
-               	addi	a1, s0, -0x110
-               	addi	a1, s0, -0x11c
-               	addi	s7, s0, -0x128
-               	addi	a1, s0, -0x134
-               	addi	a1, s0, -0x140
-               	addi	s8, s0, -0x14c
-               	addi	a1, s0, -0x158
-               	addi	a1, s0, -0x164
-               	addi	s9, s0, -0x170
-               	addi	a1, s0, -0x17c
-               	addi	a1, s0, -0x188
-               	addi	s10, s0, -0x194
-               	addi	a1, s0, -0x1a0
-               	addi	a1, s0, -0x1ac
-               	addi	a1, s0, -0x1b8
-               	addi	s11, s0, -0x1c4
-               	addi	a1, s0, -0x1d0
-               	addi	a1, s0, -0x1dc
-               	addi	t2, s0, -0x1e8
-               	sd	t2, -0x3c0(s0)
-               	addi	a2, s0, -0x1f4
-               	addi	t2, s0, -0x200
-               	sd	t2, -0x3c8(s0)
-               	addi	t2, s0, -0x20c
-               	sd	t2, -0x3d0(s0)
-               	addi	t2, s0, -0x218
-               	sd	t2, -0x3d8(s0)
-               	addi	a5, s0, -0x224
-               	addi	a5, s0, -0x230
-               	addi	a5, s0, -0x23c
-               	addi	a5, s0, -0x248
-               	addi	a5, s0, -0x254
-               	addi	a5, s0, -0x260
-               	addi	a5, s0, -0x26c
-               	addi	a5, s0, -0x278
-               	addi	a5, s0, -0x284
-               	addi	a5, s0, -0x290
-               	addi	a5, s0, -0x29c
-               	addi	a5, s0, -0x2a8
-               	addi	a5, s0, -0x2b4
-               	addi	a5, s0, -0x2c0
-               	addi	a5, s0, -0x2cc
-               	addi	a5, s0, -0x2d8
-               	addi	a5, s0, -0x2e4
-               	addi	a5, s0, -0x2f0
-               	addi	a5, s0, -0x2fc
-               	addi	a5, s0, -0x308
-               	addi	a5, s0, -0x314
-               	addi	a5, s0, -0x320
-               	addi	a5, s0, -0x32c
-               	addi	a5, s0, -0x338
-               	addi	a5, s0, -0x344
-               	addi	a5, s0, -0x350
-               	addi	a5, s0, -0x35c
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x14c>
-               	fcvt.s.lu	ft0, s1
-               	addi	a5, s0, -0x368
-               	mv	a6, a5
+               	addi	sp, sp, -0x270
+               	sd	ra, 0x268(sp)
+               	sd	s0, 0x260(sp)
+               	addi	s0, sp, 0x270
+               	sd	s1, 0x258(sp)
+               	sd	s2, 0x250(sp)
+               	sd	s3, 0x248(sp)
+               	sd	s4, 0x240(sp)
+               	sd	s5, 0x238(sp)
+               	sd	s6, 0x230(sp)
+               	sd	s7, 0x228(sp)
+               	sd	s8, 0x220(sp)
+               	sd	s9, 0x218(sp)
+               	sd	s10, 0x210(sp)
+               	addi	a1, s0, -0x6c
+               	addi	a2, s0, -0x78
+               	addi	a3, s0, -0x84
+               	addi	a3, s0, -0x90
+               	addi	s1, s0, -0x9c
+               	addi	a3, s0, -0xa8
+               	addi	a3, s0, -0xb4
+               	addi	s2, s0, -0xc0
+               	addi	a3, s0, -0xcc
+               	addi	a3, s0, -0xd8
+               	addi	a3, s0, -0xe4
+               	addi	a3, s0, -0xf0
+               	addi	s3, s0, -0xfc
+               	addi	a3, s0, -0x108
+               	addi	a3, s0, -0x114
+               	addi	s4, s0, -0x120
+               	addi	a3, s0, -0x12c
+               	addi	a3, s0, -0x138
+               	addi	s5, s0, -0x144
+               	addi	a3, s0, -0x150
+               	addi	a3, s0, -0x15c
+               	addi	s6, s0, -0x168
+               	addi	a3, s0, -0x174
+               	addi	a3, s0, -0x180
+               	addi	s7, s0, -0x18c
+               	addi	a3, s0, -0x198
+               	addi	a3, s0, -0x1a4
+               	addi	a3, s0, -0x1b0
+               	addi	a3, s0, -0x1bc
+               	addi	a3, s0, -0x1c8
+               	addi	a3, s0, -0x1d4
+               	addi	a3, s0, -0x1e0
+               	addi	a3, s0, -0x1ec
+               	addi	s8, s0, -0x1f8
+               	addi	s9, s0, -0x204
+               	addi	s10, s0, -0x210
+               	fcvt.s.lu	ft0, a0
+               	addi	a0, s0, -0x230
+               	mv	a3, a0
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(a6)
+               	sw	t0, 0x0(a3)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	a6, a5, 0x4
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, a5, 0x8
+               	addi	a3, a0, 0x4
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a0, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(a6)
-               	mv	a6, a5
-               	flw	ft1, 0x0(a6)
-               	mv	a6, s2
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, a5, 0x4
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s2, 0x4
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, a5, 0x8
-               	flw	ft1, 0x0(a6)
-               	addi	a5, s2, 0x8
-               	fsw	ft1, 0x0(a5)
-               	addi	a5, s0, -0x374
-               	mv	a6, a5
+               	sw	t0, 0x0(a3)
+               	mv	a3, a0
+               	flw	ft1, 0x0(a3)
+               	mv	a3, a1
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a0, 0x4
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a0, 0x8
+               	flw	ft1, 0x0(a3)
+               	addi	a0, a1, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x23c
+               	mv	a3, a0
                	lui	t0, 0x3f000
-               	sw	t0, 0x0(a6)
-               	addi	a6, a5, 0x4
+               	sw	t0, 0x0(a3)
+               	addi	a3, a0, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(a6)
+               	sw	t0, 0x0(a3)
                	lui	t0, 0x3e000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	a6, a5, 0x8
-               	fsw	ft1, 0x0(a6)
-               	mv	a6, a5
-               	flw	ft1, 0x0(a6)
-               	mv	a6, s3
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, a5, 0x4
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s3, 0x4
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, a5, 0x8
-               	flw	ft1, 0x0(a6)
-               	addi	a5, s3, 0x8
-               	fsw	ft1, 0x0(a5)
-               	mv	a5, s2
-               	flw	ft1, 0x0(a5)
+               	addi	a3, a0, 0x8
+               	fsw	ft1, 0x0(a3)
+               	mv	a3, a0
+               	flw	ft1, 0x0(a3)
+               	mv	a3, a2
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a0, 0x4
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a0, 0x8
+               	flw	ft1, 0x0(a3)
+               	addi	a0, a2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	a5, s2
-               	flw	ft1, 0x0(a5)
-               	mv	a5, s4
-               	fsw	ft1, 0x0(a5)
-               	addi	a5, s2, 0x4
-               	flw	ft1, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	fsw	ft1, 0x0(a5)
-               	addi	a5, s2, 0x8
-               	flw	ft1, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	fsw	ft1, 0x0(a5)
-               	mv	a5, s4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s3, 0x8
-               	flw	ft1, 0x0(a5)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s1
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, s1
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a2, 0x8
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	a5, s3
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, s3, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, s3, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	mv	a0, a2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, a2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, a2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s1
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2ac>
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x238>
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2c0>
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2d4>
-               	mv	a5, s5
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2e8>
-               	addi	a5, s5, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2fc>
-               	addi	a5, s5, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x310>
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x244>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	mv	a5, s6
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
+               	mv	a1, s3
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	addi	a5, s6, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
+               	addi	a1, s3, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	addi	a5, s6, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s6
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	addi	a1, s3, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x378>
-               	addi	a5, s6, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x38c>
-               	addi	a5, s6, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x3a0>
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x2a4>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	mv	a5, s7
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
+               	mv	a1, s4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	addi	a5, s7, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
+               	addi	a1, s4, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	addi	a5, s7, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s7
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	addi	a1, s4, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x408>
-               	addi	a5, s7, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x41c>
-               	addi	a5, s7, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x430>
-               	mv	a5, s5
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s4
-               	flw	ft1, 0x0(a5)
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x304>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	mv	a5, s8
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft1, 0x0(a5)
+               	mv	a1, s5
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	addi	a5, s8, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft1, 0x0(a5)
+               	addi	a1, s5, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	addi	a5, s8, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	addi	a1, s5, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x498>
-               	addi	a5, s8, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x4ac>
-               	addi	a5, s8, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x4c0>
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x364>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	mv	a5, s9
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
+               	mv	a1, s6
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	addi	a5, s9, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
+               	addi	a1, s6, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	addi	a5, s9, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s9
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	addi	a1, s6, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x528>
-               	addi	a5, s9, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x53c>
-               	addi	a5, s9, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x550>
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x3c4>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	mv	a5, s10
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	addi	a5, s10, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
+               	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	addi	a5, s10, 0x8
-               	fsw	ft2, 0x0(a5)
-               	mv	a5, s10
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
+               	addi	a1, s7, 0x8
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x5b8>
-               	addi	a5, s10, 0x4
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x5cc>
-               	addi	a5, s10, 0x8
-               	flw	ft0, 0x0(a5)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x5e0>
-               	addi	s1, s0, -0x3b8
-               	mv	a5, s1
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x424>
+               	addi	s4, s0, -0x26c
+               	mv	a1, s4
                	li	t0, 0x7
-               	and	a6, a5, t0
-               	bnez	a6, 0x6a8 <corpus.cases.vec.vec_f32x3.checksum+0x61c>
-               	mv	a6, a5
-               	li	a7, 0x30
-               	sd	zero, 0x0(a6)
-               	addi	a6, a6, 0x8
-               	addi	a7, a7, -0x8
+               	and	a2, a1, t0
+               	bnez	a2, 0x594 <corpus.cases.vec.vec_f32x3.checksum+0x460>
+               	mv	a2, a1
+               	li	a3, 0x30
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a7, t0, 0x690 <corpus.cases.vec.vec_f32x3.checksum+0x604>
-               	j	0x6c4 <corpus.cases.vec.vec_f32x3.checksum+0x638>
-               	mv	a6, a5
-               	li	a5, 0x30
-               	sb	zero, 0x0(a6)
-               	addi	a6, a6, 0x1
-               	addi	a5, a5, -0x1
+               	bne	a3, t0, 0x57c <corpus.cases.vec.vec_f32x3.checksum+0x448>
+               	j	0x5b0 <corpus.cases.vec.vec_f32x3.checksum+0x47c>
+               	mv	a2, a1
+               	li	a1, 0x30
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a5, t0, 0x6b0 <corpus.cases.vec.vec_f32x3.checksum+0x624>
-               	mv	a5, s1
-               	mv	a6, s4
-               	flw	ft0, 0x0(a6)
-               	mv	a6, a5
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s4, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, a5, 0x4
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s4, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, a5, 0x8
-               	fsw	ft0, 0x0(a6)
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
-               	fadd.s	ft2, ft0, ft1
-               	mv	a5, s11
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a5, s11, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a5, s11, 0x8
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s1, 0xc
-               	mv	a6, s11
-               	flw	ft0, 0x0(a6)
-               	mv	a6, a5
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s11, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, a5, 0x4
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s11, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, a5, 0x8
-               	fsw	ft0, 0x0(a6)
-               	mv	a5, s4
-               	flw	ft0, 0x0(a5)
-               	mv	a5, s5
-               	flw	ft1, 0x0(a5)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x3c0(s0)
-               	mv	a5, t2
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft1, 0x0(a5)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x3c0(s0)
-               	addi	a5, t2, 0x4
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s4, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft1, 0x0(a5)
-               	fmul.s	ft2, ft0, ft1
-               	ld	t2, -0x3c0(s0)
-               	addi	a5, t2, 0x8
-               	fsw	ft2, 0x0(a5)
-               	addi	a5, s1, 0x18
-               	ld	t2, -0x3c0(s0)
-               	mv	a6, t2
-               	flw	ft0, 0x0(a6)
-               	mv	a6, a5
-               	fsw	ft0, 0x0(a6)
-               	ld	t2, -0x3c0(s0)
-               	addi	a6, t2, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, a5, 0x4
-               	fsw	ft0, 0x0(a6)
-               	ld	t2, -0x3c0(s0)
-               	addi	a6, t2, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a1, a5, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x24
-               	mv	a5, s5
-               	flw	ft0, 0x0(a5)
-               	mv	a5, a1
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x4
-               	flw	ft0, 0x0(a5)
-               	addi	a5, a1, 0x4
-               	fsw	ft0, 0x0(a5)
-               	addi	a5, s5, 0x8
-               	flw	ft0, 0x0(a5)
-               	addi	a5, a1, 0x8
-               	fsw	ft0, 0x0(a5)
-               	mv	s2, a0
-               	li	s3, 0x0
+               	bne	a1, t0, 0x59c <corpus.cases.vec.vec_f32x3.checksum+0x468>
+               	mv	a1, s4
+               	mv	a2, s1
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	mv	a2, s3
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s3, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s3, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s4, 0x18
+               	mv	a2, s6
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s6, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s6, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s4, 0x24
+               	mv	a2, s2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	mv	s1, a0
+               	li	s2, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x868 <corpus.cases.vec.vec_f32x3.checksum+0x7dc>
-               	j	0x90c <corpus.cases.vec.vec_f32x3.checksum+0x880>
+               	bltu	s2, t0, 0x694 <corpus.cases.vec.vec_f32x3.checksum+0x560>
+               	j	0x6f0 <corpus.cases.vec.vec_f32x3.checksum+0x5bc>
                	li	t0, 0xc
-               	mul	a0, s3, t0
-               	add	a1, s1, a0
+               	mul	a0, s2, t0
+               	add	a1, s4, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	ld	t2, -0x3c8(s0)
-               	mv	a0, t2
+               	mv	a0, s8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	ld	t2, -0x3c8(s0)
-               	addi	a0, t2, 0x4
+               	addi	a0, s8, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	ld	t2, -0x3c8(s0)
-               	addi	a0, t2, 0x8
+               	addi	a0, s8, 0x8
                	fsw	ft0, 0x0(a0)
-               	ld	t2, -0x3c8(s0)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	mv	a0, s1
+               	mv	a1, s8
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x838>
-               	ld	t2, -0x3c8(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x850>
-               	ld	t2, -0x3c8(s0)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x868>
-               	addi	s3, s3, 0x1
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x5a4>
+               	addi	s2, s2, 0x1
+               	mv	s1, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x868 <corpus.cases.vec.vec_f32x3.checksum+0x7dc>
-               	addi	s3, s0, -0x388
-               	mv	a0, s3
+               	bltu	s2, t0, 0x694 <corpus.cases.vec.vec_f32x3.checksum+0x560>
+               	addi	s2, s0, -0x224
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x944 <corpus.cases.vec.vec_f32x3.checksum+0x8b8>
+               	bnez	a1, 0x728 <corpus.cases.vec.vec_f32x3.checksum+0x5f4>
                	mv	a1, a0
                	li	a2, 0x10
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x928 <corpus.cases.vec.vec_f32x3.checksum+0x89c>
+               	bne	a2, t0, 0x70c <corpus.cases.vec.vec_f32x3.checksum+0x5d8>
                	sw	zero, 0x0(a1)
-               	j	0x960 <corpus.cases.vec.vec_f32x3.checksum+0x8d4>
+               	j	0x744 <corpus.cases.vec.vec_f32x3.checksum+0x610>
                	mv	a1, a0
                	li	a0, 0x14
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x94c <corpus.cases.vec.vec_f32x3.checksum+0x8c0>
-               	mv	a0, s3
+               	bne	a0, t0, 0x730 <corpus.cases.vec.vec_f32x3.checksum+0x5fc>
+               	mv	a0, s2
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s1, 0x18
+               	addi	a1, s4, 0x18
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3d0(s0)
-               	mv	a2, t2
+               	mv	a2, s9
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3d0(s0)
-               	addi	a2, t2, 0x4
+               	addi	a2, s9, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	ld	t2, -0x3d0(s0)
-               	addi	a1, t2, 0x8
+               	addi	a1, s9, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	s1, s3, 0x4
-               	ld	t2, -0x3d0(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3d0(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3d0(s0)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
+               	addi	a1, s2, 0x4
+               	mv	a2, s9
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s9, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s9, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s2, 0x10
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x980>
-               	mv	a1, s1
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7ec <corpus.cases.vec.vec_f32x3.checksum+0x6b8>
+               	j	0x820 <corpus.cases.vec.vec_f32x3.checksum+0x6ec>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s1, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s1, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x7ec <corpus.cases.vec.vec_f32x3.checksum+0x6b8>
+               	addi	a0, s2, 0x4
+               	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	ld	t2, -0x3d8(s0)
-               	mv	a1, t2
+               	mv	a1, s10
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
+               	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	ld	t2, -0x3d8(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s10, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
+               	addi	a1, a0, 0x8
                	flw	ft0, 0x0(a1)
-               	ld	t2, -0x3d8(s0)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	ld	t2, -0x3d8(s0)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	addi	a0, s10, 0x8
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s1
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x9d4>
-               	ld	t2, -0x3d8(s0)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x9ec>
-               	ld	t2, -0x3d8(s0)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0xa04>
-               	addi	a1, s3, 0x10
+               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0x728>
+               	addi	a1, s2, 0x10
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x3.checksum+0xa18>
-               	ld	s1, 0x3c8(sp)
-               	ld	s2, 0x3c0(sp)
-               	ld	s3, 0x3b8(sp)
-               	ld	s4, 0x3b0(sp)
-               	ld	s5, 0x3a8(sp)
-               	ld	s6, 0x3a0(sp)
-               	ld	s7, 0x398(sp)
-               	ld	s8, 0x390(sp)
-               	ld	s9, 0x388(sp)
-               	ld	s10, 0x380(sp)
-               	ld	s11, 0x378(sp)
-               	ld	ra, 0x3d8(sp)
-               	ld	s0, 0x3d0(sp)
-               	addi	sp, sp, 0x3e0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x884 <corpus.cases.vec.vec_f32x3.checksum+0x750>
+               	j	0x8b8 <corpus.cases.vec.vec_f32x3.checksum+0x784>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x884 <corpus.cases.vec.vec_f32x3.checksum+0x750>
+               	ld	s1, 0x258(sp)
+               	ld	s2, 0x250(sp)
+               	ld	s3, 0x248(sp)
+               	ld	s4, 0x240(sp)
+               	ld	s5, 0x238(sp)
+               	ld	s6, 0x230(sp)
+               	ld	s7, 0x228(sp)
+               	ld	s8, 0x220(sp)
+               	ld	s9, 0x218(sp)
+               	ld	s10, 0x210(sp)
+               	ld	ra, 0x268(sp)
+               	ld	s0, 0x260(sp)
+               	addi	sp, sp, 0x270
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f32x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_f32x4.dis
@@ -3,1177 +3,691 @@ vec/vec_f32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x4.fold_vec>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.fold_vec+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.fold_vec+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.vec.vec_f32x4.fold_vec+0x44>
+               	j	0x78 <corpus.cases.vec.vec_f32x4.fold_vec+0x78>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.vec.vec_f32x4.fold_vec+0x44>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.fold_vec+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.vec.vec_f32x4.fold_vec+0x9c>
+               	j	0xd0 <corpus.cases.vec.vec_f32x4.fold_vec+0xd0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.vec.vec_f32x4.fold_vec+0x9c>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.fold_vec+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.vec.vec_f32x4.fold_vec+0xf4>
+               	j	0x128 <corpus.cases.vec.vec_f32x4.fold_vec+0x128>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.vec.vec_f32x4.fold_vec+0xf4>
+               	addi	a2, a1, 0xc
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.vec.vec_f32x4.fold_vec+0x14c>
+               	j	0x180 <corpus.cases.vec.vec_f32x4.fold_vec+0x180>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.vec.vec_f32x4.fold_vec+0x14c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_f32x4.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x620
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x628
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x630
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x620
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x638
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x640
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x648
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x650
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x658
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x660
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	s5, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	s6, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	s7, s0, -0x128
-               	addi	a1, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	s8, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	s9, s0, -0x1a8
-               	addi	a1, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	s10, s0, -0x1d8
-               	addi	a1, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	s11, s0, -0x208
-               	addi	a1, s0, -0x218
-               	addi	a1, s0, -0x228
-               	addi	t2, s0, -0x238
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a2, s0, -0x248
-               	addi	a2, s0, -0x258
-               	addi	t2, s0, -0x268
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a3, s0, -0x278
-               	addi	a3, s0, -0x288
-               	addi	t2, s0, -0x298
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a4, s0, -0x2a8
-               	addi	a4, s0, -0x2b8
-               	addi	t2, s0, -0x2c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	sp, sp, -0x5c0
+               	sd	ra, 0x5b8(sp)
+               	sd	s0, 0x5b0(sp)
+               	addi	s0, sp, 0x5c0
+               	sd	s1, 0x5a8(sp)
+               	sd	s2, 0x5a0(sp)
+               	sd	s3, 0x598(sp)
+               	sd	s4, 0x590(sp)
+               	sd	s5, 0x588(sp)
+               	sd	s6, 0x580(sp)
+               	sd	s7, 0x578(sp)
+               	sd	s8, 0x570(sp)
+               	sd	s9, 0x568(sp)
+               	sd	s10, 0x560(sp)
+               	sd	s11, 0x558(sp)
+               	mv	t2, a0
+               	sd	t2, -0x560(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x590(s0)
+               	addi	s1, s0, -0x98
+               	addi	a3, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a4, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	s2, s0, -0xf8
+               	addi	a4, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	a5, s0, -0x138
+               	addi	a5, s0, -0x148
+               	addi	s3, s0, -0x158
+               	addi	a5, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	s4, s0, -0x1a8
+               	addi	a5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	s5, s0, -0x1d8
+               	addi	a5, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	s6, s0, -0x208
+               	addi	a5, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	s7, s0, -0x238
+               	addi	a5, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	s8, s0, -0x268
+               	addi	a5, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	s9, s0, -0x298
+               	addi	a5, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	s10, s0, -0x2c8
                	addi	a5, s0, -0x2d8
                	addi	a5, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x308
-               	addi	a6, s0, -0x318
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
                	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x598(s0)
                	addi	t2, s0, -0x338
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x348
-               	addi	t5, s0, -0x358
+               	sd	t2, -0x5a0(s0)
+               	addi	a7, s0, -0x348
+               	addi	a7, s0, -0x358
                	addi	t2, s0, -0x368
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x378
-               	addi	t6, s0, -0x388
-               	addi	t6, s0, -0x398
+               	sd	t2, -0x5a8(s0)
+               	addi	t5, s0, -0x378
+               	addi	t5, s0, -0x388
+               	addi	t5, s0, -0x398
                	addi	t2, s0, -0x3a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x3b8
-               	addi	a7, s0, -0x3c8
-               	addi	a7, s0, -0x3d8
+               	sd	t2, -0x5b0(s0)
+               	addi	t6, s0, -0x3b8
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
                	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x3f8
-               	addi	t6, s0, -0x408
-               	addi	t6, s0, -0x418
-               	addi	t6, s0, -0x428
+               	sd	t2, -0x5b8(s0)
+               	addi	a0, s0, -0x3f8
+               	addi	a0, s0, -0x408
+               	addi	a0, s0, -0x418
+               	addi	a0, s0, -0x428
                	addi	t2, s0, -0x438
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x448
-               	addi	t6, s0, -0x458
+               	sd	t2, -0x568(s0)
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
                	addi	t2, s0, -0x468
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x478
+               	sd	t2, -0x570(s0)
+               	addi	a0, s0, -0x478
                	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x578(s0)
                	addi	t2, s0, -0x498
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x580(s0)
                	addi	t2, s0, -0x4a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x4b8
-               	addi	t6, s0, -0x4c8
-               	addi	t6, s0, -0x4d8
-               	addi	t6, s0, -0x4e8
-               	addi	t6, s0, -0x4f8
-               	addi	t6, s0, -0x508
-               	addi	t6, s0, -0x518
-               	addi	t6, s0, -0x528
-               	addi	t6, s0, -0x538
-               	addi	t6, s0, -0x548
-               	addi	t6, s0, -0x558
-               	addi	t6, s0, -0x568
-               	addi	t6, s0, -0x578
-               	addi	t6, s0, -0x588
-               	addi	t6, s0, -0x598
-               	addi	t6, s0, -0x5a8
-               	addi	t6, s0, -0x5b8
-               	addi	t6, s0, -0x5c8
-               	addi	t6, s0, -0x5d8
-               	addi	t6, s0, -0x5e8
-               	addi	t6, s0, -0x5f8
-               	addi	t6, s0, -0x608
-               	addi	t6, s0, -0x618
-               	addi	t6, s0, -0x628
-               	addi	t6, s0, -0x638
-               	addi	t6, s0, -0x648
-               	addi	t6, s0, -0x658
-               	addi	t6, s0, -0x668
-               	addi	t6, s0, -0x678
-               	addi	t6, s0, -0x688
-               	addi	t6, s0, -0x698
-               	addi	t6, s0, -0x6a8
-               	addi	t6, s0, -0x6b8
-               	addi	t6, s0, -0x6c8
-               	addi	t6, s0, -0x6d8
-               	addi	t6, s0, -0x6e8
-               	addi	t6, s0, -0x6f8
-               	addi	t6, s0, -0x708
-               	addi	t6, s0, -0x718
-               	addi	t6, s0, -0x728
-               	addi	t6, s0, -0x738
-               	addi	t6, s0, -0x748
-               	addi	t6, s0, -0x758
-               	addi	t6, s0, -0x768
-               	addi	t6, s0, -0x778
-               	addi	t6, s0, -0x788
-               	addi	t6, s0, -0x798
-               	addi	t6, s0, -0x7a8
-               	addi	t6, s0, -0x7b8
-               	addi	t6, s0, -0x7c8
-               	addi	t6, s0, -0x7d8
-               	addi	t6, s0, -0x7e8
-               	addi	t6, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	t6, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x444>
-               	fcvt.s.lu	ft0, s1
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	sd	t2, -0x588(s0)
+               	ld	t2, -0x560(s0)
+               	fcvt.s.lu	ft0, t2
+               	addi	a0, s0, -0x528
+               	mv	a2, a0
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	addi	a2, a0, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0xc
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s2, 0xc
-               	fsw	ft1, 0x0(t6)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	addi	a2, a0, 0xc
+               	fsw	ft1, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	addi	a0, a1, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x538
+               	mv	a2, a0
                	lui	t0, 0x3f000
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x3e000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
+               	addi	a2, a0, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x41000
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s3, 0xc
-               	fsw	ft1, 0x0(t6)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x590(s0)
+               	mv	a2, t2
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x590(s0)
+               	addi	a2, t2, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x590(s0)
+               	addi	a2, t2, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x548
+               	mv	a2, a0
                	lui	t0, 0x3f800
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x40400
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x41100
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x41d80
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s4, 0xc
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, s1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	addi	a0, s1, 0xc
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0xc
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0xc
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s5
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s6
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s3, 0x4
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a3
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s3
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s7
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0xc
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s7, 0x8
-               	flw	ft1, 0x0(t6)
+               	ld	t2, -0x590(s0)
+               	mv	a0, t2
+               	flw	ft1, 0x0(a0)
+               	mv	a0, a4
+               	fsw	ft1, 0x0(a0)
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a4, 0x4
+               	fsw	ft1, 0x0(a0)
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a4, 0x8
+               	fsw	ft1, 0x0(a0)
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a4, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a4, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a4, 0x8
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s7
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	mv	a0, a4
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, a4, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, a4, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, a4, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x738>
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x494>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x74c>
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x4a0>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	mv	a1, s4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x760>
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x51c>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s5
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x774>
-               	mv	t6, s8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x598>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s6
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x614>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x690>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x70c>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s9
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s9
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x788>
-               	addi	t6, s8, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x79c>
-               	addi	t6, s8, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x7b0>
-               	addi	t6, s8, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x7c4>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	mv	t6, s9
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0xc
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s9
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x848>
-               	addi	t6, s9, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x85c>
-               	addi	t6, s9, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x870>
-               	addi	t6, s9, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x884>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	t6, s10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0xc
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x908>
-               	addi	t6, s10, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x91c>
-               	addi	t6, s10, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x930>
-               	addi	t6, s10, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x944>
-               	mv	t6, s8
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	t6, s11
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0xc
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s11
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x9c8>
-               	addi	t6, s11, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x9dc>
-               	addi	t6, s11, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x9f0>
-               	addi	t6, s11, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xa04>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	t6, t2
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0xc
-               	fsw	ft2, 0x0(t6)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	t6, t2
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xad8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xafc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xb20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xb44>
-               	mv	a1, s6
+               	mv	a1, s2
                	flw	ft0, 0x0(a1)
-               	mv	a1, s8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xc18>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xc3c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xc60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xc84>
-               	mv	a1, s8
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s6
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xd58>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xd7c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xda0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xdc4>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
+               	mv	a1, s1
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s10, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s1, 0x8
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s10, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0xc
+               	addi	a1, s1, 0xc
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s10, 0xc
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xe98>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x804>
+               	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xebc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xee0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xf04>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s8
+               	mv	a1, s3
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s11
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s11, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s11, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
+               	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s11, 0xc
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xfd8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x880>
+               	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xffc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1020>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1044>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s2
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s2, 0x8
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
+               	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s2, 0xc
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1118>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x113c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1160>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1184>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x910>
+               	addi	a1, s0, -0x558
                	mv	a2, a1
                	sw	zero, 0x0(a2)
                	addi	a2, a1, 0x4
@@ -1184,511 +698,173 @@ Disassembly of section .text:
                	sw	zero, 0x0(a2)
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	mv	s4, a0
+               	ld	t2, -0x5a0(s0)
+               	mv	s5, t2
+               	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x130c <corpus.cases.vec.vec_f32x4.checksum+0x1260>
-               	j	0x1748 <corpus.cases.vec.vec_f32x4.checksum+0x169c>
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
+               	bltu	s6, t0, 0xb38 <corpus.cases.vec.vec_f32x4.checksum+0x9a8>
+               	j	0xd1c <corpus.cases.vec.vec_f32x4.checksum+0xb8c>
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
                	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x5a8(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1330>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xa34>
+               	mv	a1, s5
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1354>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1378>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x139c>
-               	mv	a1, s2
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a8(s0)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5b0(s0)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x5b0(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x5b0(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x5b0(s0)
+               	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x5b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xad4>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x5b8(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x5b8(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x5b8(s0)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x5b8(s0)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5b8(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x14b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x14d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x14f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x151c>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x15f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1614>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1638>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x165c>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s6, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xb64>
+               	addi	s6, s6, 0x1
+               	mv	s4, a0
+               	ld	t2, -0x5b8(s0)
                	mv	s2, t2
+               	ld	t2, -0x5b0(s0)
+               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x130c <corpus.cases.vec.vec_f32x4.checksum+0x1260>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s6, t0, 0xb38 <corpus.cases.vec.vec_f32x4.checksum+0x9a8>
+               	addi	s6, s0, -0x4e8
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1784 <corpus.cases.vec.vec_f32x4.checksum+0x16d8>
+               	bnez	a1, 0xd50 <corpus.cases.vec.vec_f32x4.checksum+0xbc0>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x176c <corpus.cases.vec.vec_f32x4.checksum+0x16c0>
-               	j	0x17a0 <corpus.cases.vec.vec_f32x4.checksum+0x16f4>
+               	bne	a2, t0, 0xd38 <corpus.cases.vec.vec_f32x4.checksum+0xba8>
+               	j	0xd6c <corpus.cases.vec.vec_f32x4.checksum+0xbdc>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x178c <corpus.cases.vec.vec_f32x4.checksum+0x16e0>
-               	mv	a0, s3
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
+               	bne	a0, t0, 0xd58 <corpus.cases.vec.vec_f32x4.checksum+0xbc8>
                	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x4
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0xc
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x30
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
@@ -1705,313 +881,315 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	li	s2, 0x0
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x568(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x568(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x568(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x568(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x10
+               	ld	t2, -0x568(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x568(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x568(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x568(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s1
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x570(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x570(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x570(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x570(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x20
+               	ld	t2, -0x570(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x570(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x570(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x570(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, s6, 0x30
+               	mv	a1, s5
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1aa0 <corpus.cases.vec.vec_f32x4.checksum+0x19f4>
-               	j	0x1bd0 <corpus.cases.vec.vec_f32x4.checksum+0x1b24>
+               	bltu	s1, t0, 0xfac <corpus.cases.vec.vec_f32x4.checksum+0xe1c>
+               	j	0x102c <corpus.cases.vec.vec_f32x4.checksum+0xe9c>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s6, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x578(s0)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x578(s0)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x578(s0)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0xc
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x578(s0)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	mv	a0, s4
+               	ld	t2, -0x578(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1aa0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1ac4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1ae8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1b0c>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0xe84>
+               	addi	s1, s1, 0x1
+               	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x1aa0 <corpus.cases.vec.vec_f32x4.checksum+0x19f4>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0xfac <corpus.cases.vec.vec_f32x4.checksum+0xe1c>
+               	addi	s1, s0, -0x518
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1c0c <corpus.cases.vec.vec_f32x4.checksum+0x1b60>
+               	bnez	a1, 0x1060 <corpus.cases.vec.vec_f32x4.checksum+0xed0>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1bf4 <corpus.cases.vec.vec_f32x4.checksum+0x1b48>
-               	j	0x1c28 <corpus.cases.vec.vec_f32x4.checksum+0x1b7c>
+               	bne	a2, t0, 0x1048 <corpus.cases.vec.vec_f32x4.checksum+0xeb8>
+               	j	0x107c <corpus.cases.vec.vec_f32x4.checksum+0xeec>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1c14 <corpus.cases.vec.vec_f32x4.checksum+0x1b68>
-               	mv	a0, s2
+               	bne	a0, t0, 0x1068 <corpus.cases.vec.vec_f32x4.checksum+0xed8>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s6, 0x20
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x580(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x580(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x580(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x580(s0)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s3
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x580(s0)
+               	mv	a2, t2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x580(s0)
+               	addi	a2, t2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x580(s0)
+               	addi	a2, t2, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x580(s0)
+               	addi	a2, t2, 0xc
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1cb0>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1164 <corpus.cases.vec.vec_f32x4.checksum+0xfd4>
+               	j	0x1198 <corpus.cases.vec.vec_f32x4.checksum+0x1008>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1164 <corpus.cases.vec.vec_f32x4.checksum+0xfd4>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x588(s0)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x588(s0)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x588(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
+               	addi	a1, a0, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x588(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x588(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1d54>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1d78>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1d9c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1dc0>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1068>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x4.checksum+0x1dd4>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x638
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x640
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x648
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x650
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x658
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x660
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x628
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x630
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x620
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1220 <corpus.cases.vec.vec_f32x4.checksum+0x1090>
+               	j	0x1254 <corpus.cases.vec.vec_f32x4.checksum+0x10c4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1220 <corpus.cases.vec.vec_f32x4.checksum+0x1090>
+               	ld	s1, 0x5a8(sp)
+               	ld	s2, 0x5a0(sp)
+               	ld	s3, 0x598(sp)
+               	ld	s4, 0x590(sp)
+               	ld	s5, 0x588(sp)
+               	ld	s6, 0x580(sp)
+               	ld	s7, 0x578(sp)
+               	ld	s8, 0x570(sp)
+               	ld	s9, 0x568(sp)
+               	ld	s10, 0x560(sp)
+               	ld	s11, 0x558(sp)
+               	ld	ra, 0x5b8(sp)
+               	ld	s0, 0x5b0(sp)
+               	addi	sp, sp, 0x5c0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f32x5.dis
+++ b/test/golden/riscv64-linux/vec/vec_f32x5.dis
@@ -3,1424 +3,796 @@ vec/vec_f32x5.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x5.fold_vec>:
-               	addi	sp, sp, -0x90
-               	sd	ra, 0x88(sp)
-               	sd	s0, 0x80(sp)
-               	addi	s0, sp, 0x90
-               	sd	s1, 0x78(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x2c
-               	addi	a1, s0, -0x40
-               	addi	a1, s0, -0x54
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x7c
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.fold_vec+0x40>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x80
+               	sd	ra, 0x78(sp)
+               	sd	s0, 0x70(sp)
+               	addi	s0, sp, 0x80
+               	addi	a2, s0, -0x24
+               	addi	a2, s0, -0x38
+               	addi	a2, s0, -0x4c
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x74
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.fold_vec+0x5c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.vec.vec_f32x5.fold_vec+0x48>
+               	j	0x7c <corpus.cases.vec.vec_f32x5.fold_vec+0x7c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x48 <corpus.cases.vec.vec_f32x5.fold_vec+0x48>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.fold_vec+0x78>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa0 <corpus.cases.vec.vec_f32x5.fold_vec+0xa0>
+               	j	0xd4 <corpus.cases.vec.vec_f32x5.fold_vec+0xd4>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xa0 <corpus.cases.vec.vec_f32x5.fold_vec+0xa0>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.fold_vec+0x94>
-               	mv	a1, a0
-               	addi	a2, s1, 0x10
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8 <corpus.cases.vec.vec_f32x5.fold_vec+0xf8>
+               	j	0x12c <corpus.cases.vec.vec_f32x5.fold_vec+0x12c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8 <corpus.cases.vec.vec_f32x5.fold_vec+0xf8>
+               	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.fold_vec+0xb0>
-               	ld	s1, 0x78(sp)
-               	ld	ra, 0x88(sp)
-               	ld	s0, 0x80(sp)
-               	addi	sp, sp, 0x90
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x150 <corpus.cases.vec.vec_f32x5.fold_vec+0x150>
+               	j	0x184 <corpus.cases.vec.vec_f32x5.fold_vec+0x184>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x150 <corpus.cases.vec.vec_f32x5.fold_vec+0x150>
+               	addi	a2, a1, 0x10
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a8 <corpus.cases.vec.vec_f32x5.fold_vec+0x1a8>
+               	j	0x1dc <corpus.cases.vec.vec_f32x5.fold_vec+0x1dc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1a8 <corpus.cases.vec.vec_f32x5.fold_vec+0x1a8>
+               	ld	ra, 0x78(sp)
+               	ld	s0, 0x70(sp)
+               	addi	sp, sp, 0x80
                	ret
 
 <corpus.cases.vec.vec_f32x5.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x270
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x270
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b0
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b8
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2c0
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2c8
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d0
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d8
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x7c
-               	addi	s3, s0, -0x90
-               	addi	s4, s0, -0xa4
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xcc
-               	addi	s5, s0, -0xe0
-               	addi	a1, s0, -0xf4
-               	addi	a1, s0, -0x108
-               	addi	s6, s0, -0x11c
-               	addi	a1, s0, -0x130
-               	addi	a1, s0, -0x144
-               	addi	s7, s0, -0x158
-               	addi	a1, s0, -0x16c
-               	addi	a1, s0, -0x180
-               	addi	a1, s0, -0x194
-               	addi	a1, s0, -0x1a8
-               	addi	s8, s0, -0x1bc
-               	addi	a1, s0, -0x1d0
-               	addi	a1, s0, -0x1e4
-               	addi	s9, s0, -0x1f8
-               	addi	a1, s0, -0x20c
-               	addi	a1, s0, -0x220
-               	addi	s10, s0, -0x234
-               	addi	a1, s0, -0x248
-               	addi	a1, s0, -0x25c
-               	addi	s11, s0, -0x270
-               	addi	a1, s0, -0x284
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2ac
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a2, s0, -0x2c0
-               	addi	a2, s0, -0x2d4
-               	addi	t2, s0, -0x2e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a3, s0, -0x2fc
-               	addi	a3, s0, -0x310
-               	addi	t2, s0, -0x324
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	sp, sp, -0x740
+               	sd	ra, 0x738(sp)
+               	sd	s0, 0x730(sp)
+               	addi	s0, sp, 0x740
+               	sd	s1, 0x728(sp)
+               	sd	s2, 0x720(sp)
+               	sd	s3, 0x718(sp)
+               	sd	s4, 0x710(sp)
+               	sd	s5, 0x708(sp)
+               	sd	s6, 0x700(sp)
+               	sd	s7, 0x6f8(sp)
+               	sd	s8, 0x6f0(sp)
+               	sd	s9, 0x6e8(sp)
+               	sd	s10, 0x6e0(sp)
+               	sd	s11, 0x6d8(sp)
+               	mv	t2, a0
+               	sd	t2, -0x6d0(s0)
+               	addi	a1, s0, -0x7c
+               	addi	t2, s0, -0x90
+               	sd	t2, -0x700(s0)
+               	addi	s1, s0, -0xa4
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xcc
+               	addi	a3, s0, -0xe0
+               	addi	a4, s0, -0xf4
+               	addi	a4, s0, -0x108
+               	addi	s2, s0, -0x11c
+               	addi	a4, s0, -0x130
+               	addi	a4, s0, -0x144
+               	addi	s3, s0, -0x158
+               	addi	a4, s0, -0x16c
+               	addi	a4, s0, -0x180
+               	addi	a4, s0, -0x194
+               	addi	a4, s0, -0x1a8
+               	addi	s4, s0, -0x1bc
+               	addi	a4, s0, -0x1d0
+               	addi	a4, s0, -0x1e4
+               	addi	s5, s0, -0x1f8
+               	addi	a4, s0, -0x20c
+               	addi	a4, s0, -0x220
+               	addi	s6, s0, -0x234
+               	addi	a4, s0, -0x248
+               	addi	a4, s0, -0x25c
+               	addi	s7, s0, -0x270
+               	addi	a4, s0, -0x284
+               	addi	a4, s0, -0x298
+               	addi	s8, s0, -0x2ac
+               	addi	a4, s0, -0x2c0
+               	addi	a4, s0, -0x2d4
+               	addi	s9, s0, -0x2e8
+               	addi	a4, s0, -0x2fc
+               	addi	a4, s0, -0x310
+               	addi	s10, s0, -0x324
                	addi	a4, s0, -0x338
                	addi	a4, s0, -0x34c
-               	addi	t2, s0, -0x360
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a5, s0, -0x374
-               	addi	a5, s0, -0x388
+               	addi	s11, s0, -0x360
+               	addi	a4, s0, -0x374
+               	addi	a4, s0, -0x388
                	addi	t2, s0, -0x39c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x708(s0)
                	addi	t2, s0, -0x3b0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x3c4
-               	addi	a7, s0, -0x3d8
+               	sd	t2, -0x710(s0)
+               	addi	a6, s0, -0x3c4
+               	addi	a6, s0, -0x3d8
                	addi	t2, s0, -0x3ec
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x400
-               	addi	t5, s0, -0x414
-               	addi	t5, s0, -0x428
+               	sd	t2, -0x718(s0)
+               	addi	a7, s0, -0x400
+               	addi	a7, s0, -0x414
+               	addi	a7, s0, -0x428
                	addi	t2, s0, -0x43c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x450
-               	addi	t6, s0, -0x464
-               	addi	t6, s0, -0x478
+               	sd	t2, -0x720(s0)
+               	addi	t5, s0, -0x450
+               	addi	t5, s0, -0x464
+               	addi	t5, s0, -0x478
                	addi	t2, s0, -0x48c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x4a0
-               	addi	a6, s0, -0x4b4
-               	addi	a6, s0, -0x4c8
-               	addi	a6, s0, -0x4dc
+               	sd	t2, -0x728(s0)
+               	addi	t6, s0, -0x4a0
+               	addi	t6, s0, -0x4b4
+               	addi	t6, s0, -0x4c8
+               	addi	t6, s0, -0x4dc
                	addi	t2, s0, -0x4f0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x504
-               	addi	a6, s0, -0x518
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x504
+               	addi	a0, s0, -0x518
                	addi	t2, s0, -0x52c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x540
-               	addi	a6, s0, -0x554
-               	addi	a6, s0, -0x568
+               	sd	t2, -0x6d8(s0)
+               	addi	a0, s0, -0x540
+               	addi	a0, s0, -0x554
+               	addi	a0, s0, -0x568
                	addi	t2, s0, -0x57c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x590
+               	sd	t2, -0x6e0(s0)
+               	addi	a0, s0, -0x590
                	addi	t2, s0, -0x5a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x6e8(s0)
                	addi	t2, s0, -0x5b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x6f0(s0)
                	addi	t2, s0, -0x5cc
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x5e0
-               	addi	a6, s0, -0x5f4
-               	addi	a6, s0, -0x608
-               	addi	a6, s0, -0x61c
-               	addi	a6, s0, -0x630
-               	addi	a6, s0, -0x644
-               	addi	a6, s0, -0x658
-               	addi	a6, s0, -0x66c
-               	addi	a6, s0, -0x680
-               	addi	a6, s0, -0x694
-               	addi	a6, s0, -0x6a8
-               	addi	a6, s0, -0x6bc
-               	addi	a6, s0, -0x6d0
-               	addi	a6, s0, -0x6e4
-               	addi	a6, s0, -0x6f8
-               	addi	a6, s0, -0x70c
-               	addi	a6, s0, -0x720
-               	addi	a6, s0, -0x734
-               	addi	a6, s0, -0x748
-               	addi	a6, s0, -0x75c
-               	addi	a6, s0, -0x770
-               	addi	a6, s0, -0x784
-               	addi	a6, s0, -0x798
-               	addi	a6, s0, -0x7ac
-               	addi	a6, s0, -0x7c0
-               	addi	a6, s0, -0x7d4
-               	addi	a6, s0, -0x7e8
-               	addi	a6, s0, -0x7fc
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f0
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7dc
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b4
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a0
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x78c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x764
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x750
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x73c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x714
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x700
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6ec
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c4
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b0
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x69c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x674
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x660
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x64c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x624
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x610
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5fc
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d4
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c0
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5ac
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x584
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x570
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x55c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x534
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x520
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x50c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e4
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d0
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4bc
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x494
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x480
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x46c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x444
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x430
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x41c
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	a6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f4
-               	add	a6, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x5d0>
-               	fcvt.s.lu	ft0, s1
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e0
-               	add	a6, s0, t0
-               	mv	s1, a6
+               	sd	t2, -0x6f8(s0)
+               	ld	t2, -0x6d0(s0)
+               	fcvt.s.lu	ft0, t2
+               	addi	a0, s0, -0x68c
+               	mv	a2, a0
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, a6, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x8
+               	addi	a2, a0, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, a6, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x10
+               	addi	a2, a0, 0xc
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x10
                	lui	t0, 0x40c80
-               	sw	t0, 0x0(s1)
-               	mv	s1, a6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	a6, s2, 0x10
-               	fsw	ft1, 0x0(a6)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3cc
-               	add	a6, s0, t0
-               	mv	s1, a6
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x10
+               	flw	ft1, 0x0(a2)
+               	addi	a0, a1, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x6a0
+               	mv	a2, a0
                	lui	t0, 0x3f000
-               	sw	t0, 0x0(s1)
-               	addi	s1, a6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x3e000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, a6, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0xc
+               	addi	a2, a0, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x41000
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a2)
                	lui	t0, 0x40000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, a6, 0x10
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, a6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	a6, s3, 0x10
-               	fsw	ft1, 0x0(a6)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
-               	add	a6, s0, t0
-               	mv	s1, a6
+               	addi	a2, a0, 0x10
+               	fsw	ft1, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x700(s0)
+               	mv	a2, t2
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x700(s0)
+               	addi	a2, t2, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x700(s0)
+               	addi	a2, t2, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x700(s0)
+               	addi	a2, t2, 0xc
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x10
+               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s0, -0x6b4
+               	mv	a2, a0
                	lui	t0, 0x3f800
-               	sw	t0, 0x0(s1)
-               	addi	s1, a6, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x40400
-               	sw	t0, 0x0(s1)
-               	addi	s1, a6, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x41100
-               	sw	t0, 0x0(s1)
-               	addi	s1, a6, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x41d80
-               	sw	t0, 0x0(s1)
-               	addi	s1, a6, 0x10
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x10
                	lui	t0, 0x42a20
-               	sw	t0, 0x0(s1)
-               	mv	s1, a6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, a6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	a6, s4, 0x10
-               	fsw	ft1, 0x0(a6)
-               	mv	a6, s2
-               	flw	ft1, 0x0(a6)
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	flw	ft1, 0x0(a2)
+               	mv	a2, s1
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	flw	ft1, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	flw	ft1, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	flw	ft1, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	fsw	ft1, 0x0(a2)
+               	addi	a2, a0, 0x10
+               	flw	ft1, 0x0(a2)
+               	addi	a0, s1, 0x10
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	a6, s2
-               	flw	ft1, 0x0(a6)
-               	mv	a6, s5
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s2, 0x4
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x4
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s2, 0x8
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x8
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s2, 0xc
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s5, 0xc
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s2, 0x10
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x10
-               	fsw	ft1, 0x0(a6)
-               	mv	a6, s5
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s5, 0x10
-               	flw	ft1, 0x0(a6)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x10
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x10
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a3, 0x10
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	a6, s5
-               	flw	ft1, 0x0(a6)
-               	mv	a6, s6
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x4
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x8
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s5, 0xc
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s5, 0x10
-               	flw	ft1, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	fsw	ft1, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s3, 0x8
-               	flw	ft1, 0x0(a6)
+               	mv	a0, a3
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x10
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0x8
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	a6, s3
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s7
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s3, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s3, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s3, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s3, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	fsw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	fsw	ft2, 0x0(a6)
-               	mv	a6, s6
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
+               	ld	t2, -0x700(s0)
+               	mv	a0, t2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x700(s0)
+               	addi	a0, t2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x10
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x8fc>
-               	addi	a6, s6, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x4dc>
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x4e8>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	mv	a1, s4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	addi	a1, s4, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x580>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s5
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s5, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x618>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s6
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s6, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x6b0>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x748>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x7e0>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s9
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x878>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x10
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x910>
-               	addi	a6, s6, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x924>
-               	addi	a6, s6, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x938>
-               	addi	a6, s6, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x94c>
-               	mv	a6, s7
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x960>
-               	addi	a6, s7, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x974>
-               	addi	a6, s7, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x988>
-               	addi	a6, s7, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x99c>
-               	addi	a6, s7, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x9b0>
-               	mv	a6, s6
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s7
-               	flw	ft1, 0x0(a6)
-               	fadd.s	ft2, ft0, ft1
-               	mv	a6, s8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	flw	ft1, 0x0(a6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a6, s8, 0x4
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	flw	ft1, 0x0(a6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a6, s8, 0x8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	flw	ft1, 0x0(a6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a6, s8, 0xc
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	flw	ft1, 0x0(a6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	a6, s8, 0x10
-               	fsw	ft2, 0x0(a6)
-               	mv	a6, s8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xa50>
-               	addi	a6, s8, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xa64>
-               	addi	a6, s8, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xa78>
-               	addi	a6, s8, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xa8c>
-               	addi	a6, s8, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xaa0>
-               	mv	a6, s6
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s7
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	a6, s9
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s9, 0x4
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s9, 0x8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s9, 0xc
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s9, 0x10
-               	fsw	ft2, 0x0(a6)
-               	mv	a6, s9
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xb40>
-               	addi	a6, s9, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xb54>
-               	addi	a6, s9, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xb68>
-               	addi	a6, s9, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xb7c>
-               	addi	a6, s9, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xb90>
-               	mv	a6, s7
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s6
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	a6, s10
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s10, 0x4
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s10, 0x8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s10, 0xc
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	flw	ft1, 0x0(a6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	a6, s10, 0x10
-               	fsw	ft2, 0x0(a6)
-               	mv	a6, s10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc30>
-               	addi	a6, s10, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc44>
-               	addi	a6, s10, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc58>
-               	addi	a6, s10, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc6c>
-               	addi	a6, s10, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc80>
-               	mv	a6, s6
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s7
-               	flw	ft1, 0x0(a6)
-               	fmul.s	ft2, ft0, ft1
-               	mv	a6, s11
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	flw	ft1, 0x0(a6)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a6, s11, 0x4
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	flw	ft1, 0x0(a6)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a6, s11, 0x8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	flw	ft1, 0x0(a6)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a6, s11, 0xc
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	flw	ft1, 0x0(a6)
-               	fmul.s	ft2, ft0, ft1
-               	addi	a6, s11, 0x10
-               	fsw	ft2, 0x0(a6)
-               	mv	a6, s11
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd20>
-               	addi	a6, s11, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd34>
-               	addi	a6, s11, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd48>
-               	addi	a6, s11, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd5c>
-               	addi	a6, s11, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd70>
-               	mv	a6, s6
-               	flw	ft0, 0x0(a6)
-               	mv	a6, s7
-               	flw	ft1, 0x0(a6)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a6, t2
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x4
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x4
-               	flw	ft1, 0x0(a6)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x4
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x8
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x8
-               	flw	ft1, 0x0(a6)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x8
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0xc
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0xc
-               	flw	ft1, 0x0(a6)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0xc
-               	fsw	ft2, 0x0(a6)
-               	addi	a6, s6, 0x10
-               	flw	ft0, 0x0(a6)
-               	addi	a6, s7, 0x10
-               	flw	ft1, 0x0(a6)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x10
-               	fsw	ft2, 0x0(a6)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a6, t2
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xe70>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x4
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xe94>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x8
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xeb8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0xc
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xedc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a6, t2, 0x10
-               	flw	ft0, 0x0(a6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xf00>
-               	mv	a1, s7
+               	mv	a1, s1
                	flw	ft0, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s11
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x10
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x9a8>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s2, 0x8
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s2, 0xc
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s7, 0x10
+               	addi	a1, s1, 0x10
                	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x10
+               	addi	a1, s2, 0x10
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a1, t2, 0x10
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1000>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1024>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1048>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x106c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1090>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x10
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1190>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x11b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x11d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x11fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1220>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s7
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x10
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1320>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1344>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1368>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x138c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x298
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x13b0>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s6
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x14b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x14d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x14f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x151c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x290
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1540>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2f4
-               	add	a1, s0, t0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xa58>
+               	addi	a1, s0, -0x6c8
                	mv	a2, a1
                	sw	zero, 0x0(a2)
                	addi	a2, a1, 0x4
@@ -1433,625 +805,203 @@ Disassembly of section .text:
                	sw	zero, 0x0(a2)
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	mv	s4, a0
+               	ld	t2, -0x710(s0)
+               	mv	s5, t2
+               	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1710 <corpus.cases.vec.vec_f32x5.checksum+0x1644>
-               	j	0x1c4c <corpus.cases.vec.vec_f32x5.checksum+0x1b80>
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x10
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
+               	bltu	s6, t0, 0xcf8 <corpus.cases.vec.vec_f32x5.checksum+0xb0c>
+               	j	0xf40 <corpus.cases.vec.vec_f32x5.checksum+0xd54>
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
                	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x718(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x10
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x718(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1740>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xbb8>
+               	mv	a1, s5
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1764>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1788>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x17ac>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x17d0>
-               	mv	a1, s2
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x718(s0)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x720(s0)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x10
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x10
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x720(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xc7c>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x728(s0)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x728(s0)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x728(s0)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x728(s0)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x10
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x288
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
+               	addi	a1, s3, 0x10
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x728(s0)
                	addi	a1, t2, 0x10
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x728(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1920>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1944>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1968>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x198c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x19b0>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s7
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x10
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1ab0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1ad4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1af8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1b1c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1b40>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x278
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s6, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x280
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0xd2c>
+               	addi	s6, s6, 0x1
+               	mv	s4, a0
+               	ld	t2, -0x728(s0)
                	mv	s2, t2
+               	ld	t2, -0x720(s0)
+               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1710 <corpus.cases.vec.vec_f32x5.checksum+0x1644>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s6, t0, 0xcf8 <corpus.cases.vec.vec_f32x5.checksum+0xb0c>
+               	addi	s6, s0, -0x648
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1c88 <corpus.cases.vec.vec_f32x5.checksum+0x1bbc>
+               	bnez	a1, 0xf74 <corpus.cases.vec.vec_f32x5.checksum+0xd88>
                	mv	a1, a0
                	li	a2, 0x78
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1c70 <corpus.cases.vec.vec_f32x5.checksum+0x1ba4>
-               	j	0x1ca4 <corpus.cases.vec.vec_f32x5.checksum+0x1bd8>
+               	bne	a2, t0, 0xf5c <corpus.cases.vec.vec_f32x5.checksum+0xd70>
+               	j	0xf90 <corpus.cases.vec.vec_f32x5.checksum+0xda4>
                	mv	a1, a0
                	li	a0, 0x78
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1c90 <corpus.cases.vec.vec_f32x5.checksum+0x1bc4>
-               	mv	a0, s3
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
+               	bne	a0, t0, 0xf7c <corpus.cases.vec.vec_f32x5.checksum+0xd90>
                	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0xc
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x10
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x14
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x10
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x28
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x3c
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
@@ -2072,480 +1022,452 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x10
                	fsw	ft0, 0x0(a1)
-               	mv	a0, s7
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
-               	mv	a0, s6
+               	mv	a0, s3
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x730(s0)
                	mv	a0, t2
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x4
+               	addi	a0, s2, 0x4
                	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x4
+               	addi	a0, s3, 0x4
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x730(s0)
                	addi	a0, t2, 0x4
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x8
+               	addi	a0, s2, 0x8
                	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x8
+               	addi	a0, s3, 0x8
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x730(s0)
                	addi	a0, t2, 0x8
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0xc
+               	addi	a0, s2, 0xc
                	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0xc
+               	addi	a0, s3, 0xc
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x730(s0)
                	addi	a0, t2, 0xc
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s7, 0x10
+               	addi	a0, s2, 0x10
                	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x10
+               	addi	a0, s3, 0x10
                	flw	ft1, 0x0(a0)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x730(s0)
                	addi	a0, t2, 0x10
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x50
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a0, s6, 0x14
+               	ld	t2, -0x730(s0)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	addi	a1, t2, 0x10
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x10
                	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x64
-               	mv	a1, s7
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s1
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x6d8(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x6d8(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x6d8(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x6d8(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x10
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x6d8(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x28
+               	ld	t2, -0x6d8(s0)
+               	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	ld	t2, -0x6d8(s0)
+               	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	ld	t2, -0x6d8(s0)
+               	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	ld	t2, -0x6d8(s0)
+               	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0xc
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s7, 0x10
+               	ld	t2, -0x6d8(s0)
+               	addi	a1, t2, 0x10
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x10
                	fsw	ft0, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s6, 0x3c
+               	mv	a1, s5
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	mv	a0, s3
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s2
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x6e0(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x6e0(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x6e0(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x6e0(s0)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s3, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	flw	ft1, 0x0(a0)
+               	fsub.s	ft2, ft0, ft1
+               	ld	t2, -0x6e0(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x50
+               	ld	t2, -0x6e0(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x6e0(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x6e0(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x6e0(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x6e0(s0)
+               	addi	a1, t2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, s6, 0x64
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2230 <corpus.cases.vec.vec_f32x5.checksum+0x2164>
-               	j	0x23a4 <corpus.cases.vec.vec_f32x5.checksum+0x22d8>
+               	bltu	s1, t0, 0x13b4 <corpus.cases.vec.vec_f32x5.checksum+0x11c8>
+               	j	0x1448 <corpus.cases.vec.vec_f32x5.checksum+0x125c>
                	li	t0, 0x14
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s6, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6e8(s0)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6e8(s0)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6e8(s0)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0xc
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6e8(s0)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x10
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6e8(s0)
                	addi	a0, t2, 0x10
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	mv	a0, s4
+               	ld	t2, -0x6e8(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x2230>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x2254>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x2278>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x229c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x22c0>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1244>
+               	addi	s1, s1, 0x1
+               	mv	s4, a0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x2230 <corpus.cases.vec.vec_f32x5.checksum+0x2164>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x308
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0x13b4 <corpus.cases.vec.vec_f32x5.checksum+0x11c8>
+               	addi	s1, s0, -0x678
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x23e0 <corpus.cases.vec.vec_f32x5.checksum+0x2314>
+               	bnez	a1, 0x147c <corpus.cases.vec.vec_f32x5.checksum+0x1290>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x23c8 <corpus.cases.vec.vec_f32x5.checksum+0x22fc>
-               	j	0x23fc <corpus.cases.vec.vec_f32x5.checksum+0x2330>
+               	bne	a2, t0, 0x1464 <corpus.cases.vec.vec_f32x5.checksum+0x1278>
+               	j	0x1498 <corpus.cases.vec.vec_f32x5.checksum+0x12ac>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x23e8 <corpus.cases.vec.vec_f32x5.checksum+0x231c>
-               	mv	a0, s2
+               	bne	a0, t0, 0x1484 <corpus.cases.vec.vec_f32x5.checksum+0x1298>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x28
+               	addi	a1, s6, 0x28
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f0(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f0(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f0(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f0(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f0(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s3
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s2, 0x24
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x6f0(s0)
+               	mv	a2, t2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x6f0(s0)
+               	addi	a2, t2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x6f0(s0)
+               	addi	a2, t2, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x6f0(s0)
+               	addi	a2, t2, 0xc
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x6f0(s0)
+               	addi	a2, t2, 0x10
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s1, 0x24
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x24a4>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15a8 <corpus.cases.vec.vec_f32x5.checksum+0x13bc>
+               	j	0x15dc <corpus.cases.vec.vec_f32x5.checksum+0x13f0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15a8 <corpus.cases.vec.vec_f32x5.checksum+0x13bc>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f8(s0)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f8(s0)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f8(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
+               	addi	a1, a0, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f8(s0)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
+               	addi	a1, a0, 0x10
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6f8(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x6f8(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x2568>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x258c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x25b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x25d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x25f8>
-               	addi	a1, s2, 0x24
+               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x1464>
+               	addi	a1, s1, 0x24
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x5.checksum+0x260c>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x288
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x290
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x298
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a0
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2a8
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b0
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2b8
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2c0
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2c8
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d0
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d8
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x278
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x280
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x270
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1678 <corpus.cases.vec.vec_f32x5.checksum+0x148c>
+               	j	0x16ac <corpus.cases.vec.vec_f32x5.checksum+0x14c0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1678 <corpus.cases.vec.vec_f32x5.checksum+0x148c>
+               	ld	s1, 0x728(sp)
+               	ld	s2, 0x720(sp)
+               	ld	s3, 0x718(sp)
+               	ld	s4, 0x710(sp)
+               	ld	s5, 0x708(sp)
+               	ld	s6, 0x700(sp)
+               	ld	s7, 0x6f8(sp)
+               	ld	s8, 0x6f0(sp)
+               	ld	s9, 0x6e8(sp)
+               	ld	s10, 0x6e0(sp)
+               	ld	s11, 0x6d8(sp)
+               	ld	ra, 0x738(sp)
+               	ld	s0, 0x730(sp)
+               	addi	sp, sp, 0x740
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f32x8.dis
+++ b/test/golden/riscv64-linux/vec/vec_f32x8.dis
@@ -3,2341 +3,1389 @@ vec/vec_f32x8.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f32x8.fold_vec>:
-               	addi	sp, sp, -0x120
-               	sd	ra, 0x118(sp)
-               	sd	s0, 0x110(sp)
-               	addi	s0, sp, 0x120
-               	sd	s1, 0x108(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x118
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0x4c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x110
+               	sd	ra, 0x108(sp)
+               	sd	s0, 0x100(sp)
+               	addi	s0, sp, 0x110
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x90
+               	addi	a2, s0, -0xb0
+               	addi	a2, s0, -0xd0
+               	addi	a2, s0, -0xf0
+               	addi	a2, s0, -0x110
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0x68>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x54 <corpus.cases.vec.vec_f32x8.fold_vec+0x54>
+               	j	0x88 <corpus.cases.vec.vec_f32x8.fold_vec+0x88>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x54 <corpus.cases.vec.vec_f32x8.fold_vec+0x54>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0x84>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xac <corpus.cases.vec.vec_f32x8.fold_vec+0xac>
+               	j	0xe0 <corpus.cases.vec.vec_f32x8.fold_vec+0xe0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xac <corpus.cases.vec.vec_f32x8.fold_vec+0xac>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0xa0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x10
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.vec.vec_f32x8.fold_vec+0x104>
+               	j	0x138 <corpus.cases.vec.vec_f32x8.fold_vec+0x138>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x104 <corpus.cases.vec.vec_f32x8.fold_vec+0x104>
+               	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0xbc>
-               	mv	a1, a0
-               	addi	a2, s1, 0x14
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x15c <corpus.cases.vec.vec_f32x8.fold_vec+0x15c>
+               	j	0x190 <corpus.cases.vec.vec_f32x8.fold_vec+0x190>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x15c <corpus.cases.vec.vec_f32x8.fold_vec+0x15c>
+               	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0xd8>
-               	mv	a1, a0
-               	addi	a2, s1, 0x18
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b4 <corpus.cases.vec.vec_f32x8.fold_vec+0x1b4>
+               	j	0x1e8 <corpus.cases.vec.vec_f32x8.fold_vec+0x1e8>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1b4 <corpus.cases.vec.vec_f32x8.fold_vec+0x1b4>
+               	addi	a2, a1, 0x14
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0xf4>
-               	mv	a1, a0
-               	addi	a2, s1, 0x1c
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20c <corpus.cases.vec.vec_f32x8.fold_vec+0x20c>
+               	j	0x240 <corpus.cases.vec.vec_f32x8.fold_vec+0x240>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x20c <corpus.cases.vec.vec_f32x8.fold_vec+0x20c>
+               	addi	a2, a1, 0x18
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.fold_vec+0x110>
-               	ld	s1, 0x108(sp)
-               	ld	ra, 0x118(sp)
-               	ld	s0, 0x110(sp)
-               	addi	sp, sp, 0x120
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x264 <corpus.cases.vec.vec_f32x8.fold_vec+0x264>
+               	j	0x298 <corpus.cases.vec.vec_f32x8.fold_vec+0x298>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x264 <corpus.cases.vec.vec_f32x8.fold_vec+0x264>
+               	addi	a2, a1, 0x1c
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2bc <corpus.cases.vec.vec_f32x8.fold_vec+0x2bc>
+               	j	0x2f0 <corpus.cases.vec.vec_f32x8.fold_vec+0x2f0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2bc <corpus.cases.vec.vec_f32x8.fold_vec+0x2bc>
+               	ld	ra, 0x108(sp)
+               	ld	s0, 0x100(sp)
+               	addi	sp, sp, 0x110
                	ret
 
 <corpus.cases.vec.vec_f32x8.checksum>:
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x550
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x570
                	sub	sp, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x558
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x560
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x550
-               	add	s0, sp, t0
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x568
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x570
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x2
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x578
                	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	ra, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x580
                	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x570
+               	add	s0, sp, t0
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x588
                	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s1, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x590
                	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s2, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x598
                	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s3, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5a0
                	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s4, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5a8
                	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s5, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5b0
                	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x2
+               	sd	s6, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5b8
                	add	t1, sp, t1
+               	sd	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5c0
+               	add	t1, sp, t1
+               	sd	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5c8
+               	add	t1, sp, t1
+               	sd	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5d0
+               	add	t1, sp, t1
+               	sd	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5d8
+               	add	t1, sp, t1
                	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x88
-               	addi	s3, s0, -0xa8
-               	addi	s4, s0, -0xc8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0x108
-               	addi	s5, s0, -0x128
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x168
-               	addi	s6, s0, -0x188
-               	addi	a1, s0, -0x1a8
-               	addi	a1, s0, -0x1c8
-               	addi	s7, s0, -0x1e8
-               	addi	a1, s0, -0x208
-               	addi	a1, s0, -0x228
-               	addi	s8, s0, -0x248
-               	addi	a1, s0, -0x268
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x2a8
-               	addi	a1, s0, -0x2c8
-               	addi	s9, s0, -0x2e8
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x328
-               	addi	s10, s0, -0x348
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x388
-               	addi	s11, s0, -0x3a8
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3e8
-               	addi	t2, s0, -0x408
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a2, s0, -0x428
-               	addi	a2, s0, -0x448
-               	addi	t2, s0, -0x468
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a3, s0, -0x488
-               	addi	a3, s0, -0x4a8
-               	addi	t2, s0, -0x4c8
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a4, s0, -0x4e8
-               	addi	a4, s0, -0x508
-               	addi	t2, s0, -0x528
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a5, s0, -0x548
-               	addi	a5, s0, -0x568
-               	addi	t2, s0, -0x588
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x5a8
-               	addi	a6, s0, -0x5c8
-               	addi	t2, s0, -0x5e8
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x608
-               	lui	t1, 0xffffe
+               	mv	t2, a0
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x628
-               	addi	t5, s0, -0x648
+               	addi	a1, s0, -0x88
+               	addi	a2, s0, -0xa8
+               	addi	s1, s0, -0xc8
+               	addi	a3, s0, -0xe8
+               	addi	a3, s0, -0x108
+               	addi	a3, s0, -0x128
+               	addi	a4, s0, -0x148
+               	addi	a4, s0, -0x168
+               	addi	s2, s0, -0x188
+               	addi	a4, s0, -0x1a8
+               	addi	a4, s0, -0x1c8
+               	addi	t2, s0, -0x1e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a5, s0, -0x208
+               	addi	a5, s0, -0x228
+               	addi	s3, s0, -0x248
+               	addi	a5, s0, -0x268
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x2a8
+               	addi	a5, s0, -0x2c8
+               	addi	s4, s0, -0x2e8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x328
+               	addi	s5, s0, -0x348
+               	addi	a5, s0, -0x368
+               	addi	a5, s0, -0x388
+               	addi	s6, s0, -0x3a8
+               	addi	a5, s0, -0x3c8
+               	addi	a5, s0, -0x3e8
+               	addi	s7, s0, -0x408
+               	addi	a5, s0, -0x428
+               	addi	a5, s0, -0x448
+               	addi	s8, s0, -0x468
+               	addi	a5, s0, -0x488
+               	addi	a5, s0, -0x4a8
+               	addi	s9, s0, -0x4c8
+               	addi	a5, s0, -0x4e8
+               	addi	a5, s0, -0x508
+               	addi	s10, s0, -0x528
+               	addi	a5, s0, -0x548
+               	addi	a5, s0, -0x568
+               	addi	s11, s0, -0x588
+               	addi	a5, s0, -0x5a8
+               	addi	a5, s0, -0x5c8
+               	addi	t2, s0, -0x5e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x608
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x628
+               	addi	a7, s0, -0x648
                	addi	t2, s0, -0x668
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x688
-               	addi	t6, s0, -0x6a8
-               	addi	t6, s0, -0x6c8
+               	addi	t5, s0, -0x688
+               	addi	t5, s0, -0x6a8
+               	addi	t5, s0, -0x6c8
                	addi	t2, s0, -0x6e8
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a7, s0, -0x708
-               	addi	a7, s0, -0x728
-               	addi	a7, s0, -0x748
+               	addi	t6, s0, -0x708
+               	addi	t6, s0, -0x728
+               	addi	t6, s0, -0x748
                	addi	t2, s0, -0x768
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t6, s0, -0x788
-               	addi	t6, s0, -0x7a8
-               	addi	t6, s0, -0x7c8
-               	addi	t6, s0, -0x7e8
+               	addi	a0, s0, -0x788
+               	addi	a0, s0, -0x7a8
+               	addi	a0, s0, -0x7c8
+               	addi	a0, s0, -0x7e8
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7f8
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7d8
-               	add	t6, s0, t0
+               	add	a0, s0, t0
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x7b8
-               	add	t6, s0, t0
+               	add	a0, s0, t0
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x798
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x778
-               	add	t6, s0, t0
+               	add	a0, s0, t0
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x758
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x738
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x718
                	add	t2, s0, t0
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	t6, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	fcvt.s.lu	ft0, t2
                	lui	t0, 0xfffff
                	addiw	t0, t0, 0x638
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x398
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x378
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x358
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x318
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x298
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x278
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x258
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x238
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x218
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1f8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1d8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1b8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x198
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x138
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xf8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xd8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xb8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x98
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x78
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x58
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x38
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x18
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x28
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x48
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x68
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x88
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xa8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xc8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xe8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x108
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x128
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x148
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x168
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x188
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x208
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x228
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x248
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x268
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x288
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x308
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x328
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x348
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x368
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x388
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x3e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x408
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x428
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x448
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x468
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x488
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x4e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x508
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x528
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x548
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x568
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x588
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x5e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x608
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x628
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x648
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x668
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x688
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x6e8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x708
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x728
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x748
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x768
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x788
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x7a8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x7c8
-               	add	t6, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x7e8
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x7f8
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x7d8
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x7b8
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x798
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x778
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x758
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x738
-               	add	t6, s0, t0
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x718
-               	add	t6, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x92c>
-               	fcvt.s.lu	ft0, s1
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x6f8
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	add	a0, s0, t0
+               	mv	a4, a0
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	addi	a4, a0, 0x4
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x10
+               	addi	a4, a0, 0xc
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x10
                	lui	t0, 0x40c80
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x41020
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x14
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x18
+               	addi	a4, a0, 0x14
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x18
                	lui	t0, 0x3f400
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x41800
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x1c
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x10
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x14
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x14
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x18
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x18
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x1c
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s2, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x6d8
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	addi	a4, a0, 0x1c
+               	fsw	ft1, 0x0(a4)
+               	mv	a4, a0
+               	flw	ft1, 0x0(a4)
+               	mv	a4, a1
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x4
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0x4
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x8
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0x8
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0xc
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0xc
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x10
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0x10
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x14
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0x14
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x18
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a1, 0x18
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x1c
+               	flw	ft1, 0x0(a4)
+               	addi	a0, a1, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x618
+               	add	a0, s0, t0
+               	mv	a4, a0
                	lui	t0, 0x3f000
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x3e000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
+               	addi	a4, a0, 0x8
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0xc
                	lui	t0, 0x41000
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x40000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x10
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x14
+               	addi	a4, a0, 0x10
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x14
                	lui	t0, 0x3fa00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a4)
                	lui	t0, 0x42000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	addi	s1, t6, 0x18
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x1c
+               	addi	a4, a0, 0x18
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x1c
                	lui	t0, 0x3d800
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x10
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x14
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x14
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x18
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x18
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x1c
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s3, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x6b8
-               	add	t6, s0, t0
-               	mv	s1, t6
+               	sw	t0, 0x0(a4)
+               	mv	a4, a0
+               	flw	ft1, 0x0(a4)
+               	mv	a4, a2
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x4
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0x4
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x8
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0x8
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0xc
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0xc
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x10
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0x10
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x14
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0x14
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x18
+               	flw	ft1, 0x0(a4)
+               	addi	a4, a2, 0x18
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x1c
+               	flw	ft1, 0x0(a4)
+               	addi	a0, a2, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5f8
+               	add	a0, s0, t0
+               	mv	a4, a0
                	lui	t0, 0x3f800
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x4
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
                	lui	t0, 0x40400
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x8
                	lui	t0, 0x41100
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0xc
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0xc
                	lui	t0, 0x41d80
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x10
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x10
                	lui	t0, 0x42a20
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x14
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x14
                	lui	t0, 0x43730
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x18
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x18
                	lui	t0, 0x44364
-               	sw	t0, 0x0(s1)
-               	addi	s1, t6, 0x1c
+               	sw	t0, 0x0(a4)
+               	addi	a4, a0, 0x1c
                	lui	t0, 0x4508b
-               	sw	t0, 0x0(s1)
-               	mv	s1, t6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x10
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x10
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x14
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x14
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x18
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x18
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, t6, 0x1c
-               	flw	ft1, 0x0(s1)
-               	addi	t6, s4, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
+               	sw	t0, 0x0(a4)
+               	mv	a4, a0
+               	flw	ft1, 0x0(a4)
+               	mv	a4, s1
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x4
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0x4
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x8
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0x8
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0xc
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0xc
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x10
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0x10
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x14
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0x14
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x18
+               	flw	ft1, 0x0(a4)
+               	addi	a4, s1, 0x18
+               	fsw	ft1, 0x0(a4)
+               	addi	a4, a0, 0x1c
+               	flw	ft1, 0x0(a4)
+               	addi	a0, s1, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s2
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0xc
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x10
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x10
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x14
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x14
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x18
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x18
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s2, 0x1c
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s5, 0x1c
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x10
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x14
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x14
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x18
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x18
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x1c
+               	flw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a3
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a3, 0x1c
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s5
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s6
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x10
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x10
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x14
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x14
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x18
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x18
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s5, 0x1c
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s3, 0xc
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a3
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x10
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x14
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x14
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x18
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x18
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a3, 0x1c
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x1c
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, a2, 0xc
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s3
-               	flw	ft1, 0x0(t6)
-               	mv	t6, s7
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x4
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x4
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x8
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x8
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0xc
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0xc
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x10
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x10
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x14
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x14
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x18
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x18
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s3, 0x1c
-               	flw	ft1, 0x0(t6)
-               	addi	t6, s7, 0x1c
-               	fsw	ft1, 0x0(t6)
-               	addi	t6, s7, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s7, 0x10
-               	flw	ft1, 0x0(t6)
+               	mv	a0, a2
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x4
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x8
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0xc
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x10
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x14
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x14
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x18
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x18
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a2, 0x1c
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x1c
+               	fsw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft1, ft0
-               	mv	t6, s7
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x10
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x14
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x14
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x18
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x18
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s7, 0x1c
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x1c
-               	fsw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x10
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x14
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x14
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x18
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x18
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x1c
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x1c
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x10
+               	fsw	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xe90>
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x9a0>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xea4>
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xeb8>
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xecc>
-               	addi	t6, s6, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xee0>
-               	addi	t6, s6, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xef4>
-               	addi	t6, s6, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf08>
-               	addi	t6, s6, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf1c>
-               	mv	t6, s8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf30>
-               	addi	t6, s8, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf44>
-               	addi	t6, s8, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf58>
-               	addi	t6, s8, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf6c>
-               	addi	t6, s8, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf80>
-               	addi	t6, s8, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf94>
-               	addi	t6, s8, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xfa8>
-               	addi	t6, s8, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xfbc>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x9ac>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	mv	t6, s9
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x10
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x14
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x14
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x14
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x18
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x18
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x18
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x1c
-               	flw	ft1, 0x0(t6)
-               	fadd.s	ft2, ft0, ft1
-               	addi	t6, s9, 0x1c
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s9
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x10b0>
-               	addi	t6, s9, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x10c4>
-               	addi	t6, s9, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x10d8>
-               	addi	t6, s9, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x10ec>
-               	addi	t6, s9, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1100>
-               	addi	t6, s9, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1114>
-               	addi	t6, s9, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1128>
-               	addi	t6, s9, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x113c>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	t6, s10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x10
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x14
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x14
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x14
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x18
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x18
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x18
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x1c
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s10, 0x1c
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1230>
-               	addi	t6, s10, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1244>
-               	addi	t6, s10, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1258>
-               	addi	t6, s10, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x126c>
-               	addi	t6, s10, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1280>
-               	addi	t6, s10, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1294>
-               	addi	t6, s10, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x12a8>
-               	addi	t6, s10, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x12bc>
-               	mv	t6, s8
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s6
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	mv	t6, s11
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x10
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x14
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x14
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x14
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x18
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x18
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x18
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s8, 0x1c
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	flw	ft1, 0x0(t6)
-               	fsub.s	ft2, ft0, ft1
-               	addi	t6, s11, 0x1c
-               	fsw	ft2, 0x0(t6)
-               	mv	t6, s11
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x13b0>
-               	addi	t6, s11, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x13c4>
-               	addi	t6, s11, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x13d8>
-               	addi	t6, s11, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x13ec>
-               	addi	t6, s11, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1400>
-               	addi	t6, s11, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1414>
-               	addi	t6, s11, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1428>
-               	addi	t6, s11, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x143c>
-               	mv	t6, s6
-               	flw	ft0, 0x0(t6)
-               	mv	t6, s8
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	t6, t2
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x4
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x4
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x4
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x8
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x8
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0xc
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0xc
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0xc
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x10
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x10
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x10
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x14
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x14
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x14
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x18
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x18
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x18
-               	fsw	ft2, 0x0(t6)
-               	addi	t6, s6, 0x1c
-               	flw	ft0, 0x0(t6)
-               	addi	t6, s8, 0x1c
-               	flw	ft1, 0x0(t6)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x1c
-               	fsw	ft2, 0x0(t6)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	t6, t2
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x15c0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x4
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x15e4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x8
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1608>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0xc
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x162c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x10
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1650>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x14
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1674>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x18
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1698>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x598
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	t6, t2, 0x1c
-               	flw	ft0, 0x0(t6)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x16bc>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x10
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x14
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x18
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x1c
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1840>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1864>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1888>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x18ac>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x18d0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x18f4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1918>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x193c>
-               	mv	a1, s8
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s6
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x14
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x18
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s8, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x1c
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1ac0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1ae4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1b08>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1b2c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1b50>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1b74>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1b98>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x588
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1bbc>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
                	mv	a1, s4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x8
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0xc
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x10
+               	addi	a1, s2, 0x10
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x10
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x14
+               	addi	a1, s2, 0x14
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x14
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x14
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x18
+               	addi	a1, s2, 0x18
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x18
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x18
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x1c
+               	addi	a1, s2, 0x1c
                	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
                	addi	a1, s4, 0x1c
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1d40>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1d64>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1d88>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1dac>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1dd0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1df4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1e18>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x580
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1e3c>
                	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xa98>
+               	mv	a1, s2
                	flw	ft0, 0x0(a1)
-               	mv	a1, s8
+               	mv	a1, s3
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s5
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s5, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s5, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
+               	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s5, 0xc
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x10
+               	addi	a1, s2, 0x10
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x10
+               	addi	a1, s3, 0x10
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
+               	addi	a1, s5, 0x10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x14
+               	addi	a1, s2, 0x14
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x14
+               	addi	a1, s3, 0x14
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
+               	addi	a1, s5, 0x14
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x18
+               	addi	a1, s2, 0x18
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x18
+               	addi	a1, s3, 0x18
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
+               	addi	a1, s5, 0x18
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x1c
+               	addi	a1, s2, 0x1c
                	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x1c
+               	addi	a1, s3, 0x1c
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
+               	addi	a1, s5, 0x1c
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1fc0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xb84>
+               	mv	a1, s3
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1fe4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2008>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x202c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2050>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2074>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2098>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x20bc>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	mv	a1, s6
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x4
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x8
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0xc
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x10
+               	addi	a1, s3, 0x10
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x10
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x14
+               	addi	a1, s3, 0x14
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x14
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x14
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x18
+               	addi	a1, s3, 0x18
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x18
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x18
-               	flw	ft1, 0x0(a1)
-               	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
                	fsw	ft2, 0x0(a1)
-               	addi	a1, s4, 0x1c
+               	addi	a1, s3, 0x1c
                	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
                	addi	a1, s6, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xc70>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s7
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x14
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x18
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s7, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xd5c>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
                	flw	ft1, 0x0(a1)
                	fdiv.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
+               	mv	a1, s8
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x14
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x18
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xe48>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	mv	a1, s9
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x14
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x18
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	addi	a1, s9, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0xf34>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x10
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x14
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x18
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s10, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1020>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s11
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x14
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x18
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	addi	a1, s11, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x110c>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2240>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2264>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2288>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x10
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x22ac>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x14
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x22d0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x14
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x18
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x22f4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x18
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s1, 0x1c
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2318>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x570
+               	addi	a1, s2, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fdiv.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x233c>
-               	lui	t0, 0xffffe
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1288>
+               	lui	t0, 0xfffff
                	addiw	t0, t0, 0x5d8
                	add	a1, s0, t0
                	mv	a2, a1
@@ -2358,967 +1406,433 @@ Disassembly of section .text:
                	sw	zero, 0x0(a2)
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x10
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x14
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x14
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x18
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x18
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x1c
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1c
                	fsw	ft0, 0x0(a1)
-               	mv	s1, a0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5d0
+               	mv	s4, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	mv	s5, t2
+               	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x25e4 <corpus.cases.vec.vec_f32x8.checksum+0x24b8>
-               	j	0x2e20 <corpus.cases.vec.vec_f32x8.checksum+0x2cf4>
-               	mv	a0, s6
+               	bltu	s6, t0, 0x1704 <corpus.cases.vec.vec_f32x8.checksum+0x1404>
+               	j	0x1c34 <corpus.cases.vec.vec_f32x8.checksum+0x1934>
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
-               	mv	a0, s4
+               	mv	a0, s1
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
+               	addi	a0, s2, 0x4
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
+               	addi	a0, s1, 0x4
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
+               	addi	a0, s2, 0x8
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
+               	addi	a0, s1, 0x8
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
+               	addi	a0, s2, 0xc
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
+               	addi	a0, s1, 0xc
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
+               	addi	a0, s2, 0x10
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x10
+               	addi	a0, s1, 0x10
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x10
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x14
+               	addi	a0, s2, 0x14
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x14
+               	addi	a0, s1, 0x14
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x14
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x18
+               	addi	a0, s2, 0x18
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x18
+               	addi	a0, s1, 0x18
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x18
                	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x1c
+               	addi	a0, s2, 0x1c
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x1c
+               	addi	a0, s1, 0x1c
                	flw	ft1, 0x0(a0)
                	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x1c
                	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	mv	a0, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2638>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x157c>
+               	mv	a1, s5
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x265c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2680>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x26a4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x26c8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x26ec>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2710>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2734>
-               	mv	a1, s2
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x10
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x10
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x10
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x14
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x14
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x14
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x18
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x18
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x18
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s5, 0x1c
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1c
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1c
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x1778>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x10
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
+               	addi	a1, s3, 0x10
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x10
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x14
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
+               	addi	a1, s3, 0x14
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x14
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x18
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
+               	addi	a1, s3, 0x18
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x18
                	fsw	ft2, 0x0(a1)
                	addi	a1, s2, 0x1c
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x568
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
+               	addi	a1, s3, 0x1c
                	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	fsub.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1c
                	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2938>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x295c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2980>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x29a4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x29c8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x29ec>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2a10>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2a34>
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x10
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x14
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x18
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	fsw	ft2, 0x0(a1)
-               	addi	a1, s6, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s8, 0x1c
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2bb8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2bdc>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2c00>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2c24>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2c48>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2c6c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2c90>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2cb4>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x560
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s6, t2
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c8
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x18f4>
+               	addi	s6, s6, 0x1
+               	mv	s4, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	s2, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x25e4 <corpus.cases.vec.vec_f32x8.checksum+0x24b8>
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x638
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s6, t0, 0x1704 <corpus.cases.vec.vec_f32x8.checksum+0x1404>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x698
+               	add	s6, s0, t0
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x2e5c <corpus.cases.vec.vec_f32x8.checksum+0x2d30>
+               	bnez	a1, 0x1c70 <corpus.cases.vec.vec_f32x8.checksum+0x1970>
                	mv	a1, a0
                	li	a2, 0x80
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x2e44 <corpus.cases.vec.vec_f32x8.checksum+0x2d18>
-               	j	0x2e78 <corpus.cases.vec.vec_f32x8.checksum+0x2d4c>
+               	bne	a2, t0, 0x1c58 <corpus.cases.vec.vec_f32x8.checksum+0x1958>
+               	j	0x1c8c <corpus.cases.vec.vec_f32x8.checksum+0x198c>
                	mv	a1, a0
                	li	a0, 0x80
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x2e64 <corpus.cases.vec.vec_f32x8.checksum+0x2d38>
-               	mv	a0, s3
-               	mv	a1, s6
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x14
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x18
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s6, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x1c
-               	fsw	ft0, 0x0(a1)
+               	bne	a0, t0, 0x1c78 <corpus.cases.vec.vec_f32x8.checksum+0x1978>
                	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x4
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0xc
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x10
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x14
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x14
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x14
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x18
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x18
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x18
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x1c
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x1c
-               	flw	ft1, 0x0(a0)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x1c
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x14
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x18
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x1c
-               	fsw	ft0, 0x0(a1)
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0xc
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0xc
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x10
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x10
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x10
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x14
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x14
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x14
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x18
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x18
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x18
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s6, 0x1c
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x1c
-               	flw	ft1, 0x0(a0)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x1c
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x40
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x10
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x14
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x18
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, a0, 0x1c
-               	fsw	ft0, 0x0(a1)
-               	addi	a0, s3, 0x60
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	mv	a1, a0
@@ -3351,185 +1865,459 @@ Disassembly of section .text:
                	flw	ft0, 0x0(a1)
                	addi	a1, a0, 0x1c
                	fsw	ft0, 0x0(a1)
-               	li	s2, 0x0
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x10
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x14
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x14
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x14
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x18
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x18
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x18
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x1c
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x1c
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x1c
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x14
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x18
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x1c
+               	fsw	ft0, 0x0(a1)
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s1
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x10
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x10
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x14
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x14
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x14
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x18
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x18
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x18
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s2, 0x1c
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x1c
+               	flw	ft1, 0x0(a0)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x1c
+               	fsw	ft2, 0x0(a0)
+               	addi	a0, s6, 0x40
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x14
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x18
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x1c
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, s6, 0x60
+               	mv	a1, s5
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x14
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x14
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x18
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x18
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x1c
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x1c
+               	fsw	ft0, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x3458 <corpus.cases.vec.vec_f32x8.checksum+0x332c>
-               	j	0x3698 <corpus.cases.vec.vec_f32x8.checksum+0x356c>
+               	bltu	s1, t0, 0x226c <corpus.cases.vec.vec_f32x8.checksum+0x1f6c>
+               	j	0x23a8 <corpus.cases.vec.vec_f32x8.checksum+0x20a8>
                	li	t0, 0x20
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s6, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0xc
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x10
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x10
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x14
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x14
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x18
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x18
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x1c
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x1c
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
+               	mv	a0, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3458>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x347c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x34a0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x34c4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x34e8>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x350c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3530>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3554>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2090>
+               	addi	s1, s1, 0x1
+               	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x3458 <corpus.cases.vec.vec_f32x8.checksum+0x332c>
-               	lui	t0, 0xffffe
-               	addiw	t0, t0, 0x5f8
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0x226c <corpus.cases.vec.vec_f32x8.checksum+0x1f6c>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x658
+               	add	s1, s0, t0
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x36d4 <corpus.cases.vec.vec_f32x8.checksum+0x35a8>
+               	bnez	a1, 0x23e4 <corpus.cases.vec.vec_f32x8.checksum+0x20e4>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x36bc <corpus.cases.vec.vec_f32x8.checksum+0x3590>
-               	j	0x36f0 <corpus.cases.vec.vec_f32x8.checksum+0x35c4>
+               	bne	a2, t0, 0x23cc <corpus.cases.vec.vec_f32x8.checksum+0x20cc>
+               	j	0x2400 <corpus.cases.vec.vec_f32x8.checksum+0x2100>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x36dc <corpus.cases.vec.vec_f32x8.checksum+0x35b0>
-               	mv	a0, s2
+               	bne	a0, t0, 0x23ec <corpus.cases.vec.vec_f32x8.checksum+0x20ec>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x40
+               	addi	a1, s6, 0x40
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3537,7 +2325,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3545,7 +2333,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3553,7 +2341,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3561,7 +2349,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3569,7 +2357,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x14
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3577,7 +2365,7 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x18
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
@@ -3585,279 +2373,248 @@ Disassembly of section .text:
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x1c
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1c
                	fsw	ft0, 0x0(a1)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xffffe
+               	addi	a1, s1, 0x10
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s3
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	mv	a2, t2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0xc
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0x10
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x14
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0x14
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x14
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x18
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a2, t2, 0x18
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x18
+               	fsw	ft0, 0x0(a2)
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x1c
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s2, 0x30
+               	addi	a2, t2, 0x1c
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x1c
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s1, 0x30
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x37f8>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2648 <corpus.cases.vec.vec_f32x8.checksum+0x2348>
+               	j	0x267c <corpus.cases.vec.vec_f32x8.checksum+0x237c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2648 <corpus.cases.vec.vec_f32x8.checksum+0x2348>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0xc
+               	addi	a1, a0, 0xc
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
+               	addi	a1, a0, 0x10
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x14
+               	addi	a1, a0, 0x14
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x14
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x18
+               	addi	a1, a0, 0x18
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x18
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x1c
+               	addi	a1, a0, 0x1c
                	flw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xffffe
+               	addi	a0, t2, 0x1c
+               	fsw	ft0, 0x0(a0)
+               	mv	a0, s4
+               	lui	t1, 0xfffff
                	addiw	t1, t1, 0x5a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x391c>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3940>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3964>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3988>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x39ac>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x14
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x39d0>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x18
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x39f4>
-               	lui	t1, 0xffffe
-               	addiw	t1, t1, 0x5a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x1c
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3a18>
-               	addi	a1, s2, 0x30
+               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x2498>
+               	addi	a1, s1, 0x30
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f32x8.checksum+0x3a2c>
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x568
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x570
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x578
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x580
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x27c0 <corpus.cases.vec.vec_f32x8.checksum+0x24c0>
+               	j	0x27f4 <corpus.cases.vec.vec_f32x8.checksum+0x24f4>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x27c0 <corpus.cases.vec.vec_f32x8.checksum+0x24c0>
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x588
                	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s1, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x590
                	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s2, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x598
                	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s3, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5a0
                	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s4, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5a8
                	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s5, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5b0
                	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x2
+               	ld	s6, 0x0(t1)
+               	lui	t1, 0x1
                	addiw	t1, t1, -0x5b8
                	add	t1, sp, t1
+               	ld	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5c0
+               	add	t1, sp, t1
+               	ld	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5c8
+               	add	t1, sp, t1
+               	ld	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5d0
+               	add	t1, sp, t1
+               	ld	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x5d8
+               	add	t1, sp, t1
                	ld	s11, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x558
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x578
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
-               	lui	t1, 0x2
-               	addiw	t1, t1, -0x560
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x580
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
-               	lui	t0, 0x2
-               	addiw	t0, t0, -0x550
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x570
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_f64x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_f64x2.dis
@@ -3,673 +3,528 @@ vec/vec_f64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_f64x2.fold_vec>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	fld	fa0, 0x0(a1)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.fold_vec+0x30>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.fold_vec+0x48>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.vec.vec_f64x2.fold_vec+0x34>
+               	j	0x68 <corpus.cases.vec.vec_f64x2.fold_vec+0x68>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x34 <corpus.cases.vec.vec_f64x2.fold_vec+0x34>
+               	addi	a2, a1, 0x8
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x84 <corpus.cases.vec.vec_f64x2.fold_vec+0x84>
+               	j	0xb8 <corpus.cases.vec.vec_f64x2.fold_vec+0xb8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x84 <corpus.cases.vec.vec_f64x2.fold_vec+0x84>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_f64x2.checksum>:
-               	addi	sp, sp, -0x770
-               	sd	ra, 0x768(sp)
-               	sd	s0, 0x760(sp)
-               	addi	s0, sp, 0x770
-               	sd	s1, 0x758(sp)
-               	sd	s2, 0x750(sp)
-               	sd	s3, 0x748(sp)
-               	sd	s4, 0x740(sp)
-               	sd	s5, 0x738(sp)
-               	sd	s6, 0x730(sp)
-               	sd	s7, 0x728(sp)
-               	sd	s8, 0x720(sp)
-               	sd	s9, 0x718(sp)
-               	sd	s10, 0x710(sp)
-               	sd	s11, 0x708(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	s5, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	s6, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	a1, s0, -0x138
-               	addi	s7, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	s8, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	s9, s0, -0x1a8
-               	addi	a1, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	s10, s0, -0x1d8
-               	addi	a1, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	s11, s0, -0x208
-               	addi	a1, s0, -0x218
-               	addi	a1, s0, -0x228
-               	addi	t2, s0, -0x238
-               	sd	t2, -0x728(s0)
-               	addi	a2, s0, -0x248
-               	addi	a2, s0, -0x258
-               	addi	t2, s0, -0x268
-               	sd	t2, -0x730(s0)
+               	addi	sp, sp, -0x560
+               	sd	ra, 0x558(sp)
+               	sd	s0, 0x550(sp)
+               	addi	s0, sp, 0x560
+               	sd	s1, 0x548(sp)
+               	sd	s2, 0x540(sp)
+               	sd	s3, 0x538(sp)
+               	sd	s4, 0x530(sp)
+               	sd	s5, 0x528(sp)
+               	sd	s6, 0x520(sp)
+               	sd	s7, 0x518(sp)
+               	sd	s8, 0x510(sp)
+               	sd	s9, 0x508(sp)
+               	sd	s10, 0x500(sp)
+               	sd	s11, 0x4f8(sp)
+               	mv	t2, a0
+               	sd	t2, -0x500(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x520(s0)
+               	addi	s1, s0, -0x98
+               	addi	a3, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	s2, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a3, s0, -0xe8
+               	addi	s3, s0, -0xf8
+               	addi	a3, s0, -0x108
+               	addi	a3, s0, -0x118
+               	addi	a3, s0, -0x128
+               	addi	a3, s0, -0x138
+               	addi	s4, s0, -0x148
+               	addi	a3, s0, -0x158
+               	addi	a3, s0, -0x168
+               	addi	s5, s0, -0x178
+               	addi	a3, s0, -0x188
+               	addi	a3, s0, -0x198
+               	addi	s6, s0, -0x1a8
+               	addi	a3, s0, -0x1b8
+               	addi	a3, s0, -0x1c8
+               	addi	s7, s0, -0x1d8
+               	addi	a3, s0, -0x1e8
+               	addi	a3, s0, -0x1f8
+               	addi	s8, s0, -0x208
+               	addi	a3, s0, -0x218
+               	addi	a3, s0, -0x228
+               	addi	s9, s0, -0x238
+               	addi	a3, s0, -0x248
+               	addi	a3, s0, -0x258
+               	addi	s10, s0, -0x268
                	addi	a3, s0, -0x278
                	addi	a3, s0, -0x288
-               	addi	t2, s0, -0x298
-               	sd	t2, -0x738(s0)
-               	addi	a4, s0, -0x2a8
-               	addi	a4, s0, -0x2b8
+               	addi	s11, s0, -0x298
+               	addi	a3, s0, -0x2a8
+               	addi	a3, s0, -0x2b8
                	addi	t2, s0, -0x2c8
-               	sd	t2, -0x740(s0)
+               	sd	t2, -0x528(s0)
                	addi	t2, s0, -0x2d8
-               	sd	t2, -0x748(s0)
-               	addi	a6, s0, -0x2e8
-               	addi	a6, s0, -0x2f8
+               	sd	t2, -0x530(s0)
+               	addi	a5, s0, -0x2e8
+               	addi	a5, s0, -0x2f8
                	addi	t2, s0, -0x308
-               	sd	t2, -0x750(s0)
-               	addi	a7, s0, -0x318
-               	addi	a7, s0, -0x328
-               	addi	a7, s0, -0x338
+               	sd	t2, -0x538(s0)
+               	addi	a6, s0, -0x318
+               	addi	a6, s0, -0x328
+               	addi	a6, s0, -0x338
                	addi	t2, s0, -0x348
-               	sd	t2, -0x758(s0)
-               	addi	t5, s0, -0x358
-               	addi	t5, s0, -0x368
-               	addi	t5, s0, -0x378
+               	sd	t2, -0x540(s0)
+               	addi	a7, s0, -0x358
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
                	addi	t2, s0, -0x388
-               	sd	t2, -0x760(s0)
-               	addi	t6, s0, -0x398
-               	addi	t6, s0, -0x3a8
-               	addi	t6, s0, -0x3b8
-               	addi	t6, s0, -0x3c8
+               	sd	t2, -0x548(s0)
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t5, s0, -0x3b8
+               	addi	t5, s0, -0x3c8
                	addi	t2, s0, -0x3d8
-               	sd	t2, -0x700(s0)
+               	sd	t2, -0x550(s0)
                	addi	t6, s0, -0x3e8
                	addi	t6, s0, -0x3f8
                	addi	t2, s0, -0x408
-               	sd	t2, -0x708(s0)
-               	addi	t6, s0, -0x418
+               	sd	t2, -0x558(s0)
+               	addi	a0, s0, -0x418
                	addi	t2, s0, -0x428
-               	sd	t2, -0x720(s0)
+               	sd	t2, -0x508(s0)
                	addi	t2, s0, -0x438
-               	sd	t2, -0x710(s0)
+               	sd	t2, -0x510(s0)
                	addi	t2, s0, -0x448
-               	sd	t2, -0x718(s0)
-               	addi	t6, s0, -0x458
-               	addi	t6, s0, -0x468
-               	addi	t6, s0, -0x478
-               	addi	t6, s0, -0x488
-               	addi	t6, s0, -0x498
-               	addi	t6, s0, -0x4a8
-               	addi	t6, s0, -0x4b8
-               	addi	t6, s0, -0x4c8
-               	addi	t6, s0, -0x4d8
-               	addi	t6, s0, -0x4e8
-               	addi	t6, s0, -0x4f8
-               	addi	t6, s0, -0x508
-               	addi	t6, s0, -0x518
-               	addi	t6, s0, -0x528
-               	addi	t6, s0, -0x538
-               	addi	t6, s0, -0x548
-               	addi	t6, s0, -0x558
-               	addi	t6, s0, -0x568
-               	addi	t6, s0, -0x578
-               	addi	t6, s0, -0x588
-               	addi	t6, s0, -0x598
-               	addi	t6, s0, -0x5a8
-               	addi	t6, s0, -0x5b8
-               	addi	t6, s0, -0x5c8
-               	addi	t6, s0, -0x5d8
-               	addi	t6, s0, -0x5e8
-               	addi	t6, s0, -0x5f8
-               	addi	t6, s0, -0x608
-               	addi	t6, s0, -0x618
-               	addi	t6, s0, -0x628
-               	addi	t6, s0, -0x638
-               	addi	t6, s0, -0x648
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x1ec>
-               	fcvt.d.lu	ft0, s1
-               	addi	t6, s0, -0x658
-               	mv	s1, t6
+               	sd	t2, -0x518(s0)
+               	ld	t2, -0x500(s0)
+               	fcvt.d.lu	ft0, t2
+               	addi	a0, s0, -0x4c8
+               	mv	a2, a0
                	lui	t0, 0x3ff8
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	sd	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0xfc002
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	mv	s1, t6
-               	fld	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsd	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	fld	ft1, 0x0(s1)
-               	addi	t6, s2, 0x8
-               	fsd	ft1, 0x0(t6)
-               	addi	t6, s0, -0x668
-               	mv	s1, t6
+               	sd	t0, 0x0(a2)
+               	mv	a2, a0
+               	fld	ft1, 0x0(a2)
+               	mv	a2, a1
+               	fsd	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	fld	ft1, 0x0(a2)
+               	addi	a0, a1, 0x8
+               	fsd	ft1, 0x0(a0)
+               	addi	a0, s0, -0x4d8
+               	mv	a2, a0
                	lui	t0, 0x3fe0
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	sd	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x4010
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	mv	s1, t6
-               	fld	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsd	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	fld	ft1, 0x0(s1)
-               	addi	t6, s3, 0x8
-               	fsd	ft1, 0x0(t6)
-               	addi	t6, s0, -0x678
-               	mv	s1, t6
+               	sd	t0, 0x0(a2)
+               	mv	a2, a0
+               	fld	ft1, 0x0(a2)
+               	ld	t2, -0x520(s0)
+               	mv	a2, t2
+               	fsd	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	fld	ft1, 0x0(a2)
+               	ld	t2, -0x520(s0)
+               	addi	a0, t2, 0x8
+               	fsd	ft1, 0x0(a0)
+               	addi	a0, s0, -0x4e8
+               	mv	a2, a0
                	lui	t0, 0x3ff0
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	addi	s1, t6, 0x8
+               	sd	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x403b
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
                	slli	t0, t0, 0xc
-               	sd	t0, 0x0(s1)
-               	mv	s1, t6
-               	fld	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsd	ft1, 0x0(s1)
-               	addi	s1, t6, 0x8
-               	fld	ft1, 0x0(s1)
-               	addi	t6, s4, 0x8
-               	fsd	ft1, 0x0(t6)
-               	mv	t6, s2
-               	fld	ft1, 0x0(t6)
+               	sd	t0, 0x0(a2)
+               	mv	a2, a0
+               	fld	ft1, 0x0(a2)
+               	mv	a2, s1
+               	fsd	ft1, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	fld	ft1, 0x0(a2)
+               	addi	a0, s1, 0x8
+               	fsd	ft1, 0x0(a0)
+               	mv	a0, a1
+               	fld	ft1, 0x0(a0)
                	fadd.d	ft2, ft1, ft0
-               	mv	t6, s2
-               	fld	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsd	ft1, 0x0(t6)
-               	addi	t6, s2, 0x8
-               	fld	ft1, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fsd	ft1, 0x0(t6)
-               	mv	t6, s5
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s3, 0x8
-               	fld	ft1, 0x0(t6)
+               	mv	a0, a1
+               	fld	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsd	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	fld	ft1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsd	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsd	ft2, 0x0(a0)
+               	ld	t2, -0x520(s0)
+               	addi	a0, t2, 0x8
+               	fld	ft1, 0x0(a0)
                	fadd.d	ft2, ft1, ft0
-               	mv	t6, s3
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fsd	ft0, 0x0(t6)
-               	addi	t6, s3, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fsd	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s5
-               	fld	fa0, 0x0(t6)
+               	ld	t2, -0x520(s0)
+               	mv	a0, t2
+               	fld	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsd	ft0, 0x0(a0)
+               	ld	t2, -0x520(s0)
+               	addi	a0, t2, 0x8
+               	fld	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsd	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsd	ft2, 0x0(a0)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x364>
-               	addi	t6, s5, 0x8
-               	fld	fa0, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x30c>
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x374>
-               	mv	t6, s6
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x384>
-               	addi	t6, s6, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x394>
-               	mv	t6, s5
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fld	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x318>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s3
+               	fld	ft1, 0x0(a1)
                	fadd.d	ft2, ft0, ft1
-               	mv	t6, s7
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft1, 0x0(t6)
+               	mv	a1, s4
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft1, 0x0(a1)
                	fadd.d	ft2, ft0, ft1
-               	addi	t6, s7, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s7
-               	fld	fa0, 0x0(t6)
+               	addi	a1, s4, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s4
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x3dc>
-               	addi	t6, s7, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x3ec>
-               	mv	t6, s5
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fld	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x35c>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s3
+               	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	mv	t6, s8
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft1, 0x0(t6)
+               	mv	a1, s5
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	addi	t6, s8, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s8
-               	fld	fa0, 0x0(t6)
+               	addi	a1, s5, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x434>
-               	addi	t6, s8, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x444>
-               	mv	t6, s6
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s5
-               	fld	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x3a0>
+               	mv	a1, s3
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s2
+               	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	mv	t6, s9
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft1, 0x0(t6)
+               	mv	a1, s6
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	addi	t6, s9, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s9
-               	fld	fa0, 0x0(t6)
+               	addi	a1, s6, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x48c>
-               	addi	t6, s9, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x49c>
-               	mv	t6, s5
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fld	ft1, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x3e4>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s3
+               	fld	ft1, 0x0(a1)
                	fmul.d	ft2, ft0, ft1
-               	mv	t6, s10
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft1, 0x0(t6)
+               	mv	a1, s7
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft1, 0x0(a1)
                	fmul.d	ft2, ft0, ft1
-               	addi	t6, s10, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s10
-               	fld	fa0, 0x0(t6)
+               	addi	a1, s7, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x4e4>
-               	addi	t6, s10, 0x8
-               	fld	fa0, 0x0(t6)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x428>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s3
+               	fld	ft1, 0x0(a1)
+               	fdiv.d	ft2, ft0, ft1
+               	mv	a1, s8
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft1, 0x0(a1)
+               	fdiv.d	ft2, ft0, ft1
+               	addi	a1, s8, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x46c>
+               	mv	a1, s3
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s2
+               	fld	ft1, 0x0(a1)
+               	fdiv.d	ft2, ft0, ft1
+               	mv	a1, s9
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft1, 0x0(a1)
+               	fdiv.d	ft2, ft0, ft1
+               	addi	a1, s9, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x4b0>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s1
+               	fld	ft1, 0x0(a1)
+               	fmul.d	ft2, ft0, ft1
+               	mv	a1, s10
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	fld	ft1, 0x0(a1)
+               	fmul.d	ft2, ft0, ft1
+               	addi	a1, s10, 0x8
+               	fsd	ft2, 0x0(a1)
+               	mv	a1, s10
                	auipc	ra, 0x0
                	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x4f4>
-               	mv	t6, s5
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s6
-               	fld	ft1, 0x0(t6)
-               	fdiv.d	ft2, ft0, ft1
-               	mv	t6, s11
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft1, 0x0(t6)
-               	fdiv.d	ft2, ft0, ft1
-               	addi	t6, s11, 0x8
-               	fsd	ft2, 0x0(t6)
-               	mv	t6, s11
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x53c>
-               	addi	t6, s11, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x54c>
-               	mv	t6, s6
-               	fld	ft0, 0x0(t6)
-               	mv	t6, s5
-               	fld	ft1, 0x0(t6)
-               	fdiv.d	ft2, ft0, ft1
-               	ld	t2, -0x728(s0)
-               	mv	t6, t2
-               	fsd	ft2, 0x0(t6)
-               	addi	t6, s6, 0x8
-               	fld	ft0, 0x0(t6)
-               	addi	t6, s5, 0x8
-               	fld	ft1, 0x0(t6)
-               	fdiv.d	ft2, ft0, ft1
-               	ld	t2, -0x728(s0)
-               	addi	t6, t2, 0x8
-               	fsd	ft2, 0x0(t6)
-               	ld	t2, -0x728(s0)
-               	mv	t6, t2
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x5a0>
-               	ld	t2, -0x728(s0)
-               	addi	t6, t2, 0x8
-               	fld	fa0, 0x0(t6)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x5b4>
-               	mv	a1, s5
+               	mv	a1, s1
                	fld	ft0, 0x0(a1)
-               	mv	a1, s4
-               	fld	ft1, 0x0(a1)
-               	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x730(s0)
-               	mv	a1, t2
-               	fsd	ft2, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	fld	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	fld	ft1, 0x0(a1)
-               	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x730(s0)
-               	addi	a1, t2, 0x8
-               	fsd	ft2, 0x0(a1)
-               	ld	t2, -0x730(s0)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x608>
-               	ld	t2, -0x730(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x61c>
-               	mv	a1, s4
-               	fld	ft0, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s3
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	ld	t2, -0x738(s0)
-               	mv	a1, t2
+               	mv	a1, s11
                	fsd	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s1, 0x8
                	fld	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s3, 0x8
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
-               	ld	t2, -0x738(s0)
-               	addi	a1, t2, 0x8
+               	addi	a1, s11, 0x8
                	fsd	ft2, 0x0(a1)
-               	ld	t2, -0x738(s0)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
+               	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x670>
-               	ld	t2, -0x738(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x684>
-               	mv	a1, s4
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x538>
+               	mv	a1, s1
                	fld	ft0, 0x0(a1)
-               	mv	a1, s5
+               	mv	a1, s2
                	fld	ft1, 0x0(a1)
                	fdiv.d	ft2, ft0, ft1
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x528(s0)
                	mv	a1, t2
                	fsd	ft2, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, s1, 0x8
                	fld	ft0, 0x0(a1)
-               	addi	a1, s5, 0x8
+               	addi	a1, s2, 0x8
                	fld	ft1, 0x0(a1)
                	fdiv.d	ft2, ft0, ft1
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x528(s0)
                	addi	a1, t2, 0x8
                	fsd	ft2, 0x0(a1)
-               	ld	t2, -0x740(s0)
+               	ld	t2, -0x528(s0)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x6d8>
-               	ld	t2, -0x740(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x6ec>
-               	addi	a1, s0, -0x6f8
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x588>
+               	addi	a1, s0, -0x4f8
                	mv	a2, a1
                	sd	zero, 0x0(a2)
                	addi	a2, a1, 0x8
                	sd	zero, 0x0(a2)
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x530(s0)
                	mv	a2, t2
                	fsd	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
-               	ld	t2, -0x748(s0)
+               	ld	t2, -0x530(s0)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
-               	mv	s1, a0
-               	ld	t2, -0x748(s0)
-               	mv	s2, t2
-               	li	s3, 0x0
+               	mv	s4, a0
+               	ld	t2, -0x530(s0)
+               	mv	s5, t2
+               	li	s6, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0x7b0 <corpus.cases.vec.vec_f64x2.checksum+0x74c>
-               	j	0x914 <corpus.cases.vec.vec_f64x2.checksum+0x8b0>
-               	mv	a0, s5
+               	bltu	s6, t0, 0x6b0 <corpus.cases.vec.vec_f64x2.checksum+0x5e8>
+               	j	0x7cc <corpus.cases.vec.vec_f64x2.checksum+0x704>
+               	mv	a0, s2
                	fld	ft0, 0x0(a0)
-               	mv	a0, s4
+               	mv	a0, s1
                	fld	ft1, 0x0(a0)
                	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x538(s0)
                	mv	a0, t2
                	fsd	ft2, 0x0(a0)
-               	addi	a0, s5, 0x8
+               	addi	a0, s2, 0x8
                	fld	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
+               	addi	a0, s1, 0x8
                	fld	ft1, 0x0(a0)
                	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x750(s0)
+               	ld	t2, -0x538(s0)
                	addi	a0, t2, 0x8
                	fsd	ft2, 0x0(a0)
-               	ld	t2, -0x750(s0)
-               	mv	a0, t2
-               	fld	fa0, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x79c>
-               	ld	t2, -0x750(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x7b0>
-               	mv	a1, s2
-               	fld	ft0, 0x0(a1)
-               	ld	t2, -0x750(s0)
+               	mv	a0, s4
+               	ld	t2, -0x538(s0)
                	mv	a1, t2
-               	fld	ft1, 0x0(a1)
-               	fadd.d	ft2, ft0, ft1
-               	ld	t2, -0x758(s0)
-               	mv	a1, t2
-               	fsd	ft2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	fld	ft0, 0x0(a1)
-               	ld	t2, -0x750(s0)
-               	addi	a1, t2, 0x8
-               	fld	ft1, 0x0(a1)
-               	fadd.d	ft2, ft0, ft1
-               	ld	t2, -0x758(s0)
-               	addi	a1, t2, 0x8
-               	fsd	ft2, 0x0(a1)
-               	ld	t2, -0x758(s0)
-               	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x80c>
-               	ld	t2, -0x758(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x820>
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x634>
                	mv	a1, s5
                	fld	ft0, 0x0(a1)
-               	mv	a1, s6
+               	ld	t2, -0x538(s0)
+               	mv	a1, t2
                	fld	ft1, 0x0(a1)
-               	fsub.d	ft2, ft0, ft1
-               	ld	t2, -0x760(s0)
+               	fadd.d	ft2, ft0, ft1
+               	ld	t2, -0x540(s0)
                	mv	a1, t2
                	fsd	ft2, 0x0(a1)
                	addi	a1, s5, 0x8
                	fld	ft0, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	ld	t2, -0x538(s0)
+               	addi	a1, t2, 0x8
                	fld	ft1, 0x0(a1)
-               	fsub.d	ft2, ft0, ft1
-               	ld	t2, -0x760(s0)
+               	fadd.d	ft2, ft0, ft1
+               	ld	t2, -0x540(s0)
                	addi	a1, t2, 0x8
                	fsd	ft2, 0x0(a1)
-               	ld	t2, -0x760(s0)
+               	ld	t2, -0x540(s0)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x874>
-               	ld	t2, -0x760(s0)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x68c>
+               	mv	a1, s2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, s3
+               	fld	ft1, 0x0(a1)
+               	fsub.d	ft2, ft0, ft1
+               	ld	t2, -0x548(s0)
+               	mv	a1, t2
+               	fsd	ft2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	fld	ft1, 0x0(a1)
+               	fsub.d	ft2, ft0, ft1
+               	ld	t2, -0x548(s0)
                	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
+               	fsd	ft2, 0x0(a1)
+               	ld	t2, -0x548(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x888>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x760(s0)
-               	mv	s5, t2
-               	ld	t2, -0x758(s0)
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x6dc>
+               	addi	s6, s6, 0x1
+               	mv	s4, a0
+               	ld	t2, -0x548(s0)
                	mv	s2, t2
+               	ld	t2, -0x540(s0)
+               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x7b0 <corpus.cases.vec.vec_f64x2.checksum+0x74c>
-               	addi	s3, s0, -0x6b8
-               	mv	a0, s3
+               	bltu	s6, t0, 0x6b0 <corpus.cases.vec.vec_f64x2.checksum+0x5e8>
+               	addi	s6, s0, -0x488
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x948 <corpus.cases.vec.vec_f64x2.checksum+0x8e4>
+               	bnez	a1, 0x800 <corpus.cases.vec.vec_f64x2.checksum+0x738>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x930 <corpus.cases.vec.vec_f64x2.checksum+0x8cc>
-               	j	0x964 <corpus.cases.vec.vec_f64x2.checksum+0x900>
+               	bne	a2, t0, 0x7e8 <corpus.cases.vec.vec_f64x2.checksum+0x720>
+               	j	0x81c <corpus.cases.vec.vec_f64x2.checksum+0x754>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x950 <corpus.cases.vec.vec_f64x2.checksum+0x8ec>
-               	mv	a0, s3
-               	mv	a1, s5
-               	fld	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsd	ft0, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	fld	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsd	ft0, 0x0(a1)
-               	mv	a0, s5
-               	fld	ft0, 0x0(a0)
+               	bne	a0, t0, 0x808 <corpus.cases.vec.vec_f64x2.checksum+0x740>
                	mv	a0, s6
-               	fld	ft1, 0x0(a0)
-               	fadd.d	ft2, ft0, ft1
-               	ld	t2, -0x700(s0)
-               	mv	a0, t2
-               	fsd	ft2, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	fld	ft0, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	fld	ft1, 0x0(a0)
-               	fadd.d	ft2, ft0, ft1
-               	ld	t2, -0x700(s0)
-               	addi	a0, t2, 0x8
-               	fsd	ft2, 0x0(a0)
-               	addi	a0, s3, 0x10
-               	ld	t2, -0x700(s0)
-               	mv	a1, t2
-               	fld	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsd	ft0, 0x0(a1)
-               	ld	t2, -0x700(s0)
-               	addi	a1, t2, 0x8
-               	fld	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsd	ft0, 0x0(a1)
-               	mv	a0, s5
-               	fld	ft0, 0x0(a0)
-               	mv	a0, s4
-               	fld	ft1, 0x0(a0)
-               	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x708(s0)
-               	mv	a0, t2
-               	fsd	ft2, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	fld	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	fld	ft1, 0x0(a0)
-               	fmul.d	ft2, ft0, ft1
-               	ld	t2, -0x708(s0)
-               	addi	a0, t2, 0x8
-               	fsd	ft2, 0x0(a0)
-               	addi	a0, s3, 0x20
-               	ld	t2, -0x708(s0)
-               	mv	a1, t2
-               	fld	ft0, 0x0(a1)
-               	mv	a1, a0
-               	fsd	ft0, 0x0(a1)
-               	ld	t2, -0x708(s0)
-               	addi	a1, t2, 0x8
-               	fld	ft0, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	fsd	ft0, 0x0(a1)
-               	addi	a0, s3, 0x30
                	mv	a1, s2
                	fld	ft0, 0x0(a1)
                	mv	a1, a0
@@ -678,130 +533,215 @@ Disassembly of section .text:
                	fld	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	fsd	ft0, 0x0(a1)
-               	li	s2, 0x0
+               	mv	a0, s2
+               	fld	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fld	ft1, 0x0(a0)
+               	fadd.d	ft2, ft0, ft1
+               	ld	t2, -0x550(s0)
+               	mv	a0, t2
+               	fsd	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fld	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fld	ft1, 0x0(a0)
+               	fadd.d	ft2, ft0, ft1
+               	ld	t2, -0x550(s0)
+               	addi	a0, t2, 0x8
+               	fsd	ft2, 0x0(a0)
+               	addi	a0, s6, 0x10
+               	ld	t2, -0x550(s0)
+               	mv	a1, t2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsd	ft0, 0x0(a1)
+               	ld	t2, -0x550(s0)
+               	addi	a1, t2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsd	ft0, 0x0(a1)
+               	mv	a0, s2
+               	fld	ft0, 0x0(a0)
+               	mv	a0, s1
+               	fld	ft1, 0x0(a0)
+               	fmul.d	ft2, ft0, ft1
+               	ld	t2, -0x558(s0)
+               	mv	a0, t2
+               	fsd	ft2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fld	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	fld	ft1, 0x0(a0)
+               	fmul.d	ft2, ft0, ft1
+               	ld	t2, -0x558(s0)
+               	addi	a0, t2, 0x8
+               	fsd	ft2, 0x0(a0)
+               	addi	a0, s6, 0x20
+               	ld	t2, -0x558(s0)
+               	mv	a1, t2
+               	fld	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsd	ft0, 0x0(a1)
+               	ld	t2, -0x558(s0)
+               	addi	a1, t2, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsd	ft0, 0x0(a1)
+               	addi	a0, s6, 0x30
+               	mv	a1, s5
+               	fld	ft0, 0x0(a1)
+               	mv	a1, a0
+               	fsd	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	fld	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	fsd	ft0, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0xa94 <corpus.cases.vec.vec_f64x2.checksum+0xa30>
-               	j	0xb04 <corpus.cases.vec.vec_f64x2.checksum+0xaa0>
+               	bltu	s1, t0, 0x94c <corpus.cases.vec.vec_f64x2.checksum+0x884>
+               	j	0x9a4 <corpus.cases.vec.vec_f64x2.checksum+0x8dc>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s6, a0
                	mv	a0, a1
                	fld	ft0, 0x0(a0)
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x508(s0)
                	mv	a0, t2
                	fsd	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	fld	ft0, 0x0(a0)
-               	ld	t2, -0x720(s0)
+               	ld	t2, -0x508(s0)
                	addi	a0, t2, 0x8
                	fsd	ft0, 0x0(a0)
-               	ld	t2, -0x720(s0)
-               	mv	a0, t2
-               	fld	fa0, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s4
+               	ld	t2, -0x508(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xa74>
-               	ld	t2, -0x720(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xa88>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0x8c4>
+               	addi	s1, s1, 0x1
+               	mv	s4, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0xa94 <corpus.cases.vec.vec_f64x2.checksum+0xa30>
-               	addi	s2, s0, -0x6e8
-               	mv	a0, s2
+               	bltu	s1, t0, 0x94c <corpus.cases.vec.vec_f64x2.checksum+0x884>
+               	addi	s1, s0, -0x4b8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xb38 <corpus.cases.vec.vec_f64x2.checksum+0xad4>
+               	bnez	a1, 0x9d8 <corpus.cases.vec.vec_f64x2.checksum+0x910>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0xb20 <corpus.cases.vec.vec_f64x2.checksum+0xabc>
-               	j	0xb54 <corpus.cases.vec.vec_f64x2.checksum+0xaf0>
+               	bne	a2, t0, 0x9c0 <corpus.cases.vec.vec_f64x2.checksum+0x8f8>
+               	j	0x9f4 <corpus.cases.vec.vec_f64x2.checksum+0x92c>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xb40 <corpus.cases.vec.vec_f64x2.checksum+0xadc>
-               	mv	a0, s2
+               	bne	a0, t0, 0x9e0 <corpus.cases.vec.vec_f64x2.checksum+0x918>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s6, 0x20
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x510(s0)
                	mv	a2, t2
                	fsd	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
-               	ld	t2, -0x710(s0)
+               	ld	t2, -0x510(s0)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
-               	addi	s3, s2, 0x10
-               	ld	t2, -0x710(s0)
-               	mv	a1, t2
-               	fld	ft0, 0x0(a1)
-               	mv	a1, s3
-               	fsd	ft0, 0x0(a1)
-               	ld	t2, -0x710(s0)
-               	addi	a1, t2, 0x8
-               	fld	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	fsd	ft0, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x510(s0)
+               	mv	a2, t2
+               	fld	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsd	ft0, 0x0(a2)
+               	ld	t2, -0x510(s0)
+               	addi	a2, t2, 0x8
+               	fld	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsd	ft0, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xb74>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa8c <corpus.cases.vec.vec_f64x2.checksum+0x9c4>
+               	j	0xac0 <corpus.cases.vec.vec_f64x2.checksum+0x9f8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s4, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s4, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xa8c <corpus.cases.vec.vec_f64x2.checksum+0x9c4>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	fld	ft0, 0x0(a1)
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x518(s0)
                	mv	a1, t2
                	fsd	ft0, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	fld	ft0, 0x0(a1)
-               	ld	t2, -0x718(s0)
-               	addi	a1, t2, 0x8
-               	fsd	ft0, 0x0(a1)
-               	ld	t2, -0x718(s0)
+               	ld	t2, -0x518(s0)
+               	addi	a0, t2, 0x8
+               	fsd	ft0, 0x0(a0)
+               	mv	a0, s4
+               	ld	t2, -0x518(s0)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xbb0>
-               	ld	t2, -0x718(s0)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xbc4>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xa30>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_f64x2.checksum+0xbd8>
-               	ld	s1, 0x758(sp)
-               	ld	s2, 0x750(sp)
-               	ld	s3, 0x748(sp)
-               	ld	s4, 0x740(sp)
-               	ld	s5, 0x738(sp)
-               	ld	s6, 0x730(sp)
-               	ld	s7, 0x728(sp)
-               	ld	s8, 0x720(sp)
-               	ld	s9, 0x718(sp)
-               	ld	s10, 0x710(sp)
-               	ld	s11, 0x708(sp)
-               	ld	ra, 0x768(sp)
-               	ld	s0, 0x760(sp)
-               	addi	sp, sp, 0x770
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb20 <corpus.cases.vec.vec_f64x2.checksum+0xa58>
+               	j	0xb54 <corpus.cases.vec.vec_f64x2.checksum+0xa8c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xb20 <corpus.cases.vec.vec_f64x2.checksum+0xa58>
+               	ld	s1, 0x548(sp)
+               	ld	s2, 0x540(sp)
+               	ld	s3, 0x538(sp)
+               	ld	s4, 0x530(sp)
+               	ld	s5, 0x528(sp)
+               	ld	s6, 0x520(sp)
+               	ld	s7, 0x518(sp)
+               	ld	s8, 0x510(sp)
+               	ld	s9, 0x508(sp)
+               	ld	s10, 0x500(sp)
+               	ld	s11, 0x4f8(sp)
+               	ld	ra, 0x558(sp)
+               	ld	s0, 0x550(sp)
+               	addi	sp, sp, 0x560
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i16x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_i16x4.dis
@@ -3,1607 +3,1304 @@ vec/vec_i16x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i16x4.fold_vec>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x20
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x30
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	lhu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.fold_vec+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x18
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x28
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.fold_vec+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_i16x4.fold_vec+0x40>
+               	j	0x74 <corpus.cases.vec.vec_i16x4.fold_vec+0x74>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_i16x4.fold_vec+0x40>
+               	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.fold_vec+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_i16x4.fold_vec+0x94>
+               	j	0xc8 <corpus.cases.vec.vec_i16x4.fold_vec+0xc8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_i16x4.fold_vec+0x94>
+               	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.fold_vec+0x90>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_i16x4.fold_vec+0xe8>
+               	j	0x11c <corpus.cases.vec.vec_i16x4.fold_vec+0x11c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_i16x4.fold_vec+0xe8>
+               	addi	a2, a1, 0x6
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_i16x4.fold_vec+0x13c>
+               	j	0x170 <corpus.cases.vec.vec_i16x4.fold_vec+0x170>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_i16x4.fold_vec+0x13c>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_i16x4.checksum>:
-               	addi	sp, sp, -0x6c0
-               	sd	ra, 0x6b8(sp)
-               	sd	s0, 0x6b0(sp)
-               	addi	s0, sp, 0x6c0
-               	sd	s1, 0x6a8(sp)
-               	sd	s2, 0x6a0(sp)
-               	sd	s3, 0x698(sp)
-               	sd	s4, 0x690(sp)
-               	sd	s5, 0x688(sp)
-               	sd	s6, 0x680(sp)
-               	sd	s7, 0x678(sp)
-               	sd	s8, 0x670(sp)
-               	sd	s9, 0x668(sp)
-               	sd	s10, 0x660(sp)
-               	sd	s11, 0x658(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x70
-               	addi	s3, s0, -0x78
-               	addi	s4, s0, -0x80
-               	addi	s5, s0, -0x88
-               	addi	a1, s0, -0x90
-               	addi	a1, s0, -0x98
-               	addi	s6, s0, -0xa0
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb0
-               	addi	s7, s0, -0xb8
-               	addi	a1, s0, -0xc0
-               	addi	a1, s0, -0xc8
-               	addi	s8, s0, -0xd0
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe0
-               	addi	s9, s0, -0xe8
-               	addi	a1, s0, -0xf0
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x100
-               	addi	a1, s0, -0x108
-               	addi	s10, s0, -0x110
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x120
-               	addi	s11, s0, -0x128
-               	addi	a1, s0, -0x130
-               	addi	a1, s0, -0x138
-               	addi	t2, s0, -0x140
-               	sd	t2, -0x680(s0)
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x150
-               	addi	t2, s0, -0x158
-               	sd	t2, -0x688(s0)
-               	addi	a1, s0, -0x160
-               	addi	a1, s0, -0x168
-               	addi	t2, s0, -0x170
-               	sd	t2, -0x690(s0)
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x180
-               	addi	t2, s0, -0x188
-               	sd	t2, -0x698(s0)
-               	addi	a1, s0, -0x190
-               	addi	a1, s0, -0x198
-               	addi	t2, s0, -0x1a0
-               	sd	t2, -0x6a0(s0)
-               	addi	a1, s0, -0x1a8
-               	addi	t2, s0, -0x1b0
-               	sd	t2, -0x6a8(s0)
-               	addi	a1, s0, -0x1b8
-               	addi	a1, s0, -0x1c0
-               	addi	t2, s0, -0x1c8
-               	sd	t2, -0x6b0(s0)
-               	addi	a1, s0, -0x1d0
-               	addi	a1, s0, -0x1d8
-               	addi	t2, s0, -0x1e0
-               	sd	t2, -0x6b8(s0)
-               	addi	a1, s0, -0x1e8
-               	addi	a1, s0, -0x1f0
-               	addi	t2, s0, -0x1f8
-               	sd	t2, -0x5f0(s0)
-               	addi	a1, s0, -0x200
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x210
-               	sd	t2, -0x5f8(s0)
-               	addi	a1, s0, -0x218
-               	addi	a1, s0, -0x220
-               	addi	t2, s0, -0x228
-               	sd	t2, -0x600(s0)
-               	addi	a1, s0, -0x230
-               	addi	t2, s0, -0x238
-               	sd	t2, -0x608(s0)
-               	addi	a1, s0, -0x240
-               	addi	t2, s0, -0x248
-               	sd	t2, -0x610(s0)
-               	addi	a1, s0, -0x250
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x260
-               	addi	a1, s0, -0x268
-               	addi	a1, s0, -0x270
-               	addi	a1, s0, -0x278
-               	addi	t2, s0, -0x280
-               	sd	t2, -0x618(s0)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x290
-               	addi	a1, s0, -0x298
-               	addi	a1, s0, -0x2a0
-               	addi	t2, s0, -0x2a8
-               	sd	t2, -0x620(s0)
-               	addi	a1, s0, -0x2b0
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c0
-               	addi	t2, s0, -0x2c8
-               	sd	t2, -0x628(s0)
-               	addi	a1, s0, -0x2d0
-               	addi	a1, s0, -0x2d8
-               	addi	a1, s0, -0x2e0
-               	addi	t2, s0, -0x2e8
-               	sd	t2, -0x630(s0)
-               	addi	a1, s0, -0x2f0
-               	addi	a1, s0, -0x2f8
-               	addi	a1, s0, -0x300
-               	addi	t2, s0, -0x308
-               	sd	t2, -0x638(s0)
-               	addi	a1, s0, -0x310
-               	addi	a1, s0, -0x318
-               	addi	a1, s0, -0x320
-               	addi	a1, s0, -0x328
-               	addi	t2, s0, -0x330
-               	sd	t2, -0x640(s0)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x340
-               	addi	t2, s0, -0x348
-               	sd	t2, -0x648(s0)
-               	addi	a1, s0, -0x350
-               	addi	a1, s0, -0x358
-               	addi	a1, s0, -0x360
-               	addi	a1, s0, -0x368
-               	addi	t2, s0, -0x370
-               	sd	t2, -0x650(s0)
-               	addi	t2, s0, -0x378
-               	sd	t2, -0x658(s0)
-               	addi	t2, s0, -0x380
-               	sd	t2, -0x660(s0)
-               	addi	t2, s0, -0x388
-               	sd	t2, -0x668(s0)
-               	addi	a1, s0, -0x390
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a0
-               	addi	a1, s0, -0x3a8
-               	addi	a1, s0, -0x3b0
-               	addi	a1, s0, -0x3b8
-               	addi	a1, s0, -0x3c0
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d0
-               	addi	a1, s0, -0x3d8
-               	addi	a1, s0, -0x3e0
-               	addi	a1, s0, -0x3e8
-               	addi	a1, s0, -0x3f0
-               	addi	a1, s0, -0x3f8
-               	addi	a1, s0, -0x400
-               	addi	a1, s0, -0x408
-               	addi	a1, s0, -0x410
-               	addi	a1, s0, -0x418
-               	addi	a1, s0, -0x420
-               	addi	a1, s0, -0x428
-               	addi	a1, s0, -0x430
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x440
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x450
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x460
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x470
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x480
-               	addi	a1, s0, -0x488
-               	addi	a1, s0, -0x490
-               	addi	a1, s0, -0x498
-               	addi	a1, s0, -0x4a0
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b0
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c0
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d0
-               	addi	a1, s0, -0x4d8
-               	addi	a1, s0, -0x4e0
-               	addi	a1, s0, -0x4e8
-               	addi	a1, s0, -0x4f0
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x500
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x510
-               	addi	a1, s0, -0x518
-               	addi	a1, s0, -0x520
-               	addi	a1, s0, -0x528
-               	addi	a1, s0, -0x530
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x540
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x550
-               	addi	a1, s0, -0x558
-               	addi	a1, s0, -0x560
-               	addi	a1, s0, -0x568
-               	addi	a1, s0, -0x570
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x580
-               	addi	a1, s0, -0x588
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x330>
+               	addi	sp, sp, -0x4a0
+               	sd	ra, 0x498(sp)
+               	sd	s0, 0x490(sp)
+               	addi	s0, sp, 0x4a0
+               	sd	s1, 0x488(sp)
+               	sd	s2, 0x480(sp)
+               	sd	s3, 0x478(sp)
+               	sd	s4, 0x470(sp)
+               	sd	s5, 0x468(sp)
+               	sd	s6, 0x460(sp)
+               	sd	s7, 0x458(sp)
+               	sd	s8, 0x450(sp)
+               	sd	s9, 0x448(sp)
+               	sd	s10, 0x440(sp)
+               	sd	s11, 0x438(sp)
                	mv	t2, a0
-               	sd	t2, -0x670(s0)
-               	ld	t2, -0x670(s0)
-               	sext.w	t2, s1
-               	sd	t2, -0x678(s0)
-               	addi	s1, s0, -0x590
-               	mv	a0, s1
+               	sd	t2, -0x3f0(s0)
+               	addi	a1, s0, -0x70
+               	addi	t2, s0, -0x78
+               	sd	t2, -0x468(s0)
+               	addi	s1, s0, -0x80
+               	addi	s2, s0, -0x88
+               	addi	a3, s0, -0x90
+               	addi	a3, s0, -0x98
+               	addi	a3, s0, -0xa0
+               	addi	a4, s0, -0xa8
+               	addi	a4, s0, -0xb0
+               	addi	s3, s0, -0xb8
+               	addi	a4, s0, -0xc0
+               	addi	a4, s0, -0xc8
+               	addi	t2, s0, -0xd0
+               	sd	t2, -0x470(s0)
+               	addi	a5, s0, -0xd8
+               	addi	a5, s0, -0xe0
+               	addi	s4, s0, -0xe8
+               	addi	a5, s0, -0xf0
+               	addi	a5, s0, -0xf8
+               	addi	a5, s0, -0x100
+               	addi	a5, s0, -0x108
+               	addi	s5, s0, -0x110
+               	addi	a5, s0, -0x118
+               	addi	a5, s0, -0x120
+               	addi	s6, s0, -0x128
+               	addi	a5, s0, -0x130
+               	addi	a5, s0, -0x138
+               	addi	s7, s0, -0x140
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x150
+               	addi	s8, s0, -0x158
+               	addi	a5, s0, -0x160
+               	addi	a5, s0, -0x168
+               	addi	s9, s0, -0x170
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x180
+               	addi	s10, s0, -0x188
+               	addi	a5, s0, -0x190
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a0
+               	addi	a5, s0, -0x1a8
+               	addi	s11, s0, -0x1b0
+               	addi	a5, s0, -0x1b8
+               	addi	a5, s0, -0x1c0
+               	addi	t2, s0, -0x1c8
+               	sd	t2, -0x478(s0)
+               	addi	a6, s0, -0x1d0
+               	addi	a6, s0, -0x1d8
+               	addi	t2, s0, -0x1e0
+               	sd	t2, -0x480(s0)
+               	addi	a7, s0, -0x1e8
+               	addi	a7, s0, -0x1f0
+               	addi	t2, s0, -0x1f8
+               	sd	t2, -0x488(s0)
+               	addi	t5, s0, -0x200
+               	addi	t5, s0, -0x208
+               	addi	t2, s0, -0x210
+               	sd	t2, -0x490(s0)
+               	addi	t6, s0, -0x218
+               	addi	t6, s0, -0x220
+               	addi	t2, s0, -0x228
+               	sd	t2, -0x498(s0)
+               	addi	a0, s0, -0x230
+               	addi	t2, s0, -0x238
+               	sd	t2, -0x3f8(s0)
+               	addi	a0, s0, -0x240
+               	addi	t2, s0, -0x248
+               	sd	t2, -0x400(s0)
+               	addi	a0, s0, -0x250
+               	addi	a0, s0, -0x258
+               	addi	a0, s0, -0x260
+               	addi	a0, s0, -0x268
+               	addi	a0, s0, -0x270
+               	addi	a0, s0, -0x278
+               	addi	t2, s0, -0x280
+               	sd	t2, -0x408(s0)
+               	addi	a0, s0, -0x288
+               	addi	a0, s0, -0x290
+               	addi	a0, s0, -0x298
+               	addi	a0, s0, -0x2a0
+               	addi	t2, s0, -0x2a8
+               	sd	t2, -0x410(s0)
+               	addi	a0, s0, -0x2b0
+               	addi	a0, s0, -0x2b8
+               	addi	a0, s0, -0x2c0
+               	addi	t2, s0, -0x2c8
+               	sd	t2, -0x418(s0)
+               	addi	a0, s0, -0x2d0
+               	addi	a0, s0, -0x2d8
+               	addi	a0, s0, -0x2e0
+               	addi	t2, s0, -0x2e8
+               	sd	t2, -0x420(s0)
+               	addi	a0, s0, -0x2f0
+               	addi	a0, s0, -0x2f8
+               	addi	a0, s0, -0x300
+               	addi	t2, s0, -0x308
+               	sd	t2, -0x428(s0)
+               	addi	a0, s0, -0x310
+               	addi	a0, s0, -0x318
+               	addi	a0, s0, -0x320
+               	addi	a0, s0, -0x328
+               	addi	t2, s0, -0x330
+               	sd	t2, -0x430(s0)
+               	addi	a0, s0, -0x338
+               	addi	a0, s0, -0x340
+               	addi	t2, s0, -0x348
+               	sd	t2, -0x438(s0)
+               	addi	a0, s0, -0x350
+               	addi	a0, s0, -0x358
+               	addi	a0, s0, -0x360
+               	addi	a0, s0, -0x368
+               	addi	t2, s0, -0x370
+               	sd	t2, -0x440(s0)
+               	addi	t2, s0, -0x378
+               	sd	t2, -0x448(s0)
+               	addi	t2, s0, -0x380
+               	sd	t2, -0x450(s0)
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x458(s0)
+               	ld	t3, -0x3f0(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x460(s0)
+               	addi	a0, s0, -0x3cc
+               	mv	a2, a0
                	li	t0, 0x3e9
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	lui	t0, 0x10
                	addiw	t0, t0, -0x44f
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x4b7
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	lui	t0, 0x10
                	addiw	t0, t0, -0x515
-               	sh	t0, 0x0(a0)
-               	mv	a0, s1
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x6
-               	sh	a1, 0x0(a0)
-               	addi	a0, s0, -0x598
-               	mv	a1, a0
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, a1
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a0, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x3d4
+               	mv	a2, a0
                	li	t0, 0xd
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	lui	t0, 0x10
                	addiw	t0, t0, -0xb
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x9
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	lui	t0, 0x10
                	addiw	t0, t0, -0x7
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x468(s0)
+               	mv	a2, t2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x468(s0)
+               	addi	a2, t2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x468(s0)
+               	addi	a2, t2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a0, 0x0(a2)
+               	ld	t2, -0x468(s0)
+               	addi	a2, t2, 0x6
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x3dc
+               	mv	a2, a0
+               	li	t0, 0x1
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	li	t0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	li	t0, 0x3
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	li	t0, 0x4
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s1
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s1, 0x6
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x3e4
+               	mv	a2, a0
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	sh	zero, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s2, 0x6
+               	sh	a0, 0x0(a2)
+               	mv	a0, a1
+               	lhu	a2, 0x0(a0)
+               	ld	t2, -0x460(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lhu	a4, 0x0(a2)
+               	mv	a2, a3
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lhu	a1, 0x0(a2)
+               	addi	a2, a3, 0x6
+               	sh	a1, 0x0(a2)
+               	mv	a1, a3
+               	sh	a0, 0x0(a1)
+               	addi	a0, a3, 0x6
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x460(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lhu	a2, 0x0(a1)
                	mv	a1, s3
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x2
+               	lhu	a2, 0x0(a1)
                	addi	a1, s3, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lhu	a2, 0x0(a1)
                	addi	a1, s3, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	a0, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	sh	a2, 0x0(a1)
                	addi	a1, s3, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s0, -0x5a0
-               	mv	a1, a0
-               	li	t0, 0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	li	t0, 0x2
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	li	t0, 0x3
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	li	t0, 0x4
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	ld	t2, -0x468(s0)
+               	addi	a0, t2, 0x2
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x460(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x468(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	mv	a1, t2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x468(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x468(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x4
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x468(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x6
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x2
+               	sh	a0, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a0, t2, 0x4
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x460(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x470(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
                	mv	a1, s4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	a0, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x470(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
                	sh	a0, 0x0(a1)
-               	addi	a0, s0, -0x5a8
-               	mv	a1, a0
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	zero, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x5d0>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x5dc>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x6
+               	sh	a1, 0x0(a2)
                	mv	a1, s5
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	a0, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	sh	a0, 0x0(a1)
-               	mv	a0, s2
-               	lhu	a1, 0x0(a0)
-               	ld	t2, -0x678(s0)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x658>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x6
+               	sh	a1, 0x0(a2)
                	mv	a1, s6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	sh	s1, 0x0(a1)
-               	mv	a1, s6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s6, 0x6
-               	lhu	a1, 0x0(a0)
-               	ld	t2, -0x678(s0)
-               	addw	a0, a1, t2
-               	mv	a1, s6
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6d4>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x6
+               	sh	a1, 0x0(a2)
                	mv	a1, s7
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x750>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x6
+               	sh	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7cc>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x6
+               	sh	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x848>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x6
+               	sh	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x8c4>
+               	mv	a1, s5
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x6
+               	sh	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x940>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x478(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x478(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x478(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x478(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x478(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x9d0>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x480(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x480(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x480(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x480(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x480(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa60>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x488(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x488(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x488(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x488(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x488(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xaf0>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x490(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x490(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x490(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x490(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x490(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb80>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x498(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x498(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x498(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x498(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x498(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc10>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x3f8(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x3f8(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x3f8(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x3f8(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x3f8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc80>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x400(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x400(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x400(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x400(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x400(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xcf0>
+               	ld	t2, -0x488(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x490(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x408(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x488(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x490(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x408(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x488(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x490(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x408(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x488(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x490(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x408(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x408(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xda0>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x6
+               	bltu	s7, t0, 0xf40 <corpus.cases.vec.vec_i16x4.checksum+0xdc0>
+               	j	0x11bc <corpus.cases.vec.vec_i16x4.checksum+0x103c>
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x410(s0)
+               	mv	a1, t2
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
-               	ld	t2, -0x678(s0)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s8, 0x4
-               	lhu	a1, 0x0(a0)
-               	ld	t2, -0x678(s0)
-               	addw	a0, a1, t2
-               	mv	a1, s8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sh	a0, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	ld	t2, -0x670(s0)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x68c>
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6a0>
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6b4>
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6c8>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6dc>
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x6f0>
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x704>
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x718>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	mv	s1, s10
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x6
-               	sh	a1, 0x0(s1)
-               	mv	a1, s10
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x79c>
-               	addi	a1, s10, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7b0>
-               	addi	a1, s10, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7c4>
-               	addi	a1, s10, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x7d8>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	mv	s1, s11
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x6
-               	sh	a1, 0x0(s1)
-               	mv	a1, s11
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x85c>
-               	addi	a1, s11, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x870>
-               	addi	a1, s11, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x884>
-               	addi	a1, s11, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x898>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s7
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	ld	t2, -0x680(s0)
-               	mv	s1, t2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	ld	t2, -0x680(s0)
-               	addi	s1, t2, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	ld	t2, -0x680(s0)
-               	addi	s1, t2, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	ld	t2, -0x680(s0)
-               	addi	s1, t2, 0x6
-               	sh	a1, 0x0(s1)
-               	ld	t2, -0x680(s0)
-               	mv	a1, t2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x930>
-               	ld	t2, -0x680(s0)
-               	addi	a1, t2, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x948>
-               	ld	t2, -0x680(s0)
-               	addi	a1, t2, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x960>
-               	ld	t2, -0x680(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x978>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	ld	t2, -0x688(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	ld	t2, -0x688(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	ld	t2, -0x688(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	ld	t2, -0x688(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x688(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa10>
-               	ld	t2, -0x688(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa28>
-               	ld	t2, -0x688(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa40>
-               	ld	t2, -0x688(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xa58>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x690(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x690(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x690(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x690(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x690(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xaf0>
-               	ld	t2, -0x690(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb08>
-               	ld	t2, -0x690(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb20>
-               	ld	t2, -0x690(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xb38>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x698(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x698(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x698(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x698(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x698(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xbd0>
-               	ld	t2, -0x698(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xbe8>
-               	ld	t2, -0x698(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc00>
-               	ld	t2, -0x698(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xc18>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x6a0(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x6a0(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x6a0(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x6a0(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6a0(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x6a8(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6a0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x6a8(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6a0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x6a8(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6a0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	ld	t2, -0x6a8(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6a8(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd40>
-               	ld	t2, -0x6a8(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd58>
-               	ld	t2, -0x6a8(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd70>
-               	ld	t2, -0x6a8(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xd88>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b0(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b0(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b0(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b0(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6b0(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe20>
-               	ld	t2, -0x6b0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe38>
-               	ld	t2, -0x6b0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe50>
-               	ld	t2, -0x6b0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe68>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b8(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b8(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b8(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	ld	t2, -0x6b8(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x6b8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xef8>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x5f0(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x5f0(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x5f0(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	ld	t2, -0x5f0(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x5f0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xf88>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x5f8(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x5f8(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x5f8(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	ld	t2, -0x5f8(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x5f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1018>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x600(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x600(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x600(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x600(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x600(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x10a8>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x608(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x608(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x608(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x608(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x608(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1118>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x610(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x610(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x610(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	ld	t2, -0x610(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x610(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1188>
-               	ld	t2, -0x5f0(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x5f8(s0)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x618(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x5f0(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x5f8(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x618(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x5f0(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x5f8(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x618(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x5f0(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x5f8(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x618(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x618(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1238>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x1304 <corpus.cases.vec.vec_i16x4.checksum+0x1258>
-               	j	0x16bc <corpus.cases.vec.vec_i16x4.checksum+0x1610>
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s1, 0x2
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	ld	t2, -0x620(s0)
+               	ld	t2, -0x410(s0)
+               	addi	a1, t2, 0x2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x410(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x410(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x410(s0)
                	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x2
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x620(s0)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xe4c>
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x410(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x418(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x410(s0)
                	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x620(s0)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x418(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x410(s0)
                	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x6
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x620(s0)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x418(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x410(s0)
                	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	ld	t2, -0x620(s0)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x418(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x418(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x12e8>
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1300>
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1318>
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1330>
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xeec>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x620(s0)
-               	mv	a1, t2
+               	mv	a1, s3
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x628(s0)
+               	addw	a1, a2, a3
+               	ld	t2, -0x420(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x628(s0)
+               	addw	a1, a2, a3
+               	ld	t2, -0x420(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x628(s0)
+               	addw	a1, a2, a3
+               	ld	t2, -0x420(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x620(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x628(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x628(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13d8>
-               	ld	t2, -0x628(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x13f0>
-               	ld	t2, -0x628(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1408>
-               	ld	t2, -0x628(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1420>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
+               	addi	a1, s3, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x630(s0)
+               	ld	t2, -0x420(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x420(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0xf7c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x428(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
+               	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x630(s0)
+               	ld	t2, -0x428(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x630(s0)
+               	ld	t2, -0x428(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
+               	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
+               	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	ld	t2, -0x630(s0)
+               	ld	t2, -0x428(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	ld	t2, -0x630(s0)
+               	ld	t2, -0x428(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14b8>
-               	ld	t2, -0x630(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14d0>
-               	ld	t2, -0x630(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x14e8>
-               	ld	t2, -0x630(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1500>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x638(s0)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x638(s0)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x638(s0)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x638(s0)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	ld	t2, -0x638(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1598>
-               	ld	t2, -0x638(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15b0>
-               	ld	t2, -0x638(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15c8>
-               	ld	t2, -0x638(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x15e0>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x638(s0)
-               	mv	s7, t2
-               	ld	t2, -0x628(s0)
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x100c>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x428(s0)
+               	mv	s3, t2
+               	ld	t2, -0x418(s0)
+               	mv	s6, t2
+               	ld	t2, -0x420(s0)
                	mv	s2, t2
-               	ld	t2, -0x630(s0)
-               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1304 <corpus.cases.vec.vec_i16x4.checksum+0x1258>
-               	addi	s3, s0, -0x5d8
-               	mv	a0, s3
+               	bltu	s7, t0, 0xf40 <corpus.cases.vec.vec_i16x4.checksum+0xdc0>
+               	addi	s7, s0, -0x3b8
+               	mv	a0, s7
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x16f0 <corpus.cases.vec.vec_i16x4.checksum+0x1644>
+               	bnez	a1, 0x11f0 <corpus.cases.vec.vec_i16x4.checksum+0x1070>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x16d8 <corpus.cases.vec.vec_i16x4.checksum+0x162c>
-               	j	0x170c <corpus.cases.vec.vec_i16x4.checksum+0x1660>
+               	bne	a2, t0, 0x11d8 <corpus.cases.vec.vec_i16x4.checksum+0x1058>
+               	j	0x120c <corpus.cases.vec.vec_i16x4.checksum+0x108c>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x16f8 <corpus.cases.vec.vec_i16x4.checksum+0x164c>
+               	bne	a0, t0, 0x11f8 <corpus.cases.vec.vec_i16x4.checksum+0x1078>
+               	mv	a0, s7
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s9
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x640(s0)
-               	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x8
-               	ld	t2, -0x640(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x640(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x648(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x430(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x648(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x648(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x648(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	ld	t2, -0x648(s0)
+               	addi	a0, s7, 0x8
+               	ld	t2, -0x430(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x648(s0)
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x648(s0)
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x648(s0)
+               	ld	t2, -0x430(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a0, s3, 0x18
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x438(s0)
+               	mv	a1, t2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	addi	a0, s7, 0x10
+               	ld	t2, -0x438(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x438(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a0, s7, 0x18
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a0, s7, 0x20
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
@@ -1620,264 +1317,240 @@ Disassembly of section .text:
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
+               	mv	a0, s3
                	lhu	a1, 0x0(a0)
-               	mv	a0, s9
+               	mv	a0, s4
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
+               	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
+               	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
+               	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
                	xor	a0, a1, a2
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x28
-               	ld	t2, -0x650(s0)
+               	addi	a0, s7, 0x28
+               	ld	t2, -0x440(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	ld	t2, -0x650(s0)
+               	ld	t2, -0x440(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	li	s2, 0x0
+               	li	s1, 0x0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x1a64 <corpus.cases.vec.vec_i16x4.checksum+0x19b8>
-               	j	0x1b2c <corpus.cases.vec.vec_i16x4.checksum+0x1a80>
-               	slli	t0, s2, 0x3
-               	add	a0, s3, t0
+               	bltu	s1, t0, 0x1564 <corpus.cases.vec.vec_i16x4.checksum+0x13e4>
+               	j	0x15e0 <corpus.cases.vec.vec_i16x4.checksum+0x1460>
+               	slli	t0, s1, 0x3
+               	add	a0, s7, t0
                	mv	a1, a0
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x658(s0)
+               	ld	t2, -0x448(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x658(s0)
+               	ld	t2, -0x448(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x658(s0)
+               	ld	t2, -0x448(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	lhu	a0, 0x0(a1)
-               	ld	t2, -0x658(s0)
+               	ld	t2, -0x448(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	ld	t2, -0x658(s0)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x448(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a20>
-               	ld	t2, -0x658(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a38>
-               	ld	t2, -0x658(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a50>
-               	ld	t2, -0x658(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1a68>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1448>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x6
-               	bltu	s2, t0, 0x1a64 <corpus.cases.vec.vec_i16x4.checksum+0x19b8>
-               	addi	s2, s0, -0x5e4
-               	mv	a0, s2
+               	bltu	s1, t0, 0x1564 <corpus.cases.vec.vec_i16x4.checksum+0x13e4>
+               	addi	s1, s0, -0x3c4
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1b64 <corpus.cases.vec.vec_i16x4.checksum+0x1ab8>
+               	bnez	a1, 0x1618 <corpus.cases.vec.vec_i16x4.checksum+0x1498>
                	mv	a1, a0
                	li	a2, 0x8
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1b48 <corpus.cases.vec.vec_i16x4.checksum+0x1a9c>
+               	bne	a2, t0, 0x15fc <corpus.cases.vec.vec_i16x4.checksum+0x147c>
                	sw	zero, 0x0(a1)
-               	j	0x1b80 <corpus.cases.vec.vec_i16x4.checksum+0x1ad4>
+               	j	0x1634 <corpus.cases.vec.vec_i16x4.checksum+0x14b4>
                	mv	a1, a0
                	li	a0, 0xc
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1b6c <corpus.cases.vec.vec_i16x4.checksum+0x1ac0>
-               	mv	a0, s2
+               	bne	a0, t0, 0x1620 <corpus.cases.vec.vec_i16x4.checksum+0x14a0>
+               	mv	a0, s1
                	li	t0, 0xdb
                	sb	t0, 0x0(a0)
-               	addi	a1, s3, 0x10
+               	addi	a1, s7, 0x10
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x660(s0)
+               	ld	t2, -0x450(s0)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x660(s0)
+               	ld	t2, -0x450(s0)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	ld	t2, -0x660(s0)
+               	ld	t2, -0x450(s0)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a1, 0x0(a2)
-               	ld	t2, -0x660(s0)
+               	ld	t2, -0x450(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	addi	s3, s2, 0x2
-               	ld	t2, -0x660(s0)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s3
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x660(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x660(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x660(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
+               	addi	a1, s1, 0x2
+               	ld	t2, -0x450(s0)
+               	mv	a2, t2
+               	lhu	a3, 0x0(a2)
+               	mv	a2, a1
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x450(s0)
+               	addi	a2, t2, 0x2
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x450(s0)
+               	addi	a2, t2, 0x4
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x450(s0)
+               	addi	a2, t2, 0x6
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a3, 0x0(a2)
+               	addi	a1, s1, 0xa
                	li	t0, 0xad
                	sb	t0, 0x0(a1)
                	lbu	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1b9c>
-               	mv	a1, s3
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x170c <corpus.cases.vec.vec_i16x4.checksum+0x158c>
+               	j	0x1740 <corpus.cases.vec.vec_i16x4.checksum+0x15c0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x170c <corpus.cases.vec.vec_i16x4.checksum+0x158c>
+               	addi	a0, s1, 0x2
+               	mv	a1, a0
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x668(s0)
+               	ld	t2, -0x458(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
+               	addi	a1, a0, 0x2
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x668(s0)
+               	ld	t2, -0x458(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	lhu	a2, 0x0(a1)
-               	ld	t2, -0x668(s0)
+               	ld	t2, -0x458(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	lhu	a2, 0x0(a1)
-               	ld	t2, -0x668(s0)
+               	addi	a1, a0, 0x6
+               	lhu	a0, 0x0(a1)
+               	ld	t2, -0x458(s0)
                	addi	a1, t2, 0x6
-               	sh	a2, 0x0(a1)
-               	ld	t2, -0x668(s0)
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x458(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1c04>
-               	ld	t2, -0x668(s0)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1c1c>
-               	ld	t2, -0x668(s0)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1c34>
-               	ld	t2, -0x668(s0)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1c4c>
-               	addi	a1, s2, 0xa
+               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1620>
+               	addi	a1, s1, 0xa
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x4.checksum+0x1c60>
-               	ld	s1, 0x6a8(sp)
-               	ld	s2, 0x6a0(sp)
-               	ld	s3, 0x698(sp)
-               	ld	s4, 0x690(sp)
-               	ld	s5, 0x688(sp)
-               	ld	s6, 0x680(sp)
-               	ld	s7, 0x678(sp)
-               	ld	s8, 0x670(sp)
-               	ld	s9, 0x668(sp)
-               	ld	s10, 0x660(sp)
-               	ld	s11, 0x658(sp)
-               	ld	ra, 0x6b8(sp)
-               	ld	s0, 0x6b0(sp)
-               	addi	sp, sp, 0x6c0
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x17c4 <corpus.cases.vec.vec_i16x4.checksum+0x1644>
+               	j	0x17f8 <corpus.cases.vec.vec_i16x4.checksum+0x1678>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x17c4 <corpus.cases.vec.vec_i16x4.checksum+0x1644>
+               	ld	s1, 0x488(sp)
+               	ld	s2, 0x480(sp)
+               	ld	s3, 0x478(sp)
+               	ld	s4, 0x470(sp)
+               	ld	s5, 0x468(sp)
+               	ld	s6, 0x460(sp)
+               	ld	s7, 0x458(sp)
+               	ld	s8, 0x450(sp)
+               	ld	s9, 0x448(sp)
+               	ld	s10, 0x440(sp)
+               	ld	s11, 0x438(sp)
+               	ld	ra, 0x498(sp)
+               	ld	s0, 0x490(sp)
+               	addi	sp, sp, 0x4a0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i16x8.dis
+++ b/test/golden/riscv64-linux/vec/vec_i16x8.dis
@@ -3,4730 +3,2556 @@ vec/vec_i16x8.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i16x8.fold_vec>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x98
-               	mv	a1, s1
-               	lhu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0x4c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x80
+               	addi	a2, s0, -0x90
+               	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0x68>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x50 <corpus.cases.vec.vec_i16x8.fold_vec+0x50>
+               	j	0x84 <corpus.cases.vec.vec_i16x8.fold_vec+0x84>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x50 <corpus.cases.vec.vec_i16x8.fold_vec+0x50>
+               	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0x84>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa4 <corpus.cases.vec.vec_i16x8.fold_vec+0xa4>
+               	j	0xd8 <corpus.cases.vec.vec_i16x8.fold_vec+0xd8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa4 <corpus.cases.vec.vec_i16x8.fold_vec+0xa4>
+               	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0xa0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xf8 <corpus.cases.vec.vec_i16x8.fold_vec+0xf8>
+               	j	0x12c <corpus.cases.vec.vec_i16x8.fold_vec+0x12c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xf8 <corpus.cases.vec.vec_i16x8.fold_vec+0xf8>
+               	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0xbc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c <corpus.cases.vec.vec_i16x8.fold_vec+0x14c>
+               	j	0x180 <corpus.cases.vec.vec_i16x8.fold_vec+0x180>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c <corpus.cases.vec.vec_i16x8.fold_vec+0x14c>
+               	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0xd8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a0 <corpus.cases.vec.vec_i16x8.fold_vec+0x1a0>
+               	j	0x1d4 <corpus.cases.vec.vec_i16x8.fold_vec+0x1d4>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a0 <corpus.cases.vec.vec_i16x8.fold_vec+0x1a0>
+               	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0xf4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1f4 <corpus.cases.vec.vec_i16x8.fold_vec+0x1f4>
+               	j	0x228 <corpus.cases.vec.vec_i16x8.fold_vec+0x228>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1f4 <corpus.cases.vec.vec_i16x8.fold_vec+0x1f4>
+               	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.fold_vec+0x110>
-               	ld	s1, 0x88(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	slli	a2, a3, 0x30
+               	srai	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x248 <corpus.cases.vec.vec_i16x8.fold_vec+0x248>
+               	j	0x27c <corpus.cases.vec.vec_i16x8.fold_vec+0x27c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x248 <corpus.cases.vec.vec_i16x8.fold_vec+0x248>
+               	addi	a2, a1, 0xe
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srai	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.vec.vec_i16x8.fold_vec+0x29c>
+               	j	0x2d0 <corpus.cases.vec.vec_i16x8.fold_vec+0x2d0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.vec.vec_i16x8.fold_vec+0x29c>
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret
 
 <corpus.cases.vec.vec_i16x8.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x18
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x20
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x28
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x30
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x38
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x40
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x48
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x50
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x58
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x60
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x68
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x70
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x78
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	t2, s0, -0x2d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x518
-               	addi	t2, s0, -0x528
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	t2, s0, -0x568
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x598
-               	addi	t2, s0, -0x5a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x638
-               	addi	t2, s0, -0x648
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x658
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x668
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x468
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x448
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x428
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x398
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x388
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x378
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x368
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x358
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x348
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x328
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x318
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x308
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x298
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x288
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x278
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x268
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x258
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x248
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x238
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x228
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x218
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x208
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x198
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x914>
+               	addi	sp, sp, -0x7d0
+               	sd	ra, 0x7c8(sp)
+               	sd	s0, 0x7c0(sp)
+               	addi	s0, sp, 0x7d0
+               	sd	s1, 0x7b8(sp)
+               	sd	s2, 0x7b0(sp)
+               	sd	s3, 0x7a8(sp)
+               	sd	s4, 0x7a0(sp)
+               	sd	s5, 0x798(sp)
+               	sd	s6, 0x790(sp)
+               	sd	s7, 0x788(sp)
+               	sd	s8, 0x780(sp)
+               	sd	s9, 0x778(sp)
+               	sd	s10, 0x770(sp)
+               	sd	s11, 0x768(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x188
-               	add	s1, s0, t0
-               	mv	a0, s1
+               	sd	t2, -0x720(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x798(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x790(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x7a0(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x7a8(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x7b0(s0)
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
+               	sd	t2, -0x7b8(s0)
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
+               	sd	t2, -0x7c0(s0)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	a0, s0, -0x4d8
+               	addi	t2, s0, -0x4e8
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	a0, s0, -0x518
+               	addi	t2, s0, -0x528
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	a0, s0, -0x558
+               	addi	t2, s0, -0x568
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	a0, s0, -0x598
+               	addi	t2, s0, -0x5a8
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	a0, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x760(s0)
+               	addi	a0, s0, -0x608
+               	addi	a0, s0, -0x618
+               	addi	t2, s0, -0x628
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x638
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x770(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x778(s0)
+               	addi	t2, s0, -0x668
+               	sd	t2, -0x780(s0)
+               	ld	t3, -0x720(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x788(s0)
+               	addi	a0, s0, -0x6e8
+               	mv	a4, a0
                	li	t0, 0x3e9
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x2
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x2
                	lui	t0, 0x10
                	addiw	t0, t0, -0x44f
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
                	li	t0, 0x4b7
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x6
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x6
                	lui	t0, 0x10
                	addiw	t0, t0, -0x515
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x8
                	li	t0, 0x581
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xa
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xa
                	lui	t0, 0x10
                	addiw	t0, t0, -0x5e7
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xc
                	li	t0, 0x641
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xe
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xe
                	lui	t0, 0x10
                	addiw	t0, t0, -0x6ad
-               	sh	t0, 0x0(a0)
-               	mv	a0, s1
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x6
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xa
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xe
-               	sh	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sh	t0, 0x0(a4)
+               	mv	a4, a0
+               	lhu	a2, 0x0(a4)
+               	mv	a4, a1
+               	sh	a2, 0x0(a4)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
                	li	t0, 0xd
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	lui	t0, 0x10
                	addiw	t0, t0, -0xb
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x9
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	lui	t0, 0x10
                	addiw	t0, t0, -0x7
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	li	t0, 0x5
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xa
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
                	lui	t0, 0x10
                	addiw	t0, t0, -0x3
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x2
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xe
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s3
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sh	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x168
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	mv	a2, t2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
                	li	t0, 0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	li	t0, 0x2
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x3
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	li	t0, 0x4
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	li	t0, 0x5
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xa
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
                	li	t0, 0x6
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x7
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xe
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
                	li	t0, 0x8
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s1
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s1, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x718
+               	mv	a2, a0
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	sh	zero, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s2, 0xe
+               	sh	a0, 0x0(a2)
+               	mv	a0, a1
+               	lhu	a2, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lhu	a4, 0x0(a2)
+               	mv	a2, a3
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lhu	a1, 0x0(a2)
+               	addi	a2, a3, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, a3
+               	sh	a0, 0x0(a1)
+               	addi	a0, a3, 0xc
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sh	a0, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a0, t2, 0x4
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x798(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a0, t2, 0xe
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
                	mv	a1, s4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	sh	a2, 0x0(a1)
                	addi	a1, s4, 0xe
                	sh	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	zero, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x8bc>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x8c8>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s5
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
-               	addi	a1, s5, 0xe
-               	sh	a0, 0x0(a1)
-               	mv	a0, s2
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x9b4>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	sh	s1, 0x0(a1)
-               	mv	a1, s6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s6, 0xc
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s6
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xaa0>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s7
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xb8c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xc78>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xd64>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xe50>
+               	mv	a1, s5
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xf3c>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x104c>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x115c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x126c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x137c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7c0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x148c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x155c>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x162c>
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x177c>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x6
+               	bltu	s7, t0, 0x1a7c <corpus.cases.vec.vec_i16x8.checksum+0x179c>
+               	j	0x1f08 <corpus.cases.vec.vec_i16x8.checksum+0x1c28>
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s8, 0xe
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	sh	a0, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfb0>
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfc4>
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfd8>
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0xfec>
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1000>
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1014>
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1028>
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x103c>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1050>
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1064>
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1078>
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x108c>
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10a0>
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10b4>
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10c8>
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x10dc>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	mv	s1, s10
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xe
-               	sh	a1, 0x0(s1)
-               	mv	a1, s10
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11d0>
-               	addi	a1, s10, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11e4>
-               	addi	a1, s10, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x11f8>
-               	addi	a1, s10, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x120c>
-               	addi	a1, s10, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1220>
-               	addi	a1, s10, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1234>
-               	addi	a1, s10, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1248>
-               	addi	a1, s10, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x125c>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	mv	s1, s11
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xe
-               	sh	a1, 0x0(s1)
-               	mv	a1, s11
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1350>
-               	addi	a1, s11, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1364>
-               	addi	a1, s11, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1378>
-               	addi	a1, s11, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x138c>
-               	addi	a1, s11, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13a0>
-               	addi	a1, s11, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13b4>
-               	addi	a1, s11, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13c8>
-               	addi	a1, s11, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x13dc>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s7
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xe
-               	sh	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1560>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1584>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x15f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1614>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1638>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x165c>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x17e0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1804>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1828>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x184c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1870>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1894>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18dc>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1a60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1a84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1aa8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1acc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1af0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b14>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1b5c>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ce0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d4c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d70>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1d94>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1db8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ddc>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2140>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2164>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2188>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21ac>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x21f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2218>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x223c>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x23c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x23e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2408>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x242c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2450>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2474>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2498>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x24bc>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2638>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x27b4>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2930>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2aac>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2be8>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xa
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xe
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2d24>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2fa0>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x30ec <corpus.cases.vec.vec_i16x8.checksum+0x2fc0>
-               	j	0x3bb8 <corpus.cases.vec.vec_i16x8.checksum+0x3a8c>
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s1, 0x4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x740(s0)
                	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x2
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x18a8>
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x6
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x8
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xa
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xa
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xc
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xe
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xe
-               	sh	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x313c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3160>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3184>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x31f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3214>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3238>
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x19d8>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s3
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
+               	addi	a1, s3, 0x6
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
+               	addi	a1, s3, 0xa
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x343c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3460>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3484>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x34f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3514>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3538>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
+               	addi	a1, s3, 0xe
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1ae8>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
+               	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
+               	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
+               	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
+               	addi	a1, s3, 0x8
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s4, 0x8
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
+               	addi	a1, s3, 0xa
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
+               	addi	a1, s4, 0xa
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
+               	addi	a1, s3, 0xc
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s4, 0xc
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
+               	addi	a1, s3, 0xe
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
+               	addi	a1, s4, 0xe
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x36bc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x36e0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3704>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3728>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x374c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3770>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3794>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x37b8>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x393c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3960>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3984>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x39f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3a14>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x3a38>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s7, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x1bf8>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x758(s0)
+               	mv	s3, t2
+               	ld	t2, -0x748(s0)
+               	mv	s6, t2
+               	ld	t2, -0x750(s0)
                	mv	s2, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x30ec <corpus.cases.vec.vec_i16x8.checksum+0x2fc0>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s7, t0, 0x1a7c <corpus.cases.vec.vec_i16x8.checksum+0x179c>
+               	addi	s2, s0, -0x6a8
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x3bf4 <corpus.cases.vec.vec_i16x8.checksum+0x3ac8>
+               	bnez	a1, 0x1f3c <corpus.cases.vec.vec_i16x8.checksum+0x1c5c>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x3bdc <corpus.cases.vec.vec_i16x8.checksum+0x3ab0>
-               	j	0x3c10 <corpus.cases.vec.vec_i16x8.checksum+0x3ae4>
+               	bne	a2, t0, 0x1f24 <corpus.cases.vec.vec_i16x8.checksum+0x1c44>
+               	j	0x1f58 <corpus.cases.vec.vec_i16x8.checksum+0x1c78>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x3bfc <corpus.cases.vec.vec_i16x8.checksum+0x3ad0>
+               	bne	a0, t0, 0x1f44 <corpus.cases.vec.vec_i16x8.checksum+0x1c64>
+               	mv	a0, s2
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sh	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s9
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xa
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xe
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
+               	addi	a0, s3, 0xa
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xa
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
+               	addi	a0, s3, 0xe
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xe
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sh	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
+               	sh	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sh	a2, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s2, 0x30
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sh	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x41f0 <corpus.cases.vec.vec_i16x8.checksum+0x40c4>
-               	j	0x442c <corpus.cases.vec.vec_i16x8.checksum+0x4300>
+               	bltu	s1, t0, 0x23b8 <corpus.cases.vec.vec_i16x8.checksum+0x20d8>
+               	j	0x2488 <corpus.cases.vec.vec_i16x8.checksum+0x21a8>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	mv	a0, t2
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x2
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x2
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x4
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x6
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x6
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x8
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xa
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xa
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xc
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xe
                	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xe
                	sh	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x41ec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4210>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4234>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4258>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x427c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x42a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x42c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x42e8>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2190>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x41f0 <corpus.cases.vec.vec_i16x8.checksum+0x40c4>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xe8
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0x23b8 <corpus.cases.vec.vec_i16x8.checksum+0x20d8>
+               	addi	s1, s0, -0x6d8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x4468 <corpus.cases.vec.vec_i16x8.checksum+0x433c>
+               	bnez	a1, 0x24bc <corpus.cases.vec.vec_i16x8.checksum+0x21dc>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x4450 <corpus.cases.vec.vec_i16x8.checksum+0x4324>
-               	j	0x4484 <corpus.cases.vec.vec_i16x8.checksum+0x4358>
+               	bne	a2, t0, 0x24a4 <corpus.cases.vec.vec_i16x8.checksum+0x21c4>
+               	j	0x24d8 <corpus.cases.vec.vec_i16x8.checksum+0x21f8>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x4470 <corpus.cases.vec.vec_i16x8.checksum+0x4344>
-               	mv	a0, s2
+               	bne	a0, t0, 0x24c4 <corpus.cases.vec.vec_i16x8.checksum+0x21e4>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s3
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x778(s0)
+               	mv	a2, t2
+               	lhu	a3, 0x0(a2)
+               	mv	a2, a1
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x2
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x4
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x6
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x8
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xa
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xc
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xe
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sh	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x458c>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2660 <corpus.cases.vec.vec_i16x8.checksum+0x2380>
+               	j	0x2694 <corpus.cases.vec.vec_i16x8.checksum+0x23b4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2660 <corpus.cases.vec.vec_i16x8.checksum+0x2380>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
+               	addi	a1, a0, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
+               	addi	a1, a0, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x8
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xa
+               	addi	a1, a0, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xa
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
+               	addi	a1, a0, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xc
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0xe
+               	lhu	a0, 0x0(a1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xe
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x46f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x471c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4740>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4764>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x4788>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x47ac>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x2464>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i16x8.checksum+0x47c0>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x28
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x30
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x38
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x40
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x48
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x50
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x58
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x60
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x68
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x70
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x78
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x18
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x20
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x276c <corpus.cases.vec.vec_i16x8.checksum+0x248c>
+               	j	0x27a0 <corpus.cases.vec.vec_i16x8.checksum+0x24c0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x276c <corpus.cases.vec.vec_i16x8.checksum+0x248c>
+               	ld	s1, 0x7b8(sp)
+               	ld	s2, 0x7b0(sp)
+               	ld	s3, 0x7a8(sp)
+               	ld	s4, 0x7a0(sp)
+               	ld	s5, 0x798(sp)
+               	ld	s6, 0x790(sp)
+               	ld	s7, 0x788(sp)
+               	ld	s8, 0x780(sp)
+               	ld	s9, 0x778(sp)
+               	ld	s10, 0x770(sp)
+               	ld	s11, 0x768(sp)
+               	ld	ra, 0x7c8(sp)
+               	ld	s0, 0x7c0(sp)
+               	addi	sp, sp, 0x7d0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i32x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_i32x4.dis
@@ -3,2624 +3,1487 @@ vec/vec_i32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i32x4.fold_vec>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.fold_vec+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.fold_vec+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3c <corpus.cases.vec.vec_i32x4.fold_vec+0x3c>
+               	j	0x70 <corpus.cases.vec.vec_i32x4.fold_vec+0x70>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3c <corpus.cases.vec.vec_i32x4.fold_vec+0x3c>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.fold_vec+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x8c <corpus.cases.vec.vec_i32x4.fold_vec+0x8c>
+               	j	0xc0 <corpus.cases.vec.vec_i32x4.fold_vec+0xc0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x8c <corpus.cases.vec.vec_i32x4.fold_vec+0x8c>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.fold_vec+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xdc <corpus.cases.vec.vec_i32x4.fold_vec+0xdc>
+               	j	0x110 <corpus.cases.vec.vec_i32x4.fold_vec+0x110>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xdc <corpus.cases.vec.vec_i32x4.fold_vec+0xdc>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12c <corpus.cases.vec.vec_i32x4.fold_vec+0x12c>
+               	j	0x160 <corpus.cases.vec.vec_i32x4.fold_vec+0x160>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x12c <corpus.cases.vec.vec_i32x4.fold_vec+0x12c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_i32x4.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x420
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x428
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x430
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x420
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x438
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x440
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x448
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x450
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x458
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x460
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x468
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x470
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x478
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x480
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x488
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	t2, s0, -0x2d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	t2, s0, -0x4d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4e8
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	t2, s0, -0x518
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x528
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	t2, s0, -0x558
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x568
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	t2, s0, -0x598
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5a8
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	t2, s0, -0x5e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5f8
-               	addi	a1, s0, -0x608
-               	addi	t2, s0, -0x618
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x628
-               	addi	t2, s0, -0x638
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x648
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x658
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x668
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x608>
+               	addi	sp, sp, -0x7c0
+               	sd	ra, 0x7b8(sp)
+               	sd	s0, 0x7b0(sp)
+               	addi	s0, sp, 0x7c0
+               	sd	s1, 0x7a8(sp)
+               	sd	s2, 0x7a0(sp)
+               	sd	s3, 0x798(sp)
+               	sd	s4, 0x790(sp)
+               	sd	s5, 0x788(sp)
+               	sd	s6, 0x780(sp)
+               	sd	s7, 0x778(sp)
+               	sd	s8, 0x770(sp)
+               	sd	s9, 0x768(sp)
+               	sd	s10, 0x760(sp)
+               	sd	s11, 0x758(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	s1, s0, t0
-               	mv	a0, s1
+               	sd	t2, -0x710(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x780(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x788(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x790(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x798(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x7a0(s0)
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
+               	sd	t2, -0x7a8(s0)
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
+               	sd	t2, -0x7b0(s0)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x718(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x720(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	t2, s0, -0x4d8
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x4e8
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	t2, s0, -0x518
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x528
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	t2, s0, -0x558
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x568
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	t2, s0, -0x598
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x5a8
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	t2, s0, -0x5e8
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x5f8
+               	addi	a0, s0, -0x608
+               	addi	t2, s0, -0x618
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x628
+               	addi	t2, s0, -0x638
+               	sd	t2, -0x760(s0)
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x768(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x770(s0)
+               	ld	t3, -0x710(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x778(s0)
+               	addi	a0, s0, -0x6d8
+               	mv	a2, a0
                	lui	t0, 0x2
                	addiw	t0, t0, 0x717
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x100
                	addiw	t0, t0, -0x5
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1d5
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x7
                	addiw	t0, t0, 0x53d
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x100
                	addiw	t0, t0, -0x8
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a0)
-               	mv	a0, s1
-               	lw	a1, 0x0(a0)
-               	mv	a0, s2
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	sw	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, a1
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x6e8
+               	mv	a2, a0
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x7
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x83
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x3f1
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x3
-               	sw	t0, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
-               	mv	a1, s3
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	mv	a2, t2
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
                	li	t0, 0x1
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x3
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	li	t0, 0x9
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x1b
-               	sw	t0, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, s1
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sw	zero, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, s2
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sw	a0, 0x0(a2)
+               	mv	a0, a1
+               	lw	a2, 0x0(a0)
+               	ld	t2, -0x778(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lw	a4, 0x0(a2)
+               	mv	a2, a3
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, a3
+               	sw	a0, 0x0(a1)
+               	addi	a0, a3, 0x8
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x778(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a0, 0x0(a1)
+               	ld	t2, -0x780(s0)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x778(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x780(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x780(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x780(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x780(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x778(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x788(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
                	mv	a1, s4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
                	addi	a1, s4, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
                	addi	a1, s4, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x788(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sw	a2, 0x0(a1)
                	addi	a1, s4, 0xc
                	sw	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sw	zero, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x5d4>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x5e0>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s5
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s2
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lw	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x65c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s6
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sw	s1, 0x0(a1)
-               	mv	a1, s6
-               	sw	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s6
-               	lw	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x6d8>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s7
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x754>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x7d0>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x84c>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x8c8>
+               	mv	a1, s5
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x944>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x790(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x9d4>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x798(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa64>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xaf4>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb84>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc14>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x718(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x718(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x718(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x718(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x718(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc84>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x720(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x720(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x720(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x720(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x720(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xcf4>
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7a8(s0)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7a8(s0)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7a8(s0)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xda4>
+               	mv	s5, a0
+               	li	s6, 0x0
+               	li	t0, 0x6
+               	bltu	s6, t0, 0xf30 <corpus.cases.vec.vec_i32x4.checksum+0xdc0>
+               	j	0x11b4 <corpus.cases.vec.vec_i32x4.checksum+0x1044>
+               	mv	a0, s3
+               	lw	a1, 0x0(a0)
+               	mv	a0, s1
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
                	sw	a0, 0x0(a1)
                	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
+               	addi	a0, s1, 0x4
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0xc
+               	sw	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe4c>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x730(s0)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xeec>
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf8c>
                	mv	a1, s3
-               	lw	s1, 0x0(a1)
-               	mv	a1, s8
-               	sw	s1, 0x0(a1)
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
                	addi	a1, s3, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	s1, 0x0(a1)
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
                	addi	a1, s3, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	sw	s1, 0x0(a1)
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
                	addi	a1, s3, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s8, 0xc
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa00>
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa14>
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa28>
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa3c>
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa50>
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa64>
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa78>
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xa8c>
-               	mv	a1, s7
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	mv	s1, s10
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xc
-               	sw	a1, 0x0(s1)
-               	mv	a1, s10
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb10>
-               	addi	a1, s10, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb24>
-               	addi	a1, s10, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb38>
-               	addi	a1, s10, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xb4c>
-               	mv	a1, s7
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	mv	s1, s11
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xc
-               	sw	a1, 0x0(s1)
-               	mv	a1, s11
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbd0>
-               	addi	a1, s11, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbe4>
-               	addi	a1, s11, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xbf8>
-               	addi	a1, s11, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xc0c>
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mv	a1, s7
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	sw	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xce0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xd4c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe44>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe68>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xe8c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, s4, 0xc
                	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xf84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfa8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0xfcc>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x10e8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x110c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x748(s0)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x12d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x12f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1318>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x133c>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	mv	a1, s7
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1410>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1434>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1458>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x147c>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x748(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1548>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1614>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x16e0>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x17ac>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1858>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1904>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1a50>
-               	mv	s1, a0
-               	li	s2, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x101c>
+               	addi	s6, s6, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x748(s0)
+               	mv	s3, t2
+               	ld	t2, -0x740(s0)
+               	mv	s2, t2
                	li	t0, 0x6
-               	bltu	s2, t0, 0x1b18 <corpus.cases.vec.vec_i32x4.checksum+0x1a6c>
-               	j	0x20d0 <corpus.cases.vec.vec_i32x4.checksum+0x2024>
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1b80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ba4>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1cb8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1cdc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d00>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1d24>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1e80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1ea4>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1f78>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1f9c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1fc0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1fe4>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s7, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
-               	li	t0, 0x6
-               	bltu	s2, t0, 0x1b18 <corpus.cases.vec.vec_i32x4.checksum+0x1a6c>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s6, t0, 0xf30 <corpus.cases.vec.vec_i32x4.checksum+0xdc0>
+               	addi	s6, s0, -0x698
+               	mv	a0, s6
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x210c <corpus.cases.vec.vec_i32x4.checksum+0x2060>
+               	bnez	a1, 0x11e8 <corpus.cases.vec.vec_i32x4.checksum+0x1078>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x20f4 <corpus.cases.vec.vec_i32x4.checksum+0x2048>
-               	j	0x2128 <corpus.cases.vec.vec_i32x4.checksum+0x207c>
+               	bne	a2, t0, 0x11d0 <corpus.cases.vec.vec_i32x4.checksum+0x1060>
+               	j	0x1204 <corpus.cases.vec.vec_i32x4.checksum+0x1094>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x2114 <corpus.cases.vec.vec_i32x4.checksum+0x2068>
-               	mv	a0, s2
-               	mv	a1, s7
+               	bne	a0, t0, 0x11f0 <corpus.cases.vec.vec_i32x4.checksum+0x1080>
+               	mv	a0, s6
+               	mv	a1, s3
                	lw	a2, 0x0(a1)
                	mv	a1, a0
                	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s3, 0x4
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s3, 0x8
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s3, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sw	a2, 0x0(a1)
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	mv	a0, s9
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a0, 0x0(a1)
-               	addi	a0, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a0
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a0, s7
+               	mv	a0, s3
                	lw	a1, 0x0(a0)
                	mv	a0, s4
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x750(s0)
                	mv	a1, t2
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x4
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x8
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
-               	addi	a0, s2, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a0, s6, 0x10
+               	ld	t2, -0x750(s0)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a0
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sw	a2, 0x0(a1)
-               	addi	a0, s2, 0x30
-               	mv	a1, s5
+               	mv	a0, s3
+               	lw	a1, 0x0(a0)
+               	mv	a0, s1
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0xc
+               	sw	a0, 0x0(a1)
+               	addi	a0, s6, 0x20
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a0
                	sw	a2, 0x0(a1)
-               	addi	a1, s5, 0x4
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s5, 0x8
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s5, 0xc
+               	ld	t2, -0x758(s0)
+               	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sw	a2, 0x0(a1)
-               	li	s3, 0x0
+               	addi	a0, s6, 0x30
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, a0
+               	sw	a2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sw	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x2428 <corpus.cases.vec.vec_i32x4.checksum+0x237c>
-               	j	0x2554 <corpus.cases.vec.vec_i32x4.checksum+0x24a8>
+               	bltu	s1, t0, 0x1444 <corpus.cases.vec.vec_i32x4.checksum+0x12d4>
+               	j	0x14c4 <corpus.cases.vec.vec_i32x4.checksum+0x1354>
                	li	t0, 0x10
-               	mul	a0, s3, t0
-               	add	a1, s2, a0
+               	mul	a0, s1, t0
+               	add	a1, s6, a0
                	mv	a0, a1
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	mv	a0, t2
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a0, t2, 0x4
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a0, t2, 0x8
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a0, t2, 0xc
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lw	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x760(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2424>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2448>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x246c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2490>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x133c>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s3, t0, 0x2428 <corpus.cases.vec.vec_i32x4.checksum+0x237c>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s1, t0, 0x1444 <corpus.cases.vec.vec_i32x4.checksum+0x12d4>
+               	addi	s1, s0, -0x6c8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x2590 <corpus.cases.vec.vec_i32x4.checksum+0x24e4>
+               	bnez	a1, 0x14f8 <corpus.cases.vec.vec_i32x4.checksum+0x1388>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x2578 <corpus.cases.vec.vec_i32x4.checksum+0x24cc>
-               	j	0x25ac <corpus.cases.vec.vec_i32x4.checksum+0x2500>
+               	bne	a2, t0, 0x14e0 <corpus.cases.vec.vec_i32x4.checksum+0x1370>
+               	j	0x1514 <corpus.cases.vec.vec_i32x4.checksum+0x13a4>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x2598 <corpus.cases.vec.vec_i32x4.checksum+0x24ec>
-               	mv	a0, s3
+               	bne	a0, t0, 0x1500 <corpus.cases.vec.vec_i32x4.checksum+0x1390>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s2, 0x20
+               	addi	a1, s6, 0x20
                	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x768(s0)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x768(s0)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x768(s0)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x768(s0)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	addi	s2, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x768(s0)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
+               	mv	a2, a1
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x768(s0)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x768(s0)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x768(s0)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sw	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2634>
-               	mv	a1, s2
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15fc <corpus.cases.vec.vec_i32x4.checksum+0x148c>
+               	j	0x1630 <corpus.cases.vec.vec_i32x4.checksum+0x14c0>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x15fc <corpus.cases.vec.vec_i32x4.checksum+0x148c>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	mv	a1, t2
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	addi	a1, a0, 0x4
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a1, t2, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	addi	a1, a0, 0x8
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a1, t2, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0xc
+               	lw	a0, 0x0(a1)
+               	ld	t2, -0x770(s0)
                	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sw	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x26d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x1520>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x26fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2720>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2744>
-               	addi	a1, s3, 0x20
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i32x4.checksum+0x2758>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x438
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x440
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x448
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x450
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x458
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x460
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x468
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x470
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x478
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x480
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x488
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x428
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x430
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x420
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x16b8 <corpus.cases.vec.vec_i32x4.checksum+0x1548>
+               	j	0x16ec <corpus.cases.vec.vec_i32x4.checksum+0x157c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x16b8 <corpus.cases.vec.vec_i32x4.checksum+0x1548>
+               	ld	s1, 0x7a8(sp)
+               	ld	s2, 0x7a0(sp)
+               	ld	s3, 0x798(sp)
+               	ld	s4, 0x790(sp)
+               	ld	s5, 0x788(sp)
+               	ld	s6, 0x780(sp)
+               	ld	s7, 0x778(sp)
+               	ld	s8, 0x770(sp)
+               	ld	s9, 0x768(sp)
+               	ld	s10, 0x760(sp)
+               	ld	s11, 0x758(sp)
+               	ld	ra, 0x7b8(sp)
+               	ld	s0, 0x7b0(sp)
+               	addi	sp, sp, 0x7c0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i64x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_i64x2.dis
@@ -3,1238 +3,768 @@ vec/vec_i64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i64x2.fold_vec>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.fold_vec+0x34>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.fold_vec+0x50>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_i64x2.fold_vec+0x30>
+               	j	0x64 <corpus.cases.vec.vec_i64x2.fold_vec+0x64>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_i64x2.fold_vec+0x30>
+               	addi	a2, a1, 0x8
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_i64x2.fold_vec+0x7c>
+               	j	0xb0 <corpus.cases.vec.vec_i64x2.fold_vec+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_i64x2.fold_vec+0x7c>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_i64x2.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b0
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b8
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c0
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c8
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	a1, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	s8, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	s9, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	t2, s0, -0x298
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2a8
-               	addi	a1, s0, -0x2b8
-               	addi	t2, s0, -0x2c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2d8
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	t2, s0, -0x3a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3b8
-               	addi	t2, s0, -0x3c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3d8
-               	addi	a1, s0, -0x3e8
-               	addi	a1, s0, -0x3f8
-               	addi	a1, s0, -0x408
-               	addi	a1, s0, -0x418
-               	addi	a1, s0, -0x428
-               	addi	t2, s0, -0x438
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x498
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	t2, s0, -0x4c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4d8
-               	addi	a1, s0, -0x4e8
-               	addi	a1, s0, -0x4f8
-               	addi	t2, s0, -0x508
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x518
-               	addi	a1, s0, -0x528
-               	addi	a1, s0, -0x538
-               	addi	t2, s0, -0x548
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x558
-               	addi	a1, s0, -0x568
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	t2, s0, -0x598
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5a8
-               	addi	a1, s0, -0x5b8
-               	addi	t2, s0, -0x5c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5d8
-               	addi	t2, s0, -0x5e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x608
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x618
-               	addi	a1, s0, -0x628
-               	addi	a1, s0, -0x638
-               	addi	a1, s0, -0x648
-               	addi	a1, s0, -0x658
-               	addi	a1, s0, -0x668
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x42c>
+               	addi	sp, sp, -0x770
+               	sd	ra, 0x768(sp)
+               	sd	s0, 0x760(sp)
+               	addi	s0, sp, 0x770
+               	sd	s1, 0x758(sp)
+               	sd	s2, 0x750(sp)
+               	sd	s3, 0x748(sp)
+               	sd	s4, 0x740(sp)
+               	sd	s5, 0x738(sp)
+               	sd	s6, 0x730(sp)
+               	sd	s7, 0x728(sp)
+               	sd	s8, 0x720(sp)
+               	sd	s9, 0x718(sp)
+               	sd	s10, 0x710(sp)
+               	sd	s11, 0x708(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
+               	sd	t2, -0x6c0(s0)
+               	addi	t2, s0, -0x78
+               	sd	t2, -0x720(s0)
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x718(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	s3, s0, -0xd8
+               	addi	a3, s0, -0xe8
+               	addi	a3, s0, -0xf8
+               	addi	s4, s0, -0x108
+               	addi	a3, s0, -0x118
+               	addi	a3, s0, -0x128
+               	addi	a3, s0, -0x138
+               	addi	a3, s0, -0x148
+               	addi	s5, s0, -0x158
+               	addi	a3, s0, -0x168
+               	addi	a3, s0, -0x178
+               	addi	s6, s0, -0x188
+               	addi	a3, s0, -0x198
+               	addi	a3, s0, -0x1a8
+               	addi	s7, s0, -0x1b8
+               	addi	a3, s0, -0x1c8
+               	addi	a3, s0, -0x1d8
+               	addi	s8, s0, -0x1e8
+               	addi	a3, s0, -0x1f8
+               	addi	a3, s0, -0x208
+               	addi	s9, s0, -0x218
+               	addi	a3, s0, -0x228
+               	addi	a3, s0, -0x238
+               	addi	s10, s0, -0x248
+               	addi	a3, s0, -0x258
+               	addi	a3, s0, -0x268
+               	addi	a3, s0, -0x278
+               	addi	a3, s0, -0x288
+               	addi	s11, s0, -0x298
+               	addi	a3, s0, -0x2a8
+               	addi	a3, s0, -0x2b8
+               	addi	t2, s0, -0x2c8
+               	sd	t2, -0x738(s0)
+               	addi	a4, s0, -0x2d8
+               	addi	a4, s0, -0x2e8
+               	addi	t2, s0, -0x2f8
+               	sd	t2, -0x740(s0)
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x748(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x750(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x758(s0)
+               	addi	t5, s0, -0x398
+               	addi	t2, s0, -0x3a8
+               	sd	t2, -0x760(s0)
+               	addi	t6, s0, -0x3b8
+               	addi	t2, s0, -0x3c8
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x3d8
+               	addi	a0, s0, -0x3e8
+               	addi	a0, s0, -0x3f8
+               	addi	a0, s0, -0x408
+               	addi	a0, s0, -0x418
+               	addi	a0, s0, -0x428
+               	addi	t2, s0, -0x438
+               	sd	t2, -0x6c8(s0)
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	t2, s0, -0x488
+               	sd	t2, -0x6d0(s0)
+               	addi	a0, s0, -0x498
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	t2, s0, -0x4c8
+               	sd	t2, -0x6d8(s0)
+               	addi	a0, s0, -0x4d8
+               	addi	a0, s0, -0x4e8
+               	addi	a0, s0, -0x4f8
+               	addi	t2, s0, -0x508
+               	sd	t2, -0x6e0(s0)
+               	addi	a0, s0, -0x518
+               	addi	a0, s0, -0x528
+               	addi	a0, s0, -0x538
+               	addi	t2, s0, -0x548
+               	sd	t2, -0x6e8(s0)
+               	addi	a0, s0, -0x558
+               	addi	a0, s0, -0x568
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	t2, s0, -0x598
+               	sd	t2, -0x6f0(s0)
+               	addi	a0, s0, -0x5a8
+               	addi	a0, s0, -0x5b8
+               	addi	t2, s0, -0x5c8
+               	sd	t2, -0x6f8(s0)
+               	addi	a0, s0, -0x5d8
+               	addi	t2, s0, -0x5e8
+               	sd	t2, -0x700(s0)
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x708(s0)
+               	addi	t2, s0, -0x608
+               	sd	t2, -0x710(s0)
+               	addi	a0, s0, -0x688
+               	mv	a2, a0
                	lui	t0, 0x3b9ad
                	addiw	t0, t0, -0x5f9
-               	sd	t0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
+               	sd	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x88ca7
                	addiw	t0, t0, -0x40b
-               	sd	t0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s2
-               	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	sd	t0, 0x0(a2)
+               	mv	a2, a0
+               	ld	a1, 0x0(a2)
+               	ld	t2, -0x720(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s0, -0x698
+               	mv	a1, a0
                	lui	t0, 0xb3
                	addiw	t0, t0, -0x2fa
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1ed
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	lui	t0, 0xfff12
                	addiw	t0, t0, -0x6b3
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x7db
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x718(s0)
                	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s3
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	addi	a0, s0, -0x6a8
+               	mv	a1, a0
                	li	t0, 0x1
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	li	t0, 0x3
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s4
+               	addi	a1, s1, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	addi	a0, s0, -0x6b8
+               	mv	a1, a0
                	sd	zero, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	sd	zero, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a0, 0x0(a1)
-               	mv	a1, s5
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	sd	a1, 0x0(a0)
-               	mv	a0, s2
-               	ld	a1, 0x0(a0)
-               	add	t2, a1, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
                	mv	a1, s2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s6
+               	addi	a1, s2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s2, 0x8
+               	ld	t2, -0x720(s0)
+               	mv	a0, t2
                	ld	a1, 0x0(a0)
-               	addi	a0, s6, 0x8
+               	ld	t2, -0x6c0(s0)
+               	add	a0, a1, t2
+               	ld	t2, -0x720(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s3
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sd	a2, 0x0(a1)
+               	mv	a1, s3
+               	sd	a0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	ld	t2, -0x6c0(s0)
+               	add	a0, a1, t2
+               	ld	t2, -0x718(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x3bc>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x3c8>
+               	mv	t2, a0
+               	sd	t2, -0x728(s0)
+               	ld	t2, -0x728(s0)
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a0, 0x0(a1)
+               	add	a1, a2, a0
+               	mv	a0, s5
                	sd	a1, 0x0(a0)
-               	mv	a0, s6
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sd	t2, 0x0(a0)
                	addi	a0, s3, 0x8
                	ld	a1, 0x0(a0)
-               	add	a0, a1, s1
-               	mv	a1, s3
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	sd	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sd	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sd	a0, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x764>
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x778>
-               	mv	a1, s7
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x78c>
-               	addi	a1, s7, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x7a0>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	add	a1, s1, s2
-               	mv	s1, s8
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	add	a1, s1, s2
-               	addi	s1, s8, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x7ec>
-               	addi	a1, s8, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x800>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	mv	s1, s9
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	addi	s1, s9, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s9
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x84c>
-               	addi	a1, s9, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x860>
-               	mv	a1, s7
-               	ld	s1, 0x0(a1)
-               	mv	a1, s6
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	mv	s1, s10
-               	sd	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s10
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8ac>
-               	addi	a1, s10, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8c0>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	mv	s1, s11
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s11
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x90c>
-               	addi	a1, s11, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x920>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s4
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sd	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x99c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x9c0>
-               	mv	a1, s7
-               	ld	a2, 0x0(a1)
-               	mv	a1, s4
-               	ld	s1, 0x0(a1)
-               	mul	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	s1, 0x0(a1)
-               	mul	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa3c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xa60>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s4
-               	ld	a3, 0x0(a1)
-               	mul	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	a3, 0x0(a1)
-               	mul	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb54>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb78>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s6
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xbf4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc18>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xc8c>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd00>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xd74>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xde8>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xe4c>
-               	mv	a1, s7
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xeb0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xf64>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0xff0 <corpus.cases.vec.vec_i64x2.checksum+0xf84>
-               	j	0x12dc <corpus.cases.vec.vec_i64x2.checksum+0x1270>
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s4, 0x8
                	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	add	a0, a1, a2
+               	addi	a1, s5, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
+               	ld	t2, -0x728(s0)
+               	mv	a0, t2
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x420>
+               	mv	t2, a0
+               	sd	t2, -0x730(s0)
+               	ld	t2, -0x730(s0)
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a0, 0x0(a1)
+               	sub	a1, a2, a0
+               	mv	a0, s6
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x8
                	ld	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	sub	a0, a1, a2
+               	addi	a1, s6, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xff8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x478>
+               	mv	a1, s4
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
+               	mv	a1, s3
+               	ld	s6, 0x0(a1)
+               	sub	a1, a2, s6
+               	mv	a2, s7
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	s6, 0x0(a1)
+               	sub	a1, a2, s6
+               	addi	a2, s7, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x101c>
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x4bc>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s8
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s8, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x500>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s9
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s9, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x544>
+               	mv	a1, s4
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s10
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s10, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x588>
+               	mv	a1, s5
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s11
+               	sd	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s5, 0x0(a1)
+               	mul	a1, a2, s5
+               	addi	a2, s11, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x5cc>
                	mv	a1, s2
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a1, s3
+               	ld	s5, 0x0(a1)
+               	sub	a1, a2, s5
+               	ld	t2, -0x738(s0)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, s3, 0x8
+               	ld	s5, 0x0(a1)
+               	sub	a1, a2, s5
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x61c>
+               	mv	a1, s2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	sub	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	sub	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x66c>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x6bc>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x70c>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x75c>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x760(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x760(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x760(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x79c>
+               	mv	a1, s4
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x7dc>
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6c8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6c8(s0)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6c8(s0)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x10b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x10dc>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s6
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1158>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x117c>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x11f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x121c>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s6, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x83c>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0xff0 <corpus.cases.vec.vec_i64x2.checksum+0xf84>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	s3, s0, t0
+               	bltu	s7, t0, 0x91c <corpus.cases.vec.vec_i64x2.checksum+0x85c>
+               	j	0xa90 <corpus.cases.vec.vec_i64x2.checksum+0x9d0>
                	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s1
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6d0(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x8a8>
+               	mv	a1, s6
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6d8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x6d0(s0)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6d8(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6d8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x900>
+               	mv	a1, s2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s3
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e0(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e0(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6e0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x950>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e8(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6e8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x9a0>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x6e8(s0)
+               	mv	s3, t2
+               	ld	t2, -0x6d8(s0)
+               	mv	s6, t2
+               	ld	t2, -0x6e0(s0)
+               	mv	s2, t2
+               	li	t0, 0x6
+               	bltu	s7, t0, 0x91c <corpus.cases.vec.vec_i64x2.checksum+0x85c>
+               	addi	s2, s0, -0x648
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1318 <corpus.cases.vec.vec_i64x2.checksum+0x12ac>
+               	bnez	a1, 0xac4 <corpus.cases.vec.vec_i64x2.checksum+0xa04>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1300 <corpus.cases.vec.vec_i64x2.checksum+0x1294>
-               	j	0x1334 <corpus.cases.vec.vec_i64x2.checksum+0x12c8>
+               	bne	a2, t0, 0xaac <corpus.cases.vec.vec_i64x2.checksum+0x9ec>
+               	j	0xae0 <corpus.cases.vec.vec_i64x2.checksum+0xa20>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1320 <corpus.cases.vec.vec_i64x2.checksum+0x12b4>
+               	bne	a0, t0, 0xacc <corpus.cases.vec.vec_i64x2.checksum+0xa0c>
+               	mv	a0, s2
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
                	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s4
+               	ld	a2, 0x0(a0)
+               	add	a0, a1, a2
+               	ld	t2, -0x6f0(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
+               	ld	a2, 0x0(a0)
+               	add	a0, a1, a2
+               	ld	t2, -0x6f0(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x6f0(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x6f0(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s1
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6f8(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6f8(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x6f8(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x6f8(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a0, s2, 0x30
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, a0
@@ -1243,299 +773,152 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s7
-               	ld	a2, 0x0(a0)
-               	add	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	ld	a2, 0x0(a0)
-               	add	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	li	s2, 0x0
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x14c4 <corpus.cases.vec.vec_i64x2.checksum+0x1458>
-               	j	0x1568 <corpus.cases.vec.vec_i64x2.checksum+0x14fc>
+               	bltu	s1, t0, 0xc10 <corpus.cases.vec.vec_i64x2.checksum+0xb50>
+               	j	0xc68 <corpus.cases.vec.vec_i64x2.checksum+0xba8>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	ld	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x700(s0)
                	mv	a0, t2
                	sd	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x700(s0)
                	addi	a0, t2, 0x8
                	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x700(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x14c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x14e4>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xb90>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x14c4 <corpus.cases.vec.vec_i64x2.checksum+0x1458>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0xc10 <corpus.cases.vec.vec_i64x2.checksum+0xb50>
+               	addi	s1, s0, -0x678
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x15a4 <corpus.cases.vec.vec_i64x2.checksum+0x1538>
+               	bnez	a1, 0xc9c <corpus.cases.vec.vec_i64x2.checksum+0xbdc>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x158c <corpus.cases.vec.vec_i64x2.checksum+0x1520>
-               	j	0x15c0 <corpus.cases.vec.vec_i64x2.checksum+0x1554>
+               	bne	a2, t0, 0xc84 <corpus.cases.vec.vec_i64x2.checksum+0xbc4>
+               	j	0xcb8 <corpus.cases.vec.vec_i64x2.checksum+0xbf8>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x15ac <corpus.cases.vec.vec_i64x2.checksum+0x1540>
-               	mv	a0, s2
+               	bne	a0, t0, 0xca4 <corpus.cases.vec.vec_i64x2.checksum+0xbe4>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	mv	a2, t2
                	sd	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s3
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sd	a2, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x708(s0)
+               	mv	a2, t2
+               	ld	a3, 0x0(a2)
+               	mv	a2, a1
+               	sd	a3, 0x0(a2)
+               	ld	t2, -0x708(s0)
+               	addi	a2, t2, 0x8
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sd	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1608>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd50 <corpus.cases.vec.vec_i64x2.checksum+0xc90>
+               	j	0xd84 <corpus.cases.vec.vec_i64x2.checksum+0xcc4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd50 <corpus.cases.vec.vec_i64x2.checksum+0xc90>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	mv	a1, t2
                	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x710(s0)
                	addi	a1, t2, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sd	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x710(s0)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x166c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x1690>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0xcfc>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i64x2.checksum+0x16a4>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b0
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b8
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c0
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c8
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xde4 <corpus.cases.vec.vec_i64x2.checksum+0xd24>
+               	j	0xe18 <corpus.cases.vec.vec_i64x2.checksum+0xd58>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xde4 <corpus.cases.vec.vec_i64x2.checksum+0xd24>
+               	ld	s1, 0x758(sp)
+               	ld	s2, 0x750(sp)
+               	ld	s3, 0x748(sp)
+               	ld	s4, 0x740(sp)
+               	ld	s5, 0x738(sp)
+               	ld	s6, 0x730(sp)
+               	ld	s7, 0x728(sp)
+               	ld	s8, 0x720(sp)
+               	ld	s9, 0x718(sp)
+               	ld	s10, 0x710(sp)
+               	ld	s11, 0x708(sp)
+               	ld	ra, 0x768(sp)
+               	ld	s0, 0x760(sp)
+               	addi	sp, sp, 0x770
                	ret

--- a/test/golden/riscv64-linux/vec/vec_i8x16.dis
+++ b/test/golden/riscv64-linux/vec/vec_i8x16.dis
@@ -3,4630 +3,4655 @@ vec/vec_i8x16.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_i8x16.fold_vec>:
-               	addi	sp, sp, -0x120
-               	sd	ra, 0x118(sp)
-               	sd	s0, 0x110(sp)
-               	addi	s0, sp, 0x120
-               	sd	s1, 0x108(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	a1, s0, -0x118
-               	mv	a1, s1
-               	lbu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x6c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x1
+               	addi	sp, sp, -0x110
+               	sd	ra, 0x108(sp)
+               	sd	s0, 0x100(sp)
+               	addi	s0, sp, 0x110
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x80
+               	addi	a2, s0, -0x90
+               	addi	a2, s0, -0xa0
+               	addi	a2, s0, -0xb0
+               	addi	a2, s0, -0xc0
+               	addi	a2, s0, -0xd0
+               	addi	a2, s0, -0xe0
+               	addi	a2, s0, -0xf0
+               	addi	a2, s0, -0x100
+               	addi	a2, s0, -0x110
+               	mv	a2, a1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x88>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x70 <corpus.cases.vec.vec_i8x16.fold_vec+0x70>
+               	j	0xa4 <corpus.cases.vec.vec_i8x16.fold_vec+0xa4>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x70 <corpus.cases.vec.vec_i8x16.fold_vec+0x70>
+               	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0xa4>
-               	mv	a1, a0
-               	addi	a2, s1, 0x3
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xc4 <corpus.cases.vec.vec_i8x16.fold_vec+0xc4>
+               	j	0xf8 <corpus.cases.vec.vec_i8x16.fold_vec+0xf8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xc4 <corpus.cases.vec.vec_i8x16.fold_vec+0xc4>
+               	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0xc0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x118 <corpus.cases.vec.vec_i8x16.fold_vec+0x118>
+               	j	0x14c <corpus.cases.vec.vec_i8x16.fold_vec+0x14c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x118 <corpus.cases.vec.vec_i8x16.fold_vec+0x118>
+               	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0xdc>
-               	mv	a1, a0
-               	addi	a2, s1, 0x5
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x16c <corpus.cases.vec.vec_i8x16.fold_vec+0x16c>
+               	j	0x1a0 <corpus.cases.vec.vec_i8x16.fold_vec+0x1a0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x16c <corpus.cases.vec.vec_i8x16.fold_vec+0x16c>
+               	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0xf8>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1c0 <corpus.cases.vec.vec_i8x16.fold_vec+0x1c0>
+               	j	0x1f4 <corpus.cases.vec.vec_i8x16.fold_vec+0x1f4>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1c0 <corpus.cases.vec.vec_i8x16.fold_vec+0x1c0>
+               	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x114>
-               	mv	a1, a0
-               	addi	a2, s1, 0x7
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x214 <corpus.cases.vec.vec_i8x16.fold_vec+0x214>
+               	j	0x248 <corpus.cases.vec.vec_i8x16.fold_vec+0x248>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x214 <corpus.cases.vec.vec_i8x16.fold_vec+0x214>
+               	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x130>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x268 <corpus.cases.vec.vec_i8x16.fold_vec+0x268>
+               	j	0x29c <corpus.cases.vec.vec_i8x16.fold_vec+0x29c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x268 <corpus.cases.vec.vec_i8x16.fold_vec+0x268>
+               	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x14c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x9
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2bc <corpus.cases.vec.vec_i8x16.fold_vec+0x2bc>
+               	j	0x2f0 <corpus.cases.vec.vec_i8x16.fold_vec+0x2f0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2bc <corpus.cases.vec.vec_i8x16.fold_vec+0x2bc>
+               	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x168>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x310 <corpus.cases.vec.vec_i8x16.fold_vec+0x310>
+               	j	0x344 <corpus.cases.vec.vec_i8x16.fold_vec+0x344>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x310 <corpus.cases.vec.vec_i8x16.fold_vec+0x310>
+               	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x184>
-               	mv	a1, a0
-               	addi	a2, s1, 0xb
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x364 <corpus.cases.vec.vec_i8x16.fold_vec+0x364>
+               	j	0x398 <corpus.cases.vec.vec_i8x16.fold_vec+0x398>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x364 <corpus.cases.vec.vec_i8x16.fold_vec+0x364>
+               	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x1a0>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3b8 <corpus.cases.vec.vec_i8x16.fold_vec+0x3b8>
+               	j	0x3ec <corpus.cases.vec.vec_i8x16.fold_vec+0x3ec>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3b8 <corpus.cases.vec.vec_i8x16.fold_vec+0x3b8>
+               	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x1bc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xd
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40c <corpus.cases.vec.vec_i8x16.fold_vec+0x40c>
+               	j	0x440 <corpus.cases.vec.vec_i8x16.fold_vec+0x440>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40c <corpus.cases.vec.vec_i8x16.fold_vec+0x40c>
+               	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x1d8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x460 <corpus.cases.vec.vec_i8x16.fold_vec+0x460>
+               	j	0x494 <corpus.cases.vec.vec_i8x16.fold_vec+0x494>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x460 <corpus.cases.vec.vec_i8x16.fold_vec+0x460>
+               	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x1f4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xf
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4b4 <corpus.cases.vec.vec_i8x16.fold_vec+0x4b4>
+               	j	0x4e8 <corpus.cases.vec.vec_i8x16.fold_vec+0x4e8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4b4 <corpus.cases.vec.vec_i8x16.fold_vec+0x4b4>
+               	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.fold_vec+0x210>
-               	ld	s1, 0x108(sp)
-               	ld	ra, 0x118(sp)
-               	ld	s0, 0x110(sp)
-               	addi	sp, sp, 0x120
+               	slli	a2, a3, 0x38
+               	srai	a2, a2, 0x38
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x508 <corpus.cases.vec.vec_i8x16.fold_vec+0x508>
+               	j	0x53c <corpus.cases.vec.vec_i8x16.fold_vec+0x53c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x508 <corpus.cases.vec.vec_i8x16.fold_vec+0x508>
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	slli	a2, a1, 0x38
+               	srai	a2, a2, 0x38
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x55c <corpus.cases.vec.vec_i8x16.fold_vec+0x55c>
+               	j	0x590 <corpus.cases.vec.vec_i8x16.fold_vec+0x590>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x55c <corpus.cases.vec.vec_i8x16.fold_vec+0x55c>
+               	ld	ra, 0x108(sp)
+               	ld	s0, 0x100(sp)
+               	addi	sp, sp, 0x110
                	ret
 
 <corpus.cases.vec.vec_i8x16.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x7f8
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x800
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	add	s0, sp, t0
-               	sd	s1, 0x7f8(sp)
-               	sd	s2, 0x7f0(sp)
-               	sd	s3, 0x7e8(sp)
-               	sd	s4, 0x7e0(sp)
-               	sd	s5, 0x7d8(sp)
-               	sd	s6, 0x7d0(sp)
-               	sd	s7, 0x7c8(sp)
-               	sd	s8, 0x7c0(sp)
-               	sd	s9, 0x7b8(sp)
-               	sd	s10, 0x7b0(sp)
-               	sd	s11, 0x7a8(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	sd	t2, -0x7c8(s0)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	sd	t2, -0x7d0(s0)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	sd	t2, -0x7d8(s0)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	sd	t2, -0x7e0(s0)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	a1, s0, -0x2d8
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	sd	t2, -0x7e8(s0)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	sd	t2, -0x7f0(s0)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	sd	t2, -0x7f8(s0)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	sd	t2, -0x800(s0)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	sd	t2, -0x720(s0)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	sd	t2, -0x728(s0)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	sd	t2, -0x730(s0)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	sd	t2, -0x738(s0)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	sd	t2, -0x740(s0)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	sd	t2, -0x748(s0)
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x518
-               	addi	t2, s0, -0x528
-               	sd	t2, -0x750(s0)
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	t2, s0, -0x568
-               	sd	t2, -0x758(s0)
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x598
-               	addi	t2, s0, -0x5a8
-               	sd	t2, -0x760(s0)
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	sd	t2, -0x768(s0)
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	sd	t2, -0x770(s0)
-               	addi	a1, s0, -0x638
-               	addi	t2, s0, -0x648
-               	sd	t2, -0x778(s0)
-               	addi	t2, s0, -0x658
-               	sd	t2, -0x780(s0)
-               	addi	t2, s0, -0x668
-               	sd	t2, -0x788(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x240>
+               	addi	sp, sp, -0x7d0
+               	sd	ra, 0x7c8(sp)
+               	sd	s0, 0x7c0(sp)
+               	addi	s0, sp, 0x7d0
+               	sd	s1, 0x7b8(sp)
+               	sd	s2, 0x7b0(sp)
+               	sd	s3, 0x7a8(sp)
+               	sd	s4, 0x7a0(sp)
+               	sd	s5, 0x798(sp)
+               	sd	s6, 0x790(sp)
+               	sd	s7, 0x788(sp)
+               	sd	s8, 0x780(sp)
+               	sd	s9, 0x778(sp)
+               	sd	s10, 0x770(sp)
+               	sd	s11, 0x768(sp)
                	mv	t2, a0
-               	sd	t2, -0x790(s0)
-               	ld	t2, -0x790(s0)
-               	sext.w	t2, s1
+               	sd	t2, -0x720(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
                	sd	t2, -0x798(s0)
-               	addi	t2, s0, -0x678
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x790(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
                	sd	t2, -0x7a0(s0)
-               	ld	t2, -0x7a0(s0)
-               	mv	a1, t2
-               	li	t0, 0xf7
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x1
-               	li	t0, 0x7
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x2
-               	li	t0, 0xfb
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x3
-               	li	t0, 0x3
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x4
-               	li	t0, 0xff
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x5
-               	li	t0, 0x2
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x6
-               	li	t0, 0xfc
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x7
-               	li	t0, 0x6
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x8
-               	li	t0, 0xf8
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x9
-               	li	t0, 0x9
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xa
-               	li	t0, 0xfd
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xb
-               	li	t0, 0x1
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xc
-               	li	t0, 0xfe
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xd
-               	li	t0, 0x4
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xe
-               	li	t0, 0xfa
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xf
-               	li	t0, 0x8
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	mv	a1, t2
-               	lbu	s1, 0x0(a1)
-               	mv	a1, s2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x688
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
                	sd	t2, -0x7a8(s0)
-               	ld	t2, -0x7a8(s0)
-               	mv	s1, t2
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x1
-               	li	t0, 0xfd
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x2
-               	li	t0, 0x4
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x3
-               	li	t0, 0xfb
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x4
-               	li	t0, 0x6
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x5
-               	li	t0, 0xf9
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x6
-               	li	t0, 0x8
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x7
-               	li	t0, 0xf7
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x8
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x9
-               	li	t0, 0xfe
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xa
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xb
-               	li	t0, 0xfc
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xc
-               	li	t0, 0x5
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xd
-               	li	t0, 0xfa
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xe
-               	li	t0, 0x7
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xf
-               	li	t0, 0xff
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s3
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x698
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
                	sd	t2, -0x7b0(s0)
-               	ld	t2, -0x7b0(s0)
-               	mv	s1, t2
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x1
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x2
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x3
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x4
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x5
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x6
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x7
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x8
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x9
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xa
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xb
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xc
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xd
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xe
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xf
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s4
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x6a8
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
                	sd	t2, -0x7b8(s0)
-               	ld	t2, -0x7b8(s0)
-               	mv	s1, t2
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x1
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x2
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x3
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x4
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x5
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x6
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x7
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x8
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x9
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xa
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xb
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xc
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xd
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xe
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xf
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s5
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xf
-               	sb	s1, 0x0(a1)
-               	mv	a1, s2
-               	lbu	s1, 0x0(a1)
-               	ld	t3, -0x798(s0)
-               	addw	t2, s1, t3
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
                	sd	t2, -0x7c0(s0)
-               	mv	s1, s2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s6
-               	sb	a1, 0x0(s1)
-               	addi	a1, s2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x1
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x3
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x5
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x7
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x9
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xb
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xd
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xf
-               	sb	s1, 0x0(a1)
-               	mv	a1, s6
-               	ld	t2, -0x7c0(s0)
-               	sb	t2, 0x0(a1)
-               	addi	a1, s6, 0x7
-               	lbu	s1, 0x0(a1)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	a0, s0, -0x4d8
+               	addi	t2, s0, -0x4e8
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	a0, s0, -0x518
+               	addi	t2, s0, -0x528
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	a0, s0, -0x558
+               	addi	t2, s0, -0x568
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	a0, s0, -0x598
+               	addi	t2, s0, -0x5a8
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	a0, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x760(s0)
+               	addi	a0, s0, -0x608
+               	addi	a0, s0, -0x618
+               	addi	t2, s0, -0x628
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x638
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x770(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x778(s0)
+               	addi	t2, s0, -0x668
+               	sd	t2, -0x780(s0)
+               	ld	t3, -0x720(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x788(s0)
+               	addi	a0, s0, -0x6e8
+               	mv	a4, a0
+               	li	t0, 0xf7
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x1
+               	li	t0, 0x7
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x2
+               	li	t0, 0xfb
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x3
+               	li	t0, 0x3
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
+               	li	t0, 0xff
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x5
+               	li	t0, 0x2
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x6
+               	li	t0, 0xfc
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x7
+               	li	t0, 0x6
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x8
+               	li	t0, 0xf8
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x9
+               	li	t0, 0x9
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xa
+               	li	t0, 0xfd
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xb
+               	li	t0, 0x1
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xc
+               	li	t0, 0xfe
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xd
+               	li	t0, 0x4
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xe
+               	li	t0, 0xfa
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xf
+               	li	t0, 0x8
+               	sb	t0, 0x0(a4)
+               	mv	a4, a0
+               	lbu	a2, 0x0(a4)
+               	mv	a4, a1
+               	sb	a2, 0x0(a4)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	li	t0, 0xfd
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	li	t0, 0x4
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	li	t0, 0xfb
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	li	t0, 0x6
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	li	t0, 0xf9
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	li	t0, 0x8
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	li	t0, 0xf7
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	li	t0, 0xfe
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	li	t0, 0xfc
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	li	t0, 0x5
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	li	t0, 0xfa
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	li	t0, 0x7
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	li	t0, 0xff
+               	sb	t0, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s6
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	sb	a1, 0x0(s1)
+               	mv	a2, t2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
+               	mv	a2, s1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, s1, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x718
+               	mv	a2, a0
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	sb	zero, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
+               	mv	a2, s2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, s2, 0xf
+               	sb	a0, 0x0(a2)
+               	mv	a0, a1
+               	lbu	a2, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lbu	a4, 0x0(a2)
+               	mv	a2, a3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	addi	a2, a3, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, a3
+               	sb	a0, 0x0(a1)
+               	addi	a0, a3, 0x7
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x3
+               	lbu	a2, 0x0(a1)
                	addi	a1, s3, 0x3
-               	lbu	s1, 0x0(a1)
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	sb	a0, 0x0(a1)
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s3
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	sb	a1, 0x0(s1)
-               	addi	a1, s8, 0xc
-               	lbu	s1, 0x0(a1)
+               	addi	a0, t2, 0x3
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s8
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	sb	a1, 0x0(s1)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
                	ld	t2, -0x790(s0)
-               	mv	a0, t2
+               	mv	a1, t2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x1
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x5
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x7
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x9
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xb
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xd
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xf
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a0, t2, 0xc
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	sb	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sb	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0xe7c>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0xe88>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1054>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1220>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0xfb0>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x13ec>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x15b8>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0xfc4>
-               	mv	a1, a0
-               	mv	s1, s7
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	mv	s2, s10
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1784>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1198>
-               	mv	a1, a0
-               	mv	s1, s7
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	mv	s2, s11
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1950>
+               	mv	a1, s5
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x136c>
-               	mv	a1, a0
-               	mv	s1, s9
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	mv	s2, t2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x1
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x2
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x3
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x5
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x6
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xa
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xb
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xd
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xe
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xf
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
-               	ld	t2, -0x7c8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1584>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	s1, 0x0(a2)
-               	mv	a2, s9
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	mv	s1, t2
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x1
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x1
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x2
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x2
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x3
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x3
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x4
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x4
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x5
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x5
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x6
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x6
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x7
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x7
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x8
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x8
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x9
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x9
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xa
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xa
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xb
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xb
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xc
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xc
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xd
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xd
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xe
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xe
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xf
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xf
-               	sb	a2, 0x0(s1)
-               	mv	a0, a1
-               	ld	t2, -0x7d0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x179c>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7d8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x19b4>
-               	mv	a1, a0
-               	mv	a2, s9
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7e0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1bcc>
-               	mv	a1, a0
-               	mv	a2, s10
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7e8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1de4>
-               	mv	a1, a0
-               	mv	a2, s5
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x1
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x2
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x3
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x4
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x5
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x6
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x8
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xa
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xb
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xc
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xd
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xe
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xf
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7f0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1ffc>
-               	mv	a1, a0
-               	mv	a2, s5
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2214>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x800(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x242c>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x720(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2644>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x728(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x285c>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x730(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x29f4>
-               	mv	a1, a0
-               	mv	a2, s9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x1
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x2
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x3
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x4
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x5
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x6
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x8
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xa
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xb
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xc
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xd
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xe
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xf
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x738(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2b8c>
-               	mv	a1, a0
-               	ld	t2, -0x800(s0)
-               	mv	a2, t2
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	mv	a2, t2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x1
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x1
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x2
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x3
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x3
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x4
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x4
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x5
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x5
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x6
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x6
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x7
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x7
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x8
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x8
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x9
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xa
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xa
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xb
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xb
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xc
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xc
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xd
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xd
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xe
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xe
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xf
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xf
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x740(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2e24>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x3
-               	bltu	s3, t0, 0x3070 <corpus.cases.vec.vec_i8x16.checksum+0x2e44>
-               	j	0x391c <corpus.cases.vec.vec_i8x16.checksum+0x36f0>
-               	mv	a0, s7
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s4
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	mv	a1, t2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x1
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x1
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x2
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x3
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x3
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x4
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x5
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x5
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x6
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x6
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x7
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x7
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x8
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x9
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x9
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xa
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xa
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xb
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xb
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xc
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xd
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xd
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xe
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xe
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xf
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xf
-               	sb	a0, 0x0(a1)
-               	mv	a0, s1
-               	ld	t2, -0x748(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x3050>
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1b1c>
                	mv	a1, s2
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1d2c>
+               	mv	a1, s2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x1f3c>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x214c>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x235c>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7c0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x256c>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x26fc>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x288c>
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2b1c>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x3
+               	bltu	s7, t0, 0x30dc <corpus.cases.vec.vec_i8x16.checksum+0x2b3c>
+               	j	0x3988 <corpus.cases.vec.vec_i8x16.checksum+0x33e8>
+               	mv	a0, s3
+               	lbu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x1
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x1
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x3
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x3
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x5
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x5
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x5
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x7
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x7
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x7
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x9
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x9
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x9
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xb
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xb
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xb
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xd
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xd
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xd
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xf
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xf
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xf
+               	sb	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2d48>
+               	mv	a1, s6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x2f98>
+               	mv	a1, s2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x1
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x1
+               	addi	a1, s3, 0x1
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x2
+               	addi	a1, s3, 0x2
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x3
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x3
+               	addi	a1, s3, 0x3
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x5
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x5
+               	addi	a1, s3, 0x5
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x6
+               	addi	a1, s3, 0x6
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x7
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x7
+               	addi	a1, s3, 0x7
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x9
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x9
+               	addi	a1, s3, 0x9
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xa
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xa
+               	addi	a1, s3, 0xa
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xb
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xb
+               	addi	a1, s3, 0xb
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xc
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xd
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xd
+               	addi	a1, s3, 0xd
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xe
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xe
+               	addi	a1, s3, 0xe
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xf
                	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x31a8>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x33b8>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x758(s0)
+               	mv	s3, t2
                	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xf
-               	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x750(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x750(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x32a0>
-               	mv	a1, s5
-               	lbu	a2, 0x0(a1)
-               	mv	a1, s7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	mv	a2, t2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x1
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x1
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x3
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x3
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x4
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x5
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x5
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x6
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x7
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x8
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x9
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xa
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xb
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xb
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xc
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xd
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xd
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xe
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xf
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x758(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x34b0>
-               	mv	a1, s7
-               	lbu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	mv	a2, t2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x1
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x1
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x3
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x3
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x4
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x5
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x5
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x6
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x7
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x8
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x9
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xa
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xb
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xb
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xc
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xd
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xd
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xe
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xf
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x760(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x36c0>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x760(s0)
-               	mv	s7, t2
+               	mv	s6, t2
                	ld	t2, -0x750(s0)
                	mv	s2, t2
-               	ld	t2, -0x758(s0)
-               	mv	s5, t2
                	li	t0, 0x3
-               	bltu	s3, t0, 0x3070 <corpus.cases.vec.vec_i8x16.checksum+0x2e44>
-               	addi	s3, s0, -0x6e8
-               	mv	a0, s3
+               	bltu	s7, t0, 0x30dc <corpus.cases.vec.vec_i8x16.checksum+0x2b3c>
+               	addi	s2, s0, -0x6a8
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x3950 <corpus.cases.vec.vec_i8x16.checksum+0x3724>
+               	bnez	a1, 0x39bc <corpus.cases.vec.vec_i8x16.checksum+0x341c>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x3938 <corpus.cases.vec.vec_i8x16.checksum+0x370c>
-               	j	0x396c <corpus.cases.vec.vec_i8x16.checksum+0x3740>
+               	bne	a2, t0, 0x39a4 <corpus.cases.vec.vec_i8x16.checksum+0x3404>
+               	j	0x39d8 <corpus.cases.vec.vec_i8x16.checksum+0x3438>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x3958 <corpus.cases.vec.vec_i8x16.checksum+0x372c>
+               	bne	a0, t0, 0x39c4 <corpus.cases.vec.vec_i8x16.checksum+0x3424>
+               	mv	a0, s2
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x3
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xf
+               	sb	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x1
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x3
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x5
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x7
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x9
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xb
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xd
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xf
-               	sb	a2, 0x0(a1)
-               	mv	a0, s7
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s9
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	mv	a1, t2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x1
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x1
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x3
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x3
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x4
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x5
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x5
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x6
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x7
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x7
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x8
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x9
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x9
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xa
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xa
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xb
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xb
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xc
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xd
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xd
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xe
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xe
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xf
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xf
-               	sb	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	ld	t2, -0x768(s0)
-               	mv	a1, t2
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x1
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x3
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x5
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x7
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x9
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xb
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xd
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xf
-               	sb	a2, 0x0(a1)
-               	mv	a0, s7
                	lbu	a1, 0x0(a0)
                	mv	a0, s4
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
+               	addi	a0, s3, 0x1
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x1
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x1
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x2
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
+               	addi	a0, s3, 0x3
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x3
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x3
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
+               	addi	a0, s3, 0x5
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x5
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x5
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x6
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
+               	addi	a0, s3, 0x7
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x7
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x7
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
+               	addi	a0, s3, 0x9
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x9
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x9
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
+               	addi	a0, s3, 0xa
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xa
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
+               	addi	a0, s3, 0xb
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xb
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xb
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
+               	addi	a0, s3, 0xd
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xd
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xd
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
+               	addi	a0, s3, 0xe
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xe
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
+               	addi	a0, s3, 0xf
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xf
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xf
                	sb	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	ld	t2, -0x770(s0)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	mv	a1, a0
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x1
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x3
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x5
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x7
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x9
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xb
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xd
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xf
                	sb	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
+               	mv	a0, s3
+               	lbu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x1
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x1
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x3
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x3
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x5
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x5
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x5
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x7
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x7
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x7
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x9
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x9
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x9
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xb
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xb
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xb
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xd
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xd
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xd
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xf
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xf
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xf
+               	sb	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	mv	a1, a0
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x1
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x1
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x3
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x3
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x5
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x5
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x7
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x7
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x9
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x9
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xb
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xb
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xd
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xd
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xf
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xf
                	sb	a2, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s2, 0x30
+               	mv	a1, s6
+               	lbu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x3
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xf
+               	sb	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x420c <corpus.cases.vec.vec_i8x16.checksum+0x3fe0>
-               	j	0x437c <corpus.cases.vec.vec_i8x16.checksum+0x4150>
+               	bltu	s1, t0, 0x4278 <corpus.cases.vec.vec_i8x16.checksum+0x3cd8>
+               	j	0x43e8 <corpus.cases.vec.vec_i8x16.checksum+0x3e48>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	mv	a0, t2
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x1
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x1
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x2
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x2
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x3
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x3
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x4
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x5
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x5
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x6
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x6
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x7
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x7
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x8
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x9
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x9
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xa
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xa
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xb
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xb
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xc
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xd
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xd
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xe
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xe
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xf
                	lbu	a1, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xf
                	sb	a1, 0x0(a0)
-               	mv	a0, s1
-               	ld	t2, -0x778(s0)
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x4138>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x3e30>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x420c <corpus.cases.vec.vec_i8x16.checksum+0x3fe0>
-               	addi	a0, s0, -0x718
-               	mv	a1, a0
+               	bltu	s1, t0, 0x4278 <corpus.cases.vec.vec_i8x16.checksum+0x3cd8>
+               	addi	s1, s0, -0x6d8
+               	mv	a0, s1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x43b0 <corpus.cases.vec.vec_i8x16.checksum+0x4184>
-               	mv	a2, a1
-               	li	a3, 0x30
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x4398 <corpus.cases.vec.vec_i8x16.checksum+0x416c>
-               	j	0x43cc <corpus.cases.vec.vec_i8x16.checksum+0x41a0>
-               	mv	a2, a1
-               	li	a1, 0x30
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x43b8 <corpus.cases.vec.vec_i8x16.checksum+0x418c>
+               	and	a1, a0, t0
+               	bnez	a1, 0x441c <corpus.cases.vec.vec_i8x16.checksum+0x3e7c>
                	mv	a1, a0
+               	li	a2, 0x30
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x4404 <corpus.cases.vec.vec_i8x16.checksum+0x3e64>
+               	j	0x4438 <corpus.cases.vec.vec_i8x16.checksum+0x3e98>
+               	mv	a1, a0
+               	li	a0, 0x30
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x4424 <corpus.cases.vec.vec_i8x16.checksum+0x3e84>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a1)
-               	addi	a2, s3, 0x20
-               	mv	a3, a2
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	mv	a3, t2
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x1
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x1
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x2
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x2
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x3
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x3
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x4
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x4
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x5
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x5
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x6
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x6
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x7
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x7
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x8
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x8
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x9
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x9
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xa
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xa
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xb
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xb
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xc
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xc
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xd
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xd
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xe
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xe
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xf
-               	lbu	a2, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	addi	s2, a0, 0x10
-               	ld	t2, -0x780(s0)
+               	sw	t0, 0x0(a0)
+               	addi	a1, s2, 0x20
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	mv	a2, t2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x1
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x3
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x4
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x5
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x6
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x7
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x8
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x9
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xa
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xb
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xc
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xd
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xe
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x778(s0)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
-               	mv	a2, s2
+               	mv	a2, a1
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x1
+               	addi	a2, a1, 0x1
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x2
+               	addi	a2, a1, 0x2
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x3
+               	addi	a2, a1, 0x3
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x4
+               	addi	a2, a1, 0x4
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x5
+               	addi	a2, a1, 0x5
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x6
+               	addi	a2, a1, 0x6
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x7
+               	addi	a2, a1, 0x7
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x8
+               	addi	a2, a1, 0x8
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x9
+               	addi	a2, a1, 0x9
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xa
+               	addi	a2, a1, 0xa
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xb
+               	addi	a2, a1, 0xb
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xc
+               	addi	a2, a1, 0xc
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xd
+               	addi	a2, a1, 0xd
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xe
+               	addi	a2, a1, 0xe
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xf
+               	addi	a2, a1, 0xf
                	sb	a3, 0x0(a2)
-               	addi	s3, a0, 0x20
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sw	t0, 0x0(s3)
-               	lw	a2, 0x0(a1)
-               	mv	a0, s1
+               	sw	t0, 0x0(a1)
+               	lw	a1, 0x0(a0)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a0, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x4458>
-               	mv	a1, s2
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	mv	a1, t2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x1
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x1
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x3
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x4
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x5
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x6
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x7
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x8
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x9
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xa
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xb
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xc
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xd
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xe
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xf
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x4158>
+               	addi	a1, s1, 0x10
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	mv	a2, t2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x1
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x3
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x4
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x5
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x6
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x7
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x8
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x9
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xa
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xb
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xc
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xd
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xe
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x45a8>
-               	lw	a1, 0x0(s3)
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x42ac>
+               	addi	a1, s1, 0x20
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x45b4>
-               	ld	s1, 0x7f8(sp)
-               	ld	s2, 0x7f0(sp)
-               	ld	s3, 0x7e8(sp)
-               	ld	s4, 0x7e0(sp)
-               	ld	s5, 0x7d8(sp)
-               	ld	s6, 0x7d0(sp)
-               	ld	s7, 0x7c8(sp)
-               	ld	s8, 0x7c0(sp)
-               	ld	s9, 0x7b8(sp)
-               	ld	s10, 0x7b0(sp)
-               	ld	s11, 0x7a8(sp)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x7f8
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x800
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	add	sp, sp, t0
+               	jalr	ra <corpus.cases.vec.vec_i8x16.checksum+0x42c4>
+               	ld	s1, 0x7b8(sp)
+               	ld	s2, 0x7b0(sp)
+               	ld	s3, 0x7a8(sp)
+               	ld	s4, 0x7a0(sp)
+               	ld	s5, 0x798(sp)
+               	ld	s6, 0x790(sp)
+               	ld	s7, 0x788(sp)
+               	ld	s8, 0x780(sp)
+               	ld	s9, 0x778(sp)
+               	ld	s10, 0x770(sp)
+               	ld	s11, 0x768(sp)
+               	ld	ra, 0x7c8(sp)
+               	ld	s0, 0x7c0(sp)
+               	addi	sp, sp, 0x7d0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_lane_ops.dis
+++ b/test/golden/riscv64-linux/vec/vec_lane_ops.dis
@@ -3,120 +3,255 @@ vec/vec_lane_ops.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_lane_ops.fold_u32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x40>
+               	j	0x74 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x74>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x40>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x94>
+               	j	0xc8 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0xc8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x94>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0xe8>
+               	j	0x11c <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x11c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0xe8>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x13c>
+               	j	0x170 <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x170>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_lane_ops.fold_u32x4+0x13c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c4 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x44>
+               	j	0x1f8 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x78>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1c4 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x44>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21c <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x9c>
+               	j	0x250 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0xd0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x21c <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x9c>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x274 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0xf4>
+               	j	0x2a8 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x128>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x274 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0xf4>
+               	addi	a2, a1, 0xc
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2cc <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x14c>
+               	j	0x300 <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x180>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2cc <corpus.cases.vec.vec_lane_ops.fold_f32x4+0x14c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_f64x2>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	fld	fa0, 0x0(a1)
-               	mv	a0, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x30>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	fld	fa0, 0x0(a2)
-               	mv	a0, a1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x48>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a2, ft0
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x344 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x34>
+               	j	0x378 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x68>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x344 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x34>
+               	addi	a2, a1, 0x8
+               	fld	ft0, 0x0(a2)
+               	fmv.x.d	a1, ft0
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x394 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x84>
+               	j	0x3c8 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0xb8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x394 <corpus.cases.vec.vec_lane_ops.fold_f64x2+0x84>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_lane_ops.fold_i8x16>:
@@ -125,7 +260,6 @@ Disassembly of section .text:
                	sd	s0, 0x110(sp)
                	addi	s0, sp, 0x120
                	sd	s1, 0x108(sp)
-               	mv	a2, a0
                	mv	s1, a1
                	addi	a1, s0, -0x28
                	addi	a1, s0, -0x38
@@ -144,116 +278,191 @@ Disassembly of section .text:
                	addi	a1, s0, -0x108
                	addi	a1, s0, -0x118
                	mv	a1, s1
-               	lbu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x450 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x78>
+               	j	0x484 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xac>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x450 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x78>
+               	addi	a1, s1, 0x1
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a4 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xcc>
+               	j	0x4d8 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x100>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4a4 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xcc>
+               	addi	a1, s1, 0x2
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f8 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x120>
+               	j	0x52c <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x154>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x4f8 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x120>
+               	addi	a1, s1, 0x3
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x54c <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x174>
+               	j	0x580 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1a8>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x54c <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x174>
+               	addi	a1, s1, 0x4
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5a0 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1c8>
+               	j	0x5d4 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1fc>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5a0 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1c8>
+               	addi	a1, s1, 0x5
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5f4 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x21c>
+               	j	0x628 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x250>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x5f4 <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x21c>
+               	addi	a1, s1, 0x6
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x6c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x1
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x260>
+               	addi	a1, s1, 0x7
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x88>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x278>
+               	addi	a1, s1, 0x8
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xa4>
-               	mv	a1, a0
-               	addi	a2, s1, 0x3
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x290>
+               	addi	a1, s1, 0x9
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xc0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x2a8>
+               	addi	a1, s1, 0xa
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xdc>
-               	mv	a1, a0
-               	addi	a2, s1, 0x5
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x2c0>
+               	addi	a1, s1, 0xb
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0xf8>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x2d8>
+               	addi	a1, s1, 0xc
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x114>
-               	mv	a1, a0
-               	addi	a2, s1, 0x7
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x2f0>
+               	addi	a1, s1, 0xd
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x130>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x308>
+               	addi	a1, s1, 0xe
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x14c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x9
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x320>
+               	addi	a1, s1, 0xf
+               	lbu	a2, 0x0(a1)
+               	slli	a1, a2, 0x38
+               	srai	a1, a1, 0x38
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x168>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x184>
-               	mv	a1, a0
-               	addi	a2, s1, 0xb
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1a0>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1bc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xd
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1d8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x1f4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xf
-               	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x210>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.fold_i8x16+0x338>
                	ld	s1, 0x108(sp)
                	ld	ra, 0x118(sp)
                	ld	s0, 0x110(sp)
@@ -262,4618 +471,4294 @@ Disassembly of section .text:
 
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x790
+               	addiw	t0, t0, 0x340
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x788
+               	addiw	t1, t1, 0x338
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x780
+               	addiw	t1, t1, 0x330
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x790
+               	addiw	t0, t0, 0x340
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x778
+               	addiw	t1, t1, 0x328
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x770
+               	addiw	t1, t1, 0x320
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x768
+               	addiw	t1, t1, 0x318
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x760
+               	addiw	t1, t1, 0x310
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x758
+               	addiw	t1, t1, 0x308
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x750
+               	addiw	t1, t1, 0x300
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x748
+               	addiw	t1, t1, 0x2f8
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x740
+               	addiw	t1, t1, 0x2f0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x738
+               	addiw	t1, t1, 0x2e8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x730
+               	addiw	t1, t1, 0x2e0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x728
+               	addiw	t1, t1, 0x2d8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x720
+               	addiw	t1, t1, 0x2d0
                	add	t1, sp, t1
                	fsd	fs0, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x718
+               	addiw	t1, t1, 0x2c8
                	add	t1, sp, t1
                	fsd	fs1, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x88
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	s3, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	s4, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	s5, s0, -0x118
-               	addi	s6, s0, -0x128
-               	addi	a1, s0, -0x138
-               	addi	s7, s0, -0x148
-               	addi	s8, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	s9, s0, -0x178
-               	addi	s10, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	s11, s0, -0x1a8
-               	addi	t2, s0, -0x1b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x1c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x1d8
-               	addi	t2, s0, -0x1e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x1f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x228
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x258
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x288
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x298
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2a8
-               	addi	t2, s0, -0x2b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x2c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2d8
-               	addi	t2, s0, -0x2e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	t2, s0, -0x318
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	t2, s0, -0x348
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x368
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x398
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x3c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x3f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x408
-               	addi	t2, s0, -0x418
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x438
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x448
-               	addi	t2, s0, -0x458
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x468
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x478
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x488
-               	addi	a1, s0, -0x498
-               	addi	a1, s0, -0x4a8
-               	addi	t2, s0, -0x4b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4f8
-               	addi	t2, s0, -0x508
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x518
-               	addi	a1, s0, -0x528
-               	addi	t2, s0, -0x538
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	a1, s0, -0x568
-               	addi	a1, s0, -0x578
-               	addi	t2, s0, -0x588
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x598
-               	addi	a1, s0, -0x5a8
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	t2, s0, -0x5d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5e8
-               	addi	a1, s0, -0x5f8
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x638
-               	addi	a1, s0, -0x648
-               	addi	t2, s0, -0x658
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x668
-               	addi	t2, s0, -0x678
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x688
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x698
-               	addi	t2, s0, -0x6a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x6b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x6c8
-               	addi	t2, s0, -0x6d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x6e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x6f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x708
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x718
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	t2, s0, -0x748
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	t2, s0, -0x778
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x788
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x798
-               	addi	t2, s0, -0x7a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x7b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x7c8
-               	addi	t2, s0, -0x7d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x7e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x468
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x448
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x428
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3a8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x398
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x388
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x378
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x368
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x358
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x348
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x328
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x318
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x308
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2f8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x298
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x288
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x278
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x268
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x258
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x248
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x238
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x228
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x218
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x208
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x198
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x18
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x28
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x38
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x48
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x58
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x68
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x78
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x88
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x98
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xa8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xb8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xc8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xd8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xe8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0xf8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x108
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x118
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x128
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x138
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x148
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x158
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x168
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x178
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x188
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x198
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x1f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x208
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x218
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x228
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x238
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x248
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x258
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x268
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x278
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x288
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x298
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2a8
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x12b0>
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x2c0
+               	add	t1, sp, t1
+               	fsd	fs2, 0x0(t1)
                	mv	t2, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, 0xc0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x90
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x2d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	fcvt.s.lu	fs0, s1
-               	fcvt.d.lu	fs1, s1
-               	sext.w	t2, s1
+               	addi	a2, s0, -0xa0
+               	addi	a2, s0, -0xb0
+               	addi	t2, s0, -0xc0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a3, s0, -0xd0
+               	addi	a3, s0, -0xe0
+               	addi	s1, s0, -0xf0
+               	addi	a3, s0, -0x100
+               	addi	a3, s0, -0x110
+               	addi	s2, s0, -0x120
+               	addi	s3, s0, -0x130
+               	addi	a3, s0, -0x140
+               	addi	s4, s0, -0x150
+               	addi	s5, s0, -0x160
+               	addi	a3, s0, -0x170
+               	addi	s6, s0, -0x180
+               	addi	s7, s0, -0x190
+               	addi	a3, s0, -0x1a0
+               	addi	s8, s0, -0x1b0
+               	addi	s9, s0, -0x1c0
+               	addi	s10, s0, -0x1d0
+               	addi	a3, s0, -0x1e0
+               	addi	s11, s0, -0x1f0
+               	addi	t2, s0, -0x200
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a4, s0, -0x210
+               	addi	t2, s0, -0x220
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x310
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x230
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x318
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a6, s0, -0x240
+               	addi	t2, s0, -0x250
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x320
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x260
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x328
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t5, s0, -0x270
+               	addi	t2, s0, -0x280
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x330
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x290
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x338
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x2a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xc8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x2b0
+               	addi	t2, s0, -0x2c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x2d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x2e0
+               	addi	t2, s0, -0x2f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x300
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x310
+               	addi	t2, s0, -0x320
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x330
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x340
+               	addi	t2, s0, -0x350
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x360
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x370
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x380
+               	addi	t2, s0, -0x390
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x70
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x68
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x3b0
+               	addi	t2, s0, -0x3c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x60
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3d0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x3e0
+               	addi	t2, s0, -0x3f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x400
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x410
+               	addi	t2, s0, -0x420
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x430
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x440
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x450
+               	addi	t2, s0, -0x460
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x28
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x470
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x20
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x480
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x18
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x490
+               	addi	a0, s0, -0x4a0
+               	addi	a0, s0, -0x4b0
+               	addi	t2, s0, -0x4c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x10
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x4d0
+               	addi	a0, s0, -0x4e0
+               	addi	t2, s0, -0x4f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x500
+               	addi	t2, s0, -0x510
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x520
+               	addi	a0, s0, -0x530
+               	addi	t2, s0, -0x540
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x550
+               	addi	a0, s0, -0x560
+               	addi	a0, s0, -0x570
+               	addi	a0, s0, -0x580
+               	addi	t2, s0, -0x590
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x5a0
+               	addi	a0, s0, -0x5b0
+               	addi	a0, s0, -0x5c0
+               	addi	a0, s0, -0x5d0
+               	addi	t2, s0, -0x5e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x5f0
+               	addi	a0, s0, -0x600
+               	addi	a0, s0, -0x610
+               	addi	a0, s0, -0x620
+               	addi	t2, s0, -0x630
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x640
+               	addi	a0, s0, -0x650
+               	addi	t2, s0, -0x660
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x670
+               	addi	t2, s0, -0x680
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x690
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x6a0
+               	addi	t2, s0, -0x6b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x6c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x6d0
+               	addi	t2, s0, -0x6e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x6f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x700
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x710
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x720
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x70
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x730
+               	addi	a0, s0, -0x740
+               	addi	t2, s0, -0x750
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x78
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x760
+               	addi	a0, s0, -0x770
+               	addi	t2, s0, -0x780
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x80
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x790
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x88
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x7a0
+               	addi	t2, s0, -0x7b0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x90
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x7c0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x98
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x7d0
+               	addi	t2, s0, -0x7e0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x7f0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s0, -0x800
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7f0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2b8
-               	add	s1, s0, t0
-               	mv	a0, s1
+               	addiw	t0, t0, 0x7e0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xc0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7c0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7b0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xc8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7a0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x790
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x780
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xe0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x770
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xe8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x760
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x750
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xf0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x740
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xf8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x730
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x100
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x720
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x108
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x710
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x110
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x700
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x118
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6f0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x120
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6e0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x128
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x130
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6c0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6b0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x138
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6a0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x690
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x140
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x680
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x148
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x670
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x660
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x650
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x150
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x640
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x630
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x158
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x620
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x160
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x610
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x600
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x168
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5f0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x170
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5e0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x178
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5c0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x180
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5b0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5a0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x188
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x590
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x190
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x580
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x570
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x560
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x198
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x550
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x540
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x530
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x520
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x510
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x500
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4f0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4e0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4c0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4b0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x4a0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x490
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x480
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x470
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x460
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x450
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x440
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x430
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x420
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x410
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x1f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x400
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x200
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3f0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3e0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x208
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x210
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3c0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3b0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x218
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x3a0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x220
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x390
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x380
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x228
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x370
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x230
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x360
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x350
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x238
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x340
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x240
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x330
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x320
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x248
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x310
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x250
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x300
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2f0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x258
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2e0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x260
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2d0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2c0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x268
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2b0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x270
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x2a0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x290
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x278
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x280
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x280
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x270
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x260
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x288
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x250
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x290
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x240
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x230
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x298
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x220
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x210
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x200
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1f0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1e0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1d0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1c0
+               	add	a0, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1b0
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xc0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	sext.w	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xc0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	fcvt.s.lu	fs0, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xc0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	fcvt.d.lu	fs1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xc0
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	sext.w	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x1a0
+               	add	a1, s0, t0
+               	mv	a2, a1
                	lui	t0, 0x11111
                	addiw	t0, t0, 0x111
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a1, 0x4
                	lui	t0, 0x22222
                	addiw	t0, t0, 0x222
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a1, 0x8
                	lui	t0, 0x33333
                	addiw	t0, t0, 0x333
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a1, 0xc
                	lui	t0, 0x44444
                	addiw	t0, t0, 0x444
-               	sw	t0, 0x0(a0)
-               	mv	a0, s1
+               	sw	t0, 0x0(a2)
+               	mv	a2, a1
+               	lw	a0, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a0, 0x0(a2)
+               	addi	a0, a1, 0x4
+               	lw	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	lw	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a2, 0x0(a0)
+               	addi	a0, a1, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addw	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addw	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	sw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	sw	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x128c>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x190
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x7
+               	and	a0, t2, t0
+               	bnez	a0, 0x1a70 <corpus.cases.vec.vec_lane_ops.checksum+0x1344>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	li	a1, 0x10
+               	sd	zero, 0x0(a0)
+               	addi	a0, a0, 0x8
+               	addi	a1, a1, -0x8
+               	li	t0, 0x0
+               	bne	a1, t0, 0x1a58 <corpus.cases.vec.vec_lane_ops.checksum+0x132c>
+               	j	0x1a9c <corpus.cases.vec.vec_lane_ops.checksum+0x1370>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	li	a1, 0x10
+               	sb	zero, 0x0(a0)
+               	addi	a0, a0, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x1a88 <corpus.cases.vec.vec_lane_ops.checksum+0x135c>
+               	addi	a0, s1, 0xc
+               	lw	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x300
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
                	lw	a1, 0x0(a0)
                	mv	a0, s2
                	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0x4
                	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0x8
                	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s2, 0xc
                	sw	a1, 0x0(a0)
                	mv	a0, s2
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lw	s1, 0x0(a1)
-               	mv	a1, s3
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	s1, 0x0(a1)
-               	mv	a1, s3
-               	sw	a0, 0x0(a1)
+               	mv	a0, s3
+               	sw	a1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	lw	a1, 0x0(a0)
                	addi	a0, s3, 0xc
-               	lw	a1, 0x0(a0)
+               	sw	a1, 0x0(a0)
+               	mv	a0, s3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x740
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lw	s1, 0x0(a1)
-               	mv	a1, s4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s4
+               	sw	t2, 0x0(a0)
+               	mv	a0, s3
                	lw	a1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x738
+               	addiw	t1, t1, -0x340
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x147c>
-               	addi	a1, s4, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x1490>
-               	addi	a1, s4, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x14a4>
-               	addi	a1, s4, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x14b8>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2c8
-               	add	s1, s0, t0
-               	mv	a1, s1
-               	li	t0, 0x7
-               	and	s2, a1, t0
-               	bnez	s2, 0x18e4 <corpus.cases.vec.vec_lane_ops.checksum+0x14fc>
-               	mv	s2, a1
-               	li	s3, 0x10
-               	sd	zero, 0x0(s2)
-               	addi	s2, s2, 0x8
-               	addi	s3, s3, -0x8
-               	li	t0, 0x0
-               	bne	s3, t0, 0x18cc <corpus.cases.vec.vec_lane_ops.checksum+0x14e4>
-               	j	0x1900 <corpus.cases.vec.vec_lane_ops.checksum+0x1518>
-               	mv	s2, a1
-               	li	a1, 0x10
-               	sb	zero, 0x0(s2)
-               	addi	s2, s2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x18ec <corpus.cases.vec.vec_lane_ops.checksum+0x1504>
-               	addi	a1, s4, 0xc
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	lw	s3, 0x0(a1)
-               	mv	a1, s5
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sw	s3, 0x0(a1)
-               	mv	a1, s5
-               	lw	s3, 0x0(a1)
-               	mv	a1, s6
-               	sw	s3, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sw	s3, 0x0(a1)
-               	mv	a1, s6
-               	sw	s2, 0x0(a1)
-               	mv	a1, s6
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	sw	s2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	sw	s2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	sw	s2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	sw	s2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	lw	s3, 0x0(a1)
-               	mv	a1, s7
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	sw	s3, 0x0(a1)
-               	mv	a1, s7
-               	lw	s3, 0x0(a1)
-               	mv	a1, s8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	sw	s3, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	s2, 0x0(a1)
-               	mv	a1, s8
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	sw	s2, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	sw	s2, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	sw	s2, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	sw	s2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	lw	s3, 0x0(a1)
-               	mv	a1, s9
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sw	s3, 0x0(a1)
-               	mv	a1, s9
-               	lw	s3, 0x0(a1)
+               	sw	a1, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lw	s2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	mv	a0, s4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s4, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s4, 0xc
+               	sw	a1, 0x0(a0)
+               	mv	a0, s4
+               	lw	a1, 0x0(a0)
+               	mv	a0, s5
+               	sw	a1, 0x0(a0)
+               	addi	a0, s4, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s5, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s4, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s5, 0xc
+               	sw	a1, 0x0(a0)
+               	addi	a0, s5, 0x4
+               	sw	s2, 0x0(a0)
+               	mv	a0, s5
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sw	a1, 0x0(a0)
+               	addi	a0, s5, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s5, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s5, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lw	s3, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	mv	a0, s6
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s6, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s6, 0xc
+               	sw	a1, 0x0(a0)
+               	mv	a0, s6
+               	lw	a1, 0x0(a0)
+               	mv	a0, s7
+               	sw	a1, 0x0(a0)
+               	addi	a0, s6, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s7, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s6, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s6, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s7, 0xc
+               	sw	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	sw	s3, 0x0(a0)
+               	mv	a0, s7
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sw	a1, 0x0(a0)
+               	addi	a0, s7, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s7, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s7, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	mv	a0, s1
+               	lw	s4, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	mv	a0, s8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s8, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s8, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s8, 0xc
+               	sw	a1, 0x0(a0)
+               	mv	a0, s8
+               	lw	a1, 0x0(a0)
+               	mv	a0, s9
+               	sw	a1, 0x0(a0)
+               	addi	a0, s8, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s9, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s8, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s9, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s8, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s9, 0xc
+               	sw	a1, 0x0(a0)
+               	addi	a0, s9, 0xc
+               	sw	s4, 0x0(a0)
+               	mv	a0, s9
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sw	a1, 0x0(a0)
+               	addi	a0, s9, 0x4
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	sw	a1, 0x0(a0)
+               	addi	a0, s9, 0x8
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sw	a1, 0x0(a0)
+               	addi	a0, s9, 0xc
+               	lw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lw	a1, 0x0(a0)
+               	mv	a0, s10
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s10, 0x4
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s10, 0x8
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s10, 0xc
+               	sw	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x2f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
                	mv	a1, s10
-               	sw	s3, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s10, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s10, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s10, 0xc
-               	sw	s3, 0x0(a1)
-               	addi	a1, s10, 0x8
-               	sw	s2, 0x0(a1)
-               	mv	a1, s10
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	sw	s2, 0x0(a1)
-               	addi	a1, s10, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	sw	s2, 0x0(a1)
-               	addi	a1, s10, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	sw	s2, 0x0(a1)
-               	addi	a1, s10, 0xc
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	sw	s2, 0x0(a1)
-               	mv	a1, s4
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	lw	s3, 0x0(a1)
-               	mv	a1, s11
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	s3, 0x0(a1)
-               	addi	a1, s11, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	s3, 0x0(a1)
-               	addi	a1, s11, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	s3, 0x0(a1)
-               	addi	a1, s11, 0xc
-               	sw	s3, 0x0(a1)
-               	mv	a1, s11
-               	lw	s3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	s3, 0x0(a1)
-               	addi	a1, s11, 0x4
-               	lw	s3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	s3, 0x0(a1)
-               	addi	a1, s11, 0x8
-               	lw	s3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	s3, 0x0(a1)
-               	addi	a1, s11, 0xc
-               	lw	s3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	s3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	s2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s2, 0x0(a1)
-               	mv	a1, s1
-               	sw	s2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	sw	s2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	sw	s2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x748
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s1
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x1984>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x19a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x19cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x750
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x19f0>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x1968>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2d8
-               	add	s2, s0, t0
-               	mv	a1, s2
+               	addiw	t0, t0, 0x180
+               	add	s5, s0, t0
+               	mv	a1, s5
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x1e1c <corpus.cases.vec.vec_lane_ops.checksum+0x1a34>
-               	mv	a2, a1
-               	li	a3, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
+               	and	s6, a1, t0
+               	bnez	s6, 0x20d8 <corpus.cases.vec.vec_lane_ops.checksum+0x19ac>
+               	mv	s6, a1
+               	li	s7, 0x10
+               	sd	zero, 0x0(s6)
+               	addi	s6, s6, 0x8
+               	addi	s7, s7, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x1e04 <corpus.cases.vec.vec_lane_ops.checksum+0x1a1c>
-               	j	0x1e38 <corpus.cases.vec.vec_lane_ops.checksum+0x1a50>
-               	mv	a2, a1
+               	bne	s7, t0, 0x20c0 <corpus.cases.vec.vec_lane_ops.checksum+0x1994>
+               	j	0x20f4 <corpus.cases.vec.vec_lane_ops.checksum+0x19c8>
+               	mv	s6, a1
                	li	a1, 0x10
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
+               	sb	zero, 0x0(s6)
+               	addi	s6, s6, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1e24 <corpus.cases.vec.vec_lane_ops.checksum+0x1a3c>
-               	addi	a1, s4, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
+               	bne	a1, t0, 0x20e0 <corpus.cases.vec.vec_lane_ops.checksum+0x19b4>
+               	mv	a1, s5
+               	lw	s6, 0x0(a1)
+               	mv	a1, s11
+               	sw	s6, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	lw	s6, 0x0(a1)
+               	addi	a1, s11, 0x4
+               	sw	s6, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	lw	s6, 0x0(a1)
+               	addi	a1, s11, 0x8
+               	sw	s6, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	lw	s6, 0x0(a1)
+               	addi	a1, s11, 0xc
+               	sw	s6, 0x0(a1)
+               	mv	a1, s11
+               	lw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	s6, 0x0(a1)
+               	addi	a1, s11, 0x4
+               	lw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	s6, 0x0(a1)
+               	addi	a1, s11, 0x8
+               	lw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	s6, 0x0(a1)
+               	addi	a1, s11, 0xc
+               	lw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	s3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	s6, 0x0(a1)
+               	mv	a1, s5
+               	sw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	s6, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	sw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	s6, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	sw	s6, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x308
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s5
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	addi	a1, s5, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	addi	a1, s5, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	addi	a1, s5, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x758
+               	addiw	t1, t1, -0x310
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a2, 0x0(a1)
+               	sw	s2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s5
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x318
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x760
+               	addiw	t1, t1, -0x318
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s5
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	addi	a1, s5, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	addi	a1, s5, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	addi	a1, s5, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x768
+               	addiw	t1, t1, -0x320
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x770
+               	addiw	t1, t1, -0x300
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	lw	a3, 0x0(a1)
+               	sw	t2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
+               	addiw	t1, t1, -0x328
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
+               	mv	a1, s5
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x328
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x328
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x328
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s5
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s5, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s5, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x778
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s5, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x780
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x390
+               	addiw	t1, t1, -0x330
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
+               	sw	s4, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s2
-               	sw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	mv	a1, s5
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x398
+               	addiw	t1, t1, -0x338
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s2
-               	lw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s5
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
+               	addiw	t1, t1, 0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x226c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x2290>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x22b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x22d8>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x214c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2e8
-               	add	s3, s0, t0
-               	mv	a1, s3
+               	addiw	t0, t0, 0x170
+               	add	s6, s0, t0
+               	mv	a1, s6
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x2704 <corpus.cases.vec.vec_lane_ops.checksum+0x231c>
-               	mv	a2, a1
-               	li	a3, 0x10
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x26ec <corpus.cases.vec.vec_lane_ops.checksum+0x2304>
-               	j	0x2720 <corpus.cases.vec.vec_lane_ops.checksum+0x2338>
-               	mv	a2, a1
-               	li	a1, 0x10
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x270c <corpus.cases.vec.vec_lane_ops.checksum+0x2324>
-               	addi	a1, s4, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s3
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x2b54>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x2b78>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x2b9c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x2bc0>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x2f8
-               	add	a1, s0, t0
-               	mv	a2, a1
-               	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x2fec <corpus.cases.vec.vec_lane_ops.checksum+0x2c04>
-               	mv	a3, a2
+               	and	a3, a1, t0
+               	bnez	a3, 0x28bc <corpus.cases.vec.vec_lane_ops.checksum+0x2190>
+               	mv	a3, a1
                	li	a4, 0x10
                	sd	zero, 0x0(a3)
                	addi	a3, a3, 0x8
                	addi	a4, a4, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x2fd4 <corpus.cases.vec.vec_lane_ops.checksum+0x2bec>
-               	j	0x3008 <corpus.cases.vec.vec_lane_ops.checksum+0x2c20>
-               	mv	a3, a2
-               	li	a2, 0x10
+               	bne	a4, t0, 0x28a4 <corpus.cases.vec.vec_lane_ops.checksum+0x2178>
+               	j	0x28d8 <corpus.cases.vec.vec_lane_ops.checksum+0x21ac>
+               	mv	a3, a1
+               	li	a1, 0x10
                	sb	zero, 0x0(a3)
                	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x2ff4 <corpus.cases.vec.vec_lane_ops.checksum+0x2c0c>
-               	addi	a2, s4, 0x8
-               	lw	a3, 0x0(a2)
-               	mv	a2, a1
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	mv	a2, a1
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	a4, 0x0(a2)
-               	mv	a2, a1
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	mv	a2, a1
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	a4, 0x0(a2)
-               	mv	a2, a1
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	mv	a2, a1
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	a4, 0x0(a2)
-               	mv	a2, a1
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
-               	mv	a2, a1
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	a3, 0x0(a2)
-               	mv	a2, a1
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
+               	bne	a1, t0, 0x28c4 <corpus.cases.vec.vec_lane_ops.checksum+0x2198>
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3424>
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3448>
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x346c>
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x430
+               	addiw	t1, t1, 0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	s2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s6
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x300
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sw	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s6
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	s4, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s6
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x88
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	s3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s6
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x80
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	sw	a3, 0x0(a1)
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3490>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x29b0>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x308
+               	addiw	t0, t0, 0x160
                	add	a1, s0, t0
-               	mv	a2, a1
+               	mv	a3, a1
                	li	t0, 0x7
-               	and	a3, a2, t0
-               	bnez	a3, 0x38bc <corpus.cases.vec.vec_lane_ops.checksum+0x34d4>
-               	mv	a3, a2
-               	li	a4, 0x10
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
+               	and	a4, a3, t0
+               	bnez	a4, 0x3120 <corpus.cases.vec.vec_lane_ops.checksum+0x29f4>
+               	mv	a4, a3
+               	li	a5, 0x10
+               	sd	zero, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a4, t0, 0x38a4 <corpus.cases.vec.vec_lane_ops.checksum+0x34bc>
-               	j	0x38d8 <corpus.cases.vec.vec_lane_ops.checksum+0x34f0>
-               	mv	a3, a2
-               	li	a2, 0x10
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
-               	addi	a2, a2, -0x1
+               	bne	a5, t0, 0x3108 <corpus.cases.vec.vec_lane_ops.checksum+0x29dc>
+               	j	0x313c <corpus.cases.vec.vec_lane_ops.checksum+0x2a10>
+               	mv	a4, a3
+               	li	a3, 0x10
+               	sb	zero, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a2, t0, 0x38c4 <corpus.cases.vec.vec_lane_ops.checksum+0x34dc>
-               	mv	a2, s4
-               	lw	a3, 0x0(a2)
-               	mv	a2, a1
-               	lw	a4, 0x0(a2)
+               	bne	a3, t0, 0x3128 <corpus.cases.vec.vec_lane_ops.checksum+0x29fc>
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a4, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a4, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a4, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a4, 0x0(a2)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a4, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a4, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a4, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a4, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a4, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x438
+               	addiw	t1, t1, 0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a4, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a4, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
+               	mv	a3, t2
+               	sw	s2, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
-               	mv	a2, a1
-               	sw	a3, 0x0(a2)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	mv	a3, a1
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x440
+               	addiw	t1, t1, 0x68
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	a3, 0x0(a2)
-               	mv	a2, a1
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	a4, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a3, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a1, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
+               	addiw	t1, t1, 0x60
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
+               	addiw	t1, t1, 0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	s2, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	mv	a3, a1
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	a4, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	s2, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	mv	a3, a1
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	a4, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	s2, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	mv	a3, a1
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	a4, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x30
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x376c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3790>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x37b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x37d8>
-               	mv	a1, s4
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x397c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x39a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x39c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x39e8>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3204>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x318
+               	addiw	t0, t0, 0x150
                	add	a1, s0, t0
-               	mv	a2, a1
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	sw	zero, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	sw	zero, 0x0(a2)
-               	mv	a2, a1
-               	lw	a3, 0x0(a2)
+               	mv	a3, a1
+               	li	t0, 0x7
+               	and	a4, a3, t0
+               	bnez	a4, 0x3974 <corpus.cases.vec.vec_lane_ops.checksum+0x3248>
+               	mv	a4, a3
+               	li	a5, 0x10
+               	sd	zero, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
+               	li	t0, 0x0
+               	bne	a5, t0, 0x395c <corpus.cases.vec.vec_lane_ops.checksum+0x3230>
+               	j	0x3990 <corpus.cases.vec.vec_lane_ops.checksum+0x3264>
+               	mv	a4, a3
+               	li	a3, 0x10
+               	sb	zero, 0x0(a4)
+               	addi	a4, a4, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x397c <corpus.cases.vec.vec_lane_ops.checksum+0x3250>
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	lw	a3, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	lw	a1, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	mv	a1, s4
-               	lw	a2, 0x0(a1)
-               	addiw	a1, a2, 0x1
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x460
+               	addiw	t1, t1, 0x28
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	s4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s5, 0x0(a1)
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3b9c>
-               	addi	a1, s4, 0x4
-               	lw	a2, 0x0(a1)
-               	addw	a1, s5, a2
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	mv	a3, a1
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x20
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	a4, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
+               	addiw	t1, t1, 0x18
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x18
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
+               	addiw	t1, t1, 0x18
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a1, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x468
+               	addiw	t1, t1, 0x18
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s5, 0x0(a1)
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3ca4>
-               	addi	a1, s4, 0x8
-               	lw	a2, 0x0(a1)
-               	xor	a1, s5, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s5, 0x0(a1)
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3dac>
-               	addi	a1, s4, 0xc
-               	lw	a2, 0x0(a1)
-               	subw	a1, s5, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3eb4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
+               	addiw	t1, t1, 0x18
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3ed8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3efc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3f20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3f44>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x34d0>
                	mv	a1, s1
-               	lw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	sw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
                	addi	a1, s1, 0x4
-               	lw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
                	addi	a1, s1, 0x8
-               	lw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
                	addi	a1, s1, 0xc
-               	lw	a2, 0x0(a1)
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
+               	sw	s4, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x40d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x40fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4120>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4144>
-               	mv	a1, s2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x42d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x42fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4320>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4344>
-               	mv	a1, s3
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x44d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x44fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4520>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4544>
-               	mv	a1, s1
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a1, s2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
+               	addiw	t1, t1, 0x8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4798>
+               	sw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x47bc>
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x47e0>
+               	lw	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4c8
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x10
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x300
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sw	t2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4804>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x366c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x328
+               	addiw	t0, t0, 0x140
+               	add	a1, s0, t0
+               	mv	a3, a1
+               	sw	zero, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	sw	zero, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	sw	zero, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	sw	zero, 0x0(a3)
+               	mv	a3, a1
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	addi	a3, a1, 0xc
+               	lw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	addiw	a1, s4, 0x1
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x37fc>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a4, 0x0(a1)
+               	addw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3920>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a4, 0x0(a1)
+               	xor	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x10
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3a44>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a4, 0x0(a1)
+               	subw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x18
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	lw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a4, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3b68>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x20
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3b84>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s1
+               	lw	a4, 0x0(a1)
+               	addw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a4, 0x0(a1)
+               	addw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a4, 0x0(a1)
+               	addw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x28
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a4, 0x0(a1)
+               	addw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x30
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3d50>
+               	mv	a1, s5
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s1
+               	lw	a4, 0x0(a1)
+               	subw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a4, 0x0(a1)
+               	subw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a4, 0x0(a1)
+               	subw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x38
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a4, 0x0(a1)
+               	subw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x40
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x3edc>
+               	mv	a1, s6
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	mv	a1, s1
+               	lw	a4, 0x0(a1)
+               	mulw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a3, t2
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a4, 0x0(a1)
+               	mulw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x4
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a4, 0x0(a1)
+               	mulw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0x8
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x48
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a4, 0x0(a1)
+               	mulw	a1, a3, a4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a3, t2, 0xc
+               	sw	a1, 0x0(a3)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x50
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4068>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a3, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	mv	a1, s5
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x58
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x60
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x68
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x42f4>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x130
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3fc00
@@ -4894,7 +4779,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -4902,7 +4787,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -4910,7 +4795,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -4918,132 +4803,103 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	fadd.s	ft1, ft0, fs0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d0
+               	addiw	t1, t1, -0x70
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x49e8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4a0c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4a30>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4a54>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x44d0>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x338
+               	addiw	t0, t0, 0x120
                	add	s1, s0, t0
                	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x4e80 <corpus.cases.vec.vec_lane_ops.checksum+0x4a98>
+               	bnez	a2, 0x4c40 <corpus.cases.vec.vec_lane_ops.checksum+0x4514>
                	mv	a2, a1
                	li	a3, 0x10
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x4e68 <corpus.cases.vec.vec_lane_ops.checksum+0x4a80>
-               	j	0x4e9c <corpus.cases.vec.vec_lane_ops.checksum+0x4ab4>
+               	bne	a3, t0, 0x4c28 <corpus.cases.vec.vec_lane_ops.checksum+0x44fc>
+               	j	0x4c5c <corpus.cases.vec.vec_lane_ops.checksum+0x4530>
                	mv	a2, a1
                	li	a1, 0x10
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x4e88 <corpus.cases.vec.vec_lane_ops.checksum+0x4aa0>
+               	bne	a1, t0, 0x4c48 <corpus.cases.vec.vec_lane_ops.checksum+0x451c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5051,7 +4907,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5059,7 +4915,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5067,7 +4923,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5075,67 +4931,67 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e0
+               	addiw	t1, t1, -0x80
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5143,7 +4999,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5151,7 +5007,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5159,7 +5015,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4e8
+               	addiw	t1, t1, -0x88
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5167,223 +5023,99 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
+               	flw	fs0, 0x0(a1)
                	mv	a1, s1
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
+               	addiw	t1, t1, -0x90
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x500
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
+               	addiw	t1, t1, -0x90
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x98
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	fs0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5391,7 +5123,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5399,7 +5131,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5407,7 +5139,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x508
+               	addiw	t1, t1, -0x98
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5415,99 +5147,223 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	mv	a1, s1
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
                	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
                	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0xa8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
                	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft1, 0x0(a1)
+               	flw	fs2, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
+               	addiw	t1, t1, -0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x510
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	fs2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5515,7 +5371,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5523,7 +5379,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5531,7 +5387,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x518
+               	addiw	t1, t1, -0xb8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5541,7 +5397,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
+               	addiw	t1, t1, -0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5549,7 +5405,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
+               	addiw	t1, t1, -0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5557,7 +5413,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
+               	addiw	t1, t1, -0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5565,163 +5421,128 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
+               	addiw	t1, t1, -0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
+               	addiw	t1, t1, -0xc0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5310>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5334>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5358>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x520
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x537c>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x4d84>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x348
+               	addiw	t0, t0, 0x110
                	add	s2, s0, t0
                	mv	a1, s2
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x57a8 <corpus.cases.vec.vec_lane_ops.checksum+0x53c0>
+               	bnez	a2, 0x54f4 <corpus.cases.vec.vec_lane_ops.checksum+0x4dc8>
                	mv	a2, a1
                	li	a3, 0x10
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x5790 <corpus.cases.vec.vec_lane_ops.checksum+0x53a8>
-               	j	0x57c4 <corpus.cases.vec.vec_lane_ops.checksum+0x53dc>
+               	bne	a3, t0, 0x54dc <corpus.cases.vec.vec_lane_ops.checksum+0x4db0>
+               	j	0x5510 <corpus.cases.vec.vec_lane_ops.checksum+0x4de4>
                	mv	a2, a1
                	li	a1, 0x10
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x57b0 <corpus.cases.vec.vec_lane_ops.checksum+0x53c8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
+               	bne	a1, t0, 0x54fc <corpus.cases.vec.vec_lane_ops.checksum+0x4dd0>
                	mv	a1, s2
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
+               	addiw	t1, t1, -0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0x4
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
+               	addiw	t1, t1, -0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
+               	addiw	t1, t1, -0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0xc
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
+               	addiw	t1, t1, -0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
+               	addiw	t1, t1, -0xc8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x528
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
+               	addiw	t1, t1, -0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
+               	addiw	t1, t1, -0xc8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xc8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xc8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	fs2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5729,7 +5550,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
+               	addiw	t1, t1, -0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5737,7 +5558,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
+               	addiw	t1, t1, -0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5745,7 +5566,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x530
+               	addiw	t1, t1, -0xd0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -5755,7 +5576,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
+               	addiw	t1, t1, -0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5763,7 +5584,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
+               	addiw	t1, t1, -0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5771,7 +5592,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
+               	addiw	t1, t1, -0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5779,13 +5600,13 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
+               	addiw	t1, t1, -0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x538
+               	addiw	t1, t1, -0xd8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5793,7 +5614,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5801,7 +5622,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5809,7 +5630,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5817,67 +5638,67 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x540
+               	addiw	t1, t1, -0xe0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -5885,7 +5706,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -5893,7 +5714,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -5901,107 +5722,101 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x548
+               	addiw	t1, t1, -0xe8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	addi	a1, s2, 0xc
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
                	mv	a1, s2
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0x4
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s2, 0xc
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
+               	addiw	t1, t1, -0xf0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x550
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xf8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xf8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	fs0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6009,7 +5824,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6017,7 +5832,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6025,7 +5840,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x558
+               	addiw	t1, t1, -0xf8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6035,7 +5850,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
+               	addiw	t1, t1, -0x100
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6043,7 +5858,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
+               	addiw	t1, t1, -0x100
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6051,7 +5866,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
+               	addiw	t1, t1, -0x100
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6059,13 +5874,13 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
+               	addiw	t1, t1, -0x100
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x560
+               	addiw	t1, t1, -0x100
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6073,7 +5888,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6081,7 +5896,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6089,7 +5904,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6097,67 +5912,67 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x568
+               	addiw	t1, t1, -0x108
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6165,7 +5980,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6173,7 +5988,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6181,7 +5996,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x570
+               	addiw	t1, t1, -0x110
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6191,7 +6006,7 @@ Disassembly of section .text:
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x118
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6199,7 +6014,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x118
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6207,7 +6022,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x118
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6215,51 +6030,22 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x118
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
+               	addiw	t1, t1, -0x118
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5d38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5d5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5d80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x578
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5da4>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5708>
                	mv	a1, s2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6267,7 +6053,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6275,7 +6061,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6283,7 +6069,7 @@ Disassembly of section .text:
                	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6291,7 +6077,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6299,7 +6085,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6307,7 +6093,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6315,173 +6101,141 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x130
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x130
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x130
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x580
+               	addiw	t1, t1, -0x120
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x588
+               	addiw	t1, t1, -0x128
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	fmul.s	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x130
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
+               	addiw	t1, t1, -0x130
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5ff8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x601c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6040>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x590
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6064>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5954>
                	mv	a1, s1
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x138
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x138
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x138
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x138
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
+               	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x598
+               	addiw	t1, t1, -0x138
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	fsub.s	ft2, ft0, ft1
-               	fmv.s	fa0, ft2
+               	flw	ft0, 0x0(a1)
+               	fsub.s	ft1, fs2, ft0
+               	fmv.x.w	a1, ft1
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6124>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5a08>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x4d8
+               	addiw	t1, t1, -0x78
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -6489,7 +6243,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x140
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6497,7 +6251,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x140
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -6505,7 +6259,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x140
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6513,23 +6267,26 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x140
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a0
+               	addiw	t1, t1, -0x140
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	flw	ft1, 0x0(a1)
                	fsub.s	ft2, ft0, ft1
-               	fmv.s	fa0, ft2
+               	fmv.x.w	a1, ft2
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x61e4>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5ad4>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x358
+               	addiw	t0, t0, 0x100
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x3ff8
@@ -6546,7 +6303,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x148
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -6554,72 +6311,72 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	fld	ft0, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x148
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x148
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	fadd.d	ft1, ft0, fs1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x148
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5a8
+               	addiw	t1, t1, -0x148
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft1, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x368
+               	addiw	t0, t0, 0xf0
                	add	s1, s0, t0
                	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x6720 <corpus.cases.vec.vec_lane_ops.checksum+0x6338>
+               	bnez	a2, 0x6354 <corpus.cases.vec.vec_lane_ops.checksum+0x5c28>
                	mv	a2, a1
                	li	a3, 0x10
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x6708 <corpus.cases.vec.vec_lane_ops.checksum+0x6320>
-               	j	0x673c <corpus.cases.vec.vec_lane_ops.checksum+0x6354>
+               	bne	a3, t0, 0x633c <corpus.cases.vec.vec_lane_ops.checksum+0x5c10>
+               	j	0x6370 <corpus.cases.vec.vec_lane_ops.checksum+0x5c44>
                	mv	a2, a1
                	li	a1, 0x10
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x6728 <corpus.cases.vec.vec_lane_ops.checksum+0x6340>
+               	bne	a1, t0, 0x635c <corpus.cases.vec.vec_lane_ops.checksum+0x5c30>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6627,7 +6384,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x158
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6635,43 +6392,43 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x158
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x158
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x160
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b8
+               	addiw	t1, t1, -0x158
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x160
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x160
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x160
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6679,7 +6436,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c0
+               	addiw	t1, t1, -0x160
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6687,7 +6444,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6695,7 +6452,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x168
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6703,43 +6460,43 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x168
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x168
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x170
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5c8
+               	addiw	t1, t1, -0x168
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x170
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft1, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x170
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x170
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6747,7 +6504,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d0
+               	addiw	t1, t1, -0x170
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -6755,25 +6512,16 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x658c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x65ac>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5e78>
                	mv	a1, s1
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x178
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6781,31 +6529,22 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x178
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
+               	addiw	t1, t1, -0x178
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x660c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x662c>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5ed4>
                	mv	a1, s1
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x180
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -6813,67 +6552,58 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x180
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x180
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x188
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	fsd	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e0
+               	addiw	t1, t1, -0x180
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5b0
+               	addiw	t1, t1, -0x150
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fld	ft1, 0x0(a1)
                	fsub.d	ft2, ft0, ft1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x188
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	fsd	ft2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
+               	addiw	t1, t1, -0x188
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fld	fa0, 0x0(a1)
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6724>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fld	fa0, 0x0(a1)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6744>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x5fc8>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x378
+               	addiw	t0, t0, 0xe0
                	add	a1, s0, t0
                	mv	a2, a1
                	li	t0, 0xf7
@@ -6926,7 +6656,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -6934,7 +6664,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
@@ -6942,7 +6672,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
@@ -6950,7 +6680,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
@@ -6958,7 +6688,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -6966,7 +6696,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
@@ -6974,7 +6704,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
@@ -6982,7 +6712,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
@@ -6990,7 +6720,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -6998,7 +6728,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
@@ -7006,7 +6736,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
@@ -7014,7 +6744,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
@@ -7022,7 +6752,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
@@ -7030,7 +6760,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
@@ -7038,7 +6768,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
@@ -7046,460 +6776,460 @@ Disassembly of section .text:
                	addi	a2, a1, 0xf
                	lbu	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f0
+               	addiw	t1, t1, -0x190
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x730
+               	addiw	t1, t1, -0x2d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x5f8
+               	addiw	t1, t1, -0x198
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x70b4>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0x6938>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, -0x388
+               	addiw	t0, t0, 0xd0
                	add	s1, s0, t0
                	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x74e0 <corpus.cases.vec.vec_lane_ops.checksum+0x70f8>
+               	bnez	a2, 0x70a8 <corpus.cases.vec.vec_lane_ops.checksum+0x697c>
                	mv	a2, a1
                	li	a3, 0x10
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x74c8 <corpus.cases.vec.vec_lane_ops.checksum+0x70e0>
-               	j	0x74fc <corpus.cases.vec.vec_lane_ops.checksum+0x7114>
+               	bne	a3, t0, 0x7090 <corpus.cases.vec.vec_lane_ops.checksum+0x6964>
+               	j	0x70c4 <corpus.cases.vec.vec_lane_ops.checksum+0x6998>
                	mv	a2, a1
                	li	a1, 0x10
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x74e8 <corpus.cases.vec.vec_lane_ops.checksum+0x7100>
+               	bne	a1, t0, 0x70b0 <corpus.cases.vec.vec_lane_ops.checksum+0x6984>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -7507,7 +7237,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -7515,7 +7245,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -7523,7 +7253,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -7531,7 +7261,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -7539,7 +7269,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -7547,7 +7277,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -7555,7 +7285,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -7563,7 +7293,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -7571,7 +7301,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -7579,7 +7309,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -7587,7 +7317,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -7595,7 +7325,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -7603,7 +7333,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -7611,7 +7341,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -7619,7 +7349,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7627,211 +7357,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x608
+               	addiw	t1, t1, -0x1a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -7839,7 +7569,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -7847,7 +7577,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -7855,7 +7585,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -7863,7 +7593,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -7871,7 +7601,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -7879,7 +7609,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -7887,7 +7617,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -7895,7 +7625,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -7903,7 +7633,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -7911,7 +7641,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -7919,7 +7649,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -7927,7 +7657,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -7935,7 +7665,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -7943,7 +7673,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7951,7 +7681,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x610
+               	addiw	t1, t1, -0x1b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -7959,7 +7689,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -7967,7 +7697,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -7975,7 +7705,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -7983,7 +7713,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -7991,7 +7721,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -7999,7 +7729,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8007,7 +7737,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8015,7 +7745,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8023,7 +7753,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8031,7 +7761,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8039,7 +7769,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8047,7 +7777,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8055,7 +7785,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8063,7 +7793,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8071,7 +7801,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8079,7 +7809,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -8087,211 +7817,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x618
+               	addiw	t1, t1, -0x1b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -8299,7 +8029,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -8307,7 +8037,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -8315,7 +8045,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -8323,7 +8053,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8331,7 +8061,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8339,7 +8069,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8347,7 +8077,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8355,7 +8085,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8363,7 +8093,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8371,7 +8101,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8379,7 +8109,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8387,7 +8117,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8395,7 +8125,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8403,7 +8133,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -8411,7 +8141,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x620
+               	addiw	t1, t1, -0x1c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -8419,7 +8149,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8427,7 +8157,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -8435,7 +8165,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -8443,7 +8173,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -8451,7 +8181,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -8459,7 +8189,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8467,7 +8197,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8475,7 +8205,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8483,7 +8213,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8491,7 +8221,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8499,7 +8229,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8507,7 +8237,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8515,7 +8245,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8523,7 +8253,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8531,7 +8261,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8539,7 +8269,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -8547,211 +8277,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x628
+               	addiw	t1, t1, -0x1c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -8759,7 +8489,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -8767,7 +8497,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -8775,7 +8505,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -8783,7 +8513,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8791,7 +8521,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8799,7 +8529,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8807,7 +8537,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8815,7 +8545,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8823,7 +8553,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8831,7 +8561,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8839,7 +8569,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8847,7 +8577,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8855,7 +8585,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8863,7 +8593,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -8871,7 +8601,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x630
+               	addiw	t1, t1, -0x1d0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -8879,7 +8609,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8887,7 +8617,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -8895,7 +8625,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -8903,7 +8633,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -8911,7 +8641,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -8919,7 +8649,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -8927,7 +8657,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -8935,7 +8665,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -8943,7 +8673,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -8951,7 +8681,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -8959,7 +8689,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -8967,7 +8697,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -8975,7 +8705,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -8983,7 +8713,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -8991,7 +8721,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -8999,7 +8729,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9007,211 +8737,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x638
+               	addiw	t1, t1, -0x1d8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9219,7 +8949,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9227,7 +8957,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9235,7 +8965,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9243,7 +8973,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9251,7 +8981,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9259,7 +8989,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9267,7 +8997,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9275,7 +9005,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9283,7 +9013,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9291,7 +9021,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9299,7 +9029,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9307,7 +9037,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9315,7 +9045,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9323,7 +9053,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9331,7 +9061,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x640
+               	addiw	t1, t1, -0x1e0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9339,7 +9069,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9347,7 +9077,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9355,7 +9085,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9363,7 +9093,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9371,7 +9101,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9379,7 +9109,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9387,7 +9117,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9395,7 +9125,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9403,7 +9133,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9411,7 +9141,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9419,7 +9149,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9427,7 +9157,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9435,7 +9165,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9443,7 +9173,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9451,7 +9181,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9459,7 +9189,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9467,211 +9197,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x648
+               	addiw	t1, t1, -0x1e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9679,7 +9409,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9687,7 +9417,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9695,7 +9425,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9703,7 +9433,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9711,7 +9441,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9719,7 +9449,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9727,7 +9457,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9735,7 +9465,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9743,7 +9473,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9751,7 +9481,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9759,7 +9489,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9767,7 +9497,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9775,7 +9505,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9783,7 +9513,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9791,7 +9521,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x650
+               	addiw	t1, t1, -0x1f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -9799,7 +9529,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9807,7 +9537,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -9815,7 +9545,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -9823,7 +9553,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -9831,7 +9561,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -9839,7 +9569,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -9847,7 +9577,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -9855,7 +9585,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -9863,7 +9593,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -9871,7 +9601,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -9879,7 +9609,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -9887,7 +9617,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -9895,7 +9625,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -9903,7 +9633,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -9911,7 +9641,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -9919,7 +9649,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -9927,211 +9657,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x658
+               	addiw	t1, t1, -0x1f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -10139,7 +9869,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -10147,7 +9877,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -10155,7 +9885,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -10163,7 +9893,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -10171,7 +9901,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -10179,7 +9909,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -10187,7 +9917,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -10195,7 +9925,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10203,7 +9933,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10211,7 +9941,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -10219,7 +9949,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -10227,7 +9957,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -10235,7 +9965,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -10243,7 +9973,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -10251,7 +9981,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x660
+               	addiw	t1, t1, -0x200
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -10259,7 +9989,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10267,7 +9997,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -10275,7 +10005,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -10283,7 +10013,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -10291,7 +10021,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -10299,7 +10029,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -10307,7 +10037,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -10315,7 +10045,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -10323,7 +10053,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -10331,7 +10061,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10339,7 +10069,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10347,7 +10077,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -10355,7 +10085,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -10363,7 +10093,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -10371,7 +10101,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -10379,7 +10109,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -10387,211 +10117,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x668
+               	addiw	t1, t1, -0x208
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -10599,7 +10329,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -10607,7 +10337,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -10615,7 +10345,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -10623,7 +10353,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -10631,7 +10361,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -10639,7 +10369,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -10647,7 +10377,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -10655,7 +10385,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10663,7 +10393,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10671,7 +10401,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -10679,7 +10409,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -10687,7 +10417,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -10695,7 +10425,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -10703,7 +10433,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -10711,7 +10441,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x670
+               	addiw	t1, t1, -0x210
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -10719,7 +10449,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10727,7 +10457,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -10735,7 +10465,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -10743,7 +10473,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -10751,7 +10481,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -10759,7 +10489,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -10767,7 +10497,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -10775,7 +10505,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -10783,7 +10513,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -10791,7 +10521,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -10799,7 +10529,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -10807,7 +10537,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -10815,7 +10545,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -10823,7 +10553,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -10831,7 +10561,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -10839,7 +10569,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -10847,211 +10577,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x678
+               	addiw	t1, t1, -0x218
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -11059,7 +10789,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -11067,7 +10797,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -11075,7 +10805,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -11083,7 +10813,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -11091,7 +10821,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -11099,7 +10829,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -11107,7 +10837,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -11115,7 +10845,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -11123,7 +10853,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -11131,7 +10861,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -11139,7 +10869,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -11147,7 +10877,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -11155,7 +10885,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -11163,7 +10893,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -11171,7 +10901,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x680
+               	addiw	t1, t1, -0x220
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -11179,7 +10909,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -11187,7 +10917,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -11195,7 +10925,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -11203,7 +10933,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -11211,7 +10941,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -11219,7 +10949,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -11227,7 +10957,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -11235,7 +10965,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -11243,7 +10973,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -11251,7 +10981,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -11259,7 +10989,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -11267,7 +10997,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -11275,7 +11005,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -11283,7 +11013,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -11291,7 +11021,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -11299,7 +11029,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -11307,211 +11037,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x688
+               	addiw	t1, t1, -0x228
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -11519,7 +11249,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -11527,7 +11257,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -11535,7 +11265,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -11543,7 +11273,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -11551,7 +11281,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -11559,7 +11289,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -11567,7 +11297,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -11575,7 +11305,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -11583,7 +11313,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -11591,7 +11321,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -11599,7 +11329,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -11607,7 +11337,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -11615,7 +11345,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -11623,7 +11353,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -11631,7 +11361,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x690
+               	addiw	t1, t1, -0x230
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -11639,7 +11369,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -11647,7 +11377,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -11655,7 +11385,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -11663,7 +11393,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -11671,7 +11401,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -11679,7 +11409,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -11687,7 +11417,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -11695,7 +11425,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -11703,7 +11433,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -11711,7 +11441,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -11719,7 +11449,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -11727,7 +11457,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -11735,7 +11465,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -11743,7 +11473,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -11751,7 +11481,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -11759,7 +11489,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -11767,211 +11497,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x698
+               	addiw	t1, t1, -0x238
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -11979,7 +11709,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -11987,7 +11717,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -11995,7 +11725,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -12003,7 +11733,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12011,7 +11741,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12019,7 +11749,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -12027,7 +11757,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -12035,7 +11765,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -12043,7 +11773,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -12051,7 +11781,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -12059,7 +11789,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -12067,7 +11797,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -12075,7 +11805,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -12083,7 +11813,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -12091,7 +11821,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a0
+               	addiw	t1, t1, -0x240
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -12099,7 +11829,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12107,7 +11837,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -12115,7 +11845,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -12123,7 +11853,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -12131,7 +11861,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -12139,7 +11869,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12147,7 +11877,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12155,7 +11885,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -12163,7 +11893,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -12171,7 +11901,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -12179,7 +11909,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -12187,7 +11917,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -12195,7 +11925,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -12203,7 +11933,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -12211,7 +11941,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -12219,7 +11949,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -12227,211 +11957,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6a8
+               	addiw	t1, t1, -0x248
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -12439,7 +12169,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -12447,7 +12177,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -12455,7 +12185,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -12463,7 +12193,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12471,7 +12201,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12479,7 +12209,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -12487,7 +12217,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -12495,7 +12225,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -12503,7 +12233,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -12511,7 +12241,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -12519,7 +12249,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -12527,7 +12257,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -12535,7 +12265,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -12543,7 +12273,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -12551,7 +12281,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b0
+               	addiw	t1, t1, -0x250
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -12559,7 +12289,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12567,7 +12297,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -12575,7 +12305,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -12583,7 +12313,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -12591,7 +12321,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -12599,7 +12329,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12607,7 +12337,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12615,7 +12345,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -12623,7 +12353,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -12631,7 +12361,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -12639,7 +12369,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -12647,7 +12377,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -12655,7 +12385,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -12663,7 +12393,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -12671,7 +12401,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -12679,7 +12409,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -12687,211 +12417,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6b8
+               	addiw	t1, t1, -0x258
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -12899,7 +12629,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -12907,7 +12637,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -12915,7 +12645,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -12923,7 +12653,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -12931,7 +12661,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -12939,7 +12669,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -12947,7 +12677,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -12955,7 +12685,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -12963,7 +12693,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -12971,7 +12701,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -12979,7 +12709,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -12987,7 +12717,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -12995,7 +12725,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -13003,7 +12733,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -13011,7 +12741,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c0
+               	addiw	t1, t1, -0x260
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -13019,7 +12749,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13027,7 +12757,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -13035,7 +12765,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13043,7 +12773,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13051,7 +12781,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13059,7 +12789,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -13067,7 +12797,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -13075,7 +12805,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -13083,7 +12813,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -13091,7 +12821,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -13099,7 +12829,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -13107,7 +12837,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -13115,7 +12845,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -13123,7 +12853,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -13131,7 +12861,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -13139,7 +12869,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -13147,211 +12877,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6c8
+               	addiw	t1, t1, -0x268
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -13359,7 +13089,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13367,7 +13097,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13375,7 +13105,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13383,7 +13113,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -13391,7 +13121,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -13399,7 +13129,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -13407,7 +13137,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -13415,7 +13145,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -13423,7 +13153,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -13431,7 +13161,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -13439,7 +13169,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -13447,7 +13177,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -13455,7 +13185,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -13463,7 +13193,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -13471,7 +13201,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d0
+               	addiw	t1, t1, -0x270
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -13479,7 +13209,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13487,7 +13217,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -13495,7 +13225,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13503,7 +13233,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13511,7 +13241,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13519,7 +13249,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -13527,7 +13257,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -13535,7 +13265,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -13543,7 +13273,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -13551,7 +13281,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -13559,7 +13289,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -13567,7 +13297,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -13575,7 +13305,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -13583,7 +13313,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -13591,7 +13321,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -13599,7 +13329,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -13607,211 +13337,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6d8
+               	addiw	t1, t1, -0x278
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -13819,7 +13549,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13827,7 +13557,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13835,7 +13565,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13843,7 +13573,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -13851,7 +13581,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -13859,7 +13589,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -13867,7 +13597,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -13875,7 +13605,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -13883,7 +13613,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -13891,7 +13621,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -13899,7 +13629,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -13907,7 +13637,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -13915,7 +13645,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -13923,7 +13653,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -13931,7 +13661,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e0
+               	addiw	t1, t1, -0x280
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -13939,7 +13669,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13947,7 +13677,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -13955,7 +13685,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -13963,7 +13693,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -13971,7 +13701,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -13979,7 +13709,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -13987,7 +13717,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -13995,7 +13725,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -14003,7 +13733,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -14011,7 +13741,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -14019,7 +13749,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -14027,7 +13757,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -14035,7 +13765,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -14043,7 +13773,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -14051,7 +13781,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -14059,7 +13789,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -14067,211 +13797,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6e8
+               	addiw	t1, t1, -0x288
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -14279,7 +14009,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -14287,7 +14017,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -14295,7 +14025,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -14303,7 +14033,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -14311,7 +14041,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -14319,7 +14049,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -14327,7 +14057,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -14335,7 +14065,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -14343,7 +14073,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -14351,7 +14081,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -14359,7 +14089,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -14367,7 +14097,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -14375,7 +14105,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -14383,7 +14113,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -14391,7 +14121,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f0
+               	addiw	t1, t1, -0x290
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -14399,7 +14129,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -14407,7 +14137,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -14415,7 +14145,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -14423,7 +14153,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -14431,7 +14161,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -14439,7 +14169,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -14447,7 +14177,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -14455,7 +14185,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -14463,7 +14193,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -14471,7 +14201,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -14479,7 +14209,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -14487,7 +14217,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -14495,7 +14225,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -14503,7 +14233,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -14511,7 +14241,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -14519,7 +14249,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -14527,211 +14257,211 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x6f8
+               	addiw	t1, t1, -0x298
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -14739,7 +14469,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -14747,7 +14477,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -14755,7 +14485,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -14763,7 +14493,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -14771,7 +14501,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -14779,7 +14509,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -14787,7 +14517,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -14795,7 +14525,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -14803,7 +14533,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -14811,7 +14541,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -14819,7 +14549,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -14827,7 +14557,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -14835,7 +14565,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -14843,7 +14573,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -14851,7 +14581,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x700
+               	addiw	t1, t1, -0x2a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
@@ -14861,7 +14591,7 @@ Disassembly of section .text:
                	mv	a1, s1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -14869,7 +14599,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -14877,7 +14607,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -14885,7 +14615,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -14893,7 +14623,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -14901,7 +14631,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -14909,7 +14639,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -14917,7 +14647,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -14925,7 +14655,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -14933,7 +14663,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -14941,7 +14671,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -14949,7 +14679,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -14957,7 +14687,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -14965,7 +14695,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -14973,7 +14703,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -14981,22 +14711,22 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x708
+               	addiw	t1, t1, -0x2a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xe628>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xdeac>
                	mv	a1, s1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -15004,7 +14734,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -15012,7 +14742,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -15020,7 +14750,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -15028,7 +14758,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -15036,7 +14766,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -15044,7 +14774,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -15052,7 +14782,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -15060,7 +14790,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -15068,7 +14798,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -15076,7 +14806,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -15084,7 +14814,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -15092,7 +14822,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -15100,7 +14830,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -15108,7 +14838,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -15116,326 +14846,326 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x710
+               	addiw	t1, t1, -0x2b0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x718
+               	addiw	t1, t1, -0x2b8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xed04>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xe588>
                	mv	a1, s1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -15443,7 +15173,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
@@ -15451,7 +15181,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
@@ -15459,7 +15189,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
@@ -15467,7 +15197,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -15475,7 +15205,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
@@ -15483,7 +15213,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
@@ -15491,7 +15221,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
@@ -15499,7 +15229,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -15507,7 +15237,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
@@ -15515,7 +15245,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
@@ -15523,7 +15253,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
@@ -15531,7 +15261,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
@@ -15539,7 +15269,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
@@ -15547,7 +15277,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
@@ -15555,383 +15285,387 @@ Disassembly of section .text:
                	addi	a1, s1, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	sb	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x1
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x2
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x3
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x5
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x6
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x7
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x9
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xa
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xb
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xd
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xe
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x720
+               	addiw	t1, t1, -0x2c0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x600
+               	addiw	t1, t1, -0x1a0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xf
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xf
                	sb	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, -0x728
+               	addiw	t1, t1, -0x2c8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xf3e0>
+               	jalr	ra <corpus.cases.vec.vec_lane_ops.checksum+0xec64>
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x778
+               	addiw	t1, t1, 0x328
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x770
+               	addiw	t1, t1, 0x320
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x768
+               	addiw	t1, t1, 0x318
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x760
+               	addiw	t1, t1, 0x310
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x758
+               	addiw	t1, t1, 0x308
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x750
+               	addiw	t1, t1, 0x300
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x748
+               	addiw	t1, t1, 0x2f8
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x740
+               	addiw	t1, t1, 0x2f0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x738
+               	addiw	t1, t1, 0x2e8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x730
+               	addiw	t1, t1, 0x2e0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x728
+               	addiw	t1, t1, 0x2d8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x720
+               	addiw	t1, t1, 0x2d0
                	add	t1, sp, t1
                	fld	fs0, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x718
+               	addiw	t1, t1, 0x2c8
                	add	t1, sp, t1
                	fld	fs1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x788
+               	addiw	t1, t1, 0x2c0
+               	add	t1, sp, t1
+               	fld	fs2, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, 0x338
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, 0x780
+               	addiw	t1, t1, 0x330
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, 0x790
+               	addiw	t0, t0, 0x340
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_mem.dis
+++ b/test/golden/riscv64-linux/vec/vec_mem.dis
@@ -3,2366 +3,1607 @@ vec/vec_mem.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_mem.fold3>:
-               	addi	sp, sp, -0x50
-               	sd	ra, 0x48(sp)
-               	sd	s0, 0x40(sp)
-               	addi	s0, sp, 0x50
-               	sd	s1, 0x38(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x24
-               	addi	a1, s0, -0x30
-               	addi	a1, s0, -0x3c
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold3+0x38>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	addi	a2, s0, -0x1c
+               	addi	a2, s0, -0x28
+               	addi	a2, s0, -0x34
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold3+0x54>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40 <corpus.cases.vec.vec_mem.fold3+0x40>
+               	j	0x74 <corpus.cases.vec.vec_mem.fold3+0x74>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x40 <corpus.cases.vec.vec_mem.fold3+0x40>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold3+0x70>
-               	ld	s1, 0x38(sp)
-               	ld	ra, 0x48(sp)
-               	ld	s0, 0x40(sp)
-               	addi	sp, sp, 0x50
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x98 <corpus.cases.vec.vec_mem.fold3+0x98>
+               	j	0xcc <corpus.cases.vec.vec_mem.fold3+0xcc>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x98 <corpus.cases.vec.vec_mem.fold3+0x98>
+               	addi	a2, a1, 0x8
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.vec.vec_mem.fold3+0xf0>
+               	j	0x124 <corpus.cases.vec.vec_mem.fold3+0x124>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xf0 <corpus.cases.vec.vec_mem.fold3+0xf0>
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
                	ret
 
 <corpus.cases.vec.vec_mem.fold5>:
-               	addi	sp, sp, -0x90
-               	sd	ra, 0x88(sp)
-               	sd	s0, 0x80(sp)
-               	addi	s0, sp, 0x90
-               	sd	s1, 0x78(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x2c
-               	addi	a1, s0, -0x40
-               	addi	a1, s0, -0x54
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x7c
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold5+0x40>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x80
+               	sd	ra, 0x78(sp)
+               	sd	s0, 0x70(sp)
+               	addi	s0, sp, 0x80
+               	addi	a2, s0, -0x24
+               	addi	a2, s0, -0x38
+               	addi	a2, s0, -0x4c
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x74
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold5+0x5c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x17c <corpus.cases.vec.vec_mem.fold5+0x48>
+               	j	0x1b0 <corpus.cases.vec.vec_mem.fold5+0x7c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x17c <corpus.cases.vec.vec_mem.fold5+0x48>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold5+0x78>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1d4 <corpus.cases.vec.vec_mem.fold5+0xa0>
+               	j	0x208 <corpus.cases.vec.vec_mem.fold5+0xd4>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x1d4 <corpus.cases.vec.vec_mem.fold5+0xa0>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold5+0x94>
-               	mv	a1, a0
-               	addi	a2, s1, 0x10
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x22c <corpus.cases.vec.vec_mem.fold5+0xf8>
+               	j	0x260 <corpus.cases.vec.vec_mem.fold5+0x12c>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x22c <corpus.cases.vec.vec_mem.fold5+0xf8>
+               	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.fold5+0xb0>
-               	ld	s1, 0x78(sp)
-               	ld	ra, 0x88(sp)
-               	ld	s0, 0x80(sp)
-               	addi	sp, sp, 0x90
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x284 <corpus.cases.vec.vec_mem.fold5+0x150>
+               	j	0x2b8 <corpus.cases.vec.vec_mem.fold5+0x184>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x284 <corpus.cases.vec.vec_mem.fold5+0x150>
+               	addi	a2, a1, 0x10
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2dc <corpus.cases.vec.vec_mem.fold5+0x1a8>
+               	j	0x310 <corpus.cases.vec.vec_mem.fold5+0x1dc>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2dc <corpus.cases.vec.vec_mem.fold5+0x1a8>
+               	ld	ra, 0x78(sp)
+               	ld	s0, 0x70(sp)
+               	addi	sp, sp, 0x80
                	ret
 
 <corpus.cases.vec.vec_mem.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x5b0
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x5b0
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5e0
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5e8
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5f0
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5f8
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x600
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x608
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x610
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x618
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x620
-               	add	t1, sp, t1
-               	fsd	fs0, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x7c
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x94
-               	addi	s5, s0, -0xa0
-               	addi	s6, s0, -0xac
-               	addi	s7, s0, -0xb8
-               	addi	s8, s0, -0xc4
-               	addi	s9, s0, -0xd0
-               	addi	s10, s0, -0xdc
-               	addi	s11, s0, -0xe8
-               	addi	t2, s0, -0xf4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x100
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x10c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x118
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x124
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x130
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x13c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x148
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	addi	sp, sp, -0x6c0
+               	sd	ra, 0x6b8(sp)
+               	sd	s0, 0x6b0(sp)
+               	addi	s0, sp, 0x6c0
+               	sd	s1, 0x6a8(sp)
+               	sd	s2, 0x6a0(sp)
+               	sd	s3, 0x698(sp)
+               	sd	s4, 0x690(sp)
+               	sd	s5, 0x688(sp)
+               	sd	s6, 0x680(sp)
+               	sd	s7, 0x678(sp)
+               	sd	s8, 0x670(sp)
+               	sd	s9, 0x668(sp)
+               	sd	s10, 0x660(sp)
+               	sd	s11, 0x658(sp)
+               	fsd	fs0, 0x650(sp)
+               	addi	t2, s0, -0x7c
+               	sd	t2, -0x580(s0)
+               	addi	a2, s0, -0x88
+               	addi	t2, s0, -0x94
+               	sd	t2, -0x670(s0)
+               	addi	a4, s0, -0xa0
+               	addi	t2, s0, -0xac
+               	sd	t2, -0x678(s0)
+               	addi	a6, s0, -0xb8
+               	addi	t2, s0, -0xc4
+               	sd	t2, -0x680(s0)
+               	addi	s1, s0, -0xd0
+               	addi	s2, s0, -0xdc
+               	addi	s3, s0, -0xe8
+               	addi	s4, s0, -0xf4
+               	addi	s5, s0, -0x100
+               	addi	s6, s0, -0x10c
+               	addi	s7, s0, -0x118
+               	addi	s8, s0, -0x124
+               	addi	s9, s0, -0x130
+               	addi	s10, s0, -0x13c
+               	addi	s11, s0, -0x148
                	addi	t2, s0, -0x154
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x6a0(s0)
                	addi	t2, s0, -0x160
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x6a8(s0)
                	addi	t2, s0, -0x16c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x570(s0)
                	addi	t2, s0, -0x178
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x578(s0)
                	addi	a1, s0, -0x184
                	addi	t2, s0, -0x190
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x588(s0)
                	addi	t2, s0, -0x19c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x590(s0)
                	addi	a1, s0, -0x1a8
                	addi	a1, s0, -0x1b4
                	addi	a1, s0, -0x1c0
                	addi	t2, s0, -0x1cc
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x598(s0)
                	addi	t2, s0, -0x1d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5a0(s0)
                	addi	t2, s0, -0x1e4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5a8(s0)
                	addi	t2, s0, -0x1f0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5b0(s0)
                	addi	t2, s0, -0x1fc
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5b8(s0)
                	addi	t2, s0, -0x208
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5c0(s0)
                	addi	t2, s0, -0x21c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5c8(s0)
                	addi	t2, s0, -0x230
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5d0(s0)
                	addi	t2, s0, -0x244
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5d8(s0)
                	addi	t2, s0, -0x258
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5e0(s0)
                	addi	t2, s0, -0x26c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5e8(s0)
                	addi	t2, s0, -0x280
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5f0(s0)
                	addi	t2, s0, -0x294
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x5f8(s0)
                	addi	t2, s0, -0x2a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x600(s0)
                	addi	t2, s0, -0x2bc
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x608(s0)
                	addi	t2, s0, -0x2d0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x610(s0)
                	addi	t2, s0, -0x2e4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x618(s0)
                	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x620(s0)
                	addi	t2, s0, -0x30c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x628(s0)
                	addi	t2, s0, -0x320
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x630(s0)
                	addi	t2, s0, -0x334
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x638(s0)
                	addi	t2, s0, -0x348
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x640(s0)
                	addi	t2, s0, -0x35c
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x648(s0)
                	addi	t2, s0, -0x370
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x650(s0)
                	addi	t2, s0, -0x384
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	sd	t2, -0x658(s0)
                	addi	t2, s0, -0x398
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3a4
-               	addi	a1, s0, -0x3b0
-               	addi	a1, s0, -0x3bc
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d4
-               	addi	a1, s0, -0x3e0
-               	addi	a1, s0, -0x3ec
-               	addi	a1, s0, -0x3f8
-               	addi	a1, s0, -0x404
-               	addi	a1, s0, -0x410
-               	addi	a1, s0, -0x41c
-               	addi	a1, s0, -0x428
-               	addi	a1, s0, -0x434
-               	addi	a1, s0, -0x440
-               	addi	a1, s0, -0x44c
-               	addi	a1, s0, -0x460
-               	addi	a1, s0, -0x474
-               	addi	a1, s0, -0x488
-               	addi	a1, s0, -0x49c
-               	addi	a1, s0, -0x4b0
-               	addi	a1, s0, -0x4c4
-               	addi	a1, s0, -0x4d8
-               	addi	a1, s0, -0x4ec
-               	addi	a1, s0, -0x500
-               	addi	a1, s0, -0x514
-               	addi	a1, s0, -0x520
-               	addi	a1, s0, -0x52c
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x544
-               	addi	a1, s0, -0x550
-               	addi	a1, s0, -0x55c
-               	addi	a1, s0, -0x570
-               	addi	a1, s0, -0x584
-               	addi	a1, s0, -0x598
-               	addi	a1, s0, -0x5ac
-               	addi	a1, s0, -0x5c0
-               	addi	a1, s0, -0x5cc
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e4
-               	addi	a1, s0, -0x5f0
-               	addi	a1, s0, -0x5fc
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x61c
-               	addi	a1, s0, -0x630
-               	addi	a1, s0, -0x644
-               	addi	a1, s0, -0x658
-               	addi	a1, s0, -0x66c
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x684
-               	addi	a1, s0, -0x690
-               	addi	a1, s0, -0x6a4
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6cc
-               	addi	a1, s0, -0x6e0
-               	addi	a1, s0, -0x6f4
-               	addi	a1, s0, -0x700
-               	addi	a1, s0, -0x70c
-               	addi	a1, s0, -0x718
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x53c>
-               	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	fcvt.s.lu	fs0, s1
-               	addi	s1, s0, -0x76c
-               	mv	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	li	t0, 0x7
-               	and	a0, t2, t0
-               	bnez	a0, 0x72c <corpus.cases.vec.vec_mem.checksum+0x5d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sd	t2, -0x660(s0)
+               	fcvt.s.lu	fs0, a0
+               	addi	t2, s0, -0x494
+               	sd	t2, -0x668(s0)
+               	ld	t2, -0x668(s0)
                	mv	a0, t2
-               	li	a1, 0x50
-               	sd	zero, 0x0(a0)
-               	addi	a0, a0, 0x8
-               	addi	a1, a1, -0x8
-               	li	t0, 0x0
-               	bne	a1, t0, 0x710 <corpus.cases.vec.vec_mem.checksum+0x5b8>
-               	sw	zero, 0x0(a0)
-               	j	0x758 <corpus.cases.vec.vec_mem.checksum+0x600>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x610
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	li	a1, 0x54
-               	sb	zero, 0x0(a0)
-               	addi	a0, a0, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x744 <corpus.cases.vec.vec_mem.checksum+0x5ec>
-               	li	t2, 0x0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
                	li	t0, 0x7
-               	bltu	t2, t0, 0x788 <corpus.cases.vec.vec_mem.checksum+0x630>
-               	j	0xc40 <corpus.cases.vec.vec_mem.checksum+0xae8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	fcvt.s.lu	ft0, t2
-               	addi	t2, s0, -0x778
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	mv	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	li	t0, 0x7
-               	and	a1, t2, t0
-               	bnez	a1, 0x824 <corpus.cases.vec.vec_mem.checksum+0x6cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	li	a0, 0x8
+               	and	a1, a0, t0
+               	bnez	a1, 0x50c <corpus.cases.vec.vec_mem.checksum+0x1ec>
+               	mv	a1, a0
+               	li	a3, 0x50
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	a0, a0, -0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a0, t0, 0x808 <corpus.cases.vec.vec_mem.checksum+0x6b0>
+               	bne	a3, t0, 0x4f0 <corpus.cases.vec.vec_mem.checksum+0x1d0>
                	sw	zero, 0x0(a1)
-               	j	0x850 <corpus.cases.vec.vec_mem.checksum+0x6f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	li	a1, 0xc
-               	sb	zero, 0x0(a0)
-               	addi	a0, a0, 0x1
-               	addi	a1, a1, -0x1
+               	j	0x528 <corpus.cases.vec.vec_mem.checksum+0x208>
+               	mv	a1, a0
+               	li	a0, 0x54
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x83c <corpus.cases.vec.vec_mem.checksum+0x6e4>
+               	bne	a0, t0, 0x514 <corpus.cases.vec.vec_mem.checksum+0x1f4>
+               	li	a0, 0x0
+               	li	t0, 0x7
+               	bltu	a0, t0, 0x538 <corpus.cases.vec.vec_mem.checksum+0x218>
+               	j	0x850 <corpus.cases.vec.vec_mem.checksum+0x530>
+               	fcvt.s.lu	ft0, a0
+               	addi	a1, s0, -0x3a4
+               	mv	a3, a1
+               	li	t0, 0x7
+               	and	a5, a3, t0
+               	bnez	a5, 0x574 <corpus.cases.vec.vec_mem.checksum+0x254>
+               	mv	a5, a3
+               	li	a7, 0x8
+               	sd	zero, 0x0(a5)
+               	addi	a5, a5, 0x8
+               	addi	a7, a7, -0x8
+               	li	t0, 0x0
+               	bne	a7, t0, 0x558 <corpus.cases.vec.vec_mem.checksum+0x238>
+               	sw	zero, 0x0(a5)
+               	j	0x590 <corpus.cases.vec.vec_mem.checksum+0x270>
+               	mv	a5, a3
+               	li	a3, 0xc
+               	sb	zero, 0x0(a5)
+               	addi	a5, a5, 0x1
+               	addi	a3, a3, -0x1
+               	li	t0, 0x0
+               	bne	a3, t0, 0x57c <corpus.cases.vec.vec_mem.checksum+0x25c>
                	fadd.s	ft1, ft0, fs0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft2, 0x0(a0)
-               	mv	a0, s2
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	fsw	ft2, 0x0(a0)
-               	mv	a0, s2
-               	flw	ft2, 0x0(a0)
-               	mv	a0, s3
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	fsw	ft2, 0x0(a0)
-               	mv	a0, s3
-               	fsw	ft1, 0x0(a0)
-               	mv	a0, s3
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft1, 0x0(a0)
-               	addi	a0, s3, 0x4
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft1, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft1, 0x0(a0)
+               	mv	a3, a1
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	mv	a3, t2
+               	fsw	ft2, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	addi	a3, t2, 0x4
+               	fsw	ft2, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	addi	a3, t2, 0x8
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	mv	a3, t2
+               	flw	ft2, 0x0(a3)
+               	mv	a3, a2
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	addi	a3, t2, 0x4
+               	flw	ft2, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x580(s0)
+               	addi	a3, t2, 0x8
+               	flw	ft2, 0x0(a3)
+               	addi	a3, a2, 0x8
+               	fsw	ft2, 0x0(a3)
+               	mv	a3, a2
+               	fsw	ft1, 0x0(a3)
+               	mv	a3, a2
+               	flw	ft1, 0x0(a3)
+               	mv	a3, a1
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a2, 0x8
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	fsw	ft1, 0x0(a3)
                	lui	t0, 0x3fa00
                	fmv.w.x	ft10, t0
                	fsub.s	ft1, ft0, ft10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft2, 0x0(a0)
-               	mv	a0, s4
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	fsw	ft2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	fsw	ft2, 0x0(a0)
-               	mv	a0, s4
-               	flw	ft2, 0x0(a0)
-               	mv	a0, s5
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	flw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	fsw	ft2, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	fsw	ft1, 0x0(a0)
-               	mv	a0, s5
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft1, 0x0(a0)
-               	addi	a0, s5, 0x4
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft1, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	flw	ft1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft1, 0x0(a0)
+               	mv	a3, a1
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	mv	a3, t2
+               	fsw	ft2, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	addi	a3, t2, 0x4
+               	fsw	ft2, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	flw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	addi	a3, t2, 0x8
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	mv	a3, t2
+               	flw	ft2, 0x0(a3)
+               	mv	a3, a4
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	addi	a3, t2, 0x4
+               	flw	ft2, 0x0(a3)
+               	addi	a3, a4, 0x4
+               	fsw	ft2, 0x0(a3)
+               	ld	t2, -0x670(s0)
+               	addi	a3, t2, 0x8
+               	flw	ft2, 0x0(a3)
+               	addi	a3, a4, 0x8
+               	fsw	ft2, 0x0(a3)
+               	addi	a3, a4, 0x4
+               	fsw	ft1, 0x0(a3)
+               	mv	a3, a4
+               	flw	ft1, 0x0(a3)
+               	mv	a3, a1
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a4, 0x4
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	fsw	ft1, 0x0(a3)
+               	addi	a3, a4, 0x8
+               	flw	ft1, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	fsw	ft1, 0x0(a3)
                	lui	t0, 0x42c80
                	fmv.w.x	ft11, t0
                	fsub.s	ft1, ft11, ft0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s6
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	fsw	ft0, 0x0(a0)
-               	mv	a0, s6
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s7
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s6, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	fsw	ft1, 0x0(a0)
-               	mv	a0, s7
-               	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x4
-               	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s8
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x4
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x600
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
-               	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a3, a1
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	mv	a3, t2
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	addi	a3, t2, 0x4
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	addi	a3, t2, 0x8
+               	fsw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	mv	a3, t2
+               	flw	ft0, 0x0(a3)
+               	mv	a3, a6
+               	fsw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	addi	a3, t2, 0x4
+               	flw	ft0, 0x0(a3)
+               	addi	a3, a6, 0x4
+               	fsw	ft0, 0x0(a3)
+               	ld	t2, -0x678(s0)
+               	addi	a3, t2, 0x8
+               	flw	ft0, 0x0(a3)
+               	addi	a3, a6, 0x8
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a6, 0x8
+               	fsw	ft1, 0x0(a3)
+               	mv	a3, a6
+               	flw	ft0, 0x0(a3)
+               	mv	a3, a1
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a6, 0x4
+               	flw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a6, 0x8
+               	flw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	fsw	ft0, 0x0(a3)
+               	mv	a3, a1
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x680(s0)
+               	mv	a3, t2
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x4
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x680(s0)
+               	addi	a3, t2, 0x4
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a1, 0x8
+               	flw	ft0, 0x0(a3)
+               	ld	t2, -0x680(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	li	t0, 0xc
+               	mul	a1, a0, t0
+               	ld	t2, -0x668(s0)
+               	add	a3, t2, a1
+               	ld	t2, -0x680(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, a3
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x680(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x680(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a0, a0, 0x1
+               	li	t0, 0x7
+               	bltu	a0, t0, 0x538 <corpus.cases.vec.vec_mem.checksum+0x218>
+               	lui	t2, 0xfcbf3
+               	addiw	t2, t2, -0x632
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x484
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x222
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x325
+               	sd	t2, -0x690(s0)
+               	li	t2, 0x7
+               	sd	t2, -0x698(s0)
+               	ld	t2, -0x698(s0)
+               	li	t1, 0x0
+               	bltu	t1, t2, 0x88c <corpus.cases.vec.vec_mem.checksum+0x56c>
+               	j	0x910 <corpus.cases.vec.vec_mem.checksum+0x5f0>
+               	ld	t3, -0x698(s0)
+               	addi	t2, t3, -0x1
+               	sd	t2, -0x688(s0)
+               	ld	t2, -0x688(s0)
                	li	t0, 0xc
                	mul	a0, t2, t0
-               	add	a1, s1, a0
-               	mv	a0, s8
-               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x668(s0)
+               	add	a1, t2, a0
                	mv	a0, a1
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x4
                	flw	ft0, 0x0(a0)
+               	mv	a0, s1
+               	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, s8, 0x8
                	flw	ft0, 0x0(a0)
-               	addi	a0, a1, 0x8
+               	addi	a0, s1, 0x4
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x1
+               	addi	a0, a1, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x690(s0)
+               	mv	a0, t2
+               	mv	a1, s1
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x5c8>
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x608
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	li	t0, 0x7
-               	bltu	t2, t0, 0x788 <corpus.cases.vec.vec_mem.checksum+0x630>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x618
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	li	s3, 0x7
+               	sd	t2, -0x690(s0)
+               	ld	t3, -0x688(s0)
+               	mv	t2, t3
+               	sd	t2, -0x698(s0)
+               	ld	t2, -0x698(s0)
                	li	t1, 0x0
-               	bltu	t1, s3, 0xc64 <corpus.cases.vec.vec_mem.checksum+0xb0c>
-               	j	0xcf4 <corpus.cases.vec.vec_mem.checksum+0xb9c>
-               	addi	s4, s3, -0x1
-               	li	t0, 0xc
-               	mul	a0, s4, t0
-               	add	a1, s1, a0
-               	mv	a0, a1
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s9
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, a1, 0x4
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	fsw	ft0, 0x0(a0)
-               	addi	a0, a1, 0x8
-               	flw	ft0, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	fsw	ft0, 0x0(a0)
-               	mv	a0, s9
-               	flw	ft0, 0x0(a0)
-               	mv	a0, s2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xb5c>
-               	addi	a1, s9, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xb70>
-               	addi	a1, s9, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xb84>
-               	mv	s2, a0
-               	mv	s3, s4
-               	li	t1, 0x0
-               	bltu	t1, s3, 0xc64 <corpus.cases.vec.vec_mem.checksum+0xb0c>
-               	addi	s3, s0, -0x7b8
-               	mv	a0, s3
+               	bltu	t1, t2, 0x88c <corpus.cases.vec.vec_mem.checksum+0x56c>
+               	addi	s1, s0, -0x3e4
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xd28 <corpus.cases.vec.vec_mem.checksum+0xbd0>
+               	bnez	a1, 0x944 <corpus.cases.vec.vec_mem.checksum+0x624>
                	mv	a1, a0
-               	li	s4, 0x40
+               	li	a3, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	s4, s4, -0x8
+               	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	s4, t0, 0xd10 <corpus.cases.vec.vec_mem.checksum+0xbb8>
-               	j	0xd44 <corpus.cases.vec.vec_mem.checksum+0xbec>
+               	bne	a3, t0, 0x92c <corpus.cases.vec.vec_mem.checksum+0x60c>
+               	j	0x960 <corpus.cases.vec.vec_mem.checksum+0x640>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xd30 <corpus.cases.vec.vec_mem.checksum+0xbd8>
+               	bne	a0, t0, 0x94c <corpus.cases.vec.vec_mem.checksum+0x62c>
                	li	a0, 0x0
                	li	t0, 0x4
-               	bltu	a0, t0, 0xd54 <corpus.cases.vec.vec_mem.checksum+0xbfc>
-               	j	0xdf4 <corpus.cases.vec.vec_mem.checksum+0xc9c>
+               	bltu	a0, t0, 0x970 <corpus.cases.vec.vec_mem.checksum+0x650>
+               	j	0xa14 <corpus.cases.vec.vec_mem.checksum+0x6f4>
                	li	t0, 0xc
                	mul	a1, a0, t0
-               	add	s4, s1, a1
-               	mv	a1, s4
+               	ld	t2, -0x668(s0)
+               	add	a3, t2, a1
+               	mv	a1, a3
                	flw	ft0, 0x0(a1)
-               	mv	a1, s10
+               	mv	a1, s2
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
+               	addi	a1, a3, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s10, 0x4
+               	addi	a1, s2, 0x4
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
+               	addi	a1, a3, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a1, s10, 0x8
+               	addi	a1, s2, 0x8
                	fsw	ft0, 0x0(a1)
                	li	t0, 0x10
                	mul	a1, a0, t0
-               	add	s4, s3, a1
-               	mv	a1, s4
-               	mv	s5, s10
-               	flw	ft0, 0x0(s5)
-               	mv	s5, a1
-               	fsw	ft0, 0x0(s5)
-               	addi	s5, s10, 0x4
-               	flw	ft0, 0x0(s5)
-               	addi	s5, a1, 0x4
-               	fsw	ft0, 0x0(s5)
-               	addi	s5, s10, 0x8
-               	flw	ft0, 0x0(s5)
-               	addi	s5, a1, 0x8
-               	fsw	ft0, 0x0(s5)
+               	add	a3, s1, a1
+               	mv	a1, a3
+               	mv	a4, s2
+               	flw	ft0, 0x0(a4)
+               	mv	a4, a1
+               	fsw	ft0, 0x0(a4)
+               	addi	a4, s2, 0x4
+               	flw	ft0, 0x0(a4)
+               	addi	a4, a1, 0x4
+               	fsw	ft0, 0x0(a4)
+               	addi	a4, s2, 0x8
+               	flw	ft0, 0x0(a4)
+               	addi	a4, a1, 0x8
+               	fsw	ft0, 0x0(a4)
                	sext.w	a1, a0
                	lui	t1, 0xaaaab
                	addiw	t1, t1, -0x556
-               	subw	s5, t1, a1
-               	addi	a1, s4, 0xc
-               	sw	s5, 0x0(a1)
+               	subw	a4, t1, a1
+               	addi	a1, a3, 0xc
+               	sw	a4, 0x0(a1)
                	addi	a0, a0, 0x1
                	li	t0, 0x4
-               	bltu	a0, t0, 0xd54 <corpus.cases.vec.vec_mem.checksum+0xbfc>
-               	li	s4, 0x0
+               	bltu	a0, t0, 0x970 <corpus.cases.vec.vec_mem.checksum+0x650>
+               	ld	t2, -0x690(s0)
+               	mv	s2, t2
+               	li	t2, 0x0
+               	sd	t2, -0x6b8(s0)
+               	ld	t2, -0x6b8(s0)
                	li	t0, 0x4
-               	bltu	s4, t0, 0xe04 <corpus.cases.vec.vec_mem.checksum+0xcac>
-               	j	0xeb4 <corpus.cases.vec.vec_mem.checksum+0xd5c>
+               	bltu	t2, t0, 0xa34 <corpus.cases.vec.vec_mem.checksum+0x714>
+               	j	0xb08 <corpus.cases.vec.vec_mem.checksum+0x7e8>
+               	ld	t2, -0x6b8(s0)
                	li	t0, 0x10
-               	mul	a0, s4, t0
-               	add	a1, s3, a0
-               	mv	a0, a1
+               	mul	a0, t2, t0
+               	add	t2, s1, a0
+               	sd	t2, -0x6b0(s0)
+               	ld	t2, -0x6b0(s0)
+               	mv	a0, t2
                	mv	a1, a0
                	flw	ft0, 0x0(a1)
-               	mv	a1, s11
+               	mv	a1, s3
                	fsw	ft0, 0x0(a1)
                	addi	a1, a0, 0x4
                	flw	ft0, 0x0(a1)
-               	addi	a1, s11, 0x4
+               	addi	a1, s3, 0x4
                	fsw	ft0, 0x0(a1)
                	addi	a1, a0, 0x8
                	flw	ft0, 0x0(a1)
-               	addi	a0, s11, 0x8
+               	addi	a0, s3, 0x8
                	fsw	ft0, 0x0(a0)
-               	mv	a0, s11
-               	flw	ft0, 0x0(a0)
                	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	mv	a1, s3
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xcfc>
-               	addi	a1, s11, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd10>
-               	addi	a1, s11, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd24>
-               	li	t0, 0x10
-               	mul	a1, s4, t0
-               	add	s5, s3, a1
-               	addi	a1, s5, 0xc
-               	lw	s5, 0x0(a1)
-               	mv	a1, s5
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd44>
-               	addi	s4, s4, 0x1
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x768>
+               	ld	t2, -0x6b0(s0)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	slli	a1, a3, 0x20
+               	srli	a1, a1, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xab4 <corpus.cases.vec.vec_mem.checksum+0x794>
+               	j	0xae8 <corpus.cases.vec.vec_mem.checksum+0x7c8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a1, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xab4 <corpus.cases.vec.vec_mem.checksum+0x794>
+               	ld	t2, -0x6b8(s0)
+               	addi	a2, t2, 0x1
                	mv	s2, a0
+               	mv	t2, a2
+               	sd	t2, -0x6b8(s0)
+               	ld	t2, -0x6b8(s0)
                	li	t0, 0x4
-               	bltu	s4, t0, 0xe04 <corpus.cases.vec.vec_mem.checksum+0xcac>
-               	addi	s3, s0, -0x7cc
-               	mv	a0, s3
+               	bltu	t2, t0, 0xa34 <corpus.cases.vec.vec_mem.checksum+0x714>
+               	addi	s1, s0, -0x3f8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0xeec <corpus.cases.vec.vec_mem.checksum+0xd94>
+               	bnez	a1, 0xb40 <corpus.cases.vec.vec_mem.checksum+0x820>
                	mv	a1, a0
-               	li	s4, 0x10
+               	li	a2, 0x10
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	s4, s4, -0x8
+               	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	s4, t0, 0xed0 <corpus.cases.vec.vec_mem.checksum+0xd78>
+               	bne	a2, t0, 0xb24 <corpus.cases.vec.vec_mem.checksum+0x804>
                	sw	zero, 0x0(a1)
-               	j	0xf08 <corpus.cases.vec.vec_mem.checksum+0xdb0>
+               	j	0xb5c <corpus.cases.vec.vec_mem.checksum+0x83c>
                	mv	a1, a0
                	li	a0, 0x14
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0xef4 <corpus.cases.vec.vec_mem.checksum+0xd9c>
-               	mv	a0, s3
+               	bne	a0, t0, 0xb48 <corpus.cases.vec.vec_mem.checksum+0x828>
+               	mv	a0, s1
                	li	t0, 0xdb
                	sb	t0, 0x0(a0)
-               	addi	a1, s1, 0x3c
-               	mv	s4, a1
-               	flw	ft0, 0x0(s4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s4, t2
-               	fsw	ft0, 0x0(s4)
-               	addi	s4, a1, 0x4
-               	flw	ft0, 0x0(s4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s4, t2, 0x4
-               	fsw	ft0, 0x0(s4)
-               	addi	s4, a1, 0x8
-               	flw	ft0, 0x0(s4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	s4, s3, 0x4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x668(s0)
+               	addi	a1, t2, 0x3c
+               	mv	a2, a1
+               	flw	ft0, 0x0(a2)
+               	mv	a2, s4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, s4, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	flw	ft0, 0x0(a2)
                	addi	a1, s4, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s3, 0x10
+               	addi	a1, s1, 0x4
+               	mv	a2, s4
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s4, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s4, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	addi	a1, s1, 0x10
                	li	t0, 0xad
                	sb	t0, 0x0(a1)
                	lbu	a1, 0x0(a0)
+               	zext.b	a0, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbf8 <corpus.cases.vec.vec_mem.checksum+0x8d8>
+               	j	0xc2c <corpus.cases.vec.vec_mem.checksum+0x90c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xbf8 <corpus.cases.vec.vec_mem.checksum+0x8d8>
+               	addi	a0, s1, 0x4
+               	mv	a1, a0
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s5
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a0, s5, 0x8
+               	fsw	ft0, 0x0(a0)
                	mv	a0, s2
+               	mv	a1, s5
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xe98>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xf1c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xf40>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xf64>
-               	addi	a1, s3, 0x10
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x948>
+               	addi	a1, s1, 0x10
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xf78>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7dc
-               	add	s2, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc8c <corpus.cases.vec.vec_mem.checksum+0x96c>
+               	j	0xcc0 <corpus.cases.vec.vec_mem.checksum+0x9a0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xc8c <corpus.cases.vec.vec_mem.checksum+0x96c>
+               	addi	s2, s0, -0x524
+               	addi	a1, s0, -0x538
                	mv	a2, a1
-               	mv	a3, s3
-               	or	s4, a2, a3
+               	mv	a3, s1
+               	or	a4, a2, a3
                	li	t0, 0x7
-               	and	s4, s4, t0
-               	bltu	a2, a3, 0x116c <corpus.cases.vec.vec_mem.checksum+0x1014>
-               	bnez	s4, 0x1140 <corpus.cases.vec.vec_mem.checksum+0xfe8>
-               	addi	s5, a2, 0x10
-               	addi	s6, a3, 0x10
-               	lw	s7, 0x0(s6)
-               	sw	s7, 0x0(s5)
-               	li	s7, 0x10
-               	addi	s5, s5, -0x8
-               	addi	s6, s6, -0x8
-               	ld	s8, 0x0(s6)
-               	sd	s8, 0x0(s5)
-               	addi	s7, s7, -0x8
+               	and	a4, a4, t0
+               	bltu	a2, a3, 0xd44 <corpus.cases.vec.vec_mem.checksum+0xa24>
+               	bnez	a4, 0xd18 <corpus.cases.vec.vec_mem.checksum+0x9f8>
+               	addi	a5, a2, 0x10
+               	addi	a6, a3, 0x10
+               	lw	a7, 0x0(a6)
+               	sw	a7, 0x0(a5)
+               	li	a7, 0x10
+               	addi	a5, a5, -0x8
+               	addi	a6, a6, -0x8
+               	ld	s3, 0x0(a6)
+               	sd	s3, 0x0(a5)
+               	addi	a7, a7, -0x8
                	li	t0, 0x0
-               	bne	s7, t0, 0x1120 <corpus.cases.vec.vec_mem.checksum+0xfc8>
-               	j	0x11cc <corpus.cases.vec.vec_mem.checksum+0x1074>
-               	addi	s5, a2, 0x14
-               	addi	s6, a3, 0x14
-               	li	s7, 0x14
-               	addi	s5, s5, -0x1
-               	addi	s6, s6, -0x1
-               	lbu	s8, 0x0(s6)
-               	sb	s8, 0x0(s5)
-               	addi	s7, s7, -0x1
+               	bne	a7, t0, 0xcf8 <corpus.cases.vec.vec_mem.checksum+0x9d8>
+               	j	0xda4 <corpus.cases.vec.vec_mem.checksum+0xa84>
+               	addi	a5, a2, 0x14
+               	addi	a6, a3, 0x14
+               	li	a7, 0x14
+               	addi	a5, a5, -0x1
+               	addi	a6, a6, -0x1
+               	lbu	s3, 0x0(a6)
+               	sb	s3, 0x0(a5)
+               	addi	a7, a7, -0x1
                	li	t0, 0x0
-               	bne	s7, t0, 0x114c <corpus.cases.vec.vec_mem.checksum+0xff4>
-               	j	0x11cc <corpus.cases.vec.vec_mem.checksum+0x1074>
-               	bnez	s4, 0x11a4 <corpus.cases.vec.vec_mem.checksum+0x104c>
-               	mv	s4, a2
-               	mv	s5, a3
-               	li	s6, 0x10
-               	ld	s7, 0x0(s5)
-               	sd	s7, 0x0(s4)
-               	addi	s4, s4, 0x8
-               	addi	s5, s5, 0x8
-               	addi	s6, s6, -0x8
+               	bne	a7, t0, 0xd24 <corpus.cases.vec.vec_mem.checksum+0xa04>
+               	j	0xda4 <corpus.cases.vec.vec_mem.checksum+0xa84>
+               	bnez	a4, 0xd7c <corpus.cases.vec.vec_mem.checksum+0xa5c>
+               	mv	a4, a2
+               	mv	a5, a3
+               	li	a6, 0x10
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, 0x8
+               	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x117c <corpus.cases.vec.vec_mem.checksum+0x1024>
-               	lw	s6, 0x0(s5)
-               	sw	s6, 0x0(s4)
-               	j	0x11cc <corpus.cases.vec.vec_mem.checksum+0x1074>
-               	mv	s4, a2
+               	bne	a6, t0, 0xd54 <corpus.cases.vec.vec_mem.checksum+0xa34>
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	j	0xda4 <corpus.cases.vec.vec_mem.checksum+0xa84>
+               	mv	a4, a2
                	mv	a2, a3
                	li	a3, 0x14
-               	lbu	s5, 0x0(a2)
-               	sb	s5, 0x0(s4)
-               	addi	s4, s4, 0x1
+               	lbu	a5, 0x0(a2)
+               	sb	a5, 0x0(a4)
+               	addi	a4, a4, 0x1
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x11b0 <corpus.cases.vec.vec_mem.checksum+0x1058>
+               	bne	a3, t0, 0xd88 <corpus.cases.vec.vec_mem.checksum+0xa68>
                	mv	a2, s2
                	mv	a3, a1
                	or	a1, a2, a3
                	li	t0, 0x7
                	and	a1, a1, t0
-               	bltu	a2, a3, 0x1248 <corpus.cases.vec.vec_mem.checksum+0x10f0>
-               	bnez	a1, 0x121c <corpus.cases.vec.vec_mem.checksum+0x10c4>
-               	addi	s4, a2, 0x10
-               	addi	s5, a3, 0x10
-               	lw	s6, 0x0(s5)
-               	sw	s6, 0x0(s4)
-               	li	s6, 0x10
-               	addi	s4, s4, -0x8
-               	addi	s5, s5, -0x8
-               	ld	s7, 0x0(s5)
-               	sd	s7, 0x0(s4)
-               	addi	s6, s6, -0x8
+               	bltu	a2, a3, 0xe20 <corpus.cases.vec.vec_mem.checksum+0xb00>
+               	bnez	a1, 0xdf4 <corpus.cases.vec.vec_mem.checksum+0xad4>
+               	addi	a4, a2, 0x10
+               	addi	a5, a3, 0x10
+               	lw	a6, 0x0(a5)
+               	sw	a6, 0x0(a4)
+               	li	a6, 0x10
+               	addi	a4, a4, -0x8
+               	addi	a5, a5, -0x8
+               	ld	a7, 0x0(a5)
+               	sd	a7, 0x0(a4)
+               	addi	a6, a6, -0x8
                	li	t0, 0x0
-               	bne	s6, t0, 0x11fc <corpus.cases.vec.vec_mem.checksum+0x10a4>
-               	j	0x12a8 <corpus.cases.vec.vec_mem.checksum+0x1150>
-               	addi	s4, a2, 0x14
-               	addi	s5, a3, 0x14
-               	li	s6, 0x14
-               	addi	s4, s4, -0x1
-               	addi	s5, s5, -0x1
-               	lbu	s7, 0x0(s5)
-               	sb	s7, 0x0(s4)
-               	addi	s6, s6, -0x1
+               	bne	a6, t0, 0xdd4 <corpus.cases.vec.vec_mem.checksum+0xab4>
+               	j	0xe80 <corpus.cases.vec.vec_mem.checksum+0xb60>
+               	addi	a4, a2, 0x14
+               	addi	a5, a3, 0x14
+               	li	a6, 0x14
+               	addi	a4, a4, -0x1
+               	addi	a5, a5, -0x1
+               	lbu	a7, 0x0(a5)
+               	sb	a7, 0x0(a4)
+               	addi	a6, a6, -0x1
                	li	t0, 0x0
-               	bne	s6, t0, 0x1228 <corpus.cases.vec.vec_mem.checksum+0x10d0>
-               	j	0x12a8 <corpus.cases.vec.vec_mem.checksum+0x1150>
-               	bnez	a1, 0x1280 <corpus.cases.vec.vec_mem.checksum+0x1128>
+               	bne	a6, t0, 0xe00 <corpus.cases.vec.vec_mem.checksum+0xae0>
+               	j	0xe80 <corpus.cases.vec.vec_mem.checksum+0xb60>
+               	bnez	a1, 0xe58 <corpus.cases.vec.vec_mem.checksum+0xb38>
                	mv	a1, a2
-               	mv	s4, a3
-               	li	s5, 0x10
-               	ld	s6, 0x0(s4)
-               	sd	s6, 0x0(a1)
+               	mv	a4, a3
+               	li	a5, 0x10
+               	ld	a6, 0x0(a4)
+               	sd	a6, 0x0(a1)
                	addi	a1, a1, 0x8
-               	addi	s4, s4, 0x8
-               	addi	s5, s5, -0x8
+               	addi	a4, a4, 0x8
+               	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x1258 <corpus.cases.vec.vec_mem.checksum+0x1100>
-               	lw	s5, 0x0(s4)
-               	sw	s5, 0x0(a1)
-               	j	0x12a8 <corpus.cases.vec.vec_mem.checksum+0x1150>
+               	bne	a5, t0, 0xe30 <corpus.cases.vec.vec_mem.checksum+0xb10>
+               	lw	a5, 0x0(a4)
+               	sw	a5, 0x0(a1)
+               	j	0xe80 <corpus.cases.vec.vec_mem.checksum+0xb60>
                	mv	a1, a2
                	mv	a2, a3
                	li	a3, 0x14
-               	lbu	s4, 0x0(a2)
-               	sb	s4, 0x0(a1)
+               	lbu	a4, 0x0(a2)
+               	sb	a4, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a2, a2, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x128c <corpus.cases.vec.vec_mem.checksum+0x1134>
-               	addi	s4, s2, 0x4
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
+               	bne	a3, t0, 0xe64 <corpus.cases.vec.vec_mem.checksum+0xb44>
+               	addi	a1, s2, 0x4
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
+               	mv	a2, s6
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
+               	addi	a2, s6, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
+               	addi	a2, s6, 0x8
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x668(s0)
+               	addi	a2, t2, 0xc
+               	mv	a3, a2
+               	flw	ft0, 0x0(a3)
+               	mv	a3, s7
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a2, 0x4
+               	flw	ft0, 0x0(a3)
+               	addi	a3, s7, 0x4
+               	fsw	ft0, 0x0(a3)
+               	addi	a3, a2, 0x8
+               	flw	ft0, 0x0(a3)
+               	addi	a2, s7, 0x8
+               	fsw	ft0, 0x0(a2)
+               	mv	a2, s6
+               	flw	ft0, 0x0(a2)
+               	mv	a2, s7
+               	flw	ft1, 0x0(a2)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
+               	mv	a2, s8
+               	fsw	ft2, 0x0(a2)
+               	addi	a2, s6, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, s7, 0x4
+               	flw	ft1, 0x0(a2)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
+               	addi	a2, s8, 0x4
+               	fsw	ft2, 0x0(a2)
+               	addi	a2, s6, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, s7, 0x8
+               	flw	ft1, 0x0(a2)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	fsw	ft0, 0x0(a1)
+               	addi	a2, s8, 0x8
+               	fsw	ft2, 0x0(a2)
+               	mv	a2, s8
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s8, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, s8, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
                	mv	a1, s2
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1368>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8c <corpus.cases.vec.vec_mem.checksum+0xc6c>
+               	j	0xfc0 <corpus.cases.vec.vec_mem.checksum+0xca0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf8c <corpus.cases.vec.vec_mem.checksum+0xc6c>
+               	addi	a1, s2, 0x4
+               	mv	a2, a1
+               	flw	ft0, 0x0(a2)
+               	mv	a2, s9
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, s9, 0x4
+               	fsw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a1, s9, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x13ec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1410>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1434>
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xcd8>
                	addi	a1, s2, 0x10
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1448>
-               	mv	a1, s3
+               	zext.b	a1, a2
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x101c <corpus.cases.vec.vec_mem.checksum+0xcfc>
+               	j	0x1050 <corpus.cases.vec.vec_mem.checksum+0xd30>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x101c <corpus.cases.vec.vec_mem.checksum+0xcfc>
+               	mv	a1, s1
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
+               	zext.b	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x145c>
-               	addi	a1, s3, 0x4
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd3c>
+               	addi	a1, s1, 0x4
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
+               	mv	a2, s10
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
+               	addi	a2, s10, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s10, 0x8
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x14e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1508>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x152c>
-               	addi	a1, s3, 0x10
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd7c>
+               	addi	a1, s1, 0x10
                	lbu	a2, 0x0(a1)
-               	mv	a1, a2
+               	zext.b	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1540>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x790
-               	add	s2, s0, t0
-               	mv	a1, s2
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xd90>
+               	addi	s1, s0, -0x564
+               	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x16e0 <corpus.cases.vec.vec_mem.checksum+0x1588>
+               	bnez	a2, 0x10f0 <corpus.cases.vec.vec_mem.checksum+0xdd0>
                	mv	a2, a1
                	li	a3, 0x28
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x16c4 <corpus.cases.vec.vec_mem.checksum+0x156c>
+               	bne	a3, t0, 0x10d4 <corpus.cases.vec.vec_mem.checksum+0xdb4>
                	sw	zero, 0x0(a2)
-               	j	0x16fc <corpus.cases.vec.vec_mem.checksum+0x15a4>
+               	j	0x110c <corpus.cases.vec.vec_mem.checksum+0xdec>
                	mv	a2, a1
                	li	a1, 0x2c
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x16e8 <corpus.cases.vec.vec_mem.checksum+0x1590>
-               	mv	a1, s2
+               	bne	a1, t0, 0x10f8 <corpus.cases.vec.vec_mem.checksum+0xdd8>
+               	mv	a1, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a1)
-               	mv	a2, s1
+               	ld	t2, -0x668(s0)
+               	mv	a2, t2
                	mv	a3, a2
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
+               	mv	a3, s11
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
+               	addi	a3, s11, 0x4
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
+               	addi	a2, s11, 0x8
                	fsw	ft0, 0x0(a2)
-               	addi	a2, s2, 0x4
+               	addi	a2, s1, 0x4
                	mv	a3, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a4, t2
+               	mv	a4, s11
                	flw	ft0, 0x0(a4)
                	mv	a4, a3
                	fsw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a4, t2, 0x4
+               	addi	a4, s11, 0x4
                	flw	ft0, 0x0(a4)
                	addi	a4, a3, 0x4
                	fsw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x5b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a4, t2, 0x8
+               	addi	a4, s11, 0x8
                	flw	ft0, 0x0(a4)
                	addi	a4, a3, 0x8
                	fsw	ft0, 0x0(a4)
-               	addi	a3, s1, 0x24
+               	ld	t2, -0x668(s0)
+               	addi	a3, t2, 0x24
                	mv	a4, a3
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	mv	a4, t2
                	fsw	ft0, 0x0(a4)
                	addi	a4, a3, 0x4
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	addi	a4, t2, 0x4
                	fsw	ft0, 0x0(a4)
                	addi	a4, a3, 0x8
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	addi	a3, t2, 0x8
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0xc
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	mv	a4, t2
                	flw	ft0, 0x0(a4)
                	mv	a4, a3
                	fsw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	addi	a4, t2, 0x4
                	flw	ft0, 0x0(a4)
                	addi	a4, a3, 0x4
                	fsw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a0(s0)
                	addi	a4, t2, 0x8
                	flw	ft0, 0x0(a4)
                	addi	a4, a3, 0x8
                	fsw	ft0, 0x0(a4)
-               	addi	a3, s1, 0x48
+               	ld	t2, -0x668(s0)
+               	addi	a3, t2, 0x48
                	mv	a4, a3
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	mv	a4, t2
                	fsw	ft0, 0x0(a4)
                	addi	a4, a3, 0x4
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	addi	a4, t2, 0x4
                	fsw	ft0, 0x0(a4)
                	addi	a4, a3, 0x8
                	flw	ft0, 0x0(a4)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	addi	a3, t2, 0x8
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x18
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	mv	a2, t2
                	flw	ft0, 0x0(a2)
                	mv	a2, a3
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	addi	a2, t2, 0x4
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0x4
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6a8(s0)
                	addi	a2, t2, 0x8
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0x8
                	fsw	ft0, 0x0(a2)
-               	addi	a2, s2, 0x28
+               	addi	a2, s1, 0x28
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a2)
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x182c>
-               	mv	s3, a0
-               	li	s4, 0x0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0xf94>
+               	mv	s2, a0
+               	li	s3, 0x0
                	li	t0, 0x3
-               	bltu	s4, t0, 0x19a0 <corpus.cases.vec.vec_mem.checksum+0x1848>
-               	j	0x1a90 <corpus.cases.vec.vec_mem.checksum+0x1938>
-               	addi	a0, s2, 0x4
+               	bltu	s3, t0, 0x12d0 <corpus.cases.vec.vec_mem.checksum+0xfb0>
+               	j	0x1340 <corpus.cases.vec.vec_mem.checksum+0x1020>
+               	addi	a0, s1, 0x4
                	li	t0, 0xc
-               	mul	a1, s4, t0
+               	mul	a1, s3, t0
                	add	a2, a0, a1
                	mv	a0, a2
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x570(s0)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a2, 0x4
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x570(s0)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a2, 0x8
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x570(s0)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a0, s2
+               	ld	t2, -0x570(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1008>
+               	addi	s3, s3, 0x1
+               	mv	s2, a0
+               	li	t0, 0x3
+               	bltu	s3, t0, 0x12d0 <corpus.cases.vec.vec_mem.checksum+0xfb0>
+               	addi	a0, s1, 0x28
+               	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1360 <corpus.cases.vec.vec_mem.checksum+0x1040>
+               	j	0x1394 <corpus.cases.vec.vec_mem.checksum+0x1074>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1360 <corpus.cases.vec.vec_mem.checksum+0x1040>
+               	ld	t2, -0x668(s0)
+               	addi	s1, t2, 0x18
+               	mv	a0, s1
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x578(s0)
+               	mv	a0, t2
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x578(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x578(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x668(s0)
+               	addi	s3, t2, 0x30
+               	mv	a0, s3
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x588(s0)
+               	mv	a0, t2
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x588(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x588(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft0, 0x0(a0)
+               	ld	t2, -0x578(s0)
                	mv	a0, t2
                	flw	ft0, 0x0(a0)
-               	mv	a0, s3
-               	fmv.s	fa0, ft0
+               	ld	t2, -0x588(s0)
+               	mv	a0, t2
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x590(s0)
+               	mv	a0, t2
+               	fsw	ft2, 0x0(a0)
+               	ld	t2, -0x578(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x588(s0)
+               	addi	a0, t2, 0x4
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0x4
+               	fsw	ft2, 0x0(a0)
+               	ld	t2, -0x578(s0)
+               	addi	a0, t2, 0x8
+               	flw	ft0, 0x0(a0)
+               	ld	t2, -0x588(s0)
+               	addi	a0, t2, 0x8
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft0, ft1
+               	ld	t2, -0x590(s0)
+               	addi	a0, t2, 0x8
+               	fsw	ft2, 0x0(a0)
+               	mv	a0, s2
+               	ld	t2, -0x590(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x18d8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1180>
+               	ld	t2, -0x590(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1190>
+               	ld	t2, -0x668(s0)
+               	addi	s2, t2, 0x24
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x598(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x18fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1920>
-               	addi	s4, s4, 0x1
-               	mv	s3, a0
-               	li	t0, 0x3
-               	bltu	s4, t0, 0x19a0 <corpus.cases.vec.vec_mem.checksum+0x1848>
-               	addi	a0, s2, 0x28
-               	lw	a1, 0x0(a0)
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1944>
-               	addi	a1, s1, 0x18
-               	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x30
+               	addi	a1, s0, -0x4a0
                	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1b14>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1b38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1b5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1b80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1ba4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1bc8>
-               	addi	a1, s1, 0x24
-               	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	fsw	ft0, 0x0(a2)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7bc
-               	add	a2, s0, t0
-               	mv	a3, a2
                	lui	t0, 0x40000
-               	sw	t0, 0x0(a3)
-               	addi	a3, a2, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a1, 0x4
                	lui	t0, 0x40800
-               	sw	t0, 0x0(a3)
-               	addi	a3, a2, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a1, 0x8
                	lui	t0, 0x41000
-               	sw	t0, 0x0(a3)
-               	mv	a3, a2
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0x4
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0x8
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft1, 0x0(a2)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft1, 0x0(a2)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft1, 0x0(a2)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft0, 0x0(a2)
-               	mv	a2, a1
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	fsw	ft0, 0x0(a2)
-               	addi	a1, s1, 0x18
+               	sw	t0, 0x0(a2)
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x598(s0)
                	mv	a1, t2
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1e88>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x4
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1eac>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x598(s0)
                	addi	a1, t2, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1ed0>
-               	addi	a1, s1, 0x24
-               	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5a0(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x5a8(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5b0(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5b0(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5b0(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5b0(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1f58>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1338>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5b8(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5b8(s0)
                	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1f7c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1fa0>
-               	addi	a1, s1, 0x30
-               	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5b8(s0)
                	addi	a1, t2, 0x8
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5b8(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2028>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1384>
+               	mv	a1, s3
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5c0(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x5c0(s0)
                	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x204c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c0(s0)
                	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x5c0(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2070>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x720
-               	add	s1, s0, t0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x13d0>
+               	addi	s1, s0, -0x510
                	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x2210 <corpus.cases.vec.vec_mem.checksum+0x20b8>
+               	bnez	a2, 0x1730 <corpus.cases.vec.vec_mem.checksum+0x1410>
                	mv	a2, a1
                	li	a3, 0x60
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x21f4 <corpus.cases.vec.vec_mem.checksum+0x209c>
+               	bne	a3, t0, 0x1714 <corpus.cases.vec.vec_mem.checksum+0x13f4>
                	sw	zero, 0x0(a2)
-               	j	0x222c <corpus.cases.vec.vec_mem.checksum+0x20d4>
+               	j	0x174c <corpus.cases.vec.vec_mem.checksum+0x142c>
                	mv	a2, a1
                	li	a1, 0x64
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x2218 <corpus.cases.vec.vec_mem.checksum+0x20c0>
+               	bne	a1, t0, 0x1738 <corpus.cases.vec.vec_mem.checksum+0x1418>
                	li	a1, 0x0
                	li	t0, 0x5
-               	bltu	a1, t0, 0x223c <corpus.cases.vec.vec_mem.checksum+0x20e4>
-               	j	0x2f84 <corpus.cases.vec.vec_mem.checksum+0x2e2c>
+               	bltu	a1, t0, 0x175c <corpus.cases.vec.vec_mem.checksum+0x143c>
+               	j	0x1f40 <corpus.cases.vec.vec_mem.checksum+0x1c20>
                	fcvt.s.lu	ft0, a1
-               	addi	a2, s0, -0x7e0
+               	addi	a2, s0, -0x40c
                	mv	a3, a2
                	li	t0, 0x7
                	and	a4, a3, t0
-               	bnez	a4, 0x2278 <corpus.cases.vec.vec_mem.checksum+0x2120>
+               	bnez	a4, 0x1798 <corpus.cases.vec.vec_mem.checksum+0x1478>
                	mv	a4, a3
                	li	a5, 0x10
                	sd	zero, 0x0(a4)
                	addi	a4, a4, 0x8
                	addi	a5, a5, -0x8
                	li	t0, 0x0
-               	bne	a5, t0, 0x225c <corpus.cases.vec.vec_mem.checksum+0x2104>
+               	bne	a5, t0, 0x177c <corpus.cases.vec.vec_mem.checksum+0x145c>
                	sw	zero, 0x0(a4)
-               	j	0x2294 <corpus.cases.vec.vec_mem.checksum+0x213c>
+               	j	0x17b4 <corpus.cases.vec.vec_mem.checksum+0x1494>
                	mv	a4, a3
                	li	a3, 0x14
                	sb	zero, 0x0(a4)
                	addi	a4, a4, 0x1
                	addi	a3, a3, -0x1
                	li	t0, 0x0
-               	bne	a3, t0, 0x2280 <corpus.cases.vec.vec_mem.checksum+0x2128>
+               	bne	a3, t0, 0x17a0 <corpus.cases.vec.vec_mem.checksum+0x1480>
                	fadd.s	ft1, ft0, fs0
                	mv	a3, a2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	mv	a3, t2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5c8(s0)
                	addi	a3, t2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	mv	a3, t2
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	mv	a3, t2
                	flw	ft1, 0x0(a3)
                	mv	a3, a2
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x4
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x4
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x8
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x8
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0xc
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0xc
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d0(s0)
                	addi	a3, t2, 0x10
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x10
@@ -2372,146 +1613,83 @@ Disassembly of section .text:
                	fsub.s	ft1, ft0, ft10
                	mv	a3, a2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	mv	a3, t2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5d8(s0)
                	addi	a3, t2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x4
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	mv	a3, t2
                	flw	ft1, 0x0(a3)
                	mv	a3, a2
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x4
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x4
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x8
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x8
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0xc
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0xc
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e0(s0)
                	addi	a3, t2, 0x10
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x10
@@ -2521,146 +1699,83 @@ Disassembly of section .text:
                	fsub.s	ft1, ft11, ft0
                	mv	a3, a2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	mv	a3, t2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5e8(s0)
                	addi	a3, t2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x8
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	mv	a3, t2
                	flw	ft1, 0x0(a3)
                	mv	a3, a2
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x4
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x4
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x8
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x8
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0xc
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0xc
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f0(s0)
                	addi	a3, t2, 0x10
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x10
@@ -2670,146 +1785,83 @@ Disassembly of section .text:
                	fadd.s	ft1, ft0, ft10
                	mv	a3, a2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	mv	a3, t2
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	mv	a3, t2
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x4
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x4
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x8
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x8
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0xc
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0xc
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x5f8(s0)
                	addi	a3, t2, 0x10
                	flw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x10
                	fsw	ft2, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0xc
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	mv	a3, t2
                	flw	ft1, 0x0(a3)
                	mv	a3, a2
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x4
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x4
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x8
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x8
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0xc
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0xc
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x600(s0)
                	addi	a3, t2, 0x10
                	flw	ft1, 0x0(a3)
                	addi	a3, a2, 0x10
@@ -2818,357 +1870,205 @@ Disassembly of section .text:
                	fsub.s	ft1, ft11, ft0
                	mv	a3, a2
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	mv	a3, t2
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x4
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x8
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0xc
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x10
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	mv	a3, t2
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	mv	a3, t2
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x4
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x4
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x8
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x8
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0xc
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0xc
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x608(s0)
                	addi	a3, t2, 0x10
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x10
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x10
                	fsw	ft1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	mv	a3, t2
                	flw	ft0, 0x0(a3)
                	mv	a3, a2
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x4
                	flw	ft0, 0x0(a3)
                	addi	a3, a2, 0x4
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x8
                	flw	ft0, 0x0(a3)
                	addi	a3, a2, 0x8
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0xc
                	flw	ft0, 0x0(a3)
                	addi	a3, a2, 0xc
                	fsw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x610(s0)
                	addi	a3, t2, 0x10
                	flw	ft0, 0x0(a3)
                	addi	a3, a2, 0x10
                	fsw	ft0, 0x0(a3)
                	mv	a3, a2
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	mv	a3, t2
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x4
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a3, t2, 0x4
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x8
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a3, t2, 0x8
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0xc
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a3, t2, 0xc
                	fsw	ft0, 0x0(a3)
                	addi	a3, a2, 0x10
                	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x10
                	fsw	ft0, 0x0(a2)
                	li	t0, 0x14
                	mul	a2, a1, t0
                	add	a3, s1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	mv	a2, t2
                	flw	ft0, 0x0(a2)
                	mv	a2, a3
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x4
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0x4
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x8
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0x8
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0xc
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0xc
                	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x668
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x618(s0)
                	addi	a2, t2, 0x10
                	flw	ft0, 0x0(a2)
                	addi	a2, a3, 0x10
                	fsw	ft0, 0x0(a2)
                	addi	a1, a1, 0x1
                	li	t0, 0x5
-               	bltu	a1, t0, 0x223c <corpus.cases.vec.vec_mem.checksum+0x20e4>
+               	bltu	a1, t0, 0x175c <corpus.cases.vec.vec_mem.checksum+0x143c>
                	mv	s2, a0
                	li	s3, 0x5
                	li	t1, 0x0
-               	bltu	t1, s3, 0x2f98 <corpus.cases.vec.vec_mem.checksum+0x2e40>
-               	j	0x3110 <corpus.cases.vec.vec_mem.checksum+0x2fb8>
-               	addi	s4, s3, -0x1
+               	bltu	t1, s3, 0x1f54 <corpus.cases.vec.vec_mem.checksum+0x1c34>
+               	j	0x1fe8 <corpus.cases.vec.vec_mem.checksum+0x1cc8>
+               	addi	s3, s3, -0x1
                	li	t0, 0x14
-               	mul	a0, s4, t0
+               	mul	a0, s3, t0
                	add	a1, s1, a0
                	mv	a0, a1
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x620(s0)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x4
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x620(s0)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x8
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x620(s0)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0xc
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x620(s0)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
                	addi	a0, a1, 0x10
                	flw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x620(s0)
                	addi	a0, t2, 0x10
                	fsw	ft0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
                	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	ld	t2, -0x620(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2f10>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2f34>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2f58>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2f7c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x660
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2fa0>
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1cb4>
                	mv	s2, a0
-               	mv	s3, s4
                	li	t1, 0x0
-               	bltu	t1, s3, 0x2f98 <corpus.cases.vec.vec_mem.checksum+0x2e40>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f0
-               	add	s3, s0, t0
+               	bltu	t1, s3, 0x1f54 <corpus.cases.vec.vec_mem.checksum+0x1c34>
+               	addi	s3, s0, -0x440
                	mv	a0, s3
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x314c <corpus.cases.vec.vec_mem.checksum+0x2ff4>
+               	bnez	a1, 0x201c <corpus.cases.vec.vec_mem.checksum+0x1cfc>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x3134 <corpus.cases.vec.vec_mem.checksum+0x2fdc>
-               	j	0x3168 <corpus.cases.vec.vec_mem.checksum+0x3010>
+               	bne	a2, t0, 0x2004 <corpus.cases.vec.vec_mem.checksum+0x1ce4>
+               	j	0x2038 <corpus.cases.vec.vec_mem.checksum+0x1d18>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x3154 <corpus.cases.vec.vec_mem.checksum+0x2ffc>
+               	bne	a0, t0, 0x2024 <corpus.cases.vec.vec_mem.checksum+0x1d04>
                	mv	a0, s3
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
@@ -3177,715 +2077,360 @@ Disassembly of section .text:
                	addi	a1, s1, 0x3c
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x628(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x628(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x628(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	addi	s4, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x658
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x10
-               	fsw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x10
+               	ld	t2, -0x628(s0)
+               	mv	a2, t2
+               	flw	ft0, 0x0(a2)
+               	mv	a2, a1
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x628(s0)
+               	addi	a2, t2, 0x4
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x628(s0)
+               	addi	a2, t2, 0x8
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x628(s0)
+               	addi	a2, t2, 0xc
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x628(s0)
+               	addi	a2, t2, 0x10
+               	flw	ft0, 0x0(a2)
+               	addi	a2, a1, 0x10
+               	fsw	ft0, 0x0(a2)
                	addi	a1, s3, 0x24
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2148 <corpus.cases.vec.vec_mem.checksum+0x1e28>
+               	j	0x217c <corpus.cases.vec.vec_mem.checksum+0x1e5c>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s2, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s2, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2148 <corpus.cases.vec.vec_mem.checksum+0x1e28>
+               	addi	a0, s3, 0x10
+               	mv	a1, a0
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x630(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x630(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x630(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x630(s0)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, a0, 0x10
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x630(s0)
+               	addi	a0, t2, 0x10
+               	fsw	ft0, 0x0(a0)
                	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3184>
-               	mv	a1, s4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x630(s0)
                	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x10
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3248>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x326c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3290>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x32b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x650
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x32d8>
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x1ed0>
                	addi	a1, s3, 0x24
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x32ec>
-               	addi	a1, s1, 0x14
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2218 <corpus.cases.vec.vec_mem.checksum+0x1ef8>
+               	j	0x224c <corpus.cases.vec.vec_mem.checksum+0x1f2c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x2218 <corpus.cases.vec.vec_mem.checksum+0x1ef8>
+               	addi	s2, s1, 0x14
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x10
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x50
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x640(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x640(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x640(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x640(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, s1, 0x50
-               	mv	a3, a2
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0x4
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0x8
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0xc
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	fsw	ft0, 0x0(a3)
-               	addi	a3, a2, 0x10
-               	flw	ft0, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x640(s0)
+               	addi	a1, t2, 0x10
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x640(s0)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x648(s0)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x640(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x640(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x640(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x648
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x640
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	flw	ft1, 0x0(a2)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x638(s0)
+               	addi	a1, t2, 0x10
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x640(s0)
+               	addi	a1, t2, 0x10
+               	flw	ft1, 0x0(a1)
                	fadd.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	fsw	ft2, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	flw	ft0, 0x0(a2)
-               	mv	a2, a1
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	fsw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x638
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x10
-               	flw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x10
-               	fsw	ft0, 0x0(a2)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x10
+               	fsw	ft2, 0x0(a1)
+               	ld	t2, -0x648(s0)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	ld	t2, -0x648(s0)
+               	addi	a1, t2, 0x10
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
+               	fsw	ft0, 0x0(a1)
                	mv	a1, s1
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x650(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3718>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2198>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x658(s0)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x373c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3760>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x10
                	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3784>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x630
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x37a8>
-               	addi	a1, s1, 0x14
-               	mv	a2, a1
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x4
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x8
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0xc
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	fsw	ft0, 0x0(a2)
-               	addi	a2, a1, 0x10
-               	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x658(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x658(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3870>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3894>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x38b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x38dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x628
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3900>
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x220c>
                	addi	a1, s1, 0x28
                	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	mv	a2, t2
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x4
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0x8
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0xc
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	addi	a2, t2, 0xc
                	fsw	ft0, 0x0(a2)
                	addi	a2, a1, 0x10
                	flw	ft0, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	addi	a1, t2, 0x10
                	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x660(s0)
                	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x39c8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x39ec>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3a10>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3a34>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x620
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x10
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x3a58>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c8
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d0
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5d8
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5e0
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5e8
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5f0
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5f8
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x600
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x608
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x610
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x618
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x620
-               	add	t1, sp, t1
-               	fld	fs0, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5b8
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x5c0
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x5b0
-               	add	sp, sp, t0
+               	jalr	ra <corpus.cases.vec.vec_mem.checksum+0x2284>
+               	ld	s1, 0x6a8(sp)
+               	ld	s2, 0x6a0(sp)
+               	ld	s3, 0x698(sp)
+               	ld	s4, 0x690(sp)
+               	ld	s5, 0x688(sp)
+               	ld	s6, 0x680(sp)
+               	ld	s7, 0x678(sp)
+               	ld	s8, 0x670(sp)
+               	ld	s9, 0x668(sp)
+               	ld	s10, 0x660(sp)
+               	ld	s11, 0x658(sp)
+               	fld	fs0, 0x650(sp)
+               	ld	ra, 0x6b8(sp)
+               	ld	s0, 0x6b0(sp)
+               	addi	sp, sp, 0x6c0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_scalar_mix.dis
+++ b/test/golden/riscv64-linux/vec/vec_scalar_mix.dis
@@ -3,1989 +3,1871 @@ vec/vec_scalar_mix.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_scalar_mix.fold_f32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	mv	a0, a2
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x44>
+               	j	0x78 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x78>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x44 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x44>
+               	addi	a2, a1, 0x4
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x9c>
+               	j	0xd0 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0xd0>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x9c <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x9c>
+               	addi	a2, a1, 0x8
                	flw	ft0, 0x0(a2)
-               	mv	a0, a1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	fmv.x.w	a2, ft0
+               	slli	a3, a2, 0x20
+               	srli	a3, a3, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0xf4>
+               	j	0x128 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x128>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xf4 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0xf4>
+               	addi	a2, a1, 0xc
+               	flw	ft0, 0x0(a2)
+               	fmv.x.w	a1, ft0
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x14c>
+               	j	0x180 <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x180>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x14c <corpus.cases.vec.vec_scalar_mix.fold_f32x4+0x14c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_i32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1cc <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x3c>
+               	j	0x200 <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x70>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1cc <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x3c>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x21c <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x8c>
+               	j	0x250 <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0xc0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x21c <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x8c>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	sext.w	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x26c <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0xdc>
+               	j	0x2a0 <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x110>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x26c <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0xdc>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	sext.w	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2bc <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x12c>
+               	j	0x2f0 <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x160>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2bc <corpus.cases.vec.vec_scalar_mix.fold_i32x4+0x12c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.fold_u32x4>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x340 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x40>
+               	j	0x374 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x74>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x340 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x40>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x394 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x94>
+               	j	0x3c8 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0xc8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x394 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x94>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3e8 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0xe8>
+               	j	0x41c <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x11c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3e8 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0xe8>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x43c <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x13c>
+               	j	0x470 <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x170>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x43c <corpus.cases.vec.vec_scalar_mix.fold_u32x4+0x13c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x2d0
+               	addiw	t0, t0, -0x550
                	sub	sp, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, -0x558
                	add	t1, sp, t1
                	sd	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, -0x560
                	add	t1, sp, t1
                	sd	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x2d0
+               	addiw	t0, t0, -0x550
                	add	s0, sp, t0
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, -0x568
                	add	t1, sp, t1
                	sd	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, -0x570
                	add	t1, sp, t1
                	sd	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, -0x578
                	add	t1, sp, t1
                	sd	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, -0x580
                	add	t1, sp, t1
                	sd	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, -0x588
                	add	t1, sp, t1
                	sd	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, -0x590
                	add	t1, sp, t1
                	sd	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, -0x598
                	add	t1, sp, t1
                	sd	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, -0x5a0
                	add	t1, sp, t1
                	sd	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, -0x5a8
                	add	t1, sp, t1
                	sd	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, -0x5b0
                	add	t1, sp, t1
                	sd	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, -0x5b8
                	add	t1, sp, t1
                	sd	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, -0x5c0
                	add	t1, sp, t1
                	fsd	fs0, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, -0x5c8
                	add	t1, sp, t1
                	fsd	fs1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, -0x5d0
                	add	t1, sp, t1
                	fsd	fs2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, -0x5d8
                	add	t1, sp, t1
                	fsd	fs3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, -0x5e0
                	add	t1, sp, t1
                	fsd	fs4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x368
-               	add	t1, sp, t1
-               	fsd	fs5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x370
-               	add	t1, sp, t1
-               	fsd	fs6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x378
-               	add	t1, sp, t1
-               	fsd	fs7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x380
-               	add	t1, sp, t1
-               	fsd	fs8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x388
-               	add	t1, sp, t1
-               	fsd	fs9, 0x0(t1)
-               	mv	t2, a0
+               	mv	s1, a0
+               	addi	t2, s0, -0xa0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
+               	addiw	t1, t1, 0x5e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s2, s0, -0xc8
-               	addi	s3, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s4, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s5, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	a1, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s6, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	a1, s0, -0x218
-               	addi	s7, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	a1, s0, -0x248
-               	addi	a1, s0, -0x258
-               	addi	s8, s0, -0x268
-               	addi	a1, s0, -0x278
-               	addi	a1, s0, -0x288
-               	addi	s9, s0, -0x298
-               	addi	a1, s0, -0x2a8
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	s10, s0, -0x2d8
-               	addi	a1, s0, -0x2e8
-               	addi	a1, s0, -0x2f8
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	a1, s0, -0x328
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	a1, s0, -0x358
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	a1, s0, -0x388
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	a1, s0, -0x3b8
-               	addi	s11, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	a1, s0, -0x3e8
-               	addi	t2, s0, -0x3f8
+               	addi	t2, s0, -0xb0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	addiw	t1, t1, 0x710
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x408
-               	addi	t2, s0, -0x418
+               	addi	a2, s0, -0xc0
+               	addi	a2, s0, -0xd0
+               	addi	s2, s0, -0xe0
+               	addi	a2, s0, -0xf0
+               	addi	a2, s0, -0x100
+               	addi	s3, s0, -0x110
+               	addi	a2, s0, -0x120
+               	addi	a2, s0, -0x130
+               	addi	a2, s0, -0x140
+               	addi	a2, s0, -0x150
+               	addi	a2, s0, -0x160
+               	addi	a2, s0, -0x170
+               	addi	a2, s0, -0x180
+               	addi	a2, s0, -0x190
+               	addi	a2, s0, -0x1a0
+               	addi	a2, s0, -0x1b0
+               	addi	s4, s0, -0x1c0
+               	addi	a2, s0, -0x1d0
+               	addi	a2, s0, -0x1e0
+               	addi	a2, s0, -0x1f0
+               	addi	s5, s0, -0x200
+               	addi	a2, s0, -0x210
+               	addi	a2, s0, -0x220
+               	addi	a2, s0, -0x230
+               	addi	s6, s0, -0x240
+               	addi	a2, s0, -0x250
+               	addi	a2, s0, -0x260
+               	addi	s7, s0, -0x270
+               	addi	a2, s0, -0x280
+               	addi	a2, s0, -0x290
+               	addi	a2, s0, -0x2a0
+               	addi	s8, s0, -0x2b0
+               	addi	a2, s0, -0x2c0
+               	addi	a2, s0, -0x2d0
+               	addi	a2, s0, -0x2e0
+               	addi	a2, s0, -0x2f0
+               	addi	a2, s0, -0x300
+               	addi	a2, s0, -0x310
+               	addi	a2, s0, -0x320
+               	addi	a2, s0, -0x330
+               	addi	a2, s0, -0x340
+               	addi	a2, s0, -0x350
+               	addi	a2, s0, -0x360
+               	addi	a2, s0, -0x370
+               	addi	a2, s0, -0x380
+               	addi	a2, s0, -0x390
+               	addi	s9, s0, -0x3a0
+               	addi	a2, s0, -0x3b0
+               	addi	a2, s0, -0x3c0
+               	addi	s10, s0, -0x3d0
+               	addi	a2, s0, -0x3e0
+               	addi	s11, s0, -0x3f0
+               	addi	t2, s0, -0x400
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
+               	addiw	t1, t1, 0x590
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x428
+               	addi	a3, s0, -0x410
+               	addi	t2, s0, -0x420
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
+               	addiw	t1, t1, 0x588
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a4, s0, -0x438
-               	addi	t2, s0, -0x448
+               	addi	t2, s0, -0x430
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
+               	addiw	t1, t1, 0x580
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x458
+               	addi	a5, s0, -0x440
+               	addi	t2, s0, -0x450
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
+               	addiw	t1, t1, 0x578
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	a6, s0, -0x468
-               	addi	t2, s0, -0x478
+               	addi	t2, s0, -0x460
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
+               	addiw	t1, t1, 0x570
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x488
+               	addi	a7, s0, -0x470
+               	addi	t2, s0, -0x480
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
+               	addiw	t1, t1, 0x568
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t5, s0, -0x498
-               	addi	t2, s0, -0x4a8
+               	addi	t2, s0, -0x490
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
+               	addiw	t1, t1, 0x560
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x4b8
+               	addi	t2, s0, -0x4a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
+               	addiw	t1, t1, 0x558
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x4c8
+               	addi	t2, s0, -0x4b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
+               	addiw	t1, t1, 0x718
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x4d8
+               	addi	a1, s0, -0x4c0
+               	addi	t2, s0, -0x4d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
+               	addiw	t1, t1, 0x708
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x4e8
-               	addi	t2, s0, -0x4f8
+               	addi	t2, s0, -0x4e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x508
+               	addi	t2, s0, -0x4f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x518
+               	addi	t2, s0, -0x500
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x528
+               	addi	t2, s0, -0x510
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6e8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x538
+               	addi	t2, s0, -0x520
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x6e0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x548
+               	addi	t2, s0, -0x530
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
+               	addiw	t1, t1, 0x6d8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x558
+               	addi	t2, s0, -0x540
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
+               	addiw	t1, t1, 0x6d0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x568
+               	addi	t2, s0, -0x550
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
+               	addiw	t1, t1, 0x6c8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x578
+               	addi	t2, s0, -0x560
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
+               	addiw	t1, t1, 0x6c0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x588
+               	addi	t2, s0, -0x570
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
+               	addiw	t1, t1, 0x6b8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x598
+               	addi	t2, s0, -0x580
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
+               	addiw	t1, t1, 0x6b0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5a8
+               	addi	t2, s0, -0x590
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5b8
+               	addi	t2, s0, -0x5a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
+               	addiw	t1, t1, 0x6a0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5c8
+               	addi	t2, s0, -0x5b0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
+               	addiw	t1, t1, 0x698
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5d8
+               	addi	a1, s0, -0x5c0
+               	addi	t2, s0, -0x5d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
+               	addiw	t1, t1, 0x690
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
+               	addi	t2, s0, -0x5e0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
+               	addiw	t1, t1, 0x688
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x608
+               	addi	a1, s0, -0x5f0
+               	addi	t2, s0, -0x600
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
+               	addiw	t1, t1, 0x680
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x618
-               	addi	t2, s0, -0x628
+               	addi	t2, s0, -0x610
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x638
+               	addi	a1, s0, -0x620
+               	addi	a1, s0, -0x630
+               	addi	t2, s0, -0x640
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x648
-               	addi	s1, s0, -0x658
-               	addi	t2, s0, -0x668
+               	addi	a1, s0, -0x650
+               	addi	a1, s0, -0x660
+               	addi	a1, s0, -0x670
+               	addi	a1, s0, -0x680
+               	addi	t2, s0, -0x690
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x678
-               	addi	s1, s0, -0x688
-               	addi	s1, s0, -0x698
-               	addi	s1, s0, -0x6a8
-               	addi	t2, s0, -0x6b8
+               	addi	t2, s0, -0x6a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x6c8
+               	addi	a1, s0, -0x6b0
+               	addi	t2, s0, -0x6c0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x6d8
-               	addi	t2, s0, -0x6e8
+               	addi	t2, s0, -0x6d0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x6f8
+               	addi	a1, s0, -0x6e0
+               	addi	t2, s0, -0x6f0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x708
-               	addi	t2, s0, -0x718
+               	addi	t2, s0, -0x700
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x728
+               	addi	a1, s0, -0x710
+               	addi	t2, s0, -0x720
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x738
-               	addi	t2, s0, -0x748
+               	addi	t2, s0, -0x730
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x758
+               	addi	t2, s0, -0x740
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x768
+               	addi	t2, s0, -0x750
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x778
+               	addi	a1, s0, -0x760
+               	addi	t2, s0, -0x770
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x788
-               	addi	t2, s0, -0x798
+               	addi	a1, s0, -0x780
+               	addi	a1, s0, -0x790
+               	addi	a1, s0, -0x7a0
+               	addi	a1, s0, -0x7b0
+               	addi	a1, s0, -0x7c0
+               	addi	a1, s0, -0x7d0
+               	addi	a1, s0, -0x7e0
+               	addi	a1, s0, -0x7f0
+               	addi	t2, s0, -0x800
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
-               	addi	s1, s0, -0x7a8
-               	addi	s1, s0, -0x7b8
-               	addi	s1, s0, -0x7c8
-               	addi	s1, s0, -0x7d8
-               	addi	s1, s0, -0x7e8
-               	addi	s1, s0, -0x7f8
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	s1, s0, t0
+               	addiw	t0, t0, 0x7f0
+               	add	a1, s0, t0
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
+               	addiw	t0, t0, 0x7e0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	s1, s0, t0
+               	addiw	t0, t0, 0x7d0
+               	add	a1, s0, t0
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
+               	addiw	t0, t0, 0x7c0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	s1, s0, t0
+               	addiw	t0, t0, 0x7b0
+               	add	a1, s0, t0
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
+               	addiw	t0, t0, 0x7a0
                	add	t2, s0, t0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	t2, s0, t0
+               	addiw	t0, t0, 0x790
+               	add	a1, s0, t0
+               	fcvt.s.lu	ft0, s1
+               	sext.w	t2, s1
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f0
                	add	t1, s0, t1
                	sd	t2, 0x0(t1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	s1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	s1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x8a4>
-               	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	fcvt.s.lu	ft0, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t3, 0x0(t1)
-               	sext.w	t2, t3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
+               	addiw	t0, t0, 0x780
+               	add	a1, s0, t0
+               	mv	a0, a1
                	lui	t0, 0x3fc00
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a0)
                	lui	t0, 0x40100
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
+               	addi	a0, a1, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
                	lui	t0, 0x40700
-               	sw	t0, 0x0(s1)
+               	sw	t0, 0x0(a0)
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fneg.s	ft1, ft11
+               	addi	a0, a1, 0xc
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, a1
+               	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x4
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x8
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x330
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s2, 0xc
-               	fsw	ft1, 0x0(s1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	lui	t0, 0x3f000
-               	sw	t0, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	lui	t0, 0x40800
-               	sw	t0, 0x0(s1)
-               	lui	t0, 0x3e000
-               	fmv.w.x	ft11, t0
-               	fneg.s	ft1, ft11
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	lui	t0, 0x41000
-               	sw	t0, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s3
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	fsw	ft1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x328
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, s2
-               	flw	ft1, 0x0(s1)
-               	fadd.s	ft2, ft1, ft0
-               	mv	s1, s2
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s2, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s2, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	fsw	ft1, 0x0(s1)
-               	mv	s1, s4
-               	fsw	ft2, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	flw	ft1, 0x0(s1)
-               	fadd.s	ft2, ft1, ft0
-               	mv	s1, s3
-               	flw	ft0, 0x0(s1)
-               	mv	s1, s5
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0x4
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0x8
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0xc
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s5, 0x8
-               	fsw	ft2, 0x0(s1)
-               	mv	s1, s4
-               	flw	ft0, 0x0(s1)
-               	mv	s1, s5
-               	flw	fs0, 0x0(s1)
-               	fmul.s	fs1, ft0, fs0
-               	addi	s1, s4, 0x4
-               	flw	fs2, 0x0(s1)
-               	addi	s1, s5, 0x4
-               	flw	fs3, 0x0(s1)
-               	fmul.s	fs4, fs2, fs3
-               	addi	s1, s4, 0x8
-               	flw	fs5, 0x0(s1)
-               	addi	s1, s5, 0x8
-               	flw	ft0, 0x0(s1)
-               	fmul.s	fs6, fs5, ft0
-               	addi	s1, s4, 0xc
-               	flw	fs7, 0x0(s1)
-               	addi	s1, s5, 0xc
-               	flw	ft0, 0x0(s1)
-               	fmul.s	fs8, fs7, ft0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x338
+               	addiw	t1, t1, 0x5e8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc48>
-               	mv	s1, a0
-               	mv	a0, s1
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc5c>
-               	mv	s1, a0
-               	mv	a0, s1
-               	fmv.s	fa0, fs6
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc70>
-               	mv	s1, a0
-               	mv	a0, s1
-               	fmv.s	fa0, fs8
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc84>
-               	mv	s1, a0
-               	fadd.s	fs9, fs1, fs4
-               	mv	a0, s1
-               	fmv.s	fa0, fs9
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc9c>
-               	mv	s1, a0
-               	fadd.s	fs1, fs9, fs6
-               	mv	a0, s1
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xcb4>
-               	mv	s1, a0
-               	fadd.s	fs4, fs1, fs8
-               	mv	a0, s1
-               	fmv.s	fa0, fs4
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xccc>
-               	mv	s1, s4
-               	flw	ft0, 0x0(s1)
-               	mv	s1, s6
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s6, 0x4
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s6, 0x8
-               	fsw	ft0, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s6, 0xc
-               	fsw	ft0, 0x0(s1)
-               	mv	s1, s6
-               	fsw	fs4, 0x0(s1)
-               	fsub.s	ft0, fs7, fs0
-               	mv	s1, s6
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s7
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s6, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s6, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s6, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	fsw	ft0, 0x0(s1)
-               	fadd.s	ft0, fs3, fs5
-               	mv	s1, s7
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	fsw	ft0, 0x0(s1)
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft0, ft11, fs2
-               	mv	s1, s8
-               	flw	ft1, 0x0(s1)
-               	mv	s1, s9
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	flw	ft1, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	fsw	ft1, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	fsw	ft0, 0x0(s1)
-               	mv	s1, s9
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xe10>
-               	addi	s1, s9, 0x4
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xe24>
-               	addi	s1, s9, 0x8
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xe38>
-               	addi	s1, s9, 0xc
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xe4c>
-               	mv	s1, s9
-               	flw	ft0, 0x0(s1)
-               	mv	s1, s5
-               	flw	ft1, 0x0(s1)
-               	fmul.s	ft2, ft0, ft1
-               	mv	s1, s10
-               	fsw	ft2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0x4
-               	flw	ft1, 0x0(s1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	s1, s10, 0x4
-               	fsw	ft2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0x8
-               	flw	ft1, 0x0(s1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	s1, s10, 0x8
-               	fsw	ft2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s5, 0xc
-               	flw	ft1, 0x0(s1)
-               	fmul.s	ft2, ft0, ft1
-               	addi	s1, s10, 0xc
-               	fsw	ft2, 0x0(s1)
-               	mv	s1, s10
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xed0>
-               	addi	s1, s10, 0x4
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xee4>
-               	addi	s1, s10, 0x8
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xef8>
-               	addi	s1, s10, 0xc
-               	flw	ft0, 0x0(s1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xf0c>
-               	mv	s1, s4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft0, ft1
-               	bnez	s1, 0x1134 <corpus.cases.vec.vec_scalar_mix.checksum+0xf30>
-               	j	0x113c <corpus.cases.vec.vec_scalar_mix.checksum+0xf38>
-               	addi	s1, s4, 0x4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft0, ft1
-               	bnez	s1, 0x1150 <corpus.cases.vec.vec_scalar_mix.checksum+0xf4c>
-               	j	0x1158 <corpus.cases.vec.vec_scalar_mix.checksum+0xf54>
-               	addi	s1, s4, 0x8
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft0, ft1
-               	bnez	s1, 0x1170 <corpus.cases.vec.vec_scalar_mix.checksum+0xf6c>
-               	fmv.d	fs0, ft0
-               	j	0x1178 <corpus.cases.vec.vec_scalar_mix.checksum+0xf74>
-               	addi	s1, s4, 0xc
-               	flw	fs0, 0x0(s1)
-               	mv	s1, s4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x4
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft1, ft0
-               	bnez	s1, 0x1194 <corpus.cases.vec.vec_scalar_mix.checksum+0xf90>
-               	j	0x119c <corpus.cases.vec.vec_scalar_mix.checksum+0xf98>
-               	addi	s1, s4, 0x4
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0x8
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft1, ft0
-               	bnez	s1, 0x11b0 <corpus.cases.vec.vec_scalar_mix.checksum+0xfac>
-               	j	0x11b8 <corpus.cases.vec.vec_scalar_mix.checksum+0xfb4>
-               	addi	s1, s4, 0x8
-               	flw	ft0, 0x0(s1)
-               	addi	s1, s4, 0xc
-               	flw	ft1, 0x0(s1)
-               	flt.s	s1, ft1, ft0
-               	bnez	s1, 0x11d0 <corpus.cases.vec.vec_scalar_mix.checksum+0xfcc>
-               	fmv.d	fs1, ft0
-               	j	0x11d8 <corpus.cases.vec.vec_scalar_mix.checksum+0xfd4>
-               	addi	s1, s4, 0xc
-               	flw	fs1, 0x0(s1)
-               	fmv.s	fa0, fs0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xfd8>
-               	fmv.s	fa0, fs1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xfe4>
-               	fsub.s	ft0, fs0, fs1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xff4>
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x4
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	addi	a0, a1, 0xc
+               	flw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft1, 0x0(a0)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	s1, s0, t0
-               	mv	s2, s1
+               	addiw	t0, t0, 0x770
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0x3f000
+               	sw	t0, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	lui	t0, 0x40800
+               	sw	t0, 0x0(a1)
+               	lui	t0, 0x3e000
+               	fmv.w.x	ft11, t0
+               	fneg.s	ft1, ft11
+               	addi	a1, a0, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	lui	t0, 0x41000
+               	sw	t0, 0x0(a1)
+               	mv	a1, a0
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft1, ft0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	flw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x4
+               	fsw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	fsw	ft1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	flw	ft1, 0x0(a0)
+               	addi	a0, s2, 0xc
+               	fsw	ft1, 0x0(a0)
+               	mv	a0, s2
+               	fsw	ft2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	flw	ft1, 0x0(a0)
+               	fadd.s	ft2, ft1, ft0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x710
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	fsw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	fsw	ft2, 0x0(a0)
+               	mv	a0, s2
+               	flw	ft0, 0x0(a0)
+               	mv	a0, s3
+               	flw	ft1, 0x0(a0)
+               	fmul.s	fs0, ft0, ft1
+               	addi	a0, s2, 0x4
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x4
+               	flw	ft1, 0x0(a0)
+               	fmul.s	fs1, ft0, ft1
+               	addi	a0, s2, 0x8
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	flw	ft1, 0x0(a0)
+               	fmul.s	fs2, ft0, ft1
+               	addi	a0, s2, 0xc
+               	flw	ft0, 0x0(a0)
+               	addi	a0, s3, 0xc
+               	flw	ft1, 0x0(a0)
+               	fmul.s	fs3, ft0, ft1
+               	fmv.x.w	a0, fs0
+               	slli	t2, a0, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t2, 0xfcbf3
+               	addiw	t2, t2, -0x632
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x484
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x222
+               	slli	t2, t2, 0xc
+               	addi	t2, t2, 0x325
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	t2, 0x0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0xe88 <corpus.cases.vec.vec_scalar_mix.checksum+0xa08>
+               	j	0xf34 <corpus.cases.vec.vec_scalar_mix.checksum+0xab4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	mul	a0, t2, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0xe88 <corpus.cases.vec.vec_scalar_mix.checksum+0xa08>
+               	fmv.x.w	a0, fs1
+               	slli	t2, a0, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5d8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	t2, 0x0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0xfa4 <corpus.cases.vec.vec_scalar_mix.checksum+0xb24>
+               	j	0x1050 <corpus.cases.vec.vec_scalar_mix.checksum+0xbd0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	mul	a0, t2, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	srl	a1, t2, a0
+               	li	t0, 0xff
+               	and	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	xor	a1, t2, a0
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a1, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x1
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	t2, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x8
+               	bltu	t2, t0, 0xfa4 <corpus.cases.vec.vec_scalar_mix.checksum+0xb24>
+               	fmv.x.w	a0, fs2
+               	slli	a1, a0, 0x20
+               	srli	a1, a1, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xbf0>
+               	fmv.x.w	a1, fs3
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc28>
+               	fadd.s	fs4, fs0, fs1
+               	fmv.x.w	a1, fs4
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xc64>
+               	fadd.s	fs0, fs4, fs2
+               	fmv.x.w	a1, fs0
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x5a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xca0>
+               	fadd.s	fs1, fs0, fs3
+               	fmv.x.w	a1, fs1
+               	slli	t2, a1, 0x20
+               	srli	t2, t2, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x598
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xcdc>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	fsw	ft0, 0x0(a1)
+               	mv	a1, s4
+               	fsw	fs1, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fsub.s	ft2, ft0, ft1
+               	mv	a1, s4
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s5
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fadd.s	ft2, ft0, ft1
+               	mv	a1, s5
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s6
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s5, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	fs0, 0x0(a1)
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft0, ft11, fs0
+               	mv	a1, s6
+               	flw	ft1, 0x0(a1)
+               	mv	a1, s7
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s7, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s7, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s7, 0xc
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s7, 0xc
+               	fsw	ft0, 0x0(a1)
+               	mv	a1, s7
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xe40>
+               	mv	a1, s7
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s3
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	mv	a1, s8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s7, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x4
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s7, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s8, 0x8
+               	fsw	ft2, 0x0(a1)
+               	addi	a1, s7, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	addi	a1, s8, 0xc
+               	fsw	ft2, 0x0(a1)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0xebc>
+               	mv	a1, s2
+               	flw	ft0, 0x0(a1)
+               	flt.s	a1, ft0, fs0
+               	bnez	a1, 0x1358 <corpus.cases.vec.vec_scalar_mix.checksum+0xed8>
+               	j	0x1360 <corpus.cases.vec.vec_scalar_mix.checksum+0xee0>
+               	addi	a1, s2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	flt.s	a1, ft0, ft1
+               	bnez	a1, 0x1374 <corpus.cases.vec.vec_scalar_mix.checksum+0xef4>
+               	j	0x137c <corpus.cases.vec.vec_scalar_mix.checksum+0xefc>
+               	addi	a1, s2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	flt.s	a1, ft0, ft1
+               	bnez	a1, 0x1390 <corpus.cases.vec.vec_scalar_mix.checksum+0xf10>
+               	j	0x1398 <corpus.cases.vec.vec_scalar_mix.checksum+0xf18>
+               	addi	a1, s2, 0xc
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft2, 0x0(a1)
+               	flt.s	a1, ft2, ft1
+               	bnez	a1, 0x13b4 <corpus.cases.vec.vec_scalar_mix.checksum+0xf34>
+               	j	0x13bc <corpus.cases.vec.vec_scalar_mix.checksum+0xf3c>
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft2, 0x0(a1)
+               	flt.s	a1, ft2, ft1
+               	bnez	a1, 0x13d0 <corpus.cases.vec.vec_scalar_mix.checksum+0xf50>
+               	j	0x13d8 <corpus.cases.vec.vec_scalar_mix.checksum+0xf58>
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft2, 0x0(a1)
+               	flt.s	a1, ft2, ft1
+               	bnez	a1, 0x13ec <corpus.cases.vec.vec_scalar_mix.checksum+0xf6c>
+               	j	0x13f4 <corpus.cases.vec.vec_scalar_mix.checksum+0xf74>
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmv.x.w	a1, ft0
+               	slli	s3, a1, 0x20
+               	srli	s3, s3, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1410 <corpus.cases.vec.vec_scalar_mix.checksum+0xf90>
+               	j	0x1444 <corpus.cases.vec.vec_scalar_mix.checksum+0xfc4>
+               	li	t0, 0x8
+               	mul	s4, a1, t0
+               	srl	s5, s3, s4
+               	li	t0, 0xff
+               	and	s4, s5, t0
+               	xor	s5, a0, s4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1410 <corpus.cases.vec.vec_scalar_mix.checksum+0xf90>
+               	fmv.x.w	a1, ft1
+               	slli	s3, a1, 0x20
+               	srli	s3, s3, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1460 <corpus.cases.vec.vec_scalar_mix.checksum+0xfe0>
+               	j	0x1494 <corpus.cases.vec.vec_scalar_mix.checksum+0x1014>
+               	li	t0, 0x8
+               	mul	s4, a1, t0
+               	srl	s5, s3, s4
+               	li	t0, 0xff
+               	and	s4, s5, t0
+               	xor	s5, a0, s4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, s5, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1460 <corpus.cases.vec.vec_scalar_mix.checksum+0xfe0>
+               	fsub.s	ft2, ft0, ft1
+               	fmv.x.w	a1, ft2
+               	slli	s3, a1, 0x20
+               	srli	s3, s3, 0x20
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1028>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x760
+               	add	a1, s0, t0
+               	mv	s3, a1
                	li	t0, 0x7
-               	sw	t0, 0x0(s2)
-               	addi	s2, s1, 0x4
+               	sw	t0, 0x0(s3)
+               	addi	s3, a1, 0x4
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0xd
-               	sw	t0, 0x0(s2)
-               	addi	s2, s1, 0x8
+               	sw	t0, 0x0(s3)
+               	addi	s3, a1, 0x8
                	li	t0, 0x15
-               	sw	t0, 0x0(s2)
-               	addi	s2, s1, 0xc
+               	sw	t0, 0x0(s3)
+               	addi	s3, a1, 0xc
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1f
-               	sw	t0, 0x0(s2)
-               	mv	s2, s1
-               	lw	s3, 0x0(s2)
-               	mv	s2, s11
-               	sw	s3, 0x0(s2)
-               	addi	s2, s1, 0x4
-               	lw	s3, 0x0(s2)
-               	addi	s2, s11, 0x4
-               	sw	s3, 0x0(s2)
-               	addi	s2, s1, 0x8
-               	lw	s3, 0x0(s2)
-               	addi	s2, s11, 0x8
-               	sw	s3, 0x0(s2)
-               	addi	s2, s1, 0xc
-               	lw	s1, 0x0(s2)
-               	addi	s2, s11, 0xc
-               	sw	s1, 0x0(s2)
-               	addi	s1, s11, 0x4
-               	lw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	s1, t2
-               	addw	s3, s2, s1
-               	mv	s1, s11
-               	lw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sw	s2, 0x0(s1)
-               	addi	s1, s11, 0x4
-               	lw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sw	s2, 0x0(s1)
-               	addi	s1, s11, 0x8
-               	lw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sw	s2, 0x0(s1)
-               	addi	s1, s11, 0xc
-               	lw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	sw	s2, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sw	s3, 0x0(s1)
+               	sw	t0, 0x0(s3)
+               	mv	s3, a1
+               	lw	s4, 0x0(s3)
+               	mv	s3, s9
+               	sw	s4, 0x0(s3)
+               	addi	s3, a1, 0x4
+               	lw	s4, 0x0(s3)
+               	addi	s3, s9, 0x4
+               	sw	s4, 0x0(s3)
+               	addi	s3, a1, 0x8
+               	lw	s4, 0x0(s3)
+               	addi	s3, s9, 0x8
+               	sw	s4, 0x0(s3)
+               	addi	s3, a1, 0xc
+               	lw	a1, 0x0(s3)
+               	addi	s3, s9, 0xc
+               	sw	a1, 0x0(s3)
+               	addi	a1, s9, 0x4
+               	lw	s3, 0x0(a1)
+               	sext.w	a1, s1
+               	addw	s1, s3, a1
+               	mv	a1, s9
+               	lw	s3, 0x0(a1)
+               	mv	a1, s10
+               	sw	s3, 0x0(a1)
+               	addi	a1, s9, 0x4
+               	lw	s3, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	sw	s3, 0x0(a1)
+               	addi	a1, s9, 0x8
+               	lw	s3, 0x0(a1)
+               	addi	a1, s10, 0x8
+               	sw	s3, 0x0(a1)
+               	addi	a1, s9, 0xc
+               	lw	s3, 0x0(a1)
+               	addi	a1, s10, 0xc
+               	sw	s3, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	sw	s1, 0x0(a1)
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
+               	addiw	t0, t0, 0x750
                	add	s1, s0, t0
-               	mv	s2, s1
+               	mv	a1, s1
                	li	t0, 0x7
-               	and	s3, s2, t0
-               	bnez	s3, 0x1380 <corpus.cases.vec.vec_scalar_mix.checksum+0x117c>
-               	mv	s3, s2
-               	li	s5, 0x10
+               	and	s3, a1, t0
+               	bnez	s3, 0x15d0 <corpus.cases.vec.vec_scalar_mix.checksum+0x1150>
+               	mv	s3, a1
+               	li	s4, 0x10
                	sd	zero, 0x0(s3)
                	addi	s3, s3, 0x8
-               	addi	s5, s5, -0x8
+               	addi	s4, s4, -0x8
                	li	t0, 0x0
-               	bne	s5, t0, 0x1368 <corpus.cases.vec.vec_scalar_mix.checksum+0x1164>
-               	j	0x139c <corpus.cases.vec.vec_scalar_mix.checksum+0x1198>
-               	mv	s3, s2
-               	li	s2, 0x10
+               	bne	s4, t0, 0x15b8 <corpus.cases.vec.vec_scalar_mix.checksum+0x1138>
+               	j	0x15ec <corpus.cases.vec.vec_scalar_mix.checksum+0x116c>
+               	mv	s3, a1
+               	li	a1, 0x10
                	sb	zero, 0x0(s3)
                	addi	s3, s3, 0x1
-               	addi	s2, s2, -0x1
-               	li	t0, 0x0
-               	bne	s2, t0, 0x1388 <corpus.cases.vec.vec_scalar_mix.checksum+0x1184>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	lw	s3, 0x0(s2)
-               	fcvt.s.w	ft0, s3
-               	mv	s2, s1
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	fsw	ft1, 0x0(s2)
-               	addi	s2, s1, 0x4
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	fsw	ft1, 0x0(s2)
-               	addi	s2, s1, 0x8
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	fsw	ft1, 0x0(s2)
-               	addi	s2, s1, 0xc
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0xc
-               	fsw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	fsw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x4
-               	fsw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0x8
-               	fsw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x318
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s2, t2, 0xc
-               	flw	ft1, 0x0(s2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x310
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	fcvt.s.w	ft0, a3
-               	mv	a1, s1
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x308
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x300
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	fcvt.s.w	ft0, a3
-               	mv	a1, s1
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	fcvt.s.w	ft0, a3
-               	mv	a1, s1
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft1, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x2e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	fsw	ft0, 0x0(a1)
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1a04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1a28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1a4c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1a70>
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	mv	a1, s4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	flw	ft1, 0x0(a1)
-               	fmul.s	ft2, ft0, ft1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1c04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1c28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1c4c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1c70>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	s2, s0, t0
-               	mv	a1, s2
-               	li	t0, 0x7
-               	and	a3, a1, t0
-               	bnez	a3, 0x1eb8 <corpus.cases.vec.vec_scalar_mix.checksum+0x1cb4>
-               	mv	a3, a1
-               	li	a4, 0x10
-               	sd	zero, 0x0(a3)
-               	addi	a3, a3, 0x8
-               	addi	a4, a4, -0x8
-               	li	t0, 0x0
-               	bne	a4, t0, 0x1ea0 <corpus.cases.vec.vec_scalar_mix.checksum+0x1c9c>
-               	j	0x1ed4 <corpus.cases.vec.vec_scalar_mix.checksum+0x1cd0>
-               	mv	a3, a1
-               	li	a1, 0x10
-               	sb	zero, 0x0(a3)
-               	addi	a3, a3, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x1ec0 <corpus.cases.vec.vec_scalar_mix.checksum+0x1cbc>
+               	bne	a1, t0, 0x15d8 <corpus.cases.vec.vec_scalar_mix.checksum+0x1158>
+               	mv	a1, s10
+               	lw	s3, 0x0(a1)
+               	fcvt.s.w	ft0, s3
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	mv	a1, s11
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s11, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s11, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	addi	a1, s11, 0xc
+               	fsw	ft1, 0x0(a1)
+               	mv	a1, s11
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s11, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s11, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s11, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x590
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	lw	a2, 0x0(a1)
+               	fcvt.s.w	ft0, a2
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x588
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x580
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s10, 0x8
+               	lw	a2, 0x0(a1)
+               	fcvt.s.w	ft0, a2
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x578
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x570
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s10, 0xc
+               	lw	a2, 0x0(a1)
+               	fcvt.s.w	ft0, a2
+               	mv	a1, s1
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x568
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft1, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s1
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x560
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	fsw	ft0, 0x0(a1)
                	mv	a1, s1
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x558
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -1993,7 +1875,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x4
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x558
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
@@ -2001,7 +1883,7 @@ Disassembly of section .text:
                	addi	a1, s1, 0x8
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x558
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
@@ -2009,13 +1891,173 @@ Disassembly of section .text:
                	addi	a1, s1, 0xc
                	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x558
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	fsw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
+               	addiw	t1, t1, 0x558
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1910>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	flw	ft0, 0x0(a1)
+               	mv	a1, s2
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x4
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0x8
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x718
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	addi	a1, s2, 0xc
+               	flw	ft1, 0x0(a1)
+               	fmul.s	ft2, ft0, ft1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x708
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x1a9c>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x740
+               	add	s3, s0, t0
+               	mv	a1, s3
+               	li	t0, 0x7
+               	and	a2, a1, t0
+               	bnez	a2, 0x1f60 <corpus.cases.vec.vec_scalar_mix.checksum+0x1ae0>
+               	mv	a2, a1
+               	li	a3, 0x10
+               	sd	zero, 0x0(a2)
+               	addi	a2, a2, 0x8
+               	addi	a3, a3, -0x8
+               	li	t0, 0x0
+               	bne	a3, t0, 0x1f48 <corpus.cases.vec.vec_scalar_mix.checksum+0x1ac8>
+               	j	0x1f7c <corpus.cases.vec.vec_scalar_mix.checksum+0x1afc>
+               	mv	a2, a1
+               	li	a1, 0x10
+               	sb	zero, 0x0(a2)
+               	addi	a2, a2, 0x1
+               	addi	a1, a1, -0x1
+               	li	t0, 0x0
+               	bne	a1, t0, 0x1f68 <corpus.cases.vec.vec_scalar_mix.checksum+0x1ae8>
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x700
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x700
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x700
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x700
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x700
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
@@ -2024,962 +2066,843 @@ Disassembly of section .text:
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
                	fcvt.w.s	a1, ft1, rtz
-               	mv	a3, s2
-               	lw	a4, 0x0(a3)
+               	mv	a2, s3
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x4
-               	lw	a4, 0x0(a3)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x4
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x8
-               	lw	a4, 0x0(a3)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x8
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0xc
-               	lw	a4, 0x0(a3)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0xc
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	lw	a4, 0x0(a3)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	lw	a4, 0x0(a3)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	lw	a4, 0x0(a3)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
+               	addiw	t1, t1, 0x6f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	lw	a4, 0x0(a3)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, s2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a3, 0x0(a1)
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft0, 0x0(a1)
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft0, 0x0(a1)
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t0, 0x40800
-               	fmv.w.x	ft10, t0
-               	fmul.s	ft1, ft0, ft10
-               	fcvt.w.s	a1, ft1, rtz
-               	mv	a3, s2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, s2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a3, 0x0(a1)
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t0, 0x40800
-               	fmv.w.x	ft10, t0
-               	fmul.s	ft1, ft0, ft10
-               	fcvt.w.s	a1, ft1, rtz
-               	mv	a3, s2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, s2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x418
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a3, 0x0(a1)
-               	mv	a1, s1
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x4
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0x8
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	fsw	ft0, 0x0(a1)
-               	addi	a1, s1, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	fsw	ft0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x410
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	lui	t0, 0x40800
-               	fmv.w.x	ft10, t0
-               	fmul.s	ft1, ft0, ft10
-               	fcvt.w.s	a1, ft1, rtz
-               	mv	a3, s2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	addi	a3, s2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x408
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	lw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a4, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, s2
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x400
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sw	a3, 0x0(a1)
-               	mv	a1, s2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x276c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2790>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x27b4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x27d8>
-               	mv	a1, s2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	mulw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	mulw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	mulw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a4, 0x0(a1)
-               	mulw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0xc
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x29ac>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x29d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x29f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2a18>
-               	mv	a1, s2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a3, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a4, 0x0(a1)
-               	subw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a3, t2
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a4, 0x0(a1)
-               	subw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x4
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a4, 0x0(a1)
-               	subw	a1, a3, a4
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a3, t2, 0x8
-               	sw	a1, 0x0(a3)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x320
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	subw	a1, a3, a2
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x6e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t0, 0x40800
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	fcvt.w.s	a1, ft1, rtz
+               	mv	a2, s3
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t0, 0x40800
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	fcvt.w.s	a1, ft1, rtz
+               	mv	a2, s3
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	mv	a1, s1
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	fsw	ft0, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	fsw	ft0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	flw	ft0, 0x0(a1)
+               	lui	t0, 0x40800
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	fcvt.w.s	a1, ft1, rtz
+               	mv	a2, s3
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	addi	a2, s3, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a3, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2bec>
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2c10>
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2c34>
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c8
+               	addiw	t1, t1, 0x6a8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x6a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2c58>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2590>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s10
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x698
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x690
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x271c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s10
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x688
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s10, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x680
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x28a8>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
+               	addiw	t0, t0, 0x730
                	add	a1, s0, t0
                	mv	a2, a1
                	lui	t0, 0x100
@@ -3002,7 +2925,7 @@ Disassembly of section .text:
                	mv	a2, a1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
@@ -3010,7 +2933,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
@@ -3018,7 +2941,7 @@ Disassembly of section .text:
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
@@ -3026,837 +2949,801 @@ Disassembly of section .text:
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x340
+               	addiw	t1, t1, 0x5f0
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addw	a1, a2, t2
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3d0
+               	addiw	t1, t1, 0x678
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	s1, 0x0(a1)
-               	mv	a1, s1
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2e54>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2aa8>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
-               	lw	s2, 0x0(a1)
-               	xor	s3, s1, s2
-               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	xor	s3, s1, a2
+               	slli	a1, s3, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2e7c>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2ad4>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
-               	lw	s5, 0x0(a1)
-               	mulw	s6, s3, s5
-               	mv	a1, s6
+               	lw	a2, 0x0(a1)
+               	mulw	s1, s3, a2
+               	slli	a1, s1, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2ea4>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2b00>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	subw	s3, s6, a2
-               	mv	a1, s3
+               	subw	s3, s1, a2
+               	slli	a1, s3, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2ecc>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x2b2c>
                	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	s6, s0, t0
-               	mv	a1, s6
+               	addiw	t0, t0, 0x720
+               	add	s1, s0, t0
+               	mv	a1, s1
                	li	t0, 0x7
                	and	a2, a1, t0
-               	bnez	a2, 0x3114 <corpus.cases.vec.vec_scalar_mix.checksum+0x2f10>
+               	bnez	a2, 0x2ff0 <corpus.cases.vec.vec_scalar_mix.checksum+0x2b70>
                	mv	a2, a1
                	li	a3, 0x10
                	sd	zero, 0x0(a2)
                	addi	a2, a2, 0x8
                	addi	a3, a3, -0x8
                	li	t0, 0x0
-               	bne	a3, t0, 0x30fc <corpus.cases.vec.vec_scalar_mix.checksum+0x2ef8>
-               	j	0x3130 <corpus.cases.vec.vec_scalar_mix.checksum+0x2f2c>
+               	bne	a3, t0, 0x2fd8 <corpus.cases.vec.vec_scalar_mix.checksum+0x2b58>
+               	j	0x300c <corpus.cases.vec.vec_scalar_mix.checksum+0x2b8c>
                	mv	a2, a1
                	li	a1, 0x10
                	sb	zero, 0x0(a2)
                	addi	a2, a2, 0x1
                	addi	a1, a1, -0x1
                	li	t0, 0x0
-               	bne	a1, t0, 0x311c <corpus.cases.vec.vec_scalar_mix.checksum+0x2f18>
-               	mv	a1, s6
+               	bne	a1, t0, 0x2ff8 <corpus.cases.vec.vec_scalar_mix.checksum+0x2b78>
+               	mv	a1, s1
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b0
+               	addiw	t1, t1, 0x668
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	s3, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s1
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3b8
+               	addiw	t1, t1, 0x660
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	sw	a2, 0x0(a1)
-               	xor	a1, s3, s1
-               	mv	a2, s6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x670
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	xor	a1, s3, a2
+               	mv	a2, s1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x4
+               	addi	a2, s1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x8
+               	addi	a2, s1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0xc
+               	addi	a2, s1, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a0
+               	addiw	t1, t1, 0x658
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s1
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3a8
+               	addiw	t1, t1, 0x650
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	sw	a2, 0x0(a1)
-               	addw	a1, s3, s2
-               	mv	a2, s6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x670
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	addw	a1, s3, a2
+               	mv	a2, s1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x4
+               	addi	a2, s1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x8
+               	addi	a2, s1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0xc
+               	addi	a2, s1, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x390
+               	addiw	t1, t1, 0x648
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s1
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x398
+               	addiw	t1, t1, 0x640
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	sw	a2, 0x0(a1)
-               	subw	a1, s3, s5
-               	mv	a2, s6
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x670
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	subw	a1, s3, a2
+               	mv	a2, s1
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x4
+               	addi	a2, s1, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0x8
+               	addi	a2, s1, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
-               	addi	a2, s6, 0xc
+               	addi	a2, s1, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x370
+               	addiw	t1, t1, 0x638
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	lw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a3, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s1
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x388
+               	addiw	t1, t1, 0x630
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	sw	a2, 0x0(a1)
-               	mv	a1, s6
+               	mv	a1, s1
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
+               	addi	a1, s1, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
+               	addi	a1, s1, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
+               	addi	a1, s1, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3734>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3758>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x377c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x380
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x37a0>
-               	mv	a1, s6
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x628
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	sw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x628
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x33d4>
+               	mv	a1, s1
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x4
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0x8
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x378
+               	addiw	t1, t1, 0x620
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x3c0
+               	addiw	t1, t1, 0x670
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a1, t2, 0xc
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
+               	addiw	t1, t1, 0x618
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3974>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3998>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x39bc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x368
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x39e0>
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x35a0>
                	mv	s1, a0
-               	li	s2, 0x0
+               	li	s3, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x3c00 <corpus.cases.vec.vec_scalar_mix.checksum+0x39fc>
-               	j	0x4018 <corpus.cases.vec.vec_scalar_mix.checksum+0x3e14>
-               	mv	a0, s4
+               	bltu	s3, t0, 0x3a3c <corpus.cases.vec.vec_scalar_mix.checksum+0x35bc>
+               	j	0x3de0 <corpus.cases.vec.vec_scalar_mix.checksum+0x3960>
+               	mv	a0, s2
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0xc
+               	addi	a0, s2, 0xc
                	flw	ft1, 0x0(a0)
                	fadd.s	ft2, ft0, ft1
-               	addi	a0, s4, 0x4
+               	addi	a0, s2, 0x4
                	flw	ft0, 0x0(a0)
-               	addi	a0, s4, 0x8
+               	addi	a0, s2, 0x8
                	flw	ft3, 0x0(a0)
                	fsub.s	ft4, ft0, ft3
                	lui	t0, 0x3f000
@@ -3865,346 +3752,297 @@ Disassembly of section .text:
                	lui	t0, 0x3fa00
                	fmv.w.x	ft10, t0
                	fadd.s	ft3, ft1, ft10
-               	mv	a0, s4
+               	mv	a0, s2
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft1, 0x0(a0)
-               	addi	a0, s4, 0x4
+               	addi	a0, s2, 0x4
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft1, 0x0(a0)
-               	addi	a0, s4, 0x8
+               	addi	a0, s2, 0x8
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft1, 0x0(a0)
-               	addi	a0, s4, 0xc
+               	addi	a0, s2, 0xc
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft2, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x360
+               	addiw	t1, t1, 0x610
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft4, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x358
+               	addiw	t1, t1, 0x608
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	flw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft1, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	flw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	mv	a0, t2
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	flw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x4
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	flw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0x8
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x350
+               	addiw	t1, t1, 0x600
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	flw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft0, 0x0(a0)
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
                	addi	a0, t2, 0xc
                	fsw	ft3, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	flw	ft0, 0x0(a0)
                	mv	a0, s1
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3d7c>
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3da0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3dc4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	flw	ft0, 0x0(a1)
-               	fmv.s	fa0, ft0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3de8>
-               	addi	s2, s2, 0x1
+               	jalr	ra <corpus.cases.vec.vec_scalar_mix.checksum+0x3934>
+               	addi	s3, s3, 0x1
                	mv	s1, a0
                	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x348
+               	addiw	t1, t1, 0x5f8
                	add	t1, s0, t1
                	ld	t2, 0x0(t1)
-               	mv	s4, t2
+               	mv	s2, t2
                	li	t0, 0x4
-               	bltu	s2, t0, 0x3c00 <corpus.cases.vec.vec_scalar_mix.checksum+0x39fc>
+               	bltu	s3, t0, 0x3a3c <corpus.cases.vec.vec_scalar_mix.checksum+0x35bc>
                	mv	a0, s1
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2e8
+               	addiw	t1, t1, -0x568
                	add	t1, sp, t1
                	ld	s1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2f0
+               	addiw	t1, t1, -0x570
                	add	t1, sp, t1
                	ld	s2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2f8
+               	addiw	t1, t1, -0x578
                	add	t1, sp, t1
                	ld	s3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x300
+               	addiw	t1, t1, -0x580
                	add	t1, sp, t1
                	ld	s4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x308
+               	addiw	t1, t1, -0x588
                	add	t1, sp, t1
                	ld	s5, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x310
+               	addiw	t1, t1, -0x590
                	add	t1, sp, t1
                	ld	s6, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x318
+               	addiw	t1, t1, -0x598
                	add	t1, sp, t1
                	ld	s7, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x320
+               	addiw	t1, t1, -0x5a0
                	add	t1, sp, t1
                	ld	s8, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x328
+               	addiw	t1, t1, -0x5a8
                	add	t1, sp, t1
                	ld	s9, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x330
+               	addiw	t1, t1, -0x5b0
                	add	t1, sp, t1
                	ld	s10, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x338
+               	addiw	t1, t1, -0x5b8
                	add	t1, sp, t1
                	ld	s11, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x340
+               	addiw	t1, t1, -0x5c0
                	add	t1, sp, t1
                	fld	fs0, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x348
+               	addiw	t1, t1, -0x5c8
                	add	t1, sp, t1
                	fld	fs1, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x350
+               	addiw	t1, t1, -0x5d0
                	add	t1, sp, t1
                	fld	fs2, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x358
+               	addiw	t1, t1, -0x5d8
                	add	t1, sp, t1
                	fld	fs3, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x360
+               	addiw	t1, t1, -0x5e0
                	add	t1, sp, t1
                	fld	fs4, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x368
-               	add	t1, sp, t1
-               	fld	fs5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x370
-               	add	t1, sp, t1
-               	fld	fs6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x378
-               	add	t1, sp, t1
-               	fld	fs7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x380
-               	add	t1, sp, t1
-               	fld	fs8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x388
-               	add	t1, sp, t1
-               	fld	fs9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x2d8
+               	addiw	t1, t1, -0x558
                	add	t1, sp, t1
                	ld	ra, 0x0(t1)
                	lui	t1, 0x1
-               	addiw	t1, t1, -0x2e0
+               	addiw	t1, t1, -0x560
                	add	t1, sp, t1
                	ld	s0, 0x0(t1)
                	lui	t0, 0x1
-               	addiw	t0, t0, -0x2d0
+               	addiw	t0, t0, -0x550
                	add	sp, sp, t0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u16x8.dis
+++ b/test/golden/riscv64-linux/vec/vec_u16x8.dis
@@ -3,4734 +3,2560 @@ vec/vec_u16x8.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u16x8.fold_vec>:
-               	addi	sp, sp, -0xa0
-               	sd	ra, 0x98(sp)
-               	sd	s0, 0x90(sp)
-               	addi	s0, sp, 0xa0
-               	sd	s1, 0x88(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x98
-               	mv	a1, s1
-               	lhu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0x4c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	addi	sp, sp, -0x90
+               	sd	ra, 0x88(sp)
+               	sd	s0, 0x80(sp)
+               	addi	s0, sp, 0x90
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x80
+               	addi	a2, s0, -0x90
+               	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0x68>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x50 <corpus.cases.vec.vec_u16x8.fold_vec+0x50>
+               	j	0x84 <corpus.cases.vec.vec_u16x8.fold_vec+0x84>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x50 <corpus.cases.vec.vec_u16x8.fold_vec+0x50>
+               	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0x84>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa4 <corpus.cases.vec.vec_u16x8.fold_vec+0xa4>
+               	j	0xd8 <corpus.cases.vec.vec_u16x8.fold_vec+0xd8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xa4 <corpus.cases.vec.vec_u16x8.fold_vec+0xa4>
+               	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0xa0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xf8 <corpus.cases.vec.vec_u16x8.fold_vec+0xf8>
+               	j	0x12c <corpus.cases.vec.vec_u16x8.fold_vec+0x12c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xf8 <corpus.cases.vec.vec_u16x8.fold_vec+0xf8>
+               	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0xbc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c <corpus.cases.vec.vec_u16x8.fold_vec+0x14c>
+               	j	0x180 <corpus.cases.vec.vec_u16x8.fold_vec+0x180>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x14c <corpus.cases.vec.vec_u16x8.fold_vec+0x14c>
+               	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0xd8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a0 <corpus.cases.vec.vec_u16x8.fold_vec+0x1a0>
+               	j	0x1d4 <corpus.cases.vec.vec_u16x8.fold_vec+0x1d4>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1a0 <corpus.cases.vec.vec_u16x8.fold_vec+0x1a0>
+               	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0xf4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1f4 <corpus.cases.vec.vec_u16x8.fold_vec+0x1f4>
+               	j	0x228 <corpus.cases.vec.vec_u16x8.fold_vec+0x228>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1f4 <corpus.cases.vec.vec_u16x8.fold_vec+0x1f4>
+               	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.fold_vec+0x110>
-               	ld	s1, 0x88(sp)
-               	ld	ra, 0x98(sp)
-               	ld	s0, 0x90(sp)
-               	addi	sp, sp, 0xa0
+               	slli	a2, a3, 0x30
+               	srli	a2, a2, 0x30
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x248 <corpus.cases.vec.vec_u16x8.fold_vec+0x248>
+               	j	0x27c <corpus.cases.vec.vec_u16x8.fold_vec+0x27c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x248 <corpus.cases.vec.vec_u16x8.fold_vec+0x248>
+               	addi	a2, a1, 0xe
+               	lhu	a1, 0x0(a2)
+               	slli	a2, a1, 0x30
+               	srli	a2, a2, 0x30
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.vec.vec_u16x8.fold_vec+0x29c>
+               	j	0x2d0 <corpus.cases.vec.vec_u16x8.fold_vec+0x2d0>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x29c <corpus.cases.vec.vec_u16x8.fold_vec+0x29c>
+               	ld	ra, 0x88(sp)
+               	ld	s0, 0x80(sp)
+               	addi	sp, sp, 0x90
                	ret
 
 <corpus.cases.vec.vec_u16x8.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x18
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x20
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x28
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x30
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x38
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x40
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x48
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x50
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x58
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x60
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x68
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x70
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x78
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	t2, s0, -0x2d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x518
-               	addi	t2, s0, -0x528
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	t2, s0, -0x568
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x598
-               	addi	t2, s0, -0x5a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x638
-               	addi	t2, s0, -0x648
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x658
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x668
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x548
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x538
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x528
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x508
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x498
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x488
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x478
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x468
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x458
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x448
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x438
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x428
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x418
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x408
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x3a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x398
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x388
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x378
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x368
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x358
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x348
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x338
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x328
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x318
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x308
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x2a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x298
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x288
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x278
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x268
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x258
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x248
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x238
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x228
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x218
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x208
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x1a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x198
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x914>
+               	addi	sp, sp, -0x7d0
+               	sd	ra, 0x7c8(sp)
+               	sd	s0, 0x7c0(sp)
+               	addi	s0, sp, 0x7d0
+               	sd	s1, 0x7b8(sp)
+               	sd	s2, 0x7b0(sp)
+               	sd	s3, 0x7a8(sp)
+               	sd	s4, 0x7a0(sp)
+               	sd	s5, 0x798(sp)
+               	sd	s6, 0x790(sp)
+               	sd	s7, 0x788(sp)
+               	sd	s8, 0x780(sp)
+               	sd	s9, 0x778(sp)
+               	sd	s10, 0x770(sp)
+               	sd	s11, 0x768(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x188
-               	add	s1, s0, t0
-               	mv	a0, s1
+               	sd	t2, -0x720(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x798(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x790(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x7a0(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x7a8(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x7b0(s0)
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
+               	sd	t2, -0x7b8(s0)
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
+               	sd	t2, -0x7c0(s0)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	a0, s0, -0x4d8
+               	addi	t2, s0, -0x4e8
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	a0, s0, -0x518
+               	addi	t2, s0, -0x528
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	a0, s0, -0x558
+               	addi	t2, s0, -0x568
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	a0, s0, -0x598
+               	addi	t2, s0, -0x5a8
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	a0, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x760(s0)
+               	addi	a0, s0, -0x608
+               	addi	a0, s0, -0x618
+               	addi	t2, s0, -0x628
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x638
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x770(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x778(s0)
+               	addi	t2, s0, -0x668
+               	sd	t2, -0x780(s0)
+               	ld	t3, -0x720(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x788(s0)
+               	addi	a0, s0, -0x6e8
+               	mv	a4, a0
                	lui	t0, 0x10
                	addiw	t0, t0, -0x10
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x2
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x2
                	li	t0, 0x1
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
                	lui	t0, 0x8
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x6
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x6
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0x8
                	lui	t0, 0x1
                	addiw	t0, t0, 0x1
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xa
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xa
                	li	t0, 0x2
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xc
                	lui	t0, 0xa
                	addiw	t0, t0, -0x3c0
-               	sh	t0, 0x0(a0)
-               	addi	a0, s1, 0xe
+               	sh	t0, 0x0(a4)
+               	addi	a4, a0, 0xe
                	lui	t0, 0x3
                	addiw	t0, t0, 0x39
-               	sh	t0, 0x0(a0)
-               	mv	a0, s1
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x2
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x6
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xa
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	sh	a1, 0x0(a0)
-               	addi	a0, s1, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s2, 0xe
-               	sh	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x178
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sh	t0, 0x0(a4)
+               	mv	a4, a0
+               	lhu	a2, 0x0(a4)
+               	mv	a4, a1
+               	sh	a2, 0x0(a4)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
                	li	t0, 0x11
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	lui	t0, 0x10
                	addiw	t0, t0, -0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x8
                	addiw	t0, t0, 0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	li	t0, 0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0xf
                	addiw	t0, t0, -0x5a0
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xa
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
                	lui	t0, 0x7
                	addiw	t0, t0, 0x530
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x6
                	addiw	t0, t0, 0x3c1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xe
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
                	lui	t0, 0xd
                	addiw	t0, t0, 0x431
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s3
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sh	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x168
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	mv	a2, t2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
                	li	t0, 0x1
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x2
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
                	li	t0, 0x3
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x9
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x6
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
                	li	t0, 0x1b
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	li	t0, 0x51
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xa
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
                	li	t0, 0xf3
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x2d9
-               	sh	t0, 0x0(a1)
-               	addi	a1, a0, 0xe
+               	sh	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
                	lui	t0, 0x1
                	addiw	t0, t0, -0x775
-               	sh	t0, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	sh	t0, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s1
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s1, 0xe
+               	sh	a0, 0x0(a2)
+               	addi	a0, s0, -0x718
+               	mv	a2, a0
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sh	zero, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	sh	zero, 0x0(a2)
+               	mv	a2, a0
+               	lhu	a4, 0x0(a2)
+               	mv	a2, s2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lhu	a0, 0x0(a2)
+               	addi	a2, s2, 0xe
+               	sh	a0, 0x0(a2)
+               	mv	a0, a1
+               	lhu	a2, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lhu	a4, 0x0(a2)
+               	mv	a2, a3
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x2
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x6
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0xa
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lhu	a4, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sh	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lhu	a1, 0x0(a2)
+               	addi	a2, a3, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, a3
+               	sh	a0, 0x0(a1)
+               	addi	a0, a3, 0xc
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, a3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sh	a0, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a0, t2, 0x4
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x798(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a0, t2, 0xe
+               	lhu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
                	mv	a1, s4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
                	addi	a1, s4, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
+               	sh	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	sh	a2, 0x0(a1)
                	addi	a1, s4, 0xe
                	sh	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x158
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	zero, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	zero, 0x0(a1)
-               	mv	a1, a0
-               	lhu	s1, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x8cc>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x8d8>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s5
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	lhu	a0, 0x0(a1)
-               	addi	a1, s5, 0xe
-               	sh	a0, 0x0(a1)
-               	mv	a0, s2
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x9c4>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	sh	s1, 0x0(a1)
-               	mv	a1, s6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s6, 0xc
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s6
-               	lhu	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xab0>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xe
+               	sh	a1, 0x0(a2)
                	mv	a1, s7
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xb9c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xc88>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xd74>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xe60>
+               	mv	a1, s5
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s5, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lhu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xe
+               	sh	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xf4c>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x105c>
+               	mv	a1, s2
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x116c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x127c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x138c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7c0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x149c>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x156c>
+               	mv	a1, s4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lhu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x163c>
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x4
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x6
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x8
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xa
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xc
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xe
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x178c>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x6
+               	bltu	s7, t0, 0x1a8c <corpus.cases.vec.vec_u16x8.checksum+0x17ac>
+               	j	0x1f18 <corpus.cases.vec.vec_u16x8.checksum+0x1c38>
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
                	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s8, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s8, 0xe
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x60
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sh	s1, 0x0(a1)
-               	addi	a1, s8, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	sh	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	sh	a0, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x68
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfc0>
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfd4>
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xfe8>
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0xffc>
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1010>
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1024>
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1038>
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x104c>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1060>
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1074>
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1088>
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x109c>
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10b0>
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10c4>
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10d8>
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x10ec>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	mv	s1, s10
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xe
-               	sh	a1, 0x0(s1)
-               	mv	a1, s10
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x11e0>
-               	addi	a1, s10, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x11f4>
-               	addi	a1, s10, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1208>
-               	addi	a1, s10, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x121c>
-               	addi	a1, s10, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1230>
-               	addi	a1, s10, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1244>
-               	addi	a1, s10, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1258>
-               	addi	a1, s10, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x126c>
-               	mv	a1, s7
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	mv	s1, s11
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s7, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xe
-               	sh	a1, 0x0(s1)
-               	mv	a1, s11
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1360>
-               	addi	a1, s11, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1374>
-               	addi	a1, s11, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1388>
-               	addi	a1, s11, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x139c>
-               	addi	a1, s11, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13b0>
-               	addi	a1, s11, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13c4>
-               	addi	a1, s11, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13d8>
-               	addi	a1, s11, 0xe
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x13ec>
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s7
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x2
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x6
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xa
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	sh	a1, 0x0(s1)
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xe
-               	sh	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1570>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1594>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x15b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x15dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1600>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1624>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1648>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x58
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x166c>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x17f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1814>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1838>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x185c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1880>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18a4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18c8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x50
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18ec>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1a70>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1a94>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1ab8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1adc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b00>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b24>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b48>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x48
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1b6c>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1cf0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d14>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d5c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1d80>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1da4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1dc8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x40
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1dec>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x38
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	lhu	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2150>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2174>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2198>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x21bc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x21e0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2204>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2228>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x30
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x224c>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x23d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x23f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2418>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x243c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2460>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2484>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24a8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x28
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x24cc>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x20
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2648>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x27c4>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2940>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2abc>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2bf8>
-               	mv	a1, s9
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x2
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x6
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xa
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s9, 0xe
-               	lhu	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xc0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2d34>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xe0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xd8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2fb0>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x30fc <corpus.cases.vec.vec_u16x8.checksum+0x2fd0>
-               	j	0x3bc8 <corpus.cases.vec.vec_u16x8.checksum+0x3a9c>
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s1, 0x4
                	lhu	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x740(s0)
                	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x2
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x18b8>
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x2
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x6
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x6
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x8
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xa
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xa
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xa
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xa
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xc
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xc
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s4, 0xe
-               	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xc
+               	sh	a1, 0x0(a2)
+               	addi	a1, s6, 0xe
+               	lhu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xe
-               	sh	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	lhu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x314c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3170>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3194>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x31b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x31dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3200>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3224>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3248>
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x19e8>
                	mv	a1, s2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s3
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
+               	addi	a1, s3, 0x6
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
+               	addi	a1, s3, 0xa
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
                	addi	a1, s2, 0xe
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xb0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x344c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3470>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3494>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x34b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x34dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3500>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3524>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3548>
-               	mv	a1, s5
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s7
+               	addi	a1, s3, 0xe
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0xe
+               	sh	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1af8>
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lhu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
                	mv	a2, t2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
+               	addi	a1, s3, 0x2
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
+               	addi	a1, s4, 0x2
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x2
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
+               	addi	a1, s3, 0x4
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0x4
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x4
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
+               	addi	a1, s3, 0x6
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
+               	addi	a1, s4, 0x6
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x6
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
+               	addi	a1, s3, 0x8
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s4, 0x8
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x8
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
+               	addi	a1, s3, 0xa
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
+               	addi	a1, s4, 0xa
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xa
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
+               	addi	a1, s3, 0xc
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s4, 0xc
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xc
                	sh	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
+               	addi	a1, s3, 0xe
                	lhu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
+               	addi	a1, s4, 0xe
                	lhu	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x36cc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x36f0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3714>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3738>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x375c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3780>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x37a4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x37c8>
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x2
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x6
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xa
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sh	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lhu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xe
-               	sh	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x394c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3970>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3994>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x39b8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x39dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a00>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a24>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x3a48>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x98
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s7, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x1c08>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x758(s0)
+               	mv	s3, t2
+               	ld	t2, -0x748(s0)
+               	mv	s6, t2
+               	ld	t2, -0x750(s0)
                	mv	s2, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0xa0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x30fc <corpus.cases.vec.vec_u16x8.checksum+0x2fd0>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x118
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s7, t0, 0x1a8c <corpus.cases.vec.vec_u16x8.checksum+0x17ac>
+               	addi	s2, s0, -0x6a8
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x3c04 <corpus.cases.vec.vec_u16x8.checksum+0x3ad8>
+               	bnez	a1, 0x1f4c <corpus.cases.vec.vec_u16x8.checksum+0x1c6c>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x3bec <corpus.cases.vec.vec_u16x8.checksum+0x3ac0>
-               	j	0x3c20 <corpus.cases.vec.vec_u16x8.checksum+0x3af4>
+               	bne	a2, t0, 0x1f34 <corpus.cases.vec.vec_u16x8.checksum+0x1c54>
+               	j	0x1f68 <corpus.cases.vec.vec_u16x8.checksum+0x1c88>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x3c0c <corpus.cases.vec.vec_u16x8.checksum+0x3ae0>
+               	bne	a0, t0, 0x1f54 <corpus.cases.vec.vec_u16x8.checksum+0x1c74>
+               	mv	a0, s2
+               	mv	a1, s3
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sh	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s9
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xa
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lhu	a1, 0x0(a0)
-               	addi	a0, s9, 0xe
-               	lhu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x90
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sh	a2, 0x0(a1)
-               	mv	a0, s7
                	lhu	a1, 0x0(a0)
                	mv	a0, s4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x2
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x6
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
+               	addi	a0, s3, 0xa
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xa
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	sh	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
+               	addi	a0, s3, 0xe
                	lhu	a1, 0x0(a0)
                	addi	a0, s4, 0xe
                	lhu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	sh	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x88
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sh	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
+               	mv	a0, s3
+               	lhu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
+               	sh	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lhu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lhu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
+               	sh	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
                	lhu	a2, 0x0(a1)
                	mv	a1, a0
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
                	lhu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sh	a2, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s2, 0x30
+               	mv	a1, s6
+               	lhu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x2
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x6
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xa
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sh	a2, 0x0(a1)
+               	addi	a1, s6, 0xe
+               	lhu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sh	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4200 <corpus.cases.vec.vec_u16x8.checksum+0x40d4>
-               	j	0x443c <corpus.cases.vec.vec_u16x8.checksum+0x4310>
+               	bltu	s1, t0, 0x23c8 <corpus.cases.vec.vec_u16x8.checksum+0x20e8>
+               	j	0x2498 <corpus.cases.vec.vec_u16x8.checksum+0x21b8>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	mv	a0, t2
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x2
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x2
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x4
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x6
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x6
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x8
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xa
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xa
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lhu	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xc
                	sh	a2, 0x0(a0)
                	addi	a0, a1, 0xe
                	lhu	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xe
                	sh	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lhu	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x41fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4220>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4244>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4268>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x428c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x42b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x42d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x80
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x42f8>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x21a0>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4200 <corpus.cases.vec.vec_u16x8.checksum+0x40d4>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0xe8
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0x23c8 <corpus.cases.vec.vec_u16x8.checksum+0x20e8>
+               	addi	s1, s0, -0x6d8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x4478 <corpus.cases.vec.vec_u16x8.checksum+0x434c>
+               	bnez	a1, 0x24cc <corpus.cases.vec.vec_u16x8.checksum+0x21ec>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x4460 <corpus.cases.vec.vec_u16x8.checksum+0x4334>
-               	j	0x4494 <corpus.cases.vec.vec_u16x8.checksum+0x4368>
+               	bne	a2, t0, 0x24b4 <corpus.cases.vec.vec_u16x8.checksum+0x21d4>
+               	j	0x24e8 <corpus.cases.vec.vec_u16x8.checksum+0x2208>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x4480 <corpus.cases.vec.vec_u16x8.checksum+0x4354>
-               	mv	a0, s2
+               	bne	a0, t0, 0x24d4 <corpus.cases.vec.vec_u16x8.checksum+0x21f4>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	mv	a2, a1
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	mv	a2, t2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x2
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x2
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x4
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x6
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x6
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x8
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xa
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xa
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lhu	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xc
                	sh	a3, 0x0(a2)
                	addi	a2, a1, 0xe
                	lhu	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xe
                	sh	a1, 0x0(a2)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, s3
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x78
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sh	a2, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x778(s0)
+               	mv	a2, t2
+               	lhu	a3, 0x0(a2)
+               	mv	a2, a1
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x2
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x4
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x6
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x8
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xa
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xc
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sh	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xe
+               	lhu	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sh	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x459c>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2670 <corpus.cases.vec.vec_u16x8.checksum+0x2390>
+               	j	0x26a4 <corpus.cases.vec.vec_u16x8.checksum+0x23c4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x2670 <corpus.cases.vec.vec_u16x8.checksum+0x2390>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x2
+               	addi	a1, a0, 0x2
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x2
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x4
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x6
+               	addi	a1, a0, 0x6
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x6
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x8
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xa
+               	addi	a1, a0, 0xa
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xa
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
+               	addi	a1, a0, 0xc
                	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xc
                	sh	a2, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	lhu	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0xe
+               	lhu	a0, 0x0(a1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xe
-               	sh	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sh	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46c0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x2
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x46e4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4708>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x6
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x472c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4750>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xa
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4774>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x4798>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x70
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xe
-               	lhu	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x47bc>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x2474>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u16x8.checksum+0x47d0>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x28
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x30
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x38
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x40
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x48
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x50
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x58
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x60
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x68
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x70
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x78
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x18
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x20
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x10
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x277c <corpus.cases.vec.vec_u16x8.checksum+0x249c>
+               	j	0x27b0 <corpus.cases.vec.vec_u16x8.checksum+0x24d0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x277c <corpus.cases.vec.vec_u16x8.checksum+0x249c>
+               	ld	s1, 0x7b8(sp)
+               	ld	s2, 0x7b0(sp)
+               	ld	s3, 0x7a8(sp)
+               	ld	s4, 0x7a0(sp)
+               	ld	s5, 0x798(sp)
+               	ld	s6, 0x790(sp)
+               	ld	s7, 0x788(sp)
+               	ld	s8, 0x780(sp)
+               	ld	s9, 0x778(sp)
+               	ld	s10, 0x770(sp)
+               	ld	s11, 0x768(sp)
+               	ld	ra, 0x7c8(sp)
+               	ld	s0, 0x7c0(sp)
+               	addi	sp, sp, 0x7d0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u32x4.dis
+++ b/test/golden/riscv64-linux/vec/vec_u32x4.dis
@@ -3,2614 +3,1488 @@ vec/vec_u32x4.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u32x4.fold_vec>:
-               	addi	sp, sp, -0x60
-               	sd	ra, 0x58(sp)
-               	sd	s0, 0x50(sp)
-               	addi	s0, sp, 0x60
-               	sd	s1, 0x48(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	mv	a1, s1
-               	lw	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.fold_vec+0x3c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	addi	sp, sp, -0x50
+               	sd	ra, 0x48(sp)
+               	sd	s0, 0x40(sp)
+               	addi	s0, sp, 0x50
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.fold_vec+0x58>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_u32x4.fold_vec+0x40>
+               	j	0x74 <corpus.cases.vec.vec_u32x4.fold_vec+0x74>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x40 <corpus.cases.vec.vec_u32x4.fold_vec+0x40>
+               	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.fold_vec+0x74>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_u32x4.fold_vec+0x94>
+               	j	0xc8 <corpus.cases.vec.vec_u32x4.fold_vec+0xc8>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x94 <corpus.cases.vec.vec_u32x4.fold_vec+0x94>
+               	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.fold_vec+0x90>
-               	ld	s1, 0x48(sp)
-               	ld	ra, 0x58(sp)
-               	ld	s0, 0x50(sp)
-               	addi	sp, sp, 0x60
+               	slli	a2, a3, 0x20
+               	srli	a2, a2, 0x20
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_u32x4.fold_vec+0xe8>
+               	j	0x11c <corpus.cases.vec.vec_u32x4.fold_vec+0x11c>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xe8 <corpus.cases.vec.vec_u32x4.fold_vec+0xe8>
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_u32x4.fold_vec+0x13c>
+               	j	0x170 <corpus.cases.vec.vec_u32x4.fold_vec+0x170>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x13c <corpus.cases.vec.vec_u32x4.fold_vec+0x13c>
+               	ld	ra, 0x48(sp)
+               	ld	s0, 0x40(sp)
+               	addi	sp, sp, 0x50
                	ret
 
 <corpus.cases.vec.vec_u32x4.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x410
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x418
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x420
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x410
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x428
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x430
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x438
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x440
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x448
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x450
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x458
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x460
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x468
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x470
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x478
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	t2, s0, -0x2d8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x518
-               	addi	t2, s0, -0x528
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	t2, s0, -0x568
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x598
-               	addi	t2, s0, -0x5a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x638
-               	addi	t2, s0, -0x648
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x658
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x668
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x798
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x788
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x768
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x758
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x738
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x728
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x718
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x708
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x6a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x698
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x688
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x678
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x668
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x658
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x648
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x638
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x628
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x618
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x608
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5f8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5e8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5d8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5c8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5b8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x5a8
-               	add	a1, s0, t0
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x598
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x614>
+               	addi	sp, sp, -0x7d0
+               	sd	ra, 0x7c8(sp)
+               	sd	s0, 0x7c0(sp)
+               	addi	s0, sp, 0x7d0
+               	sd	s1, 0x7b8(sp)
+               	sd	s2, 0x7b0(sp)
+               	sd	s3, 0x7a8(sp)
+               	sd	s4, 0x7a0(sp)
+               	sd	s5, 0x798(sp)
+               	sd	s6, 0x790(sp)
+               	sd	s7, 0x788(sp)
+               	sd	s8, 0x780(sp)
+               	sd	s9, 0x778(sp)
+               	sd	s10, 0x770(sp)
+               	sd	s11, 0x768(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sext.w	t2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x588
-               	add	s1, s0, t0
-               	mv	a0, s1
+               	sd	t2, -0x720(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x790(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x798(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x7a0(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x7a8(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x7b0(s0)
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
+               	sd	t2, -0x7b8(s0)
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
+               	sd	t2, -0x7c0(s0)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	a0, s0, -0x4d8
+               	addi	t2, s0, -0x4e8
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	a0, s0, -0x518
+               	addi	t2, s0, -0x528
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	a0, s0, -0x558
+               	addi	t2, s0, -0x568
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	a0, s0, -0x598
+               	addi	t2, s0, -0x5a8
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	a0, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x760(s0)
+               	addi	a0, s0, -0x608
+               	addi	a0, s0, -0x618
+               	addi	t2, s0, -0x628
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x638
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x770(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x778(s0)
+               	addi	t2, s0, -0x668
+               	sd	t2, -0x780(s0)
+               	ld	t3, -0x720(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x788(s0)
+               	addi	a0, s0, -0x6e8
+               	mv	a2, a0
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x10
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x1
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
-               	sw	t0, 0x0(a0)
-               	addi	a0, s1, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sw	t0, 0x0(a0)
-               	mv	a0, s1
-               	lw	a1, 0x0(a0)
-               	mv	a0, s2
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0x4
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sw	a1, 0x0(a0)
-               	addi	a0, s1, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s2, 0xc
-               	sw	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x578
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, a1
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
                	li	t0, 0x11
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x80
                	slli	t0, t0, 0xc
                	addi	t0, t0, 0x1
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x1
-               	sw	t0, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
-               	mv	a1, s3
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x568
-               	add	a0, s0, t0
-               	mv	a1, a0
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x790(s0)
+               	mv	a2, t2
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	ld	t2, -0x790(s0)
+               	addi	a2, t2, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
                	li	t0, 0x1
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x4
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
                	li	t0, 0x3
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0x8
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	li	t0, 0x9
-               	sw	t0, 0x0(a1)
-               	addi	a1, a0, 0xc
+               	sw	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
                	li	t0, 0x1b
-               	sw	t0, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
+               	sw	t0, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, s1
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sw	a0, 0x0(a2)
+               	addi	a0, s0, -0x718
+               	mv	a2, a0
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sw	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sw	zero, 0x0(a2)
+               	mv	a2, a0
+               	lw	a4, 0x0(a2)
+               	mv	a2, s2
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lw	a0, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sw	a0, 0x0(a2)
+               	mv	a0, a1
+               	lw	a2, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lw	a4, 0x0(a2)
+               	mv	a2, a3
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lw	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lw	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sw	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lw	a1, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, a3
+               	sw	a0, 0x0(a1)
+               	addi	a0, a3, 0x8
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sw	a0, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a0, t2, 0x4
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	mv	a1, t2
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a0, t2, 0xc
+               	lw	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x798(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
                	mv	a1, s4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
                	addi	a1, s4, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
                	addi	a1, s4, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
+               	sw	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sw	a2, 0x0(a1)
                	addi	a1, s4, 0xc
                	sw	a0, 0x0(a1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x558
-               	add	a0, s0, t0
-               	mv	a1, a0
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sw	zero, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sw	zero, 0x0(a1)
-               	mv	a1, a0
-               	lw	s1, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x5cc>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x5d8>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s5
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	lw	a0, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s2
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s2
-               	lw	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x654>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s6
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sw	s1, 0x0(a1)
-               	mv	a1, s6
-               	sw	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s6
-               	lw	s1, 0x0(a1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x6d0>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sw	a1, 0x0(a2)
                	mv	a1, s7
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x74c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x7c8>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x844>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x8c0>
+               	mv	a1, s5
+               	lw	a2, 0x0(a1)
+               	mv	a1, s1
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lw	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sw	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x93c>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s3
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x9cc>
+               	mv	a1, s2
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa5c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xaec>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb7c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7c0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc0c>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc7c>
+               	mv	a1, s4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lw	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xcec>
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x4
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x8
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xc
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd9c>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x6
+               	bltu	s7, t0, 0xf3c <corpus.cases.vec.vec_u32x4.checksum+0xdbc>
+               	j	0x11b8 <corpus.cases.vec.vec_u32x4.checksum+0x1038>
+               	mv	a0, s3
+               	lw	a1, 0x0(a0)
+               	mv	a0, s1
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
                	sw	a0, 0x0(a1)
                	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s3
-               	lw	s1, 0x0(a1)
-               	mv	a1, s8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s8, 0xc
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x460
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addw	a0, a1, t2
-               	mv	a1, s8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	sw	s1, 0x0(a1)
-               	addi	a1, s8, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	sw	a0, 0x0(a1)
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x468
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa00>
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa14>
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa28>
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa3c>
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa50>
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa64>
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa78>
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xa8c>
-               	mv	a1, s7
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	mv	s1, s10
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
-               	addw	a1, s1, s2
-               	addi	s1, s10, 0xc
-               	sw	a1, 0x0(s1)
-               	mv	a1, s10
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb10>
-               	addi	a1, s10, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb24>
-               	addi	a1, s10, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb38>
-               	addi	a1, s10, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xb4c>
-               	mv	a1, s7
-               	lw	s1, 0x0(a1)
-               	mv	a1, s9
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	mv	s1, s11
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s7, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	addi	s1, s11, 0xc
-               	sw	a1, 0x0(s1)
-               	mv	a1, s11
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbd0>
-               	addi	a1, s11, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbe4>
-               	addi	a1, s11, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xbf8>
-               	addi	a1, s11, 0xc
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xc0c>
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mv	a1, s7
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x4
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sw	a1, 0x0(s1)
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	s2, 0x0(a1)
-               	subw	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0xc
-               	sw	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xce0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd28>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x458
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xd4c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	s1, 0x0(a1)
-               	mulw	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe44>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe68>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x450
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe8c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfa8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x448
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xfcc>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10a0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10c4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x10e8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x440
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x110c>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x438
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	lw	a3, 0x0(a1)
-               	mulw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x12d0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x12f4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1318>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x430
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x133c>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	mv	a1, s7
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1410>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1434>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1458>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x428
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x147c>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	subw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x420
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1548>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1614>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x16e0>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x17ac>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1858>
-               	mv	a1, s9
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x4
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0x8
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s9, 0xc
-               	lw	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1904>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1a50>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x1b1c <corpus.cases.vec.vec_u32x4.checksum+0x1a70>
-               	j	0x20a8 <corpus.cases.vec.vec_u32x4.checksum+0x1ffc>
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s1, 0x4
                	lw	a2, 0x0(a0)
                	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	sw	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x740(s0)
                	mv	a1, t2
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xe48>
+               	mv	a1, s6
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sw	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sw	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0x8
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sw	a1, 0x0(a2)
+               	addi	a1, s6, 0xc
+               	lw	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
                	addi	a1, t2, 0xc
-               	sw	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lw	a1, 0x0(a0)
-               	mv	a0, s1
+               	lw	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b3c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1b84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ba8>
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xee8>
                	mv	a1, s2
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, s3
                	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
                	addi	a1, s2, 0xc
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1cbc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1ce0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d04>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1d28>
-               	mv	a1, s5
-               	lw	a2, 0x0(a1)
-               	mv	a1, s7
+               	addi	a1, s3, 0xc
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0xc
+               	sw	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0xf78>
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, s4
+               	lw	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
                	mv	a2, t2
                	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
+               	addi	a1, s3, 0x4
                	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
+               	addi	a1, s4, 0x4
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x4
                	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
+               	addi	a1, s3, 0x8
                	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
+               	addi	a1, s4, 0x8
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0x8
                	sw	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
+               	addi	a1, s3, 0xc
                	lw	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
+               	addi	a1, s4, 0xc
                	lw	a3, 0x0(a1)
                	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x758(s0)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1dfc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e44>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1e68>
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, s9
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x4
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sw	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lw	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0xc
-               	sw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f3c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f60>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1f84>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1fa8>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x498
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s7, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1008>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x758(s0)
+               	mv	s3, t2
+               	ld	t2, -0x748(s0)
+               	mv	s6, t2
+               	ld	t2, -0x750(s0)
                	mv	s2, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x4a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x1b1c <corpus.cases.vec.vec_u32x4.checksum+0x1a70>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x518
-               	add	s3, s0, t0
-               	mv	a0, s3
+               	bltu	s7, t0, 0xf3c <corpus.cases.vec.vec_u32x4.checksum+0xdbc>
+               	addi	s2, s0, -0x6a8
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x20e4 <corpus.cases.vec.vec_u32x4.checksum+0x2038>
+               	bnez	a1, 0x11ec <corpus.cases.vec.vec_u32x4.checksum+0x106c>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x20cc <corpus.cases.vec.vec_u32x4.checksum+0x2020>
-               	j	0x2100 <corpus.cases.vec.vec_u32x4.checksum+0x2054>
+               	bne	a2, t0, 0x11d4 <corpus.cases.vec.vec_u32x4.checksum+0x1054>
+               	j	0x1208 <corpus.cases.vec.vec_u32x4.checksum+0x1088>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x20ec <corpus.cases.vec.vec_u32x4.checksum+0x2040>
+               	bne	a0, t0, 0x11f4 <corpus.cases.vec.vec_u32x4.checksum+0x1074>
+               	mv	a0, s2
+               	mv	a1, s3
+               	lw	a2, 0x0(a1)
+               	mv	a1, a0
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sw	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lw	a2, 0x0(a1)
-               	mv	a1, a0
-               	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sw	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a0, s7
-               	lw	a1, 0x0(a0)
-               	mv	a0, s9
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lw	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lw	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	sw	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a0
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x490
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sw	a2, 0x0(a1)
-               	mv	a0, s7
                	lw	a1, 0x0(a0)
                	mv	a0, s4
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	sw	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lw	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lw	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	sw	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a0
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x488
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sw	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
+               	mv	a0, s3
+               	lw	a1, 0x0(a0)
+               	mv	a0, s1
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
+               	sw	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lw	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lw	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
+               	sw	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
                	lw	a2, 0x0(a1)
                	mv	a1, a0
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
                	lw	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sw	a2, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s2, 0x30
+               	mv	a1, s6
+               	lw	a2, 0x0(a1)
+               	mv	a1, a0
+               	sw	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sw	a2, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sw	a2, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lw	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sw	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x2400 <corpus.cases.vec.vec_u32x4.checksum+0x2354>
-               	j	0x252c <corpus.cases.vec.vec_u32x4.checksum+0x2480>
+               	bltu	s1, t0, 0x1448 <corpus.cases.vec.vec_u32x4.checksum+0x12c8>
+               	j	0x14c8 <corpus.cases.vec.vec_u32x4.checksum+0x1348>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	mv	a0, t2
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x4
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lw	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x8
                	sw	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xc
                	sw	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	lw	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x23fc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2420>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2444>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x480
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2468>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1330>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x2400 <corpus.cases.vec.vec_u32x4.checksum+0x2354>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x4e8
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0x1448 <corpus.cases.vec.vec_u32x4.checksum+0x12c8>
+               	addi	s1, s0, -0x6d8
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x2568 <corpus.cases.vec.vec_u32x4.checksum+0x24bc>
+               	bnez	a1, 0x14fc <corpus.cases.vec.vec_u32x4.checksum+0x137c>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x2550 <corpus.cases.vec.vec_u32x4.checksum+0x24a4>
-               	j	0x2584 <corpus.cases.vec.vec_u32x4.checksum+0x24d8>
+               	bne	a2, t0, 0x14e4 <corpus.cases.vec.vec_u32x4.checksum+0x1364>
+               	j	0x1518 <corpus.cases.vec.vec_u32x4.checksum+0x1398>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x2570 <corpus.cases.vec.vec_u32x4.checksum+0x24c4>
-               	mv	a0, s2
+               	bne	a0, t0, 0x1504 <corpus.cases.vec.vec_u32x4.checksum+0x1384>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	mv	a2, a1
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	mv	a2, t2
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0x4
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x4
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	lw	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x8
                	sw	a3, 0x0(a2)
                	addi	a2, a1, 0xc
                	lw	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xc
                	sw	a1, 0x0(a2)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, s3
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x478
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sw	a2, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x778(s0)
+               	mv	a2, t2
+               	lw	a3, 0x0(a2)
+               	mv	a2, a1
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x4
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x8
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sw	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xc
+               	lw	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sw	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x260c>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1600 <corpus.cases.vec.vec_u32x4.checksum+0x1480>
+               	j	0x1634 <corpus.cases.vec.vec_u32x4.checksum+0x14b4>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x1600 <corpus.cases.vec.vec_u32x4.checksum+0x1480>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
                	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x4
+               	addi	a1, a0, 0x4
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x4
                	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
+               	addi	a1, a0, 0x8
                	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0x8
                	sw	a2, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	lw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0xc
+               	lw	a0, 0x0(a1)
+               	ld	t2, -0x780(s0)
                	addi	a1, t2, 0xc
-               	sw	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sw	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x26b0>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x4
+               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x1514>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x26d4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x26f8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x470
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0xc
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x271c>
-               	addi	a1, s2, 0x20
-               	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u32x4.checksum+0x2730>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x428
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x430
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x438
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x440
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x448
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x450
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x458
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x460
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x468
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x470
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x478
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x418
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x420
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x410
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x16bc <corpus.cases.vec.vec_u32x4.checksum+0x153c>
+               	j	0x16f0 <corpus.cases.vec.vec_u32x4.checksum+0x1570>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x16bc <corpus.cases.vec.vec_u32x4.checksum+0x153c>
+               	ld	s1, 0x7b8(sp)
+               	ld	s2, 0x7b0(sp)
+               	ld	s3, 0x7a8(sp)
+               	ld	s4, 0x7a0(sp)
+               	ld	s5, 0x798(sp)
+               	ld	s6, 0x790(sp)
+               	ld	s7, 0x788(sp)
+               	ld	s8, 0x780(sp)
+               	ld	s9, 0x778(sp)
+               	ld	s10, 0x770(sp)
+               	ld	s11, 0x768(sp)
+               	ld	ra, 0x7c8(sp)
+               	ld	s0, 0x7c0(sp)
+               	addi	sp, sp, 0x7d0
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u64x2.dis
+++ b/test/golden/riscv64-linux/vec/vec_u64x2.dis
@@ -3,1231 +3,761 @@ vec/vec_u64x2.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u64x2.fold_vec>:
-               	addi	sp, sp, -0x40
-               	sd	ra, 0x38(sp)
-               	sd	s0, 0x30(sp)
-               	addi	s0, sp, 0x40
-               	sd	s1, 0x28(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	mv	a1, s1
-               	ld	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.fold_vec+0x34>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	addi	sp, sp, -0x30
+               	sd	ra, 0x28(sp)
+               	sd	s0, 0x20(sp)
+               	addi	s0, sp, 0x30
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.fold_vec+0x50>
-               	ld	s1, 0x28(sp)
-               	ld	ra, 0x38(sp)
-               	ld	s0, 0x30(sp)
-               	addi	sp, sp, 0x40
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_u64x2.fold_vec+0x30>
+               	j	0x64 <corpus.cases.vec.vec_u64x2.fold_vec+0x64>
+               	li	t0, 0x8
+               	mul	a4, a2, t0
+               	srl	a5, a3, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x30 <corpus.cases.vec.vec_u64x2.fold_vec+0x30>
+               	addi	a2, a1, 0x8
+               	ld	a1, 0x0(a2)
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_u64x2.fold_vec+0x7c>
+               	j	0xb0 <corpus.cases.vec.vec_u64x2.fold_vec+0xb0>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0x7c <corpus.cases.vec.vec_u64x2.fold_vec+0x7c>
+               	ld	ra, 0x28(sp)
+               	ld	s0, 0x20(sp)
+               	addi	sp, sp, 0x30
                	ret
 
 <corpus.cases.vec.vec_u64x2.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	add	s0, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	sd	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	sd	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	sd	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	sd	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	sd	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	sd	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	sd	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b0
-               	add	t1, sp, t1
-               	sd	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b8
-               	add	t1, sp, t1
-               	sd	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c0
-               	add	t1, sp, t1
-               	sd	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c8
-               	add	t1, sp, t1
-               	sd	s11, 0x0(t1)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	a1, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	s8, s0, -0x158
-               	addi	a1, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	s9, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x288
-               	addi	t2, s0, -0x298
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2a8
-               	addi	a1, s0, -0x2b8
-               	addi	t2, s0, -0x2c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x2d8
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x398
-               	addi	t2, s0, -0x3a8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3b8
-               	addi	t2, s0, -0x3c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x3d8
-               	addi	a1, s0, -0x3e8
-               	addi	a1, s0, -0x3f8
-               	addi	a1, s0, -0x408
-               	addi	a1, s0, -0x418
-               	addi	a1, s0, -0x428
-               	addi	t2, s0, -0x438
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	t2, s0, -0x488
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x498
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	t2, s0, -0x4c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x4d8
-               	addi	a1, s0, -0x4e8
-               	addi	a1, s0, -0x4f8
-               	addi	t2, s0, -0x508
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x518
-               	addi	a1, s0, -0x528
-               	addi	a1, s0, -0x538
-               	addi	t2, s0, -0x548
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x558
-               	addi	a1, s0, -0x568
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	t2, s0, -0x598
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5a8
-               	addi	a1, s0, -0x5b8
-               	addi	t2, s0, -0x5c8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x5d8
-               	addi	t2, s0, -0x5e8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x5f8
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	t2, s0, -0x608
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	addi	a1, s0, -0x618
-               	addi	a1, s0, -0x628
-               	addi	a1, s0, -0x638
-               	addi	a1, s0, -0x648
-               	addi	a1, s0, -0x658
-               	addi	a1, s0, -0x668
-               	addi	a1, s0, -0x678
-               	addi	a1, s0, -0x688
-               	addi	a1, s0, -0x698
-               	addi	a1, s0, -0x6a8
-               	addi	a1, s0, -0x6b8
-               	addi	a1, s0, -0x6c8
-               	addi	a1, s0, -0x6d8
-               	addi	a1, s0, -0x6e8
-               	addi	a1, s0, -0x6f8
-               	addi	a1, s0, -0x708
-               	addi	a1, s0, -0x718
-               	addi	a1, s0, -0x728
-               	addi	a1, s0, -0x738
-               	addi	a1, s0, -0x748
-               	addi	a1, s0, -0x758
-               	addi	a1, s0, -0x768
-               	addi	a1, s0, -0x778
-               	addi	a1, s0, -0x788
-               	addi	a1, s0, -0x798
-               	addi	a1, s0, -0x7a8
-               	addi	a1, s0, -0x7b8
-               	addi	a1, s0, -0x7c8
-               	addi	a1, s0, -0x7d8
-               	addi	a1, s0, -0x7e8
-               	addi	a1, s0, -0x7f8
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7f8
-               	add	a1, s0, t0
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x42c>
+               	addi	sp, sp, -0x770
+               	sd	ra, 0x768(sp)
+               	sd	s0, 0x760(sp)
+               	addi	s0, sp, 0x770
+               	sd	s1, 0x758(sp)
+               	sd	s2, 0x750(sp)
+               	sd	s3, 0x748(sp)
+               	sd	s4, 0x740(sp)
+               	sd	s5, 0x738(sp)
+               	sd	s6, 0x730(sp)
+               	sd	s7, 0x728(sp)
+               	sd	s8, 0x720(sp)
+               	sd	s9, 0x718(sp)
+               	sd	s10, 0x710(sp)
+               	sd	s11, 0x708(sp)
                	mv	t2, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7e8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
+               	sd	t2, -0x6c0(s0)
+               	addi	t2, s0, -0x78
+               	sd	t2, -0x720(s0)
+               	addi	t2, s0, -0x88
+               	sd	t2, -0x718(s0)
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	s3, s0, -0xd8
+               	addi	a3, s0, -0xe8
+               	addi	a3, s0, -0xf8
+               	addi	s4, s0, -0x108
+               	addi	a3, s0, -0x118
+               	addi	a3, s0, -0x128
+               	addi	a3, s0, -0x138
+               	addi	a3, s0, -0x148
+               	addi	s5, s0, -0x158
+               	addi	a3, s0, -0x168
+               	addi	a3, s0, -0x178
+               	addi	s6, s0, -0x188
+               	addi	a3, s0, -0x198
+               	addi	a3, s0, -0x1a8
+               	addi	s7, s0, -0x1b8
+               	addi	a3, s0, -0x1c8
+               	addi	a3, s0, -0x1d8
+               	addi	s8, s0, -0x1e8
+               	addi	a3, s0, -0x1f8
+               	addi	a3, s0, -0x208
+               	addi	s9, s0, -0x218
+               	addi	a3, s0, -0x228
+               	addi	a3, s0, -0x238
+               	addi	s10, s0, -0x248
+               	addi	a3, s0, -0x258
+               	addi	a3, s0, -0x268
+               	addi	a3, s0, -0x278
+               	addi	a3, s0, -0x288
+               	addi	s11, s0, -0x298
+               	addi	a3, s0, -0x2a8
+               	addi	a3, s0, -0x2b8
+               	addi	t2, s0, -0x2c8
+               	sd	t2, -0x738(s0)
+               	addi	a4, s0, -0x2d8
+               	addi	a4, s0, -0x2e8
+               	addi	t2, s0, -0x2f8
+               	sd	t2, -0x740(s0)
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
+               	sd	t2, -0x748(s0)
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
+               	sd	t2, -0x750(s0)
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
+               	sd	t2, -0x758(s0)
+               	addi	t5, s0, -0x398
+               	addi	t2, s0, -0x3a8
+               	sd	t2, -0x760(s0)
+               	addi	t6, s0, -0x3b8
+               	addi	t2, s0, -0x3c8
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x3d8
+               	addi	a0, s0, -0x3e8
+               	addi	a0, s0, -0x3f8
+               	addi	a0, s0, -0x408
+               	addi	a0, s0, -0x418
+               	addi	a0, s0, -0x428
+               	addi	t2, s0, -0x438
+               	sd	t2, -0x6c8(s0)
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	t2, s0, -0x488
+               	sd	t2, -0x6d0(s0)
+               	addi	a0, s0, -0x498
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	t2, s0, -0x4c8
+               	sd	t2, -0x6d8(s0)
+               	addi	a0, s0, -0x4d8
+               	addi	a0, s0, -0x4e8
+               	addi	a0, s0, -0x4f8
+               	addi	t2, s0, -0x508
+               	sd	t2, -0x6e0(s0)
+               	addi	a0, s0, -0x518
+               	addi	a0, s0, -0x528
+               	addi	a0, s0, -0x538
+               	addi	t2, s0, -0x548
+               	sd	t2, -0x6e8(s0)
+               	addi	a0, s0, -0x558
+               	addi	a0, s0, -0x568
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	t2, s0, -0x598
+               	sd	t2, -0x6f0(s0)
+               	addi	a0, s0, -0x5a8
+               	addi	a0, s0, -0x5b8
+               	addi	t2, s0, -0x5c8
+               	sd	t2, -0x6f8(s0)
+               	addi	a0, s0, -0x5d8
+               	addi	t2, s0, -0x5e8
+               	sd	t2, -0x700(s0)
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x708(s0)
+               	addi	t2, s0, -0x608
+               	sd	t2, -0x710(s0)
+               	addi	a0, s0, -0x688
+               	mv	a2, a0
                	li	t0, -0x10
-               	sd	t0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
+               	sd	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sd	t0, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s2
-               	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s2, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7d8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	sd	t0, 0x0(a2)
+               	mv	a2, a0
+               	ld	a1, 0x0(a2)
+               	ld	t2, -0x720(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s0, -0x698
+               	mv	a1, a0
                	li	t0, 0x11
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	li	t0, -0x1
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x718(s0)
                	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s3
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s3, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7c8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	addi	a0, s0, -0x6a8
+               	mv	a1, a0
                	li	t0, 0x1
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	li	t0, 0x1b
                	sd	t0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s4
+               	addi	a1, s1, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6c0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	sd	a1, 0x0(a0)
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x7b8
-               	add	t2, s0, t0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	addi	a0, s0, -0x6b8
+               	mv	a1, a0
                	sd	zero, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	addi	a1, a0, 0x8
                	sd	zero, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a0, 0x0(a1)
-               	mv	a1, s5
-               	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a0, t2, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s5, 0x8
-               	sd	a1, 0x0(a0)
-               	mv	a0, s2
-               	ld	a1, 0x0(a0)
-               	add	t2, a1, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	sd	t2, 0x0(t1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
                	mv	a1, s2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
                	ld	a0, 0x0(a1)
-               	mv	a1, s6
+               	addi	a1, s2, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s2, 0x8
+               	ld	t2, -0x720(s0)
+               	mv	a0, t2
                	ld	a1, 0x0(a0)
-               	addi	a0, s6, 0x8
+               	ld	t2, -0x6c0(s0)
+               	add	a0, a1, t2
+               	ld	t2, -0x720(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s3
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x720(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sd	a2, 0x0(a1)
+               	mv	a1, s3
+               	sd	a0, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	ld	t2, -0x6c0(s0)
+               	add	a0, a1, t2
+               	ld	t2, -0x718(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x718(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x3a0>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x3ac>
+               	mv	t2, a0
+               	sd	t2, -0x728(s0)
+               	ld	t2, -0x728(s0)
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a0, 0x0(a1)
+               	add	a1, a2, a0
+               	mv	a0, s5
                	sd	a1, 0x0(a0)
-               	mv	a0, s6
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6b0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	sd	t2, 0x0(a0)
                	addi	a0, s3, 0x8
                	ld	a1, 0x0(a0)
-               	add	a0, a1, s1
-               	mv	a1, s3
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	sd	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sd	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	sd	a0, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6d8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x748>
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x75c>
-               	mv	a1, s7
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x770>
-               	addi	a1, s7, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x784>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	add	a1, s1, s2
-               	mv	s1, s8
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	add	a1, s1, s2
-               	addi	s1, s8, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x7d0>
-               	addi	a1, s8, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x7e4>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	mv	s1, s9
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	addi	s1, s9, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s9
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x830>
-               	addi	a1, s9, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x844>
-               	mv	a1, s7
-               	ld	s1, 0x0(a1)
-               	mv	a1, s6
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	mv	s1, s10
-               	sd	a1, 0x0(s1)
-               	addi	a1, s7, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	s2, 0x0(a1)
-               	sub	a1, s1, s2
-               	addi	s1, s10, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s10
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x890>
-               	addi	a1, s10, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8a4>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s7
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	mv	s1, s11
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	addi	s1, s11, 0x8
-               	sd	a1, 0x0(s1)
-               	mv	a1, s11
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8f0>
-               	addi	a1, s11, 0x8
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x904>
-               	mv	a1, s6
-               	ld	s1, 0x0(a1)
-               	mv	a1, s4
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s1, t2
-               	sd	a1, 0x0(s1)
-               	addi	a1, s6, 0x8
-               	ld	s1, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	s2, 0x0(a1)
-               	mul	a1, s1, s2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	s1, t2, 0x8
-               	sd	a1, 0x0(s1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	s1, 0x0(a1)
-               	mv	a1, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x980>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x9a4>
-               	mv	a1, s7
-               	ld	a2, 0x0(a1)
-               	mv	a1, s4
-               	ld	s1, 0x0(a1)
-               	mul	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	s1, 0x0(a1)
-               	mul	a1, a2, s1
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa20>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6a0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xa44>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s4
-               	ld	a3, 0x0(a1)
-               	mul	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x698
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	ld	a3, 0x0(a1)
-               	mul	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb38>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x690
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb5c>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s6
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xbd8>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x688
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xbfc>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	sub	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x680
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xc70>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	and	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xce4>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	or	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xd58>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x740
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xdcc>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x738
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe30>
-               	mv	a1, s7
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	ld	a2, 0x0(a1)
-               	not	a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x730
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xe94>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x678
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x670
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x728
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xf48>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0xfd4 <corpus.cases.vec.vec_u64x2.checksum+0xf68>
-               	j	0x12c0 <corpus.cases.vec.vec_u64x2.checksum+0x1254>
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
+               	addi	a0, s4, 0x8
                	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
+               	add	a0, a1, a2
+               	addi	a1, s5, 0x8
                	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
+               	ld	t2, -0x728(s0)
+               	mv	a0, t2
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x404>
+               	mv	t2, a0
+               	sd	t2, -0x730(s0)
+               	ld	t2, -0x730(s0)
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a0, 0x0(a1)
+               	sub	a1, a2, a0
+               	mv	a0, s6
+               	sd	a1, 0x0(a0)
+               	addi	a0, s3, 0x8
                	ld	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	sub	a0, a1, a2
+               	addi	a1, s6, 0x8
                	sd	a0, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x730(s0)
                	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a1, s6
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xfdc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x45c>
+               	mv	a1, s4
                	ld	a2, 0x0(a1)
-               	mv	a1, a2
+               	mv	a1, s3
+               	ld	s6, 0x0(a1)
+               	sub	a1, a2, s6
+               	mv	a2, s7
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	s6, 0x0(a1)
+               	sub	a1, a2, s6
+               	addi	a2, s7, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1000>
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x4a0>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s8
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s8, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x4e4>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s9
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s9, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s9
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x528>
+               	mv	a1, s4
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s10
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	addi	a2, s10, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s10
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x56c>
+               	mv	a1, s5
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	s6, 0x0(a1)
+               	mul	a1, a2, s6
+               	mv	a2, s11
+               	sd	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	s5, 0x0(a1)
+               	mul	a1, a2, s5
+               	addi	a2, s11, 0x8
+               	sd	a1, 0x0(a2)
+               	mv	a1, s11
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x5b0>
                	mv	a1, s2
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	mv	a1, s3
+               	ld	s5, 0x0(a1)
+               	sub	a1, a2, s5
+               	ld	t2, -0x738(s0)
                	mv	a2, t2
                	sd	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x720
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, s3, 0x8
+               	ld	s5, 0x0(a1)
+               	sub	a1, a2, s5
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x600>
+               	mv	a1, s2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	sub	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	sub	a1, a2, a3
+               	ld	t2, -0x740(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x650>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x6a0>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x6f0>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x740>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x760(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x760(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x760(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x780>
+               	mv	a1, s4
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x7c0>
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6c8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x750(s0)
                	addi	a1, t2, 0x8
                	ld	a3, 0x0(a1)
                	xor	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6c8(s0)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x6c8(s0)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x109c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x10c0>
-               	mv	a1, s5
-               	ld	a2, 0x0(a1)
-               	mv	a1, s6
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x113c>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1160>
-               	mv	a1, s6
-               	ld	a2, 0x0(a1)
-               	mv	a1, s7
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a2, t2
-               	sd	a1, 0x0(a2)
-               	addi	a1, s6, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	ld	a3, 0x0(a1)
-               	add	a1, a2, a3
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a2, t2, 0x8
-               	sd	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x11dc>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1200>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x708
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s6, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x718
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s2, t2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x710
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	s5, t2
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x820>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
                	li	t0, 0x6
-               	bltu	s3, t0, 0xfd4 <corpus.cases.vec.vec_u64x2.checksum+0xf68>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x778
-               	add	s3, s0, t0
+               	bltu	s7, t0, 0x900 <corpus.cases.vec.vec_u64x2.checksum+0x840>
+               	j	0xa74 <corpus.cases.vec.vec_u64x2.checksum+0x9b4>
                	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s1
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6d0(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x88c>
+               	mv	a1, s6
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x6d0(s0)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6d8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	ld	a2, 0x0(a1)
+               	ld	t2, -0x6d0(s0)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x6d8(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6d8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x8e4>
+               	mv	a1, s2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s3
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e0(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e0(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6e0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x934>
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, s4
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e8(s0)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	ld	a3, 0x0(a1)
+               	add	a1, a2, a3
+               	ld	t2, -0x6e8(s0)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	ld	t2, -0x6e8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x984>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x6e8(s0)
+               	mv	s3, t2
+               	ld	t2, -0x6d8(s0)
+               	mv	s6, t2
+               	ld	t2, -0x6e0(s0)
+               	mv	s2, t2
+               	li	t0, 0x6
+               	bltu	s7, t0, 0x900 <corpus.cases.vec.vec_u64x2.checksum+0x840>
+               	addi	s2, s0, -0x648
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x12fc <corpus.cases.vec.vec_u64x2.checksum+0x1290>
+               	bnez	a1, 0xaa8 <corpus.cases.vec.vec_u64x2.checksum+0x9e8>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x12e4 <corpus.cases.vec.vec_u64x2.checksum+0x1278>
-               	j	0x1318 <corpus.cases.vec.vec_u64x2.checksum+0x12ac>
+               	bne	a2, t0, 0xa90 <corpus.cases.vec.vec_u64x2.checksum+0x9d0>
+               	j	0xac4 <corpus.cases.vec.vec_u64x2.checksum+0xa04>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1304 <corpus.cases.vec.vec_u64x2.checksum+0x1298>
+               	bne	a0, t0, 0xab0 <corpus.cases.vec.vec_u64x2.checksum+0x9f0>
+               	mv	a0, s2
+               	mv	a1, s3
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
                	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s4
+               	ld	a2, 0x0(a0)
+               	add	a0, a1, a2
+               	ld	t2, -0x6f0(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s4, 0x8
+               	ld	a2, 0x0(a0)
+               	add	a0, a1, a2
+               	ld	t2, -0x6f0(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x6f0(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x6f0(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	mv	a0, s3
+               	ld	a1, 0x0(a0)
+               	mv	a0, s1
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6f8(s0)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	ld	a2, 0x0(a0)
+               	mul	a0, a1, a2
+               	ld	t2, -0x6f8(s0)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x6f8(s0)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	ld	t2, -0x6f8(s0)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a0, s2, 0x30
                	mv	a1, s6
                	ld	a2, 0x0(a1)
                	mv	a1, a0
@@ -1236,299 +766,152 @@ Disassembly of section .text:
                	ld	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sd	a2, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s7
-               	ld	a2, 0x0(a0)
-               	add	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s7, 0x8
-               	ld	a2, 0x0(a0)
-               	add	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x700
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	mv	a0, s6
-               	ld	a1, 0x0(a0)
-               	mv	a0, s4
-               	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	sd	a0, 0x0(a1)
-               	addi	a0, s6, 0x8
-               	ld	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	ld	a2, 0x0(a0)
-               	mul	a0, a1, a2
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	sd	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a0
-               	sd	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sd	a2, 0x0(a1)
-               	li	s2, 0x0
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x14a8 <corpus.cases.vec.vec_u64x2.checksum+0x143c>
-               	j	0x154c <corpus.cases.vec.vec_u64x2.checksum+0x14e0>
+               	bltu	s1, t0, 0xbf4 <corpus.cases.vec.vec_u64x2.checksum+0xb34>
+               	j	0xc4c <corpus.cases.vec.vec_u64x2.checksum+0xb8c>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	ld	a2, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x700(s0)
                	mv	a0, t2
                	sd	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	ld	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x700(s0)
                	addi	a0, t2, 0x8
                	sd	a1, 0x0(a0)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a0, t2
-               	ld	a1, 0x0(a0)
-               	mv	a0, s1
+               	mv	a0, s5
+               	ld	t2, -0x700(s0)
+               	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x14a4>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6f0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x14c8>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xb74>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x14a8 <corpus.cases.vec.vec_u64x2.checksum+0x143c>
-               	lui	t0, 0xfffff
-               	addiw	t0, t0, 0x748
-               	add	s2, s0, t0
-               	mv	a0, s2
+               	bltu	s1, t0, 0xbf4 <corpus.cases.vec.vec_u64x2.checksum+0xb34>
+               	addi	s1, s0, -0x678
+               	mv	a0, s1
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x1588 <corpus.cases.vec.vec_u64x2.checksum+0x151c>
+               	bnez	a1, 0xc80 <corpus.cases.vec.vec_u64x2.checksum+0xbc0>
                	mv	a1, a0
                	li	a2, 0x30
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x1570 <corpus.cases.vec.vec_u64x2.checksum+0x1504>
-               	j	0x15a4 <corpus.cases.vec.vec_u64x2.checksum+0x1538>
+               	bne	a2, t0, 0xc68 <corpus.cases.vec.vec_u64x2.checksum+0xba8>
+               	j	0xc9c <corpus.cases.vec.vec_u64x2.checksum+0xbdc>
                	mv	a1, a0
                	li	a0, 0x30
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x1590 <corpus.cases.vec.vec_u64x2.checksum+0x1524>
-               	mv	a0, s2
+               	bne	a0, t0, 0xc88 <corpus.cases.vec.vec_u64x2.checksum+0xbc8>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
                	sw	t0, 0x0(a0)
-               	addi	a1, s3, 0x20
+               	addi	a1, s2, 0x20
                	mv	a2, a1
                	ld	a3, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	mv	a2, t2
                	sd	a3, 0x0(a2)
                	addi	a2, a1, 0x8
                	ld	a1, 0x0(a2)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x708(s0)
                	addi	a2, t2, 0x8
                	sd	a1, 0x0(a2)
-               	addi	s3, s2, 0x10
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, s3
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e8
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sd	a2, 0x0(a1)
-               	addi	a1, s2, 0x20
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x708(s0)
+               	mv	a2, t2
+               	ld	a3, 0x0(a2)
+               	mv	a2, a1
+               	sd	a3, 0x0(a2)
+               	ld	t2, -0x708(s0)
+               	addi	a2, t2, 0x8
+               	ld	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sd	a3, 0x0(a2)
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
                	sw	t0, 0x0(a1)
                	lw	a1, 0x0(a0)
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x15ec>
-               	mv	a1, s3
+               	slli	a0, a1, 0x20
+               	srli	a0, a0, 0x20
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd34 <corpus.cases.vec.vec_u64x2.checksum+0xc74>
+               	j	0xd68 <corpus.cases.vec.vec_u64x2.checksum+0xca8>
+               	li	t0, 0x8
+               	mul	a2, a1, t0
+               	srl	a3, a0, a2
+               	li	t0, 0xff
+               	and	a2, a3, t0
+               	xor	a3, s5, a2
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	s5, a3, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0xd34 <corpus.cases.vec.vec_u64x2.checksum+0xc74>
+               	addi	a0, s1, 0x10
+               	mv	a1, a0
                	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	ld	t2, -0x710(s0)
                	mv	a1, t2
                	sd	a2, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	ld	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	ld	t2, -0x710(s0)
                	addi	a1, t2, 0x8
-               	sd	a2, 0x0(a1)
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
+               	sd	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x710(s0)
                	mv	a1, t2
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1650>
-               	lui	t1, 0xfffff
-               	addiw	t1, t1, 0x6e0
-               	add	t1, s0, t1
-               	ld	t2, 0x0(t1)
-               	addi	a1, t2, 0x8
-               	ld	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1674>
-               	addi	a1, s2, 0x20
+               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0xce0>
+               	addi	a1, s1, 0x20
                	lw	a2, 0x0(a1)
-               	mv	a1, a2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u64x2.checksum+0x1688>
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x678
-               	add	t1, sp, t1
-               	ld	s1, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x680
-               	add	t1, sp, t1
-               	ld	s2, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x688
-               	add	t1, sp, t1
-               	ld	s3, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x690
-               	add	t1, sp, t1
-               	ld	s4, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x698
-               	add	t1, sp, t1
-               	ld	s5, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a0
-               	add	t1, sp, t1
-               	ld	s6, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6a8
-               	add	t1, sp, t1
-               	ld	s7, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b0
-               	add	t1, sp, t1
-               	ld	s8, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6b8
-               	add	t1, sp, t1
-               	ld	s9, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c0
-               	add	t1, sp, t1
-               	ld	s10, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x6c8
-               	add	t1, sp, t1
-               	ld	s11, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x668
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x670
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x660
-               	add	sp, sp, t0
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
+               	li	a2, 0x0
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xdc8 <corpus.cases.vec.vec_u64x2.checksum+0xd08>
+               	j	0xdfc <corpus.cases.vec.vec_u64x2.checksum+0xd3c>
+               	li	t0, 0x8
+               	mul	a3, a2, t0
+               	srl	a4, a1, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a2, a2, 0x1
+               	li	t0, 0x8
+               	bltu	a2, t0, 0xdc8 <corpus.cases.vec.vec_u64x2.checksum+0xd08>
+               	ld	s1, 0x758(sp)
+               	ld	s2, 0x750(sp)
+               	ld	s3, 0x748(sp)
+               	ld	s4, 0x740(sp)
+               	ld	s5, 0x738(sp)
+               	ld	s6, 0x730(sp)
+               	ld	s7, 0x728(sp)
+               	ld	s8, 0x720(sp)
+               	ld	s9, 0x718(sp)
+               	ld	s10, 0x710(sp)
+               	ld	s11, 0x708(sp)
+               	ld	ra, 0x768(sp)
+               	ld	s0, 0x760(sp)
+               	addi	sp, sp, 0x770
                	ret

--- a/test/golden/riscv64-linux/vec/vec_u8x16.dis
+++ b/test/golden/riscv64-linux/vec/vec_u8x16.dis
@@ -3,4629 +3,4638 @@ vec/vec_u8x16.o:
 Disassembly of section .text:
 
 <corpus.cases.vec.vec_u8x16.fold_vec>:
-               	addi	sp, sp, -0x120
-               	sd	ra, 0x118(sp)
-               	sd	s0, 0x110(sp)
-               	addi	s0, sp, 0x120
-               	sd	s1, 0x108(sp)
-               	mv	a2, a0
-               	mv	s1, a1
-               	addi	a1, s0, -0x28
-               	addi	a1, s0, -0x38
-               	addi	a1, s0, -0x48
-               	addi	a1, s0, -0x58
-               	addi	a1, s0, -0x68
-               	addi	a1, s0, -0x78
-               	addi	a1, s0, -0x88
-               	addi	a1, s0, -0x98
-               	addi	a1, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	a1, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	a1, s0, -0x108
-               	addi	a1, s0, -0x118
-               	mv	a1, s1
-               	lbu	a3, 0x0(a1)
-               	mv	a0, a2
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x6c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x1
+               	addi	sp, sp, -0x110
+               	sd	ra, 0x108(sp)
+               	sd	s0, 0x100(sp)
+               	addi	s0, sp, 0x110
+               	addi	a2, s0, -0x20
+               	addi	a2, s0, -0x30
+               	addi	a2, s0, -0x40
+               	addi	a2, s0, -0x50
+               	addi	a2, s0, -0x60
+               	addi	a2, s0, -0x70
+               	addi	a2, s0, -0x80
+               	addi	a2, s0, -0x90
+               	addi	a2, s0, -0xa0
+               	addi	a2, s0, -0xb0
+               	addi	a2, s0, -0xc0
+               	addi	a2, s0, -0xd0
+               	addi	a2, s0, -0xe0
+               	addi	a2, s0, -0xf0
+               	addi	a2, s0, -0x100
+               	addi	a2, s0, -0x110
+               	mv	a2, a1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x88>
-               	mv	a1, a0
-               	addi	a2, s1, 0x2
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.vec.vec_u8x16.fold_vec+0x6c>
+               	j	0xa0 <corpus.cases.vec.vec_u8x16.fold_vec+0xa0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x6c <corpus.cases.vec.vec_u8x16.fold_vec+0x6c>
+               	addi	a2, a1, 0x1
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0xa4>
-               	mv	a1, a0
-               	addi	a2, s1, 0x3
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xbc <corpus.cases.vec.vec_u8x16.fold_vec+0xbc>
+               	j	0xf0 <corpus.cases.vec.vec_u8x16.fold_vec+0xf0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0xbc <corpus.cases.vec.vec_u8x16.fold_vec+0xbc>
+               	addi	a2, a1, 0x2
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0xc0>
-               	mv	a1, a0
-               	addi	a2, s1, 0x4
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x10c <corpus.cases.vec.vec_u8x16.fold_vec+0x10c>
+               	j	0x140 <corpus.cases.vec.vec_u8x16.fold_vec+0x140>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x10c <corpus.cases.vec.vec_u8x16.fold_vec+0x10c>
+               	addi	a2, a1, 0x3
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0xdc>
-               	mv	a1, a0
-               	addi	a2, s1, 0x5
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.vec.vec_u8x16.fold_vec+0x15c>
+               	j	0x190 <corpus.cases.vec.vec_u8x16.fold_vec+0x190>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x15c <corpus.cases.vec.vec_u8x16.fold_vec+0x15c>
+               	addi	a2, a1, 0x4
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0xf8>
-               	mv	a1, a0
-               	addi	a2, s1, 0x6
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ac <corpus.cases.vec.vec_u8x16.fold_vec+0x1ac>
+               	j	0x1e0 <corpus.cases.vec.vec_u8x16.fold_vec+0x1e0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1ac <corpus.cases.vec.vec_u8x16.fold_vec+0x1ac>
+               	addi	a2, a1, 0x5
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x114>
-               	mv	a1, a0
-               	addi	a2, s1, 0x7
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1fc <corpus.cases.vec.vec_u8x16.fold_vec+0x1fc>
+               	j	0x230 <corpus.cases.vec.vec_u8x16.fold_vec+0x230>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x1fc <corpus.cases.vec.vec_u8x16.fold_vec+0x1fc>
+               	addi	a2, a1, 0x6
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x130>
-               	mv	a1, a0
-               	addi	a2, s1, 0x8
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x24c <corpus.cases.vec.vec_u8x16.fold_vec+0x24c>
+               	j	0x280 <corpus.cases.vec.vec_u8x16.fold_vec+0x280>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x24c <corpus.cases.vec.vec_u8x16.fold_vec+0x24c>
+               	addi	a2, a1, 0x7
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x14c>
-               	mv	a1, a0
-               	addi	a2, s1, 0x9
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x29c <corpus.cases.vec.vec_u8x16.fold_vec+0x29c>
+               	j	0x2d0 <corpus.cases.vec.vec_u8x16.fold_vec+0x2d0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x29c <corpus.cases.vec.vec_u8x16.fold_vec+0x29c>
+               	addi	a2, a1, 0x8
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x168>
-               	mv	a1, a0
-               	addi	a2, s1, 0xa
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.vec.vec_u8x16.fold_vec+0x2ec>
+               	j	0x320 <corpus.cases.vec.vec_u8x16.fold_vec+0x320>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x2ec <corpus.cases.vec.vec_u8x16.fold_vec+0x2ec>
+               	addi	a2, a1, 0x9
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x184>
-               	mv	a1, a0
-               	addi	a2, s1, 0xb
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x33c <corpus.cases.vec.vec_u8x16.fold_vec+0x33c>
+               	j	0x370 <corpus.cases.vec.vec_u8x16.fold_vec+0x370>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x33c <corpus.cases.vec.vec_u8x16.fold_vec+0x33c>
+               	addi	a2, a1, 0xa
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x1a0>
-               	mv	a1, a0
-               	addi	a2, s1, 0xc
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x38c <corpus.cases.vec.vec_u8x16.fold_vec+0x38c>
+               	j	0x3c0 <corpus.cases.vec.vec_u8x16.fold_vec+0x3c0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x38c <corpus.cases.vec.vec_u8x16.fold_vec+0x38c>
+               	addi	a2, a1, 0xb
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x1bc>
-               	mv	a1, a0
-               	addi	a2, s1, 0xd
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3dc <corpus.cases.vec.vec_u8x16.fold_vec+0x3dc>
+               	j	0x410 <corpus.cases.vec.vec_u8x16.fold_vec+0x410>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x3dc <corpus.cases.vec.vec_u8x16.fold_vec+0x3dc>
+               	addi	a2, a1, 0xc
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x1d8>
-               	mv	a1, a0
-               	addi	a2, s1, 0xe
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x42c <corpus.cases.vec.vec_u8x16.fold_vec+0x42c>
+               	j	0x460 <corpus.cases.vec.vec_u8x16.fold_vec+0x460>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x42c <corpus.cases.vec.vec_u8x16.fold_vec+0x42c>
+               	addi	a2, a1, 0xd
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x1f4>
-               	mv	a1, a0
-               	addi	a2, s1, 0xf
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.vec.vec_u8x16.fold_vec+0x47c>
+               	j	0x4b0 <corpus.cases.vec.vec_u8x16.fold_vec+0x4b0>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x47c <corpus.cases.vec.vec_u8x16.fold_vec+0x47c>
+               	addi	a2, a1, 0xe
                	lbu	a3, 0x0(a2)
-               	mv	a0, a1
-               	mv	a1, a3
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.fold_vec+0x210>
-               	ld	s1, 0x108(sp)
-               	ld	ra, 0x118(sp)
-               	ld	s0, 0x110(sp)
-               	addi	sp, sp, 0x120
+               	zext.b	a2, a3
+               	li	a3, 0x0
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4cc <corpus.cases.vec.vec_u8x16.fold_vec+0x4cc>
+               	j	0x500 <corpus.cases.vec.vec_u8x16.fold_vec+0x500>
+               	li	t0, 0x8
+               	mul	a4, a3, t0
+               	srl	a5, a2, a4
+               	li	t0, 0xff
+               	and	a4, a5, t0
+               	xor	a5, a0, a4
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a5, t0
+               	addi	a3, a3, 0x1
+               	li	t0, 0x8
+               	bltu	a3, t0, 0x4cc <corpus.cases.vec.vec_u8x16.fold_vec+0x4cc>
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	zext.b	a2, a1
+               	li	a1, 0x0
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.vec.vec_u8x16.fold_vec+0x51c>
+               	j	0x550 <corpus.cases.vec.vec_u8x16.fold_vec+0x550>
+               	li	t0, 0x8
+               	mul	a3, a1, t0
+               	srl	a4, a2, a3
+               	li	t0, 0xff
+               	and	a3, a4, t0
+               	xor	a4, a0, a3
+               	lui	t0, 0x10000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1b3
+               	mul	a0, a4, t0
+               	addi	a1, a1, 0x1
+               	li	t0, 0x8
+               	bltu	a1, t0, 0x51c <corpus.cases.vec.vec_u8x16.fold_vec+0x51c>
+               	ld	ra, 0x108(sp)
+               	ld	s0, 0x100(sp)
+               	addi	sp, sp, 0x110
                	ret
 
 <corpus.cases.vec.vec_u8x16.checksum>:
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	sub	sp, sp, t0
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x7f8
-               	add	t1, sp, t1
-               	sd	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x800
-               	add	t1, sp, t1
-               	sd	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	add	s0, sp, t0
-               	sd	s1, 0x7f8(sp)
-               	sd	s2, 0x7f0(sp)
-               	sd	s3, 0x7e8(sp)
-               	sd	s4, 0x7e0(sp)
-               	sd	s5, 0x7d8(sp)
-               	sd	s6, 0x7d0(sp)
-               	sd	s7, 0x7c8(sp)
-               	sd	s8, 0x7c0(sp)
-               	sd	s9, 0x7b8(sp)
-               	sd	s10, 0x7b0(sp)
-               	sd	s11, 0x7a8(sp)
-               	mv	s1, a0
-               	addi	s2, s0, -0x78
-               	addi	s3, s0, -0x88
-               	addi	s4, s0, -0x98
-               	addi	s5, s0, -0xa8
-               	addi	a1, s0, -0xb8
-               	addi	a1, s0, -0xc8
-               	addi	s6, s0, -0xd8
-               	addi	a1, s0, -0xe8
-               	addi	a1, s0, -0xf8
-               	addi	s7, s0, -0x108
-               	addi	a1, s0, -0x118
-               	addi	a1, s0, -0x128
-               	addi	s8, s0, -0x138
-               	addi	a1, s0, -0x148
-               	addi	a1, s0, -0x158
-               	addi	s9, s0, -0x168
-               	addi	a1, s0, -0x178
-               	addi	a1, s0, -0x188
-               	addi	a1, s0, -0x198
-               	addi	a1, s0, -0x1a8
-               	addi	s10, s0, -0x1b8
-               	addi	a1, s0, -0x1c8
-               	addi	a1, s0, -0x1d8
-               	addi	s11, s0, -0x1e8
-               	addi	a1, s0, -0x1f8
-               	addi	a1, s0, -0x208
-               	addi	t2, s0, -0x218
-               	sd	t2, -0x7c8(s0)
-               	addi	a1, s0, -0x228
-               	addi	a1, s0, -0x238
-               	addi	t2, s0, -0x248
-               	sd	t2, -0x7d0(s0)
-               	addi	a1, s0, -0x258
-               	addi	a1, s0, -0x268
-               	addi	t2, s0, -0x278
-               	sd	t2, -0x7d8(s0)
-               	addi	a1, s0, -0x288
-               	addi	a1, s0, -0x298
-               	addi	t2, s0, -0x2a8
-               	sd	t2, -0x7e0(s0)
-               	addi	a1, s0, -0x2b8
-               	addi	a1, s0, -0x2c8
-               	addi	a1, s0, -0x2d8
-               	addi	a1, s0, -0x2e8
-               	addi	t2, s0, -0x2f8
-               	sd	t2, -0x7e8(s0)
-               	addi	a1, s0, -0x308
-               	addi	a1, s0, -0x318
-               	addi	t2, s0, -0x328
-               	sd	t2, -0x7f0(s0)
-               	addi	a1, s0, -0x338
-               	addi	a1, s0, -0x348
-               	addi	t2, s0, -0x358
-               	sd	t2, -0x7f8(s0)
-               	addi	a1, s0, -0x368
-               	addi	a1, s0, -0x378
-               	addi	t2, s0, -0x388
-               	sd	t2, -0x800(s0)
-               	addi	a1, s0, -0x398
-               	addi	a1, s0, -0x3a8
-               	addi	t2, s0, -0x3b8
-               	sd	t2, -0x720(s0)
-               	addi	a1, s0, -0x3c8
-               	addi	a1, s0, -0x3d8
-               	addi	t2, s0, -0x3e8
-               	sd	t2, -0x728(s0)
-               	addi	a1, s0, -0x3f8
-               	addi	t2, s0, -0x408
-               	sd	t2, -0x730(s0)
-               	addi	a1, s0, -0x418
-               	addi	t2, s0, -0x428
-               	sd	t2, -0x738(s0)
-               	addi	a1, s0, -0x438
-               	addi	a1, s0, -0x448
-               	addi	a1, s0, -0x458
-               	addi	a1, s0, -0x468
-               	addi	a1, s0, -0x478
-               	addi	a1, s0, -0x488
-               	addi	t2, s0, -0x498
-               	sd	t2, -0x740(s0)
-               	addi	a1, s0, -0x4a8
-               	addi	a1, s0, -0x4b8
-               	addi	a1, s0, -0x4c8
-               	addi	a1, s0, -0x4d8
-               	addi	t2, s0, -0x4e8
-               	sd	t2, -0x748(s0)
-               	addi	a1, s0, -0x4f8
-               	addi	a1, s0, -0x508
-               	addi	a1, s0, -0x518
-               	addi	t2, s0, -0x528
-               	sd	t2, -0x750(s0)
-               	addi	a1, s0, -0x538
-               	addi	a1, s0, -0x548
-               	addi	a1, s0, -0x558
-               	addi	t2, s0, -0x568
-               	sd	t2, -0x758(s0)
-               	addi	a1, s0, -0x578
-               	addi	a1, s0, -0x588
-               	addi	a1, s0, -0x598
-               	addi	t2, s0, -0x5a8
-               	sd	t2, -0x760(s0)
-               	addi	a1, s0, -0x5b8
-               	addi	a1, s0, -0x5c8
-               	addi	a1, s0, -0x5d8
-               	addi	a1, s0, -0x5e8
-               	addi	t2, s0, -0x5f8
-               	sd	t2, -0x768(s0)
-               	addi	a1, s0, -0x608
-               	addi	a1, s0, -0x618
-               	addi	t2, s0, -0x628
-               	sd	t2, -0x770(s0)
-               	addi	a1, s0, -0x638
-               	addi	t2, s0, -0x648
-               	sd	t2, -0x778(s0)
-               	addi	t2, s0, -0x658
-               	sd	t2, -0x780(s0)
-               	addi	t2, s0, -0x668
-               	sd	t2, -0x788(s0)
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x240>
+               	addi	sp, sp, -0x7d0
+               	sd	ra, 0x7c8(sp)
+               	sd	s0, 0x7c0(sp)
+               	addi	s0, sp, 0x7d0
+               	sd	s1, 0x7b8(sp)
+               	sd	s2, 0x7b0(sp)
+               	sd	s3, 0x7a8(sp)
+               	sd	s4, 0x7a0(sp)
+               	sd	s5, 0x798(sp)
+               	sd	s6, 0x790(sp)
+               	sd	s7, 0x788(sp)
+               	sd	s8, 0x780(sp)
+               	sd	s9, 0x778(sp)
+               	sd	s10, 0x770(sp)
+               	sd	s11, 0x768(sp)
                	mv	t2, a0
-               	sd	t2, -0x790(s0)
-               	ld	t2, -0x790(s0)
-               	sext.w	t2, s1
+               	sd	t2, -0x720(s0)
+               	addi	a1, s0, -0x78
+               	addi	t2, s0, -0x88
                	sd	t2, -0x798(s0)
-               	addi	t2, s0, -0x678
+               	addi	s1, s0, -0x98
+               	addi	s2, s0, -0xa8
+               	addi	a3, s0, -0xb8
+               	addi	a3, s0, -0xc8
+               	addi	a3, s0, -0xd8
+               	addi	a4, s0, -0xe8
+               	addi	a4, s0, -0xf8
+               	addi	s3, s0, -0x108
+               	addi	a4, s0, -0x118
+               	addi	a4, s0, -0x128
+               	addi	t2, s0, -0x138
+               	sd	t2, -0x790(s0)
+               	addi	a5, s0, -0x148
+               	addi	a5, s0, -0x158
+               	addi	s4, s0, -0x168
+               	addi	a5, s0, -0x178
+               	addi	a5, s0, -0x188
+               	addi	a5, s0, -0x198
+               	addi	a5, s0, -0x1a8
+               	addi	s5, s0, -0x1b8
+               	addi	a5, s0, -0x1c8
+               	addi	a5, s0, -0x1d8
+               	addi	s6, s0, -0x1e8
+               	addi	a5, s0, -0x1f8
+               	addi	a5, s0, -0x208
+               	addi	s7, s0, -0x218
+               	addi	a5, s0, -0x228
+               	addi	a5, s0, -0x238
+               	addi	s8, s0, -0x248
+               	addi	a5, s0, -0x258
+               	addi	a5, s0, -0x268
+               	addi	s9, s0, -0x278
+               	addi	a5, s0, -0x288
+               	addi	a5, s0, -0x298
+               	addi	s10, s0, -0x2a8
+               	addi	a5, s0, -0x2b8
+               	addi	a5, s0, -0x2c8
+               	addi	a5, s0, -0x2d8
+               	addi	a5, s0, -0x2e8
+               	addi	s11, s0, -0x2f8
+               	addi	a5, s0, -0x308
+               	addi	a5, s0, -0x318
+               	addi	t2, s0, -0x328
                	sd	t2, -0x7a0(s0)
-               	ld	t2, -0x7a0(s0)
-               	mv	a1, t2
-               	li	t0, 0xf0
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x1
-               	li	t0, 0x1
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x2
-               	li	t0, 0x80
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x3
-               	li	t0, 0xff
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x4
-               	li	t0, 0x11
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x5
-               	li	t0, 0x2
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x6
-               	li	t0, 0xc8
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x7
-               	li	t0, 0x63
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x8
-               	sb	zero, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x9
-               	li	t0, 0x7
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xa
-               	li	t0, 0xfa
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xb
-               	li	t0, 0x21
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xc
-               	li	t0, 0x80
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xd
-               	li	t0, 0x40
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xe
-               	li	t0, 0x5
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xf
-               	li	t0, 0xc7
-               	sb	t0, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	mv	a1, t2
-               	lbu	s1, 0x0(a1)
-               	mv	a1, s2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a0(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x688
+               	addi	a6, s0, -0x338
+               	addi	a6, s0, -0x348
+               	addi	t2, s0, -0x358
                	sd	t2, -0x7a8(s0)
-               	ld	t2, -0x7a8(s0)
-               	mv	s1, t2
-               	li	t0, 0x11
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x1
-               	li	t0, 0xff
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x2
-               	li	t0, 0x81
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x3
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x4
-               	li	t0, 0xc8
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x5
-               	li	t0, 0x64
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x6
-               	li	t0, 0x39
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x7
-               	li	t0, 0x15
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x8
-               	li	t0, 0xff
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0x9
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xa
-               	li	t0, 0x6
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xb
-               	li	t0, 0xde
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xc
-               	li	t0, 0x80
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xd
-               	li	t0, 0xc0
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xe
-               	li	t0, 0xfb
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	s1, t2, 0xf
-               	li	t0, 0x39
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s3
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7a8(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s3, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x698
+               	addi	a7, s0, -0x368
+               	addi	a7, s0, -0x378
+               	addi	t2, s0, -0x388
                	sd	t2, -0x7b0(s0)
-               	ld	t2, -0x7b0(s0)
-               	mv	s1, t2
-               	li	t0, 0x1
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x1
-               	li	t0, 0x3
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x2
-               	li	t0, 0x9
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x3
-               	li	t0, 0x1b
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x4
-               	li	t0, 0x2
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x5
-               	li	t0, 0x6
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x6
-               	li	t0, 0x12
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x7
-               	li	t0, 0x36
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x8
-               	li	t0, 0x4
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0x9
-               	li	t0, 0xc
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xa
-               	li	t0, 0x24
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xb
-               	li	t0, 0x6c
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xc
-               	li	t0, 0x8
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xd
-               	li	t0, 0x18
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xe
-               	li	t0, 0x48
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	s1, t2, 0xf
-               	li	t0, 0xd8
-               	sb	t0, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s4
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b0(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s4, 0xf
-               	sb	s1, 0x0(a1)
-               	addi	t2, s0, -0x6a8
+               	addi	t5, s0, -0x398
+               	addi	t5, s0, -0x3a8
+               	addi	t2, s0, -0x3b8
                	sd	t2, -0x7b8(s0)
-               	ld	t2, -0x7b8(s0)
-               	mv	s1, t2
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x1
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x2
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x3
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x4
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x5
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x6
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x7
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x8
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0x9
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xa
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xb
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xc
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xd
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xe
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	s1, t2, 0xf
-               	sb	zero, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	mv	s1, t2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s5
-               	sb	a1, 0x0(s1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x1
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x2
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x3
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x4
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x5
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x6
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x7
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x8
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0x9
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xa
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xb
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xc
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xd
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xe
-               	sb	s1, 0x0(a1)
-               	ld	t2, -0x7b8(s0)
-               	addi	a1, t2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s5, 0xf
-               	sb	s1, 0x0(a1)
-               	mv	a1, s2
-               	lbu	s1, 0x0(a1)
-               	ld	t3, -0x798(s0)
-               	addw	t2, s1, t3
+               	addi	t6, s0, -0x3c8
+               	addi	t6, s0, -0x3d8
+               	addi	t2, s0, -0x3e8
                	sd	t2, -0x7c0(s0)
-               	mv	s1, s2
-               	lbu	a1, 0x0(s1)
-               	mv	s1, s6
-               	sb	a1, 0x0(s1)
-               	addi	a1, s2, 0x1
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x1
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x2
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x3
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x4
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x5
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x6
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x7
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x8
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0x9
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xa
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xb
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xc
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xd
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xe
-               	sb	s1, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	lbu	s1, 0x0(a1)
-               	addi	a1, s6, 0xf
-               	sb	s1, 0x0(a1)
-               	mv	a1, s6
-               	ld	t2, -0x7c0(s0)
-               	sb	t2, 0x0(a1)
-               	addi	a1, s6, 0x7
-               	lbu	s1, 0x0(a1)
+               	addi	a0, s0, -0x3f8
+               	addi	t2, s0, -0x408
+               	sd	t2, -0x728(s0)
+               	addi	a0, s0, -0x418
+               	addi	t2, s0, -0x428
+               	sd	t2, -0x730(s0)
+               	addi	a0, s0, -0x438
+               	addi	a0, s0, -0x448
+               	addi	a0, s0, -0x458
+               	addi	a0, s0, -0x468
+               	addi	a0, s0, -0x478
+               	addi	a0, s0, -0x488
+               	addi	t2, s0, -0x498
+               	sd	t2, -0x738(s0)
+               	addi	a0, s0, -0x4a8
+               	addi	a0, s0, -0x4b8
+               	addi	a0, s0, -0x4c8
+               	addi	a0, s0, -0x4d8
+               	addi	t2, s0, -0x4e8
+               	sd	t2, -0x740(s0)
+               	addi	a0, s0, -0x4f8
+               	addi	a0, s0, -0x508
+               	addi	a0, s0, -0x518
+               	addi	t2, s0, -0x528
+               	sd	t2, -0x748(s0)
+               	addi	a0, s0, -0x538
+               	addi	a0, s0, -0x548
+               	addi	a0, s0, -0x558
+               	addi	t2, s0, -0x568
+               	sd	t2, -0x750(s0)
+               	addi	a0, s0, -0x578
+               	addi	a0, s0, -0x588
+               	addi	a0, s0, -0x598
+               	addi	t2, s0, -0x5a8
+               	sd	t2, -0x758(s0)
+               	addi	a0, s0, -0x5b8
+               	addi	a0, s0, -0x5c8
+               	addi	a0, s0, -0x5d8
+               	addi	a0, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	sd	t2, -0x760(s0)
+               	addi	a0, s0, -0x608
+               	addi	a0, s0, -0x618
+               	addi	t2, s0, -0x628
+               	sd	t2, -0x768(s0)
+               	addi	a0, s0, -0x638
+               	addi	t2, s0, -0x648
+               	sd	t2, -0x770(s0)
+               	addi	t2, s0, -0x658
+               	sd	t2, -0x778(s0)
+               	addi	t2, s0, -0x668
+               	sd	t2, -0x780(s0)
+               	ld	t3, -0x720(s0)
+               	sext.w	t2, t3
+               	sd	t2, -0x788(s0)
+               	addi	a0, s0, -0x6e8
+               	mv	a4, a0
+               	li	t0, 0xf0
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x1
+               	li	t0, 0x1
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x2
+               	li	t0, 0x80
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x3
+               	li	t0, 0xff
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x4
+               	li	t0, 0x11
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x5
+               	li	t0, 0x2
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x6
+               	li	t0, 0xc8
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x7
+               	li	t0, 0x63
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0x8
+               	sb	zero, 0x0(a4)
+               	addi	a4, a0, 0x9
+               	li	t0, 0x7
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xa
+               	li	t0, 0xfa
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xb
+               	li	t0, 0x21
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xc
+               	li	t0, 0x80
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xd
+               	li	t0, 0x40
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xe
+               	li	t0, 0x5
+               	sb	t0, 0x0(a4)
+               	addi	a4, a0, 0xf
+               	li	t0, 0xc7
+               	sb	t0, 0x0(a4)
+               	mv	a4, a0
+               	lbu	a2, 0x0(a4)
+               	mv	a4, a1
+               	sb	a2, 0x0(a4)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x6f8
+               	mv	a2, a0
+               	li	t0, 0x11
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	li	t0, 0xff
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	li	t0, 0x81
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	li	t0, 0xc8
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	li	t0, 0x64
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	li	t0, 0x39
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	li	t0, 0x15
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	li	t0, 0xff
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	li	t0, 0x6
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	li	t0, 0xde
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	li	t0, 0x80
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	li	t0, 0xc0
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	li	t0, 0xfb
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	li	t0, 0x39
+               	sb	t0, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s6
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s6, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	sb	a1, 0x0(s1)
+               	mv	a2, t2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	ld	t2, -0x798(s0)
+               	addi	a2, t2, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x708
+               	mv	a2, a0
+               	li	t0, 0x1
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	li	t0, 0x3
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	li	t0, 0x9
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	li	t0, 0x1b
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	li	t0, 0x2
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	li	t0, 0x6
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	li	t0, 0x12
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	li	t0, 0x36
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	li	t0, 0x4
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	li	t0, 0xc
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	li	t0, 0x24
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	li	t0, 0x6c
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	li	t0, 0x8
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	li	t0, 0x18
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	li	t0, 0x48
+               	sb	t0, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	li	t0, 0xd8
+               	sb	t0, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
+               	mv	a2, s1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s1, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, s1, 0xf
+               	sb	a0, 0x0(a2)
+               	addi	a0, s0, -0x718
+               	mv	a2, a0
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	sb	zero, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	sb	zero, 0x0(a2)
+               	mv	a2, a0
+               	lbu	a4, 0x0(a2)
+               	mv	a2, s2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, s2, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a0, 0xf
+               	lbu	a0, 0x0(a2)
+               	addi	a2, s2, 0xf
+               	sb	a0, 0x0(a2)
+               	mv	a0, a1
+               	lbu	a2, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a2, t2
+               	mv	a2, a1
+               	lbu	a4, 0x0(a2)
+               	mv	a2, a3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x1
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x2
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x3
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x4
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x5
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x6
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x7
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x8
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0x9
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xa
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xb
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xc
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xd
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a4, 0x0(a2)
+               	addi	a2, a3, 0xe
+               	sb	a4, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	addi	a2, a3, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, a3
+               	sb	a0, 0x0(a1)
+               	addi	a0, a3, 0x7
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	mv	a1, a3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x3
+               	lbu	a2, 0x0(a1)
                	addi	a1, s3, 0x3
-               	lbu	s1, 0x0(a1)
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, a3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	sb	a0, 0x0(a1)
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s3
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s3, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s8, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	sb	a1, 0x0(s1)
-               	addi	a1, s8, 0xc
-               	lbu	s1, 0x0(a1)
+               	addi	a0, t2, 0x3
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
                	ld	t2, -0x798(s0)
-               	addw	a1, s1, t2
-               	mv	s1, s8
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	sb	s2, 0x0(s1)
-               	addi	s1, s8, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	sb	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	sb	a1, 0x0(s1)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
                	ld	t2, -0x790(s0)
-               	mv	a0, t2
+               	mv	a1, t2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x1
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x5
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x7
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x9
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xb
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xd
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x798(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xf
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a0, t2, 0xc
+               	lbu	a1, 0x0(a0)
+               	ld	t2, -0x788(s0)
+               	addw	a0, a1, t2
+               	ld	t2, -0x790(s0)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	sb	a2, 0x0(a1)
+               	ld	t2, -0x790(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	sb	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	sb	a0, 0x0(a1)
+               	lui	a0, 0xfcbf3
+               	addiw	a0, a0, -0x632
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x484
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x222
+               	slli	a0, a0, 0xc
+               	addi	a0, a0, 0x325
+               	mv	a1, s3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0xe78>
+               	mv	a1, s4
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0xe84>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	mv	a2, s5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	addi	a2, s5, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s5
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1050>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s6, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s6
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x121c>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	mv	a2, s7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	addi	a2, s7, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s7
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0xfac>
-               	mv	a1, a0
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x13e8>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s8, 0xf
+               	sb	a1, 0x0(a2)
+               	mv	a1, s8
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x15b4>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s9, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s9
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0xfc0>
-               	mv	a1, a0
-               	mv	s1, s7
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	mv	s2, s10
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	lbu	s3, 0x0(s1)
-               	addw	s1, s2, s3
-               	addi	s2, s10, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1780>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s10
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s10, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s10
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1194>
-               	mv	a1, a0
-               	mv	s1, s7
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	mv	s2, s11
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x1
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x2
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x3
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x4
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x5
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x6
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x8
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0x9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xa
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xb
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xc
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xd
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xe
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s7, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s9, 0xf
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	addi	s2, s11, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x194c>
+               	mv	a1, s5
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	mv	a2, s11
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x1
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x2
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x3
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x4
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x5
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x6
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x7
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0x9
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xa
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xb
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xc
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xd
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xe
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s5, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s1, 0xf
+               	lbu	a3, 0x0(a1)
+               	mulw	a1, a2, a3
+               	addi	a2, s11, 0xf
+               	sb	a1, 0x0(a2)
                	mv	a1, s11
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1368>
-               	mv	a1, a0
-               	mv	s1, s9
-               	lbu	s2, 0x0(s1)
-               	mv	s1, s7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	mv	s2, t2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x1
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x1
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x1
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x2
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x2
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x2
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x3
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x3
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x3
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x4
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x4
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x4
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x5
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x5
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x5
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x6
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x6
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x6
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x7
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x7
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x7
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x8
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x8
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x8
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0x9
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0x9
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0x9
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xa
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xa
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xa
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xb
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xb
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xb
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xc
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xc
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xc
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xd
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xd
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xd
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xe
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xe
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xe
-               	sb	s1, 0x0(s2)
-               	addi	s1, s9, 0xf
-               	lbu	s2, 0x0(s1)
-               	addi	s1, s7, 0xf
-               	lbu	s3, 0x0(s1)
-               	subw	s1, s2, s3
-               	ld	t2, -0x7c8(s0)
-               	addi	s2, t2, 0xf
-               	sb	s1, 0x0(s2)
-               	mv	a0, a1
-               	ld	t2, -0x7c8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1580>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	s1, 0x0(a2)
-               	mv	a2, s9
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	mv	s1, t2
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x1
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x1
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x2
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x2
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x3
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x3
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x4
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x4
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x5
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x5
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x6
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x6
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x7
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x7
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x8
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x8
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0x9
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0x9
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xa
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xa
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xb
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xb
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xc
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xc
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xd
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xd
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xe
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xe
-               	sb	a2, 0x0(s1)
-               	addi	a2, s7, 0xf
-               	lbu	s1, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	s2, 0x0(a2)
-               	mulw	a2, s1, s2
-               	ld	t2, -0x7d0(s0)
-               	addi	s1, t2, 0xf
-               	sb	a2, 0x0(s1)
-               	mv	a0, a1
-               	ld	t2, -0x7d0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1798>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	s1, 0x0(a2)
-               	mulw	a2, a3, s1
-               	ld	t2, -0x7d8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7d8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x19b0>
-               	mv	a1, a0
-               	mv	a2, s9
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e0(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7e0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1bc8>
-               	mv	a1, a0
-               	mv	a2, s10
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x1
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x2
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x3
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x4
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x5
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x6
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x7
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x8
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0x9
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xa
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xb
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xc
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xd
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xe
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s10, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s4, 0xf
-               	lbu	a4, 0x0(a2)
-               	mulw	a2, a3, a4
-               	ld	t2, -0x7e8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7e8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1de0>
-               	mv	a1, a0
-               	mv	a2, s5
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x1
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x2
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x3
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x4
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x5
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x6
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x8
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0x9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xa
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xb
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xc
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xd
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xe
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s7, 0xf
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f0(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7f0(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1ff8>
-               	mv	a1, a0
-               	mv	a2, s5
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s5, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	subw	a2, a3, a4
-               	ld	t2, -0x7f8(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x7f8(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2210>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	and	a2, a3, a4
-               	ld	t2, -0x800(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x800(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2428>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	or	a2, a3, a4
-               	ld	t2, -0x720(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x720(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2640>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	mv	a2, s9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x1
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x3
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x4
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x5
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x6
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x7
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x8
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0x9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xa
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xb
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xc
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xd
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xe
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	addi	a2, s9, 0xf
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x728(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x728(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2858>
-               	mv	a1, a0
-               	mv	a2, s7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x1
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x2
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x3
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x4
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x5
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x6
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x8
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0x9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xa
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xb
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xc
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xd
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xe
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s7, 0xf
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x730(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x730(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x29f0>
-               	mv	a1, a0
-               	mv	a2, s9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x1
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x2
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x3
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x4
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x5
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x6
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x7
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x8
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0x9
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xa
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xb
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xc
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xd
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xe
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	addi	a2, s9, 0xf
-               	lbu	a3, 0x0(a2)
-               	not	a2, a3
-               	ld	t2, -0x738(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x738(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2b88>
-               	mv	a1, a0
-               	ld	t2, -0x800(s0)
-               	mv	a2, t2
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	mv	a2, t2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	mv	a3, t2
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x1
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x1
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x1
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x2
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x2
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x2
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x3
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x3
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x3
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x4
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x4
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x4
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x5
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x5
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x5
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x6
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x6
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x6
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x7
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x7
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x7
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x8
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x8
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x8
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0x9
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0x9
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0x9
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xa
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xa
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xa
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xb
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xb
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xb
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xc
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xc
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xc
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xd
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xd
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xd
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xe
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xe
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xe
-               	sb	a2, 0x0(a3)
-               	ld	t2, -0x800(s0)
-               	addi	a2, t2, 0xf
-               	lbu	a3, 0x0(a2)
-               	ld	t2, -0x720(s0)
-               	addi	a2, t2, 0xf
-               	lbu	a4, 0x0(a2)
-               	xor	a2, a3, a4
-               	ld	t2, -0x740(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	mv	a0, a1
-               	ld	t2, -0x740(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2e20>
-               	mv	s1, a0
-               	mv	s2, s5
-               	li	s3, 0x0
-               	li	t0, 0x6
-               	bltu	s3, t0, 0x306c <corpus.cases.vec.vec_u8x16.checksum+0x2e40>
-               	j	0x3918 <corpus.cases.vec.vec_u8x16.checksum+0x36ec>
-               	mv	a0, s7
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s4
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	mv	a1, t2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x1
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x1
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x2
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x3
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x3
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x4
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x4
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x5
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x5
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x6
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x6
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x7
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x7
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x8
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x8
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0x9
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x9
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xa
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xa
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xb
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xb
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xc
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xc
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xd
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xd
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xe
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xe
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s4, 0xf
-               	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xf
-               	sb	a0, 0x0(a1)
-               	mv	a0, s1
-               	ld	t2, -0x748(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x304c>
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1b18>
                	mv	a1, s2
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7a0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1d28>
+               	mv	a1, s2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s2, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	subw	a1, a2, a3
+               	ld	t2, -0x7a8(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7a8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x1f38>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	ld	t2, -0x7b0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2148>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	ld	t2, -0x7b8(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b8(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2358>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x7c0(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7c0(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2568>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x728(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x728(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x26f8>
+               	mv	a1, s4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x1
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x2
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x3
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x4
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x5
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x6
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x7
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x8
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0x9
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xa
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xb
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xc
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xd
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xe
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s4, 0xf
+               	lbu	a2, 0x0(a1)
+               	not	a1, a2
+               	ld	t2, -0x730(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x730(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2888>
+               	ld	t2, -0x7b0(s0)
+               	mv	a1, t2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
                	mv	a1, t2
                	lbu	a3, 0x0(a1)
                	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x7b0(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x7b8(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x738(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x738(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2b18>
+               	mv	s5, a0
+               	mv	s6, s2
+               	li	s7, 0x0
+               	li	t0, 0x6
+               	bltu	s7, t0, 0x3098 <corpus.cases.vec.vec_u8x16.checksum+0x2b38>
+               	j	0x3944 <corpus.cases.vec.vec_u8x16.checksum+0x33e4>
+               	mv	a0, s3
+               	lbu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x1
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x1
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x3
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x3
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x5
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x5
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x5
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x7
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x7
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x7
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x9
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x9
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x9
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xb
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xb
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xb
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xd
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xd
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xd
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xf
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xf
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xf
+               	sb	a0, 0x0(a1)
+               	mv	a0, s5
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2d44>
+               	mv	a1, s6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	mv	a1, t2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x1
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x1
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x2
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x2
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x3
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x3
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x4
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x4
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x5
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x5
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x6
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x6
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x7
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x7
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x8
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x8
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0x9
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0x9
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xa
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xa
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xb
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xb
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xc
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xc
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xd
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xd
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xe
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xe
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s6, 0xf
+               	lbu	a2, 0x0(a1)
+               	ld	t2, -0x740(s0)
+               	addi	a1, t2, 0xf
+               	lbu	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	ld	t2, -0x748(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x748(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x2f94>
+               	mv	a1, s2
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	mv	a2, t2
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x1
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x1
+               	addi	a1, s3, 0x1
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x1
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x2
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x2
+               	addi	a1, s3, 0x2
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x2
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x3
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x3
+               	addi	a1, s3, 0x3
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x3
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x4
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x4
+               	addi	a1, s3, 0x4
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x4
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x5
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x5
+               	addi	a1, s3, 0x5
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x5
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x6
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x6
+               	addi	a1, s3, 0x6
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x6
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x7
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x7
+               	addi	a1, s3, 0x7
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x7
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x8
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x8
+               	addi	a1, s3, 0x8
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x8
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0x9
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0x9
+               	addi	a1, s3, 0x9
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0x9
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xa
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xa
+               	addi	a1, s3, 0xa
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xa
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xb
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xb
+               	addi	a1, s3, 0xb
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xb
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xc
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xc
+               	addi	a1, s3, 0xc
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xc
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xd
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xd
+               	addi	a1, s3, 0xd
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xd
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xe
                	lbu	a2, 0x0(a1)
-               	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xe
+               	addi	a1, s3, 0xe
                	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
+               	addw	a1, a2, a3
                	ld	t2, -0x750(s0)
                	addi	a2, t2, 0xe
                	sb	a1, 0x0(a2)
                	addi	a1, s2, 0xf
                	lbu	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x750(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x750(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x31a4>
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, s4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	mv	a2, t2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x1
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x1
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x2
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x2
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x3
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x3
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x4
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x4
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x5
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x5
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x6
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x6
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x7
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x7
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x8
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x8
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0x9
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0x9
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xa
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xa
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xb
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xb
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xc
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xc
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xd
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xd
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xe
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xe
+               	sb	a1, 0x0(a2)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, s4, 0xf
+               	lbu	a3, 0x0(a1)
+               	addw	a1, a2, a3
+               	ld	t2, -0x758(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x758(s0)
+               	mv	a1, t2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x33b4>
+               	addi	s7, s7, 0x1
+               	mv	s5, a0
+               	ld	t2, -0x758(s0)
+               	mv	s3, t2
                	ld	t2, -0x748(s0)
-               	addi	a1, t2, 0xf
-               	lbu	a3, 0x0(a1)
-               	xor	a1, a2, a3
-               	ld	t2, -0x750(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x750(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x329c>
-               	mv	a1, s5
-               	lbu	a2, 0x0(a1)
-               	mv	a1, s7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	mv	a2, t2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x1
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x1
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x3
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x3
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x4
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x5
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x5
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x6
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x7
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x8
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0x9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0x9
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xa
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xb
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xb
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xc
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xd
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xd
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xe
-               	sb	a1, 0x0(a2)
-               	addi	a1, s5, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s7, 0xf
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x758(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x758(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x34ac>
-               	mv	a1, s7
-               	lbu	a2, 0x0(a1)
-               	mv	a1, s9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	mv	a2, t2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x1
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x1
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x2
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x2
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x3
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x3
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x4
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x4
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x5
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x5
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x6
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x6
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x7
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x7
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x8
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x8
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0x9
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0x9
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xa
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xa
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xb
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xb
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xc
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xc
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xd
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xd
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xe
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xe
-               	sb	a1, 0x0(a2)
-               	addi	a1, s7, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, s9, 0xf
-               	lbu	a3, 0x0(a1)
-               	addw	a1, a2, a3
-               	ld	t2, -0x760(s0)
-               	addi	a2, t2, 0xf
-               	sb	a1, 0x0(a2)
-               	ld	t2, -0x760(s0)
-               	mv	a1, t2
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x36bc>
-               	addi	s3, s3, 0x1
-               	mv	s1, a0
-               	ld	t2, -0x760(s0)
-               	mv	s7, t2
+               	mv	s6, t2
                	ld	t2, -0x750(s0)
                	mv	s2, t2
-               	ld	t2, -0x758(s0)
-               	mv	s5, t2
                	li	t0, 0x6
-               	bltu	s3, t0, 0x306c <corpus.cases.vec.vec_u8x16.checksum+0x2e40>
-               	addi	s3, s0, -0x6e8
-               	mv	a0, s3
+               	bltu	s7, t0, 0x3098 <corpus.cases.vec.vec_u8x16.checksum+0x2b38>
+               	addi	s2, s0, -0x6a8
+               	mv	a0, s2
                	li	t0, 0x7
                	and	a1, a0, t0
-               	bnez	a1, 0x394c <corpus.cases.vec.vec_u8x16.checksum+0x3720>
+               	bnez	a1, 0x3978 <corpus.cases.vec.vec_u8x16.checksum+0x3418>
                	mv	a1, a0
                	li	a2, 0x40
                	sd	zero, 0x0(a1)
                	addi	a1, a1, 0x8
                	addi	a2, a2, -0x8
                	li	t0, 0x0
-               	bne	a2, t0, 0x3934 <corpus.cases.vec.vec_u8x16.checksum+0x3708>
-               	j	0x3968 <corpus.cases.vec.vec_u8x16.checksum+0x373c>
+               	bne	a2, t0, 0x3960 <corpus.cases.vec.vec_u8x16.checksum+0x3400>
+               	j	0x3994 <corpus.cases.vec.vec_u8x16.checksum+0x3434>
                	mv	a1, a0
                	li	a0, 0x40
                	sb	zero, 0x0(a1)
                	addi	a1, a1, 0x1
                	addi	a0, a0, -0x1
                	li	t0, 0x0
-               	bne	a0, t0, 0x3954 <corpus.cases.vec.vec_u8x16.checksum+0x3728>
+               	bne	a0, t0, 0x3980 <corpus.cases.vec.vec_u8x16.checksum+0x3420>
+               	mv	a0, s2
+               	mv	a1, s3
+               	lbu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x3
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, s3, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xf
+               	sb	a2, 0x0(a1)
                	mv	a0, s3
-               	mv	a1, s7
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x1
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x3
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x5
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x7
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x9
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xb
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xd
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sb	a2, 0x0(a1)
-               	addi	a1, s7, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xf
-               	sb	a2, 0x0(a1)
-               	mv	a0, s7
-               	lbu	a1, 0x0(a0)
-               	mv	a0, s9
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	mv	a1, t2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x1
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x1
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x2
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x2
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x3
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x3
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x4
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x4
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x5
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x5
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x6
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x6
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x7
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x7
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x8
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x8
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0x9
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x9
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xa
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xa
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xb
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xb
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xc
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xc
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xd
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xd
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xe
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xe
-               	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
-               	lbu	a1, 0x0(a0)
-               	addi	a0, s9, 0xf
-               	lbu	a2, 0x0(a0)
-               	addw	a0, a1, a2
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xf
-               	sb	a0, 0x0(a1)
-               	addi	a0, s3, 0x10
-               	ld	t2, -0x768(s0)
-               	mv	a1, t2
-               	lbu	a2, 0x0(a1)
-               	mv	a1, a0
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x1
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x1
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x2
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x2
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x3
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x3
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x4
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x4
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x5
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x5
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x6
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x6
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x7
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x7
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x8
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x8
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0x9
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0x9
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xa
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xa
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xb
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xb
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xc
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xc
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xd
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xd
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xe
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xe
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x768(s0)
-               	addi	a1, t2, 0xf
-               	lbu	a2, 0x0(a1)
-               	addi	a1, a0, 0xf
-               	sb	a2, 0x0(a1)
-               	mv	a0, s7
                	lbu	a1, 0x0(a0)
                	mv	a0, s4
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x1
+               	addi	a0, s3, 0x1
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x1
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x1
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x2
+               	addi	a0, s3, 0x2
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x2
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x3
+               	addi	a0, s3, 0x3
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x3
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x3
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x4
+               	addi	a0, s3, 0x4
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x4
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x5
+               	addi	a0, s3, 0x5
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x5
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x5
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x6
+               	addi	a0, s3, 0x6
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x6
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x7
+               	addi	a0, s3, 0x7
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x7
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x7
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x8
+               	addi	a0, s3, 0x8
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x8
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0x9
+               	addi	a0, s3, 0x9
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0x9
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x9
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xa
+               	addi	a0, s3, 0xa
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xa
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xb
+               	addi	a0, s3, 0xb
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xb
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xb
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xc
+               	addi	a0, s3, 0xc
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xc
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xd
+               	addi	a0, s3, 0xd
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xd
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xd
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xe
+               	addi	a0, s3, 0xe
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xe
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	sb	a0, 0x0(a1)
-               	addi	a0, s7, 0xf
+               	addi	a0, s3, 0xf
                	lbu	a1, 0x0(a0)
                	addi	a0, s4, 0xf
                	lbu	a2, 0x0(a0)
-               	mulw	a0, a1, a2
-               	ld	t2, -0x770(s0)
+               	addw	a0, a1, a2
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xf
                	sb	a0, 0x0(a1)
-               	addi	a0, s3, 0x20
-               	ld	t2, -0x770(s0)
+               	addi	a0, s2, 0x10
+               	ld	t2, -0x760(s0)
                	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	mv	a1, a0
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x1
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x3
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x5
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x7
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x9
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xb
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xd
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sb	a2, 0x0(a1)
-               	ld	t2, -0x770(s0)
+               	ld	t2, -0x760(s0)
                	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xf
                	sb	a2, 0x0(a1)
-               	addi	a0, s3, 0x30
-               	mv	a1, s2
+               	mv	a0, s3
+               	lbu	a1, 0x0(a0)
+               	mv	a0, s1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x1
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x1
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x1
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x2
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x2
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x3
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x3
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x3
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x4
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x4
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x5
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x5
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x5
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x6
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x6
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x7
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x7
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x7
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x8
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0x9
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0x9
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x9
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xa
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xa
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xb
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xb
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xb
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xc
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xc
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xd
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xd
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xd
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xe
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xe
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
+               	sb	a0, 0x0(a1)
+               	addi	a0, s3, 0xf
+               	lbu	a1, 0x0(a0)
+               	addi	a0, s1, 0xf
+               	lbu	a2, 0x0(a0)
+               	mulw	a0, a1, a2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xf
+               	sb	a0, 0x0(a1)
+               	addi	a0, s2, 0x20
+               	ld	t2, -0x768(s0)
+               	mv	a1, t2
                	lbu	a2, 0x0(a1)
                	mv	a1, a0
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x1
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x1
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x1
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x2
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x2
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x3
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x3
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x3
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x4
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x4
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x5
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x5
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x5
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x6
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x6
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x7
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x7
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x7
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x8
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x8
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x9
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0x9
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0x9
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xa
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xa
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xb
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xb
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xb
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xc
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xc
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xd
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xd
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xd
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xe
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xe
                	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xf
+               	ld	t2, -0x768(s0)
+               	addi	a1, t2, 0xf
                	lbu	a2, 0x0(a1)
                	addi	a1, a0, 0xf
                	sb	a2, 0x0(a1)
-               	li	s2, 0x0
+               	addi	a0, s2, 0x30
+               	mv	a1, s6
+               	lbu	a2, 0x0(a1)
+               	mv	a1, a0
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x1
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x1
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x2
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x2
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x3
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x3
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x4
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x4
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x5
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x5
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x6
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x6
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x7
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x7
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x8
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0x9
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0x9
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xa
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xa
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xb
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xb
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xc
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xc
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xd
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xd
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xe
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xe
+               	sb	a2, 0x0(a1)
+               	addi	a1, s6, 0xf
+               	lbu	a2, 0x0(a1)
+               	addi	a1, a0, 0xf
+               	sb	a2, 0x0(a1)
+               	li	s1, 0x0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4208 <corpus.cases.vec.vec_u8x16.checksum+0x3fdc>
-               	j	0x4378 <corpus.cases.vec.vec_u8x16.checksum+0x414c>
+               	bltu	s1, t0, 0x4234 <corpus.cases.vec.vec_u8x16.checksum+0x3cd4>
+               	j	0x43a4 <corpus.cases.vec.vec_u8x16.checksum+0x3e44>
                	li	t0, 0x10
-               	mul	a0, s2, t0
-               	add	a1, s3, a0
+               	mul	a0, s1, t0
+               	add	a1, s2, a0
                	mv	a0, a1
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	mv	a0, t2
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x1
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x1
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x2
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x2
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x3
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x3
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x4
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x4
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x5
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x5
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x6
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x6
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x7
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x7
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x8
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x8
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0x9
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0x9
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xa
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xa
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xb
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xb
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xc
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xc
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xd
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xd
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xe
                	lbu	a2, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xe
                	sb	a2, 0x0(a0)
                	addi	a0, a1, 0xf
                	lbu	a1, 0x0(a0)
-               	ld	t2, -0x778(s0)
+               	ld	t2, -0x770(s0)
                	addi	a0, t2, 0xf
                	sb	a1, 0x0(a0)
-               	mv	a0, s1
-               	ld	t2, -0x778(s0)
+               	mv	a0, s5
+               	ld	t2, -0x770(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x4134>
-               	addi	s2, s2, 0x1
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x3e2c>
+               	addi	s1, s1, 0x1
+               	mv	s5, a0
                	li	t0, 0x4
-               	bltu	s2, t0, 0x4208 <corpus.cases.vec.vec_u8x16.checksum+0x3fdc>
-               	addi	a0, s0, -0x718
-               	mv	a1, a0
+               	bltu	s1, t0, 0x4234 <corpus.cases.vec.vec_u8x16.checksum+0x3cd4>
+               	addi	s1, s0, -0x6d8
+               	mv	a0, s1
                	li	t0, 0x7
-               	and	a2, a1, t0
-               	bnez	a2, 0x43ac <corpus.cases.vec.vec_u8x16.checksum+0x4180>
-               	mv	a2, a1
-               	li	a3, 0x30
-               	sd	zero, 0x0(a2)
-               	addi	a2, a2, 0x8
-               	addi	a3, a3, -0x8
-               	li	t0, 0x0
-               	bne	a3, t0, 0x4394 <corpus.cases.vec.vec_u8x16.checksum+0x4168>
-               	j	0x43c8 <corpus.cases.vec.vec_u8x16.checksum+0x419c>
-               	mv	a2, a1
-               	li	a1, 0x30
-               	sb	zero, 0x0(a2)
-               	addi	a2, a2, 0x1
-               	addi	a1, a1, -0x1
-               	li	t0, 0x0
-               	bne	a1, t0, 0x43b4 <corpus.cases.vec.vec_u8x16.checksum+0x4188>
+               	and	a1, a0, t0
+               	bnez	a1, 0x43d8 <corpus.cases.vec.vec_u8x16.checksum+0x3e78>
                	mv	a1, a0
+               	li	a2, 0x30
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x43c0 <corpus.cases.vec.vec_u8x16.checksum+0x3e60>
+               	j	0x43f4 <corpus.cases.vec.vec_u8x16.checksum+0x3e94>
+               	mv	a1, a0
+               	li	a0, 0x30
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x43e0 <corpus.cases.vec.vec_u8x16.checksum+0x3e80>
+               	mv	a0, s1
                	lui	t0, 0x100
                	slli	t0, t0, 0xc
                	addi	t0, t0, -0x1
-               	sw	t0, 0x0(a1)
-               	addi	a2, s3, 0x20
-               	mv	a3, a2
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	mv	a3, t2
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x1
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x1
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x2
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x2
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x3
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x3
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x4
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x4
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x5
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x5
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x6
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x6
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x7
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x7
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x8
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x8
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0x9
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0x9
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xa
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xa
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xb
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xb
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xc
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xc
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xd
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xd
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xe
-               	lbu	a4, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xe
-               	sb	a4, 0x0(a3)
-               	addi	a3, a2, 0xf
-               	lbu	a2, 0x0(a3)
-               	ld	t2, -0x780(s0)
-               	addi	a3, t2, 0xf
-               	sb	a2, 0x0(a3)
-               	addi	s2, a0, 0x10
-               	ld	t2, -0x780(s0)
+               	sw	t0, 0x0(a0)
+               	addi	a1, s2, 0x20
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	mv	a2, t2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x1
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x3
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x4
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x5
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x6
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x7
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x8
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0x9
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xa
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xb
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xc
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xd
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xe
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	ld	t2, -0x778(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	addi	a1, s1, 0x10
+               	ld	t2, -0x778(s0)
                	mv	a2, t2
                	lbu	a3, 0x0(a2)
-               	mv	a2, s2
+               	mv	a2, a1
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x1
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x1
+               	addi	a2, a1, 0x1
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x2
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x2
+               	addi	a2, a1, 0x2
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x3
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x3
+               	addi	a2, a1, 0x3
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x4
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x4
+               	addi	a2, a1, 0x4
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x5
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x5
+               	addi	a2, a1, 0x5
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x6
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x6
+               	addi	a2, a1, 0x6
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x7
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x7
+               	addi	a2, a1, 0x7
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x8
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x8
+               	addi	a2, a1, 0x8
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0x9
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0x9
+               	addi	a2, a1, 0x9
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xa
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xa
+               	addi	a2, a1, 0xa
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xb
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xb
+               	addi	a2, a1, 0xb
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xc
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xc
+               	addi	a2, a1, 0xc
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xd
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xd
+               	addi	a2, a1, 0xd
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xe
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xe
+               	addi	a2, a1, 0xe
                	sb	a3, 0x0(a2)
-               	ld	t2, -0x780(s0)
+               	ld	t2, -0x778(s0)
                	addi	a2, t2, 0xf
                	lbu	a3, 0x0(a2)
-               	addi	a2, s2, 0xf
+               	addi	a2, a1, 0xf
                	sb	a3, 0x0(a2)
-               	addi	s3, a0, 0x20
+               	addi	a1, s1, 0x20
                	lui	t0, 0x12345
                	addiw	t0, t0, 0x678
-               	sw	t0, 0x0(s3)
-               	lw	a2, 0x0(a1)
-               	mv	a0, s1
+               	sw	t0, 0x0(a1)
+               	lw	a1, 0x0(a0)
+               	slli	a2, a1, 0x20
+               	srli	a2, a2, 0x20
+               	mv	a0, s5
                	mv	a1, a2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x4454>
-               	mv	a1, s2
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	mv	a1, t2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x1
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x1
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x2
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x2
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x3
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x3
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x4
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x4
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x5
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x5
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x6
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x6
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x7
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x7
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x8
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x8
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0x9
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0x9
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xa
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xa
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xb
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xb
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xc
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xc
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xd
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xd
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xe
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xe
-               	sb	a2, 0x0(a1)
-               	addi	a1, s2, 0xf
-               	lbu	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
-               	addi	a1, t2, 0xf
-               	sb	a2, 0x0(a1)
-               	ld	t2, -0x788(s0)
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x4154>
+               	addi	a1, s1, 0x10
+               	mv	a2, a1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	mv	a2, t2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x1
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x1
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x2
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x2
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x3
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x3
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x4
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x4
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x5
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x5
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x6
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x6
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x7
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x7
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x8
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x8
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0x9
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0x9
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xa
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xa
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xb
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xb
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xc
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xc
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xd
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xd
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xe
+               	lbu	a3, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xe
+               	sb	a3, 0x0(a2)
+               	addi	a2, a1, 0xf
+               	lbu	a1, 0x0(a2)
+               	ld	t2, -0x780(s0)
+               	addi	a2, t2, 0xf
+               	sb	a1, 0x0(a2)
+               	ld	t2, -0x780(s0)
                	mv	a1, t2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x45a4>
-               	lw	a1, 0x0(s3)
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x42a8>
+               	addi	a1, s1, 0x20
+               	lw	a2, 0x0(a1)
+               	slli	a1, a2, 0x20
+               	srli	a1, a1, 0x20
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x45b0>
-               	ld	s1, 0x7f8(sp)
-               	ld	s2, 0x7f0(sp)
-               	ld	s3, 0x7e8(sp)
-               	ld	s4, 0x7e0(sp)
-               	ld	s5, 0x7d8(sp)
-               	ld	s6, 0x7d0(sp)
-               	ld	s7, 0x7c8(sp)
-               	ld	s8, 0x7c0(sp)
-               	ld	s9, 0x7b8(sp)
-               	ld	s10, 0x7b0(sp)
-               	ld	s11, 0x7a8(sp)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x7f8
-               	add	t1, sp, t1
-               	ld	ra, 0x0(t1)
-               	lui	t1, 0x1
-               	addiw	t1, t1, -0x800
-               	add	t1, sp, t1
-               	ld	s0, 0x0(t1)
-               	lui	t0, 0x1
-               	addiw	t0, t0, -0x7f0
-               	add	sp, sp, t0
+               	jalr	ra <corpus.cases.vec.vec_u8x16.checksum+0x42c0>
+               	ld	s1, 0x7b8(sp)
+               	ld	s2, 0x7b0(sp)
+               	ld	s3, 0x7a8(sp)
+               	ld	s4, 0x7a0(sp)
+               	ld	s5, 0x798(sp)
+               	ld	s6, 0x790(sp)
+               	ld	s7, 0x788(sp)
+               	ld	s8, 0x780(sp)
+               	ld	s9, 0x778(sp)
+               	ld	s10, 0x770(sp)
+               	ld	s11, 0x768(sp)
+               	ld	ra, 0x7c8(sp)
+               	ld	s0, 0x7c0(sp)
+               	addi	sp, sp, 0x7d0
                	ret

--- a/test/golden/x86_64-linux/bits/logic_u32.dis
+++ b/test/golden/x86_64-linux/bits/logic_u32.dis
@@ -11,178 +11,460 @@ Disassembly of section .text:
                	movq	%r13, -0x48(%rbp)
                	movq	%r14, -0x50(%rbp)
                	movq	%r15, -0x58(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      # imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      # imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      # imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%r12d, %r15d
-               	andl	%ebx, %r15d
-               	movl	%r15d, %esi
-               	callq	 <L1>
+               	xorl	%ebx, %r14d
+               	movl	%ebx, %eax
+               	andl	%r12d, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r8d
-               	orl	%ebx, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
+               	movl	%ebx, %edx
+               	orl	%r12d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	xorl	%ebx, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	xorl	$-0x1, %edx
+               	movl	%ebx, %edx
+               	xorl	%r12d, %edx
                	movl	%edx, %esi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
                	movl	%ebx, %edx
                	xorl	$-0x1, %edx
                	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movl	%r12d, %edx
+               	xorl	$-0x1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
                	movl	%r13d, %edx
                	andl	%r14d, %edx
                	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
                	movl	%r13d, %edx
                	orl	%r14d, %edx
                	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r8d
-               	xorl	%r14d, %r8d
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	xorl	$-0x1, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	xorl	$-0x1, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	andl	%r13d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	orl	%r14d, %esi
-               	callq	 <L12>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	andl	%r14d, %esi
-               	callq	 <L13>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	orl	%r13d, %esi
-               	callq	 <L14>
+               	movl	%r13d, %edx
+               	xorl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r15d, %esi
-               	orl	%r8d, %esi
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	xorl	$-0x1, %r15d
-               	movl	%r15d, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %edx
+               	movl	%r13d, %edx
                	xorl	$-0x1, %edx
                	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	%rax, %r15
-               	movl	$0x0, %r8d
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movl	%r14d, %edx
+               	xorl	$-0x1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movl	%ebx, %edx
+               	andl	%r13d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movl	%r12d, %edx
+               	orl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movl	%ebx, %edx
+               	andl	%r14d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movl	%r12d, %edx
+               	orl	%r13d, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L26>
+<L26>:
+               	movl	%ebx, %r15d
+               	andl	%r12d, %r15d
+               	movl	%r13d, %r8d
+               	xorl	%r14d, %r8d
                	movq	%r8, -0x28(%rbp)
                	movq	-0x28(%rbp), %r8
-               	cmpl	$0x8, %r8d
-               	jb	 <L19>
-               	jmp	 <L23>
-<L19>:
-               	movq	-0x28(%rbp), %r9
-               	movl	%r12d, %r8d
-               	xorl	%r9d, %r8d
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x28(%rbp), %r8
-               	movl	%ebx, %edx
-               	orl	%r8d, %edx
-               	movq	-0x28(%rbp), %r8
-               	movl	%r14d, %esi
-               	xorl	%r8d, %esi
-               	movl	%r13d, %r8d
-               	andl	%esi, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	movl	%r8d, %esi
-               	andl	%edx, %esi
-               	movq	%r15, %rdi
-               	callq	 <L20>
-<L20>:
+               	movl	%r15d, %esi
+               	orl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
+               	callq	 <L27>
+<L27>:
+               	movl	%ebx, %esi
+               	orl	%r12d, %esi
+               	xorl	$-0x1, %esi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	xorl	$-0x1, %r15d
+               	movq	%rax, %rdi
+               	movl	%r15d, %esi
+               	callq	 <L29>
+<L29>:
+               	movq	-0x28(%rbp), %r8
                	movl	%r8d, %edx
-               	orl	%r9d, %edx
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
+               	xorl	$-0x1, %edx
                	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x20(%rbp)
                	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movl	%r8d, %ecx
-               	xorl	%r9d, %ecx
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	movq	-0x28(%rbp), %r8
+               	cmpl	$0x8, %r8d
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
+               	movl	%ebx, %r8d
+               	xorl	%r9d, %r8d
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movl	%r12d, %edi
+               	orl	%r8d, %edi
+               	movq	-0x20(%rbp), %r8
+               	movl	%r14d, %r15d
+               	xorl	%r8d, %r15d
+               	movl	%r13d, %r8d
+               	andl	%r15d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %r15d
+               	andl	%edi, %r15d
+               	movl	%r15d, %edi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	orl	%r9d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movl	%r8d, %eax
+               	xorl	%r9d, %eax
+               	xorl	$-0x1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x20(%rbp), %r8
                	movl	%r8d, %eax
                	addl	$0x1, %eax
+               	movq	%r15, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpl	$0x8, %r8d
-               	jb	 <L19>
-<L23>:
-               	movq	%r15, %rax
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13

--- a/test/golden/x86_64-linux/bits/logic_u64.dis
+++ b/test/golden/x86_64-linux/bits/logic_u64.dis
@@ -12,170 +12,442 @@ Disassembly of section .text:
                	movq	%r14, -0x50(%rbp)
                	movq	%r15, -0x58(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 # imm = 0x5555555555555555
                	xorq	%rbx, %r14
-               	movq	%rbx, %r15
-               	andq	%r12, %r15
-               	movq	%r15, %rsi
-               	callq	 <L1>
+               	movq	%rbx, %rax
+               	andq	%r12, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r8
-               	orq	%r12, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
+               	movq	%rbx, %rax
+               	orq	%r12, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	xorq	%r12, %rsi
-               	callq	 <L3>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L4>
+               	movq	%rbx, %rax
+               	xorq	%r12, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L5>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	andq	%r14, %rsi
-               	callq	 <L6>
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	orq	%r14, %rsi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %r8
-               	xorq	%r14, %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	%r12, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L9>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	xorq	$-0x1, %rsi
-               	callq	 <L10>
+               	movq	%r13, %rax
+               	andq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	andq	%r13, %rsi
-               	callq	 <L11>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	orq	%r14, %rsi
-               	callq	 <L12>
+               	movq	%r13, %rax
+               	orq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	andq	%r14, %rsi
-               	callq	 <L13>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
+               	movq	%r13, %rax
+               	xorq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r13, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%rbx, %rax
+               	andq	%r13, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movq	%r12, %rax
+               	orq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movq	%rbx, %rax
+               	andq	%r14, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
                	movq	%r12, %rsi
                	orq	%r13, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movq	%rdx, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	%rbx, %r15
+               	andq	%r12, %r15
+               	movq	%r13, %r8
+               	xorq	%r14, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x28(%rbp), %r8
                	movq	%r15, %rsi
                	orq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L27>
+<L27>:
+               	movq	%rbx, %rsi
+               	orq	%r12, %rsi
+               	xorq	$-0x1, %rsi
                	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
                	xorq	$-0x1, %r15
-               	movq	%r15, %rsi
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movq	%r15, %rsi
+               	callq	 <L29>
+<L29>:
+               	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdx
                	xorq	$-0x1, %rdx
+               	movq	%rax, %rdi
                	movq	%rdx, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r15
+               	callq	 <L30>
+<L30>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L19>
-               	jmp	 <L23>
-<L19>:
-               	movq	-0x28(%rbp), %r9
+               	jb	 <L31>
+               	jmp	 <L38>
+<L31>:
+               	movq	-0x20(%rbp), %r9
                	movq	%rbx, %r8
                	xorq	%r9, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x28(%rbp), %r8
-               	movq	%r12, %rdx
-               	orq	%r8, %rdx
-               	movq	-0x28(%rbp), %r8
-               	movq	%r14, %rsi
-               	xorq	%r8, %rsi
+               	movq	%r8, -0x18(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r12, %rdi
+               	orq	%r8, %rdi
+               	movq	-0x20(%rbp), %r8
+               	movq	%r14, %r15
+               	xorq	%r8, %r15
                	movq	%r13, %r8
-               	andq	%rsi, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	andq	%rdx, %rsi
+               	andq	%r15, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %r15
+               	andq	%rdi, %r15
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	orq	%r9, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
                	movq	%r15, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x10(%rbp), %r9
+               	movq	%r8, %rax
+               	xorq	%r9, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
                	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movq	%r8, %rsi
-               	orq	%r9, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	-0x8(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r15
-               	movq	-0x28(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x28(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L19>
-<L23>:
-               	movq	%r15, %rax
+               	jb	 <L31>
+<L38>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13

--- a/test/golden/x86_64-linux/bits/shift_i32.dis
+++ b/test/golden/x86_64-linux/bits/shift_i32.dis
@@ -11,218 +11,497 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      # imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      # imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      # imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%ebx, %esi
-               	callq	 <L1>
-<L1>:
+               	xorl	%ebx, %r14d
+               	movslq	%r12d, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L4>
+               	movl	%r12d, %eax
+               	shll	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L5>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L6>
+               	movslq	%r12d, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L8>
+               	movl	%r12d, %eax
+               	sarl	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L9>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	%r12d, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
                	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	sarl	%edx
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shll	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movl	%r13d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	sarl	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L14>
+               	movl	%r13d, %eax
+               	sarl	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L15>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L16>
+               	movl	%r13d, %eax
+               	sarl	$0x1f, %eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L17>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L18>
+               	movl	%r14d, %eax
+               	shll	%eax
+               	movslq	%eax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	sarl	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L19>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
+               	movl	%r14d, %eax
+               	sarl	%eax
+               	movq	%rdx, %rdi
+               	movl	%eax, %esi
                	callq	 <L20>
 <L20>:
+               	movl	%ebx, %edx
+               	shll	$0x5, %edx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	sarl	$0x3f, %edx
                	movl	%edx, %esi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L22>
-               	jmp	 <L27>
-<L22>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
                	movl	%ebx, %edx
-               	shll	%cl, %edx
-               	movq	%r15, %rdi
+               	sarl	$0x5, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L22>
+<L22>:
+               	movl	%r12d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L23>
 <L23>:
+               	movl	%r12d, %edx
+               	sarl	$0x20, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L24>
 <L24>:
+               	movl	%r12d, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r12d, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r13d, %esi
-               	shll	%cl, %esi
+               	movl	%edx, %esi
                	callq	 <L25>
 <L25>:
+               	movl	%r12d, %edx
+               	sarl	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r14d, %edx
-               	sarl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L22>
+               	movl	%r12d, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L27>
 <L27>:
-               	movl	$0x1e, %r13d
-               	cmpl	$0x28, %r13d
-               	jb	 <L28>
-               	jmp	 <L31>
+               	movl	%r12d, %edx
+               	sarl	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L28>
 <L28>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r15, %rdi
-               	movl	%eax, %esi
+               	movl	%r13d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
                	callq	 <L29>
 <L29>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	sarl	%cl, %edx
+               	movl	%r13d, %edx
+               	sarl	$0x3f, %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L30>
 <L30>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %r15
-               	cmpl	$0x28, %r13d
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movslq	%esi, %rdi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rsi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r13d, %eax
+               	shll	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r14d, %eax
+               	sarl	%cl, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movl	%edx, %esi
+               	addl	%ebx, %esi
+               	movl	%esi, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movslq	%esi, %rdi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%r12d, %edi
+               	sarl	%cl, %edi
+               	movslq	%edi, %r13
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %edx
+               	movq	%rsi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L41>
+<L46>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/bits/shift_i64.dis
+++ b/test/golden/x86_64-linux/bits/shift_i64.dis
@@ -12,192 +12,469 @@ Disassembly of section .text:
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 # imm = 0x5555555555555555
                	xorq	%rbx, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r12, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	%rsi
-               	callq	 <L2>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x3f, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L4>
+               	movq	%r12, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	%rsi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x3f, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	%rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	%rsi
-               	callq	 <L8>
+               	movq	%r12, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	$0x3f, %rsi
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shlq	%rsi
-               	callq	 <L10>
+               	movq	%r12, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movq	%r13, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	%r13, %rdx
+               	sarq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r13, %rdx
+               	sarq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
                	movq	%r14, %rsi
                	sarq	%rsi
-               	callq	 <L11>
-<L11>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	shlq	$0x5, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	sarq	$0x5, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x40, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x41, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x41, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x7f, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	sarq	$0x7f, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	$0x40, %rsi
                	callq	 <L20>
 <L20>:
+               	movq	%rbx, %rsi
+               	shlq	$0x5, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	sarq	$0x7f, %rsi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L22>
-               	jmp	 <L27>
+               	movq	%rbx, %rsi
+               	sarq	$0x5, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	sarq	%cl, %rsi
+               	sarq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
+               	movq	%r12, %rsi
+               	shlq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rsi
-               	shlq	%cl, %rsi
                	callq	 <L25>
 <L25>:
+               	movq	%r12, %rsi
+               	sarq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rsi
-               	sarq	%cl, %rsi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L22>
-<L27>:
-               	movq	$0x3c, %r13
-               	cmpq	$0x48, %r13
-               	jb	 <L28>
-               	jmp	 <L31>
-<L28>:
-               	movq	%r13, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movq	%r12, %rsi
+               	sarq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	%r13, %rsi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movq	%r14, %rcx
-               	movq	%r12, %rsi
-               	sarq	%cl, %rsi
+               	movq	%r13, %rsi
+               	sarq	$0x7f, %rsi
                	movq	%rax, %rdi
                	callq	 <L30>
 <L30>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r15
-               	cmpq	$0x48, %r13
-               	jb	 <L28>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+               	jmp	 <L40>
 <L31>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rsi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L32>
+<L33>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r13, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	sarq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L38>
+<L39>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L31>
+<L40>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+               	jmp	 <L46>
+<L41>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L42>
+<L43>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	sarq	%cl, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L44>
+<L45>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L41>
+<L46>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/bits/shift_u32.dis
+++ b/test/golden/x86_64-linux/bits/shift_u32.dis
@@ -11,212 +11,491 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %ebx       # imm = 0xFFFFFFFF
-               	xorl	%r12d, %ebx
+               	movl	%edi, %ebx
+               	movl	$0xffffffff, %r12d      # imm = 0xFFFFFFFF
+               	xorl	%ebx, %r12d
                	movl	$0xaaaaaaaa, %r13d      # imm = 0xAAAAAAAA
-               	xorl	%r12d, %r13d
+               	xorl	%ebx, %r13d
                	movl	$0x55555555, %r14d      # imm = 0x55555555
-               	xorl	%r12d, %r14d
-               	movl	%ebx, %esi
-               	callq	 <L1>
-<L1>:
+               	xorl	%ebx, %r14d
+               	movl	%r12d, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movl	%r12d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L4>
+               	movl	%r12d, %eax
+               	shll	$0x1f, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L5>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x1f, %edx
-               	movl	%edx, %esi
-               	callq	 <L6>
+               	movl	%r12d, %eax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L7>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L8>
+               	movl	%r12d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
                	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shll	%edx
-               	movl	%edx, %esi
-               	callq	 <L9>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %edx
-               	shrl	%edx
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	%r12d, %eax
+               	shrl	$0x1f, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
                	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shll	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %edx
-               	shrl	$0x5, %edx
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movl	%r13d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L14>
+               	movl	%r13d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L15>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x21, %edx
-               	movl	%edx, %esi
-               	callq	 <L16>
+               	movl	%r14d, %eax
+               	shll	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
                	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shll	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L17>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %edx
-               	shrl	$0x3f, %edx
-               	movl	%edx, %esi
-               	callq	 <L18>
+               	movl	%r14d, %eax
+               	shrl	%eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
                	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shll	$0x20, %edx
-               	movl	%edx, %esi
-               	callq	 <L19>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %edx
-               	shrl	$0x3f, %edx
-               	movl	%edx, %esi
+               	movl	%ebx, %eax
+               	shll	$0x5, %eax
+               	movq	%rdx, %rdi
+               	movl	%eax, %esi
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L21>
-               	jmp	 <L26>
-<L21>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
                	movl	%ebx, %edx
-               	shll	%cl, %edx
-               	movq	%r15, %rdi
+               	shrl	$0x5, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L21>
+<L21>:
+               	movl	%r12d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L22>
 <L22>:
+               	movl	%r12d, %edx
+               	shrl	$0x20, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L23>
 <L23>:
+               	movl	%r12d, %edx
+               	shll	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r12d, %r8d
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r13d, %esi
-               	shll	%cl, %esi
+               	movl	%edx, %esi
                	callq	 <L24>
 <L24>:
+               	movl	%r12d, %edx
+               	shrl	$0x21, %edx
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movl	%r14d, %edx
-               	shrl	%cl, %edx
                	movl	%edx, %esi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x20, %r8d
-               	jb	 <L21>
+               	movl	%r12d, %edx
+               	shll	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L26>
 <L26>:
-               	movl	$0x1e, %r13d
-               	cmpl	$0x28, %r13d
-               	jb	 <L27>
-               	jmp	 <L30>
+               	movl	%r12d, %edx
+               	shrl	$0x3f, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L27>
 <L27>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	movl	%r14d, %ecx
-               	movl	%ebx, %eax
-               	shll	%cl, %eax
-               	movq	%r15, %rdi
-               	movl	%eax, %esi
+               	movl	%r13d, %edx
+               	shll	$0x20, %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
                	callq	 <L28>
 <L28>:
-               	movl	%r14d, %ecx
-               	movl	%ebx, %edx
-               	shrl	%cl, %edx
+               	movl	%r13d, %edx
+               	shrl	$0x3f, %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
                	callq	 <L29>
 <L29>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %r15
-               	cmpl	$0x28, %r13d
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movl	%esi, %edi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rsi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movl	%r12d, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r13d, %eax
+               	shll	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, %ecx
+               	movl	%r14d, %eax
+               	shrl	%cl, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	addl	$0x1, %eax
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpl	$0x20, %r8d
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movl	$0x1e, %edx
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movl	%edx, %esi
+               	addl	%ebx, %esi
+               	movl	%esi, %ecx
+               	movl	%r12d, %esi
+               	shll	%cl, %esi
+               	movl	%esi, %edi
+               	movq	%rax, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movl	%edx, %edi
+               	addl	%ebx, %edi
+               	movl	%edi, %ecx
+               	movl	%r12d, %edi
+               	shrl	%cl, %edi
+               	movl	%edi, %r13d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+<L44>:
+               	addl	$0x1, %edx
+               	movq	%rsi, %rax
+               	cmpl	$0x28, %edx
+               	jb	 <L40>
+<L45>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/bits/shift_u64.dis
+++ b/test/golden/x86_64-linux/bits/shift_u64.dis
@@ -12,187 +12,464 @@ Disassembly of section .text:
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	$-0x1, %r12
                	xorq	%rbx, %r12
                	movabsq	$-0x5555555555555556, %r13 # imm = 0xAAAAAAAAAAAAAAAA
                	xorq	%rbx, %r13
                	movabsq	$0x5555555555555555, %r14 # imm = 0x5555555555555555
                	xorq	%rbx, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r12, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	%rsi
-               	callq	 <L2>
+               	movq	%r12, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x3f, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L4>
+               	movq	%r12, %rdx
+               	shlq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	%rsi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x3f, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	%rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shrq	%rsi
-               	callq	 <L8>
+               	movq	%r12, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shlq	%rsi
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	shrq	%rsi
-               	callq	 <L10>
+               	movq	%r12, %rdx
+               	shrq	$0x3f, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movq	%r13, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	%r13, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%r14, %rdx
+               	shlq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%r14, %rdx
+               	shrq	%rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
                	movq	%rbx, %rsi
                	shlq	$0x5, %rsi
-               	callq	 <L11>
-<L11>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	shrq	$0x5, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x40, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x41, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x41, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shlq	$0x7f, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	shrq	$0x7f, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shlq	$0x40, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	shrq	$0x7f, %rsi
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L21>
-               	jmp	 <L26>
+               	movq	%rbx, %rsi
+               	shrq	$0x5, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L21>
 <L21>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rcx
                	movq	%r12, %rsi
-               	shrq	%cl, %rsi
+               	shrq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
+               	movq	%r12, %rsi
+               	shlq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r13, %rsi
-               	shlq	%cl, %rsi
                	callq	 <L24>
 <L24>:
+               	movq	%r12, %rsi
+               	shrq	$0x41, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	%r14, %rsi
-               	shrq	%cl, %rsi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r15
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L21>
-<L26>:
-               	movq	$0x3c, %r13
-               	cmpq	$0x48, %r13
-               	jb	 <L27>
-               	jmp	 <L30>
-<L27>:
-               	movq	%r13, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rcx
                	movq	%r12, %rsi
-               	shlq	%cl, %rsi
-               	movq	%r15, %rdi
+               	shlq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	%r12, %rsi
+               	shrq	$0x7f, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movq	%r13, %rsi
+               	shlq	$0x40, %rsi
+               	movq	%rax, %rdi
                	callq	 <L28>
 <L28>:
-               	movq	%r14, %rcx
-               	movq	%r12, %rsi
-               	shrq	%cl, %rsi
+               	movq	%r13, %rsi
+               	shrq	$0x7f, %rsi
                	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r15
-               	cmpq	$0x48, %r13
-               	jb	 <L27>
+               	movq	%rax, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+               	jmp	 <L39>
 <L30>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
                	movq	%r15, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rsi, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r15
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L31>
+<L32>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%r12, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r13, %rax
+               	shlq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%rbx, %rax
+               	movq	%rax, %rcx
+               	movq	%r14, %rax
+               	shrq	%cl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L30>
+<L39>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3c, %rdx
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+               	jmp	 <L45>
+<L40>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shlq	%cl, %rsi
+               	movq	%rax, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L41>
+<L42>:
+               	movq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L43>
+<L44>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x48, %rdx
+               	jb	 <L40>
+<L45>:
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/call/call_chain.dis
+++ b/test/golden/x86_64-linux/call/call_chain.dis
@@ -58,51 +58,52 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.burn>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x110, %rsp            # imm = 0x110
-               	movq	%rbx, -0xe8(%rbp)
-               	movq	%r12, -0xf0(%rbp)
-               	movq	%r13, -0xf8(%rbp)
-               	movq	%r14, -0x100(%rbp)
-               	movq	%r15, -0x108(%rbp)
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
                	movq	%rdi, %r8
                	xorq	$0x1, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rdi, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r8
-               	addq	$0x2, %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	%rdi, %rdx
-               	xorq	$-0x1, %rdx
+               	imulq	$0x3, %rdx, %rdx
                	movq	%rdx, %r8
-               	addq	$0x3, %r8
+               	addq	$0x2, %r8
                	movq	%r8, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	imulq	$0x5, %rbx, %rbx
-               	addq	$0x4, %rbx
+               	movq	%rdi, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	%rsi, %r8
+               	addq	$0x3, %r8
+               	movq	%r8, -0x28(%rbp)
                	movq	%rdi, %r12
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %r12
+               	imulq	$0x5, %r12, %r12
+               	addq	$0x4, %r12
                	movq	%rdi, %r13
-               	imulq	$0x7, %r13, %r13
-               	addq	$0x6, %r13
-               	movq	%rdx, %r14
-               	imulq	$0x9, %r14, %r14
-               	movq	%rdi, %r15
-               	addq	$0x12345678, %r15       # imm = 0x12345678
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %r13
+               	movq	%rdi, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	$0x6, %r14
+               	movq	%rsi, %r15
+               	imulq	$0x9, %r15, %r15
+               	movq	%rdi, %r8
+               	addq	$0x12345678, %r8        # imm = 0x12345678
+               	movq	%r8, -0x8(%rbp)
                	movq	%rdi, %rax
                	imulq	$0xb, %rax, %rax
                	addq	$0xa, %rax
                	movq	%rdi, %r8
                	xorq	$0x55555555, %r8        # imm = 0x55555555
-               	movq	%r8, -0x10(%rbp)
-               	movq	%rdi, %rcx
-               	imulq	$0xd, %rcx, %rcx
-               	addq	$0xc, %rcx
-               	xorq	%rdi, %rdx
-               	movq	%rdi, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rdi, %rdx
+               	imulq	$0xd, %rdx, %rdx
+               	addq	$0xc, %rdx
+               	xorq	%rdi, %rsi
+               	movq	%rdi, %rbx
+               	andq	$0x3ff, %rbx            # imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
@@ -116,11 +117,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L1>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0xfd>
-               	movq	%rdi, %rsi
-               	shrq	$0x5, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
+               	divsd	, %xmm1 <corpus.cases.call.call_chain.burn+0x101>
+               	movq	%rdi, %rbx
+               	shrq	$0x5, %rbx
+               	andq	$0x3ff, %rbx            # imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L2>
                	cvtsi2sd	%r11, %xmm0
@@ -134,11 +135,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L3>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x143>
-               	movq	%rdi, %rsi
-               	shrq	$0xb, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
+               	divsd	, %xmm2 <corpus.cases.call.call_chain.burn+0x147>
+               	movq	%rdi, %rbx
+               	shrq	$0xb, %rbx
+               	andq	$0x3ff, %rbx            # imm = 0x3FF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L4>
                	cvtsi2sd	%r11, %xmm0
@@ -152,11 +153,11 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L5>:
                	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x189>
-               	movq	%rdi, %rsi
-               	shrq	$0x11, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	divsd	, %xmm3 <corpus.cases.call.call_chain.burn+0x18d>
+               	movq	%rdi, %rbx
+               	shrq	$0x11, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
@@ -170,11 +171,11 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x1cf>
-               	movq	%rdi, %rsi
-               	shrq	$0x17, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	divss	, %xmm4 <corpus.cases.call.call_chain.burn+0x1d3>
+               	movq	%rdi, %rbx
+               	shrq	$0x17, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
@@ -188,7 +189,7 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x215>
+               	divss	, %xmm5 <corpus.cases.call.call_chain.burn+0x219>
                	shrq	$0x1d, %rdi
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
@@ -205,165 +206,221 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x258>
-               	movq	-0x8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x18(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x20(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x30(%rbp)
+               	divss	, %xmm6 <corpus.cases.call.call_chain.burn+0x25c>
                	movq	-0x10(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	%rcx, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	-0x28(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x38(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x78(%rbp)
-               	movsd	%xmm1, -0x88(%rbp)
-               	movsd	%xmm2, -0x98(%rbp)
-               	movsd	%xmm3, -0xa8(%rbp)
-               	movsd	%xmm4, -0xb8(%rbp)
-               	movsd	%xmm5, -0xc8(%rbp)
-               	movsd	%xmm6, -0xd8(%rbp)
-               	movq	$0x0, %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x18(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
+               	movq	%rdx, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	movq	-0x60(%rbp), %r8
-               	movq	-0x68(%rbp), %r9
-               	movq	%r8, %rsi
-               	addq	%r9, %rsi
-               	movq	-0x68(%rbp), %r8
-               	movq	-0x28(%rbp), %r9
-               	movq	%r8, %rdi
-               	xorq	%r9, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%rbx, %rdx
-               	xorq	%r12, %rbx
-               	addq	%r13, %r12
-               	xorq	%r14, %r13
-               	addq	%r15, %r14
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%rbx, %r15
                	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r15
-               	movq	-0x30(%rbp), %r9
-               	movq	-0x70(%rbp), %r10
+               	xorq	%r8, %rbx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	%r12, %rax
+               	xorq	%r13, %r12
+               	addq	%r14, %r13
+               	movq	-0x50(%rbp), %r8
+               	xorq	%r8, %r14
+               	movq	-0x50(%rbp), %r8
+               	movq	-0x38(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x58(%rbp), %r9
+               	movq	%r8, %rsi
+               	xorq	%r9, %rsi
+               	movq	-0x58(%rbp), %r9
+               	movq	-0x40(%rbp), %r10
                	movq	%r9, %r8
                	addq	%r10, %r8
+               	movq	%r8, -0x70(%rbp)
+               	movq	-0x40(%rbp), %r9
+               	movq	-0x60(%rbp), %r10
+               	movq	%r9, %r8
+               	xorq	%r10, %r8
+               	movq	%r8, -0x78(%rbp)
+               	movq	-0x60(%rbp), %r9
+               	movq	-0x68(%rbp), %r10
+               	movq	%r9, %r8
+               	addq	%r10, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x88(%rbp)
+               	addsd	%xmm2, %xmm1
+               	subsd	%xmm3, %xmm2
+               	addsd	%xmm1, %xmm3
+               	addss	%xmm5, %xmm4
+               	subss	%xmm6, %xmm5
+               	addss	%xmm4, %xmm6
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
                	movq	%r8, -0x48(%rbp)
-               	movq	-0x70(%rbp), %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x70(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x78(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x80(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	-0x88(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x68(%rbp)
+               	cmpq	$0x6, %rdi
+               	jb	 <L12>
+<L13>:
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rbx, %rax
+               	movq	-0x30(%rbp), %r8
+               	xorq	%r8, %rax
+               	xorq	%r12, %rax
+               	xorq	%r13, %rax
+               	xorq	%r14, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	-0x50(%rbp), %r8
                	movq	-0x38(%rbp), %r9
                	movq	%r8, %rax
                	xorq	%r9, %rax
-               	movq	-0x38(%rbp), %r9
-               	movq	-0x78(%rbp), %r10
-               	movq	%r9, %r8
-               	addq	%r10, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	%rsi, %rcx
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
-               	movsd	-0x98(%rbp), %xmm1
-               	subsd	-0xa8(%rbp), %xmm1
-               	movsd	-0xa8(%rbp), %xmm2
-               	addsd	%xmm0, %xmm2
-               	movss	-0xb8(%rbp), %xmm3
-               	addss	-0xc8(%rbp), %xmm3
-               	movss	-0xc8(%rbp), %xmm4
-               	subss	-0xd8(%rbp), %xmm4
-               	movss	-0xd8(%rbp), %xmm5
-               	addss	%xmm3, %xmm5
-               	movq	-0x40(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	-0x48(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x78(%rbp)
-               	movsd	%xmm0, -0x88(%rbp)
-               	movsd	%xmm1, -0x98(%rbp)
-               	movsd	%xmm2, -0xa8(%rbp)
-               	movsd	%xmm3, -0xb8(%rbp)
-               	movsd	%xmm4, -0xc8(%rbp)
-               	movsd	%xmm5, -0xd8(%rbp)
-               	movq	-0x58(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	-0x58(%rbp), %r8
+               	xorq	%r8, %rax
                	movq	-0x40(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L12>
-<L13>:
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdx
+               	xorq	%r8, %rax
                	movq	-0x60(%rbp), %r8
-               	movq	-0x68(%rbp), %r9
-               	movq	%r8, %rsi
-               	xorq	%r9, %rsi
-               	movq	-0x28(%rbp), %r8
-               	xorq	%r8, %rsi
-               	xorq	%rbx, %rsi
-               	xorq	%r12, %rsi
-               	xorq	%r13, %rsi
-               	movq	%rdx, %rdi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	xorq	%r15, %r14
-               	movq	-0x30(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x70(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x38(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	-0x78(%rbp), %r8
-               	xorq	%r8, %r14
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	xorq	%r8, %rax
+               	movq	-0x68(%rbp), %r8
+               	xorq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movsd	-0x88(%rbp), %xmm6
-               	addsd	-0x98(%rbp), %xmm6
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	addsd	-0xa8(%rbp), %xmm0
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movss	-0xb8(%rbp), %xmm0
-               	addss	-0xc8(%rbp), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	-0xd8(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L18>
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	%xmm2, %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	addsd	%xmm3, %xmm1
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	-0xe8(%rbp), %rbx
-               	movq	-0xf0(%rbp), %r12
-               	movq	-0xf8(%rbp), %r13
-               	movq	-0x100(%rbp), %r14
-               	movq	-0x108(%rbp), %r15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
+               	addss	%xmm5, %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	addss	%xmm6, %xmm1
+               	movd	%xmm1, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%rdx, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -371,12 +428,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_chain.chain>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x100, %rsp            # imm = 0x100
+               	movq	%rbx, -0xd8(%rbp)
+               	movq	%r12, -0xe0(%rbp)
+               	movq	%r13, -0xe8(%rbp)
+               	movq	%r14, -0xf0(%rbp)
+               	movq	%r15, -0xf8(%rbp)
                	movq	%rdi, %rbx
                	movq	%rsi, %r12
                	movq	%rdx, %r13
@@ -384,51 +441,52 @@ Disassembly of section .text:
                	imulq	$0x3, %rax, %rax
                	movq	%rax, %r8
                	addq	$0x1, %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	%r12, %r15
                	xorq	$0x12345678, %r15       # imm = 0x12345678
                	movq	%r12, %r8
-               	movq	%r8, -0x50(%rbp)
+               	movq	%r8, -0x68(%rbp)
                	xorq	$-0x1, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	%r12, %rcx
-               	imulq	$0x5, %rcx, %rcx
-               	movq	%rcx, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	%r12, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	movq	%rdx, %r8
                	addq	%rbx, %r8
                	movq	%r8, -0x8(%rbp)
                	movq	%r12, %r8
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	addq	%r11, %r8
-               	movq	%r8, -0x58(%rbp)
+               	movq	%r8, -0x60(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x7, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x3, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	%r12, %r14
-               	xorq	$0x55555555, %r14       # imm = 0x55555555
+               	movq	%r8, -0x18(%rbp)
+               	movq	%r12, %r8
+               	xorq	$0x55555555, %r8        # imm = 0x55555555
+               	movq	%r8, -0x20(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x9, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	-0x50(%rbp), %r9
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x68(%rbp), %r9
                	movq	%r9, %r8
                	addq	$0xb, %r8
-               	movq	%r8, -0x28(%rbp)
+               	movq	%r8, -0x30(%rbp)
                	movq	%r12, %rdx
                	imulq	$0xd, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x5, %r8
-               	movq	%r8, -0x30(%rbp)
+               	movq	%r8, -0x38(%rbp)
                	movq	%r12, %r8
                	xorq	%rbx, %r8
-               	movq	%r8, -0x38(%rbp)
+               	movq	%r8, -0x40(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x11, %rdx, %rdx
                	movq	%rdx, %r8
                	addq	$0x7, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	%r8, -0x48(%rbp)
                	movq	%r12, %rdx
                	shrq	%rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
@@ -446,8 +504,8 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L1>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x138>
-               	movsd	%xmm14, -0x68(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x13c>
+               	movsd	%xmm14, -0x78(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x9, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
@@ -465,8 +523,8 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L3>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x186>
-               	movsd	%xmm14, -0x78(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x18a>
+               	movsd	%xmm14, -0x88(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x13, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
@@ -484,8 +542,8 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L5>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x1d4>
-               	movsd	%xmm14, -0x88(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.chain+0x1db>
+               	movsd	%xmm14, -0x98(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x3, %rdx
                	andq	$0xff, %rdx
@@ -503,8 +561,8 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x225>
-               	movss	%xmm14, -0x98(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x22c>
+               	movss	%xmm14, -0xa8(%rbp)
                	movq	%r12, %rdx
                	shrq	$0xd, %rdx
                	andq	$0xff, %rdx
@@ -522,8 +580,8 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x276>
-               	movss	%xmm14, -0xa8(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x27d>
+               	movss	%xmm14, -0xb8(%rbp)
                	movq	%r12, %rdx
                	shrq	$0x19, %rdx
                	andq	$0xff, %rdx
@@ -541,149 +599,350 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x2c7>
-               	movss	%xmm14, -0xb8(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_chain.chain+0x2ce>
+               	movss	%xmm14, -0xc8(%rbp)
                	movq	$0x0, %r11
                	cmpq	%rbx, %r11
-               	jb	 <L14>
+               	jb	 <L15>
                	movq	%r12, %rdi
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L13>
+               	movq	%rax, %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	movq	%r13, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x48(%rbp)
-               	jmp	 <L16>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x58(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
 <L14>:
+               	movq	-0x58(%rbp), %r8
+               	movq	%r8, %r14
+               	jmp	 <L17>
+<L15>:
                	movq	%rbx, %rdi
                	subq	$0x1, %rdi
                	imulq	$0x3, %r12, %r12
                	addq	%rbx, %r12
                	movq	%r12, %rsi
                	movq	%r13, %rdx
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x48(%rbp)
+               	callq	 <L16>
 <L16>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L17>
+               	movq	%rax, %r14
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x10(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L22>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L23>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L25>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
 <L25>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L28>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	%rax, %rdi
-               	movsd	-0x68(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movsd	-0x78(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movsd	-0x88(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L34>
-<L34>:
-               	movsd	-0x68(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	-0x88(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L35>
-<L35>:
-               	movss	-0x98(%rbp), %xmm0
-               	addss	-0xa8(%rbp), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	-0xb8(%rbp), %xmm1
-               	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L36>
-<L36>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x18(%rbp), %r8
-               	movq	-0x10(%rbp), %r9
-               	movq	%r8, %rcx
-               	xorq	%r9, %rcx
-               	movq	-0x40(%rbp), %r8
-               	xorq	%r8, %rcx
-               	movq	%rax, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L37>
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L34>
+<L35>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L36>
 <L37>:
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L38>
+<L39>:
+               	movq	%r14, %rdi
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L40>
+<L40>:
+               	movq	-0x78(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	-0x88(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	movq	-0x98(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movl	-0xa8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	movl	-0xb8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
+               	movl	-0xc8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
+               	movsd	-0x78(%rbp), %xmm0
+               	addsd	-0x88(%rbp), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	-0x98(%rbp), %xmm1
+               	movq	%xmm1, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
+               	movss	-0xa8(%rbp), %xmm0
+               	addss	-0xb8(%rbp), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	-0xc8(%rbp), %xmm1
+               	movd	%xmm1, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	-0x10(%rbp), %r8
+               	movq	-0x18(%rbp), %r9
+               	movq	%r8, %rdx
+               	xorq	%r9, %rdx
+               	movq	-0x48(%rbp), %r8
+               	xorq	%r8, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L49>
+<L49>:
+               	movq	-0xd8(%rbp), %rbx
+               	movq	-0xe0(%rbp), %r12
+               	movq	-0xe8(%rbp), %r13
+               	movq	-0xf0(%rbp), %r14
+               	movq	-0xf8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -760,12 +1019,13 @@ Disassembly of section .text:
                	movq	%r14, %rsi
                	callq	 <L8>
 <L8>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
+               	movl	-0x20(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x20(%rbp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	-0x28(%rbp), %rbx
@@ -932,11 +1192,12 @@ Disassembly of section .text:
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
+               	movq	-0x60(%rbp), %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
+               	movl	-0x70(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
@@ -961,15 +1222,16 @@ Disassembly of section .text:
                	callq	 <L21>
 <L21>:
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
+               	movq	-0x20(%rbp), %rsi
                	callq	 <L22>
 <L22>:
                	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
+               	movq	-0x30(%rbp), %rsi
                	callq	 <L23>
 <L23>:
                	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
+               	movl	-0x40(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
@@ -1264,11 +1526,13 @@ Disassembly of section .text:
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
-               	movsd	-0xe8(%rbp), %xmm0
+               	movq	-0xe8(%rbp), %rsi
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rdi
-               	movss	-0xf8(%rbp), %xmm0
+               	movl	-0xf8(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rdi
@@ -1297,15 +1561,17 @@ Disassembly of section .text:
                	callq	 <L31>
 <L31>:
                	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
+               	movq	-0xb8(%rbp), %rsi
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rdi
-               	movsd	-0xc8(%rbp), %xmm0
+               	movq	-0xc8(%rbp), %rsi
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
+               	movl	-0xd8(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
@@ -1346,24 +1612,26 @@ Disassembly of section .text:
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
+               	movq	-0x68(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x68(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x78(%rbp), %xmm0
                	callq	 <L44>
 <L44>:
+               	movq	-0x88(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x88(%rbp), %xmm0
                	callq	 <L45>
 <L45>:
+               	movl	-0x98(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
                	callq	 <L46>
 <L46>:
+               	movl	-0xa8(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
                	callq	 <L47>
 <L47>:
                	addq	%r15, %r12
@@ -1771,11 +2039,13 @@ Disassembly of section .text:
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rdi
-               	movsd	-0x180(%rbp), %xmm0
+               	movq	-0x180(%rbp), %rsi
                	callq	 <L33>
 <L33>:
                	movq	%rax, %rdi
-               	movss	-0x98(%rbp), %xmm0
+               	movl	-0x98(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
@@ -1804,15 +2074,17 @@ Disassembly of section .text:
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movsd	-0x150(%rbp), %xmm0
+               	movq	-0x150(%rbp), %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movsd	-0x160(%rbp), %xmm0
+               	movq	-0x160(%rbp), %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movss	-0x170(%rbp), %xmm0
+               	movl	-0x170(%rbp), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
@@ -1857,24 +2129,28 @@ Disassembly of section .text:
                	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x100(%rbp), %xmm0
                	callq	 <L51>
 <L51>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
                	callq	 <L52>
 <L52>:
+               	movq	-0x120(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x120(%rbp), %xmm0
                	callq	 <L53>
 <L53>:
+               	movl	-0x130(%rbp), %esi
+               	movl	%esi, %ebx
                	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
+               	movq	%rbx, %rsi
                	callq	 <L54>
 <L54>:
+               	movl	-0x140(%rbp), %esi
+               	movl	%esi, %ebx
                	movq	%rax, %rdi
-               	movss	-0x140(%rbp), %xmm0
+               	movq	%rbx, %rsi
                	callq	 <L55>
 <L55>:
                	movq	-0x20(%rbp), %r8
@@ -1927,20 +2203,22 @@ Disassembly of section .text:
                	movq	%r8, %rsi
                	callq	 <L65>
 <L65>:
+               	movq	-0xb8(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
                	callq	 <L66>
 <L66>:
+               	movq	-0xc8(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xc8(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
+               	movl	-0xd8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
+               	movl	-0xe8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xe8(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
                	movq	-0xa0(%rbp), %r8
@@ -1970,8 +2248,6 @@ Disassembly of section .text:
                	movq	%r14, -0x1f0(%rbp)
                	movq	%r15, -0x1f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1979,43 +2255,43 @@ Disassembly of section .text:
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
                	movq	$0x10, %rdi
                	addq	%rbx, %rdi
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdx
-               	callq	 <L3>
-<L3>:
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	movq	$0x1, %rdi
                	addq	%rbx, %rdi
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdx
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L5>
-               	jmp	 <L77>
-<L5>:
+               	jb	 <L4>
+               	jmp	 <L76>
+<L4>:
                	leaq	(%r12,%r14,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
@@ -2057,76 +2333,76 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L6>
+               	jl	 <L5>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L7>
-<L6>:
+               	jmp	 <L6>
+<L5>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L7>:
+<L6>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x1d9>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x1db>
                	movsd	%xmm14, -0x100(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x12, %rdx
                	andq	$0x3ff, %rdx            # imm = 0x3FF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L8>
+               	jl	 <L7>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
+               	jmp	 <L8>
+<L7>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L9>:
+<L8>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x22a>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x22c>
                	movsd	%xmm14, -0x110(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0xb, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L10>
+               	jl	 <L9>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L11>
-<L10>:
+               	jmp	 <L10>
+<L9>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L11>:
+<L10>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x27b>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x27d>
                	movss	%xmm14, -0x120(%rbp)
                	movq	%rcx, %rdx
                	shrq	$0x13, %rdx
                	andq	$0xff, %rdx
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L12>
+               	jl	 <L11>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L13>
-<L12>:
+               	jmp	 <L12>
+<L11>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L13>:
+<L12>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x2cc>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x2ce>
                	movss	%xmm14, -0x130(%rbp)
                	imulq	$0x3, %rcx, %rcx
                	addq	$0x5, %rcx
@@ -2160,95 +2436,95 @@ Disassembly of section .text:
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L14>
+               	jl	 <L13>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L15>
-<L14>:
+               	jmp	 <L14>
+<L13>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L15>:
+<L14>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x392>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x394>
                	movsd	%xmm14, -0x148(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x10, %rsi
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L16>
+               	jl	 <L15>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L17>
-<L16>:
+               	jmp	 <L16>
+<L15>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L17>:
+<L16>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x3e3>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x3e5>
                	movsd	%xmm14, -0x158(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x1a, %rsi
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L17>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L18>
+<L17>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
+<L18>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x434>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x436>
                	movsd	%xmm14, -0x168(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x9, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L19>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L20>
+<L19>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L21>:
+<L20>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x485>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x487>
                	movss	%xmm14, -0x178(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x1b, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d6>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x4d8>
                	movss	%xmm14, -0x188(%rbp)
                	addq	$0x1d, %rcx
                	movq	%rcx, %r8
@@ -2276,57 +2552,57 @@ Disassembly of section .text:
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x588>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x58a>
                	movsd	%xmm14, -0x198(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0xe, %rsi
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5d9>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x5db>
                	movsd	%xmm14, -0x1a8(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x15, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x62a>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x62c>
                	movss	%xmm14, -0x1b8(%rbp)
                	imulq	$0x7, %rcx, %rcx
                	addq	$0x1, %rcx
@@ -2345,169 +2621,173 @@ Disassembly of section .text:
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L31>:
+<L30>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b4>
+               	divsd	, %xmm14 <corpus.cases.call.call_chain.checksum+0x6b6>
                	movsd	%xmm14, -0x1c8(%rbp)
                	movq	%rcx, %rsi
                	shrq	$0x7, %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L33>:
+<L32>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x705>
+               	divss	, %xmm14 <corpus.cases.call.call_chain.checksum+0x707>
                	movss	%xmm14, -0xe8(%rbp)
                	xorq	$0x3039, %rcx           # imm = 0x3039
                	movq	%rcx, %rdi
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %rsi
                	movq	%r13, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	%rax, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
+               	movq	-0xd0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
+               	movq	-0xd8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L37>
 <L37>:
                	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x1c8(%rbp), %rsi
                	callq	 <L38>
 <L38>:
                	movq	%rax, %rdi
-               	movsd	-0x1c8(%rbp), %xmm0
+               	movl	-0xe8(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movss	-0xe8(%rbp), %xmm0
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x198(%rbp), %rsi
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rdi
-               	movsd	-0x198(%rbp), %xmm0
+               	movq	-0x1a8(%rbp), %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movsd	-0x1a8(%rbp), %xmm0
+               	movl	-0x1b8(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rdi
-               	movss	-0x1b8(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
                	movq	%rax, %rdi
                	movq	-0xa0(%rbp), %r8
                	movq	-0xc0(%rbp), %r9
                	movq	%r8, %rsi
                	xorq	%r9, %rsi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rdi
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L55>
 <L55>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x148(%rbp), %rsi
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rdi
-               	movsd	-0x148(%rbp), %xmm0
+               	movq	-0x158(%rbp), %rsi
                	callq	 <L57>
 <L57>:
                	movq	%rax, %rdi
-               	movsd	-0x158(%rbp), %xmm0
+               	movq	-0x168(%rbp), %rsi
                	callq	 <L58>
 <L58>:
                	movq	%rax, %rdi
-               	movsd	-0x168(%rbp), %xmm0
+               	movl	-0x178(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L59>
 <L59>:
                	movq	%rax, %rdi
-               	movss	-0x178(%rbp), %xmm0
+               	movl	-0x188(%rbp), %ecx
+               	movl	%ecx, %esi
                	callq	 <L60>
 <L60>:
-               	movq	%rax, %rdi
-               	movss	-0x188(%rbp), %xmm0
-               	callq	 <L61>
-<L61>:
                	movq	%rax, %rdi
                	movq	-0x70(%rbp), %r8
                	movq	-0x80(%rbp), %r9
@@ -2516,91 +2796,93 @@ Disassembly of section .text:
                	movq	-0x98(%rbp), %r8
                	addq	%r8, %rcx
                	movq	%rcx, %rsi
+               	callq	 <L61>
+<L61>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L62>
 <L62>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L63>
 <L63>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L64>
 <L64>:
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
+               	movq	-0x40(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L65>
 <L65>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
+               	movq	-0x48(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L66>
 <L66>:
                	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L67>
 <L67>:
                	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
+               	movq	-0x58(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
+               	movq	-0x60(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L69>
 <L69>:
                	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L70>
 <L70>:
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L71>
 <L71>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x100(%rbp), %xmm0
                	callq	 <L72>
 <L72>:
+               	movl	-0x120(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
                	callq	 <L73>
 <L73>:
+               	movl	-0x130(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x120(%rbp), %xmm0
                	callq	 <L74>
 <L74>:
-               	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
                	movq	-0x48(%rbp), %r8
                	xorq	%r8, %r15
                	movq	-0x68(%rbp), %r8
                	xorq	%r8, %r15
                	movq	%rax, %rdi
                	movq	%r15, %rsi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L5>
-<L77>:
+               	jb	 <L4>
+<L76>:
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
                	movq	%rcx, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L77>
+<L77>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L78>
+<L78>:
                	movq	-0x1d8(%rbp), %rbx
                	movq	-0x1e0(%rbp), %r12
                	movq	-0x1e8(%rbp), %r13

--- a/test/golden/x86_64-linux/call/call_float_regs.dis
+++ b/test/golden/x86_64-linux/call/call_float_regs.dis
@@ -56,135 +56,417 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.takef16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            # imm = 0x100
-               	movss	%xmm0, -0x40(%rbp)
-               	movsd	%xmm1, -0x50(%rbp)
-               	movss	%xmm2, -0x60(%rbp)
-               	movsd	%xmm3, -0x70(%rbp)
-               	movss	%xmm4, -0x80(%rbp)
-               	movsd	%xmm5, -0x90(%rbp)
-               	movss	%xmm6, -0xa0(%rbp)
-               	movsd	%xmm7, -0xb0(%rbp)
+               	subq	$0xe0, %rsp
+               	movq	%rbx, -0xd8(%rbp)
+               	movss	%xmm0, -0x30(%rbp)
+               	movsd	%xmm1, -0x40(%rbp)
+               	movsd	%xmm3, -0x50(%rbp)
+               	movsd	%xmm5, -0x60(%rbp)
+               	movsd	%xmm7, -0x70(%rbp)
                	movq	0x10(%rbp), %r11
-               	movq	%r11, -0xc0(%rbp)
+               	movq	%r11, -0x80(%rbp)
                	movq	0x18(%rbp), %r11
-               	movq	%r11, -0x20(%rbp)
+               	movq	%r11, -0x90(%rbp)
                	movq	0x20(%rbp), %r11
-               	movq	%r11, -0xd0(%rbp)
+               	movq	%r11, -0xa0(%rbp)
                	movq	0x28(%rbp), %r11
-               	movq	%r11, -0xe0(%rbp)
+               	movq	%r11, -0xb0(%rbp)
                	movq	0x30(%rbp), %r11
-               	movq	%r11, -0xf0(%rbp)
+               	movq	%r11, -0xc0(%rbp)
                	movq	0x38(%rbp), %r11
-               	movq	%r11, -0x10(%rbp)
+               	movq	%r11, -0xd0(%rbp)
                	movq	0x40(%rbp), %r11
-               	movq	%r11, -0x100(%rbp)
+               	movq	%r11, -0x10(%rbp)
                	movq	0x48(%rbp), %r11
-               	movq	%r11, -0x30(%rbp)
-               	callq	 <L0>
+               	movq	%r11, -0x20(%rbp)
+               	movl	-0x30(%rbp), %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x50(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	-0x40(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
-               	callq	 <L3>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L4>
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x80(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L6>
+               	movq	-0x50(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	-0xb0(%rbp), %xmm0
-               	callq	 <L8>
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	-0x60(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm0
-               	callq	 <L12>
+               	movd	%xmm6, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movss	-0xf0(%rbp), %xmm0
-               	callq	 <L13>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L14>
+               	movq	-0x70(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
-               	callq	 <L16>
+               	movl	-0x80(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
-               	mulss	-0x80(%rbp), %xmm0
-               	movss	-0x40(%rbp), %xmm1
-               	addss	%xmm0, %xmm1
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	subss	-0xa0(%rbp), %xmm0
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
+               	movq	-0x90(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movl	-0xa0(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0xb0(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movl	-0xc0(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0xd0(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movl	-0x10(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movq	-0x20(%rbp), %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
+               	mulss	%xmm4, %xmm0
+               	movss	-0x30(%rbp), %xmm2
+               	addss	%xmm0, %xmm2
+               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
+               	subss	%xmm6, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	mulsd	-0x90(%rbp), %xmm0
-               	movsd	-0x50(%rbp), %xmm1
+               	callq	 <L32>
+<L32>:
+               	movsd	-0x50(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movsd	-0x40(%rbp), %xmm1
                	addsd	%xmm0, %xmm1
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	subsd	-0xb0(%rbp), %xmm0
-               	callq	 <L18>
-<L18>:
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%xmm0, %rsi
                	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	-0xd0(%rbp), %xmm0
-               	movss	-0xf0(%rbp), %xmm1
-               	mulss	-0x100(%rbp), %xmm1
+               	callq	 <L33>
+<L33>:
+               	movss	-0x80(%rbp), %xmm0
+               	subss	-0xa0(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm1
+               	mulss	-0x10(%rbp), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
-               	callq	 <L19>
-<L19>:
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	subsd	-0xe0(%rbp), %xmm0
-               	movsd	-0x10(%rbp), %xmm1
-               	mulsd	-0x30(%rbp), %xmm1
+               	callq	 <L34>
+<L34>:
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
+               	movsd	-0xd0(%rbp), %xmm1
+               	mulsd	-0x20(%rbp), %xmm1
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
                	addsd	%xmm1, %xmm2
-               	movsd	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1]
-               	callq	 <L20>
-<L20>:
+               	movq	%xmm2, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movq	-0xd8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -193,10 +475,10 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x100, %rsp            # imm = 0x100
-               	movss	%xmm0, -0x40(%rbp)
-               	movss	%xmm1, -0x50(%rbp)
-               	movss	%xmm2, -0x60(%rbp)
-               	movss	%xmm3, -0x10(%rbp)
+               	movss	%xmm0, -0x30(%rbp)
+               	movss	%xmm1, -0x40(%rbp)
+               	movss	%xmm2, -0x50(%rbp)
+               	movss	%xmm3, -0x60(%rbp)
                	movss	%xmm4, -0x70(%rbp)
                	movss	%xmm5, -0x80(%rbp)
                	movss	%xmm6, -0x90(%rbp)
@@ -214,90 +496,94 @@ Disassembly of section .text:
                	movq	0x38(%rbp), %r11
                	movq	%r11, -0x100(%rbp)
                	movq	0x40(%rbp), %r11
-               	movq	%r11, -0x20(%rbp)
+               	movq	%r11, -0x10(%rbp)
                	movq	0x48(%rbp), %r11
-               	movq	%r11, -0x30(%rbp)
+               	movq	%r11, -0x20(%rbp)
+               	movl	-0x30(%rbp), %eax
+               	movl	%eax, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	movl	-0x40(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movl	-0x50(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x50(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movl	-0x60(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x60(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
+               	movl	-0x70(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	movl	-0x80(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movss	-0x80(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movss	-0x90(%rbp), %xmm0
+               	movss	-0xa0(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
+               	movss	-0xb0(%rbp), %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movss	-0xb0(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
+               	movss	-0xe0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
+               	movss	-0xf0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movss	-0xf0(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movss	-0x10(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
                	movss	-0x20(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movss	-0x30(%rbp), %xmm0
+               	addss	-0x20(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movss	-0x40(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
                	movss	-0xa0(%rbp), %xmm0
                	subss	-0xf0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
-               	mulss	-0x20(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -305,119 +591,113 @@ Disassembly of section .text:
 <corpus.cases.call.call_float_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4b0, %rsp            # imm = 0x4B0
-               	movq	%rbx, -0x448(%rbp)
-               	movq	%r12, -0x450(%rbp)
-               	movq	%r13, -0x458(%rbp)
-               	movq	%r14, -0x460(%rbp)
-               	movq	%r15, -0x468(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x310, %rsp            # imm = 0x310
+               	movq	%rbx, -0x2a8(%rbp)
+               	movq	%r12, -0x2b0(%rbp)
+               	movq	%r13, -0x2b8(%rbp)
+               	movq	%r14, -0x2c0(%rbp)
+               	movq	%r15, -0x2c8(%rbp)
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0xa0, %rdx
 <L0>:
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0xa0, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L0>
+               	movq	$0x0, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	movq	$0x0, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rdx, %rsi
+               	movq	%rcx, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rsi
+               	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rsi
-               	addq	%rbx, %rsi
-               	leaq	(%rcx,%rdx,8), %rdi
-               	movq	%rsi, (%rdi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L2>
+               	addq	%r11, %rdx
+               	addq	%rdi, %rdx
+               	leaq	(%rax,%rcx,8), %rsi
+               	movq	%rdx, (%rsi)
+               	addq	$0x1, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x50(%rbp), %rbx
+               	leaq	(%rbx), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x50, %rdx
 <L3>:
-               	leaq	-0xf0(%rbp), %rbx
-               	leaq	(%rbx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0x50, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L3>
+               	leaq	-0xf0(%rbp), %r12
+               	leaq	(%r12), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0xa0, %rdx
 <L4>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L4>
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0xa0, %rsi
+               	movq	$0x0, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+               	jmp	 <L10>
 <L5>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L5>
-               	movq	$0x0, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-               	jmp	 <L11>
-<L6>:
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfff, %rsi            # imm = 0xFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x176>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x15e>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x182>
-               	leaq	(%rbx,%rdx,4), %rsi
-               	movss	%xmm0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          # imm = 0xFFFFF
-               	movq	%rdi, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x16a>
+               	leaq	(%rbx,%rcx,4), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	(%rax,%rcx,8), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1d0>
+               	subsd	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x1b8>
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1dc>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8,%rdx,8), %rsi
-               	movsd	%xmm0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x14, %rdx
-               	jb	 <L6>
-<L11>:
-               	movq	%rax, %r8
+               	divsd	, %xmm0 <corpus.cases.call.call_float_regs.checksum+0x1c4>
+               	leaq	(%r12,%rcx,8), %rdx
+               	movsd	%xmm0, (%rdx)
+               	addq	$0x1, %rcx
+               	cmpq	$0x14, %rcx
+               	jb	 <L5>
+<L10>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x1a0(%rbp)
                	movq	$0x0, %r8
                	movq	%r8, -0x198(%rbp)
@@ -425,80 +705,74 @@ Disassembly of section .text:
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-               	jmp	 <L38>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L18>
+<L11>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0x3, %rax
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x27d>
-               	movss	%xmm14, -0x288(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x265>
+               	movss	%xmm14, -0x278(%rbp)
                	leaq	(%rbx), %r8
-               	movq	%r8, -0x290(%rbp)
-               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r8
                	movss	(%r8), %xmm0
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0x288(%rbp), %xmm14
+               	addss	-0x278(%rbp), %xmm14
                	movss	%xmm14, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
+               	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %r11
                	movq	%r11, -0x1d8(%rbp)
                	leaq	0x8(%rbx), %r8
-               	movq	%r8, -0x298(%rbp)
-               	movq	-0x298(%rbp), %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	-0x288(%rbp), %r8
                	movl	(%r8), %r11d
                	movl	%r11d, -0x1e8(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r12), %rdx
                	movsd	(%rdx), %xmm4
                	leaq	0x10(%rbx), %r8
-               	movq	%r8, -0x2a0(%rbp)
-               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x290(%rbp), %r8
                	movss	(%r8), %xmm5
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x28(%r8), %rsi
+               	leaq	0x28(%r12), %rsi
                	movsd	(%rsi), %xmm6
                	leaq	0x18(%rbx), %r14
                	movss	(%r14), %xmm7
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x38(%r8), %rsi
+               	leaq	0x38(%r12), %rsi
                	movsd	(%rsi), %xmm9
                	leaq	0x20(%rbx), %r13
                	movss	(%r13), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x48(%r8), %rsi
+               	leaq	0x48(%r12), %rsi
                	movsd	(%rsi), %xmm10
                	leaq	0x28(%rbx), %r15
                	movss	(%r15), %xmm11
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x58(%r8), %rsi
+               	leaq	0x58(%r12), %rsi
                	movsd	(%rsi), %xmm12
-               	leaq	0x30(%rbx), %r12
-               	movss	(%r12), %xmm13
+               	leaq	0x30(%rbx), %r8
+               	movq	%r8, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %r8
-               	leaq	0x68(%r8), %rsi
+               	movss	(%r8), %xmm13
+               	leaq	0x68(%r12), %rsi
                	movsd	(%rsi), %xmm1
                	leaq	0x38(%rbx), %r8
                	movq	%r8, -0x1c8(%rbp)
                	movq	-0x1c8(%rbp), %r8
                	movss	(%r8), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x78(%r8), %rsi
+               	leaq	0x78(%r12), %rsi
                	movsd	(%rsi), %xmm3
                	movsd	%xmm0, (%rsp)
                	movsd	%xmm10, 0x8(%rsp)
@@ -516,366 +790,197 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm5            # xmm5 = xmm6[0],xmm5[1]
                	movss	%xmm7, %xmm6            # xmm6 = xmm7[0],xmm6[1,2,3]
                	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
-               	callq	 <L15>
-<L15>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rsi
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %r8
-               	movq	%r8, -0x2a8(%rbp)
-               	movq	-0x2a8(%rbp), %r8
-               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	movq	-0x280(%rbp), %r8
                	movl	(%r8), %r11d
-               	movl	%r11d, -0x208(%rbp)
+               	movl	%r11d, -0x1f8(%rbp)
                	leaq	0x4(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x2b8(%rbp)
-               	movq	-0x298(%rbp), %r8
-               	movl	(%r8), %r11d
-               	movl	%r11d, -0x2c8(%rbp)
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x1f8(%rbp)
-               	movq	-0x2a0(%rbp), %r8
-               	movl	(%r8), %r11d
-               	movl	%r11d, -0x2d8(%rbp)
-               	leaq	0x14(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x2e8(%rbp)
-               	movl	(%r14), %r11d
-               	movl	%r11d, -0x2f8(%rbp)
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x308(%rbp)
-               	movl	(%r13), %r11d
-               	movl	%r11d, -0x318(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x328(%rbp)
-               	movl	(%r15), %r11d
-               	movl	%r11d, -0x338(%rbp)
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x348(%rbp)
-               	movl	(%r12), %r11d
-               	movl	%r11d, -0x358(%rbp)
-               	leaq	0x34(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x368(%rbp)
-               	movq	-0x1c8(%rbp), %r8
+               	movl	%r11d, -0x208(%rbp)
+               	movq	-0x288(%rbp), %r8
                	movl	(%r8), %r11d
                	movl	%r11d, -0x218(%rbp)
-               	leaq	0x3c(%rbx), %rax
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r11d
+               	movl	%r11d, -0x228(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movss	(%r8), %xmm4
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	movss	(%r14), %xmm6
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm7
+               	movss	(%r13), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	movss	(%r15), %xmm11
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	movq	-0x1b0(%rbp), %r8
+               	movss	(%r8), %xmm13
+               	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm0
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0x288(%rbp), %xmm14
-               	movss	%xmm14, -0x228(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movss	(%r8), %xmm1
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
+               	addss	-0x278(%rbp), %xmm3
+               	movsd	%xmm9, (%rsp)
+               	movsd	%xmm10, 0x8(%rsp)
+               	movsd	%xmm11, 0x10(%rsp)
+               	movsd	%xmm12, 0x18(%rsp)
+               	movsd	%xmm13, 0x20(%rsp)
+               	movsd	%xmm0, 0x28(%rsp)
+               	movsd	%xmm1, 0x30(%rsp)
+               	movsd	%xmm3, 0x38(%rsp)
+               	movss	-0x1f8(%rbp), %xmm0
+               	movss	-0x208(%rbp), %xmm1
+               	movss	-0x218(%rbp), %xmm2
+               	movss	-0x228(%rbp), %xmm3
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r13
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r13, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movss	-0x208(%rbp), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movss	-0x2b8(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movss	-0x2c8(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movss	-0x1f8(%rbp), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movss	-0x2d8(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0x2e8(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movss	-0x2f8(%rbp), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movss	-0x308(%rbp), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movss	-0x318(%rbp), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movss	-0x328(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movss	-0x338(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movss	-0x348(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movss	-0x358(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	-0x368(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0x218(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	-0x228(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movss	-0x208(%rbp), %xmm0
-               	addss	-0x228(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movss	-0x308(%rbp), %xmm0
-               	subss	-0x358(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movss	-0x1f8(%rbp), %xmm0
-               	mulss	-0x218(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r12
-               	movq	-0x2a8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L37>
-<L37>:
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
                	movq	%r8, -0x1a0(%rbp)
-               	movq	%r12, %r8
+               	movq	%r13, %r8
                	movq	%r8, -0x198(%rbp)
                	movq	%rcx, %r8
                	movq	%r8, -0x1a8(%rbp)
                	movq	-0x1a8(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L12>
-<L38>:
+               	jb	 <L11>
+<L18>:
                	leaq	0x4c(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x258(%rbp)
+               	movl	%r11d, -0x238(%rbp)
                	leaq	0x48(%rbx), %rax
                	movl	(%rax), %r11d
-               	movl	%r11d, -0x378(%rbp)
-               	leaq	0x44(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x388(%rbp)
-               	leaq	0x40(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x238(%rbp)
-               	leaq	0x3c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x398(%rbp)
-               	leaq	0x38(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3a8(%rbp)
-               	leaq	0x34(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3b8(%rbp)
-               	leaq	0x30(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3c8(%rbp)
-               	leaq	0x2c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3d8(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3e8(%rbp)
-               	leaq	0x24(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x3f8(%rbp)
-               	leaq	0x20(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x408(%rbp)
-               	leaq	0x1c(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x418(%rbp)
-               	leaq	0x18(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x428(%rbp)
-               	leaq	0x14(%rbx), %rax
-               	movl	(%rax), %r11d
                	movl	%r11d, -0x248(%rbp)
+               	leaq	0x44(%rbx), %rax
+               	movss	(%rax), %xmm2
+               	leaq	0x40(%rbx), %rax
+               	movss	(%rax), %xmm3
+               	leaq	0x3c(%rbx), %rax
+               	movss	(%rax), %xmm4
+               	leaq	0x38(%rbx), %rax
+               	movss	(%rax), %xmm5
+               	leaq	0x34(%rbx), %rax
+               	movss	(%rax), %xmm6
+               	leaq	0x30(%rbx), %rax
+               	movss	(%rax), %xmm7
+               	leaq	0x2c(%rbx), %rax
+               	movss	(%rax), %xmm8
+               	leaq	0x28(%rbx), %rax
+               	movss	(%rax), %xmm9
+               	leaq	0x24(%rbx), %rax
+               	movss	(%rax), %xmm10
+               	leaq	0x20(%rbx), %rax
+               	movss	(%rax), %xmm11
+               	leaq	0x1c(%rbx), %rax
+               	movss	(%rax), %xmm12
+               	leaq	0x18(%rbx), %rax
+               	movss	(%rax), %xmm13
+               	leaq	0x14(%rbx), %rax
+               	movss	(%rax), %xmm0
                	leaq	0x10(%rbx), %rax
-               	movl	(%rax), %r11d
-               	movl	%r11d, -0x438(%rbp)
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movss	-0x258(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	movss	-0x378(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	movss	-0x388(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
+               	movss	(%rax), %xmm1
+               	movsd	%xmm8, (%rsp)
+               	movsd	%xmm9, 0x8(%rsp)
+               	movsd	%xmm10, 0x10(%rsp)
+               	movsd	%xmm11, 0x18(%rsp)
+               	movsd	%xmm12, 0x20(%rsp)
+               	movsd	%xmm13, 0x28(%rsp)
+               	movsd	%xmm0, 0x30(%rsp)
+               	movsd	%xmm1, 0x38(%rsp)
                	movss	-0x238(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movss	-0x398(%rbp), %xmm0
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movss	-0x3a8(%rbp), %xmm0
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movss	-0x3b8(%rbp), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movss	-0x3c8(%rbp), %xmm0
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
-               	movss	-0x3d8(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movss	-0x3e8(%rbp), %xmm0
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	movss	-0x3f8(%rbp), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movss	-0x408(%rbp), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	movss	-0x418(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movss	-0x428(%rbp), %xmm0
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movss	-0x248(%rbp), %xmm0
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movss	-0x438(%rbp), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movss	-0x258(%rbp), %xmm0
-               	addss	-0x438(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movss	-0x3c8(%rbp), %xmm0
-               	subss	-0x418(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	movss	-0x238(%rbp), %xmm0
-               	mulss	-0x248(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	movss	-0x248(%rbp), %xmm1
+               	callq	 <L19>
+<L19>:
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
-<L59>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L60>:
+<L21>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x926>
+               	subss	, %xmm1 <corpus.cases.call.call_float_regs.checksum+0x667>
                	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x934>
-               	movss	%xmm14, -0x268(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rax
+               	divss	, %xmm14 <corpus.cases.call.call_float_regs.checksum+0x675>
+               	movss	%xmm14, -0x258(%rbp)
+               	leaq	(%r12), %rax
                	movq	(%rax), %r11
-               	movq	%r11, -0x278(%rbp)
+               	movq	%r11, -0x268(%rbp)
                	leaq	0x4(%rbx), %rax
                	movss	(%rax), %xmm2
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x10(%r8), %rax
+               	leaq	0x10(%r12), %rax
                	movsd	(%rax), %xmm3
                	leaq	0xc(%rbx), %rax
                	movss	(%rax), %xmm4
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x20(%r8), %rax
+               	leaq	0x20(%r12), %rax
                	movsd	(%rax), %xmm5
                	leaq	0x14(%rbx), %rax
                	movss	(%rax), %xmm6
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x30(%r8), %rax
+               	leaq	0x30(%r12), %rax
                	movsd	(%rax), %xmm7
                	movq	-0x198(%rbp), %r8
                	movq	%r8, %rax
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L22>
                	cvtsi2ss	%r11, %xmm8
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm8
                	addss	%xmm8, %xmm8
-<L62>:
+<L23>:
                	movss	%xmm8, %xmm9            # xmm9 = xmm8[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x9e2>
+               	subss	, %xmm9 <corpus.cases.call.call_float_regs.checksum+0x70b>
                	movss	%xmm9, %xmm8            # xmm8 = xmm9[0],xmm8[1,2,3]
-               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x9f0>
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x40(%r8), %rax
+               	divss	, %xmm8 <corpus.cases.call.call_float_regs.checksum+0x719>
+               	leaq	0x40(%r12), %rax
                	movsd	(%rax), %xmm9
                	leaq	0x24(%rbx), %rax
                	movss	(%rax), %xmm10
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x50(%r8), %rax
+               	leaq	0x50(%r12), %rax
                	movsd	(%rax), %xmm11
                	leaq	0x2c(%rbx), %rax
                	movss	(%rax), %xmm12
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x60(%r8), %rax
+               	leaq	0x60(%r12), %rax
                	movsd	(%rax), %xmm13
                	leaq	0x34(%rbx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x70(%r8), %rax
+               	leaq	0x70(%r12), %rax
                	movsd	(%rax), %xmm1
                	movsd	%xmm8, (%rsp)
                	movsd	%xmm9, 0x8(%rsp)
@@ -885,20 +990,20 @@ Disassembly of section .text:
                	movsd	%xmm13, 0x28(%rsp)
                	movsd	%xmm0, 0x30(%rsp)
                	movsd	%xmm1, 0x38(%rsp)
-               	movss	-0x268(%rbp), %xmm0
-               	movsd	-0x278(%rbp), %xmm1
-               	callq	 <L63>
-<L63>:
+               	movss	-0x258(%rbp), %xmm0
+               	movsd	-0x268(%rbp), %xmm1
+               	callq	 <L24>
+<L24>:
                	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x448(%rbp), %rbx
-               	movq	-0x450(%rbp), %r12
-               	movq	-0x458(%rbp), %r13
-               	movq	-0x460(%rbp), %r14
-               	movq	-0x468(%rbp), %r15
+               	callq	 <L25>
+<L25>:
+               	movq	-0x2a8(%rbp), %rbx
+               	movq	-0x2b0(%rbp), %r12
+               	movq	-0x2b8(%rbp), %r13
+               	movq	-0x2c0(%rbp), %r14
+               	movq	-0x2c8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_indirect.dis
+++ b/test/golden/x86_64-linux/call/call_indirect.dis
@@ -59,28 +59,81 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.fold24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -174,85 +227,280 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movl	%esi, %r12d
-               	movsd	%xmm0, -0x18(%rbp)
-               	movq	%rdx, %r13
-               	movss	%xmm1, -0x28(%rbp)
-               	movq	%rcx, %r14
-               	movl	%r8d, %r15d
-               	movsd	%xmm2, -0x38(%rbp)
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rcx, %rax
+               	movl	%r8d, %ebx
                	movq	%r9, %r8
-               	movq	%r8, -0x40(%rbp)
+               	movq	%r8, -0x18(%rbp)
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x48(%rbp)
-               	movss	%xmm3, -0x58(%rbp)
+               	movq	%r8, -0x10(%rbp)
                	movq	0x18(%rbp), %r8
                	movq	%r8, -0x8(%rbp)
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %r15 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%r14, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r14
+               	movq	%r12, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movsd	-0x18(%rbp), %xmm0
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L4>
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x28(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	-0x38(%rbp), %xmm0
-               	callq	 <L8>
+               	movd	%xmm1, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm0
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movslq	%ebx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r15, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	%r15, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -323,49 +571,46 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            # imm = 0x2E0
-               	movq	%rbx, -0x298(%rbp)
-               	movq	%r12, -0x2a0(%rbp)
-               	movq	%r13, -0x2a8(%rbp)
-               	movq	%r14, -0x2b0(%rbp)
-               	movq	%r15, -0x2b8(%rbp)
+               	subq	$0x300, %rsp            # imm = 0x300
+               	movq	%rbx, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
                	movq	%rdi, %r8
-               	movq	%r8, -0x120(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x130(%rbp)
-               	movq	-0x130(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	leaq	-0xe0(%rbp), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
                	movq	$0x60, %rdi
-<L1>:
+<L0>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
-               	jne	 <L1>
+               	jne	 <L0>
                	movq	$0x0, %rsi
                	cmpq	$0xc, %rsi
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rsi, %rdi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdi
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	addq	%r8, %rdi
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	leaq	(%r8,%rsi,8), %r13
                	movq	%rdi, (%r13)
                	addq	$0x1, %rsi
                	cmpq	$0xc, %rsi
-               	jb	 <L2>
-<L3>:
-               	leaq	-0x90(%rbp), %r13
+               	jb	 <L1>
+<L2>:
+               	leaq	-0x30(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -373,24 +618,24 @@ Disassembly of section .text:
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x116>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x10e>
                	movq	%rdi, (%rsi)
                	leaq	0x8(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x124>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x11c>
                	movq	%rdi, (%rsi)
                	leaq	0x10(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x132>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x12a>
                	movq	%rdi, (%rsi)
                	leaq	0x18(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x140>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x138>
                	movq	%rdi, (%rsi)
                	leaq	0x20(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x14e>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x146>
                	movq	%rdi, (%rsi)
                	leaq	0x28(%r13), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x15c>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x154>
                	movq	%rdi, (%rsi)
-               	leaq	-0xa0(%rbp), %r8
+               	leaq	-0x40(%rbp), %r8
                	movq	%r8, -0x128(%rbp)
                	movq	-0x128(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -398,197 +643,113 @@ Disassembly of section .text:
                	movq	$0x0, 0x8(%r8)
                	movq	-0x128(%rbp), %r8
                	leaq	(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x19b>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x190>
                	movq	%rdi, (%rsi)
                	movq	-0x128(%rbp), %r8
                	leaq	0x8(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1b0>
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1a5>
                	movq	%rdi, (%rsi)
-               	leaq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x138(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1ef>
-               	movq	%rdi, (%rsi)
-               	movq	-0x138(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x204>
-               	movq	%rdi, (%rsi)
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0x150(%rbp), %r8
-               	cmpq	$0xc, %r8
-               	jb	 <L4>
-               	jmp	 <L15>
-<L4>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %r14
-               	movq	(%r14), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r12
-               	leaq	(%r13,%r12,8), %r15
-               	movq	(%r15), %rcx
-               	movq	(%r14), %rsi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%rcx
-               	movq	%rax, %r8
+               	leaq	-0x50(%rbp), %r8
                	movq	%r8, -0x148(%rbp)
                	movq	-0x148(%rbp), %r8
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	$0x0, (%r8)
                	movq	-0x148(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1e1>
+               	movq	%rdi, (%rsi)
+               	movq	-0x148(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	leaq	, %rdi <corpus.cases.call.call_indirect.checksum+0x1f6>
+               	movq	%rdi, (%rsi)
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L5>
+               	addq	$0x1, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x118(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0xc, %r14
+               	jb	 <L3>
+               	jmp	 <L15>
+<L3>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	leaq	(%r13,%r8,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x138(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %r15
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x158(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rbx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x158(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %r8
-               	movq	(%r15), %rbx
-               	movq	(%r14), %rsi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%rbx
+               	movq	-0x130(%rbp), %r8
+               	leaq	(%r13,%r8,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%r15, %rdi
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x160(%rbp), %r8
+               	callq	*%r8
                	movq	%rax, %rsi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%rbx, %rdi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	movq	%r12, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %r12
                	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %r14
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
-               	movq	%rax, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rbx
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	cmpq	$0x0, %rcx
-               	je	 <L12>
-               	cmpq	$0x1, %rcx
-               	je	 <L11>
-               	cmpq	$0x2, %rcx
-               	je	 <L10>
-               	cmpq	$0x3, %rcx
-               	je	 <L9>
-               	cmpq	$0x4, %rcx
-               	je	 <L8>
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3bb>
-               	jmp	 <L13>
-<L8>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3c7>
-               	jmp	 <L13>
-<L9>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3d3>
-               	jmp	 <L13>
-<L10>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3df>
-               	jmp	 <L13>
-<L11>:
-               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x3eb>
-               	jmp	 <L13>
-<L12>:
-               	leaq	, %r12 <L13>
-<L13>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x150(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	*%r12
-               	movq	%rax, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x148(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	%rsi, %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	-0x150(%rbp), %r8
-               	cmpq	$0xc, %r8
-               	jb	 <L4>
-<L15>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x6, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rbx
-               	movq	-0x140(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	$0x0, %r14
-               	movq	%rcx, %r15
-               	cmpq	$0x8, %r14
-               	jb	 <L16>
-               	jmp	 <L18>
-<L16>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	addq	%r14, %rsi
                	movq	%rsi, %rax
                	movq	$0x6, %rsi
                	xorl	%edx, %edx
@@ -596,14 +757,131 @@ Disassembly of section .text:
                	movq	%rdx, %rsi
                	leaq	(%r13,%rsi,8), %rdi
                	movq	(%rdi), %r8
-               	movq	%r8, -0x158(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x158(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%r15, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x170(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	-0x170(%rbp), %r8
                	callq	*%r8
                	movq	%rax, %rsi
+               	movq	%rbx, %rdi
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %rbx
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	cmpq	$0x0, %rsi
+               	je	 <L12>
+               	cmpq	$0x1, %rsi
+               	je	 <L11>
+               	cmpq	$0x2, %rsi
+               	je	 <L10>
+               	cmpq	$0x3, %rsi
+               	je	 <L9>
+               	cmpq	$0x4, %rsi
+               	je	 <L8>
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x469>
+               	jmp	 <L13>
+<L8>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x475>
+               	jmp	 <L13>
+<L9>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x481>
+               	jmp	 <L13>
+<L10>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x48d>
+               	jmp	 <L13>
+<L11>:
+               	leaq	, %r12 <corpus.cases.call.call_indirect.checksum+0x499>
+               	jmp	 <L13>
+<L12>:
+               	leaq	, %r12 <L13>
+<L13>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%r15, %rdi
                	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	*%r12
+               	movq	%rax, %rsi
+               	movq	%rbx, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x120(%rbp)
+               	cmpq	$0xc, %r14
+               	jb	 <L3>
+<L15>:
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	(%r13,%rsi,8), %rdi
+               	movq	(%rdi), %rsi
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	-0x120(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r14
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L18>
+<L16>:
+               	movq	-0x180(%rbp), %r9
+               	leaq	(%r9,%r14,8), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	addq	%r14, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x6, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%r13,%rdi,8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x198(%rbp), %r8
+               	callq	*%r8
+               	movq	%rax, %rsi
+               	movq	-0x208(%rbp), %r8
                	movq	%r8, %rdi
                	callq	*%r15
                	movq	%rax, %r12
@@ -614,478 +892,424 @@ Disassembly of section .text:
                	movq	%rax, %rbx
                	addq	$0x1, %r14
                	movq	%r12, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x158(%rbp), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x198(%rbp), %r8
                	movq	%r8, %r15
                	cmpq	$0x8, %r14
                	jb	 <L16>
 <L18>:
+               	movq	%rbx, %r8
+               	movq	%r8, -0x238(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x8, %r13
                	jb	 <L19>
-               	jmp	 <L25>
+               	jmp	 <L28>
 <L19>:
-               	movq	-0x130(%rbp), %r8
-               	leaq	(%r8,%r13,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x2, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r14
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	addq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x2, %rsi
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %r15
-               	leaq	-0xc8(%rbp), %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0x188(%rbp), %r8
-               	addq	%r8, %rsi
-               	leaq	-0xe0(%rbp), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x168(%rbp), %r8
-               	callq	*%r8
-               	movq	-0x1e8(%rbp), %r8
-               	movq	-0x1e8(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x1e8(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x1e8(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	-0x170(%rbp), %r9
-               	movq	%r9, 0x10(%r8)
-               	movq	-0x160(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x160(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x178(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x180(%rbp)
-               	movq	%rbx, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
                	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1f0(%rbp)
-               	movq	-0x1f0(%rbp), %r8
-               	movq	-0x128(%rbp), %r8
-               	leaq	(%r8,%r15,8), %r12
-               	movq	(%r12), %r15
-               	leaq	-0xf8(%rbp), %rsi
-               	movq	-0x160(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0x160(%rbp), %r9
-               	movq	0x8(%r9), %r8
-               	movq	%r8, -0x190(%rbp)
-               	movq	-0x160(%rbp), %r9
-               	movq	0x10(%r9), %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	%rdi, (%rsi)
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, 0x8(%rsi)
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, 0x10(%rsi)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	0x10(%rsi), %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%rdi, (%rsp)
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, 0x8(%rsp)
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, 0x10(%rsp)
-               	callq	*%r15
-               	movq	%rax, %rsi
-               	movq	-0x1f0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %r15
-               	movq	(%r12), %r8
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	leaq	(%r8,%r14,8), %rsi
-               	movq	(%rsi), %r12
-               	movq	-0x130(%rbp), %r8
                	leaq	(%r8,%r13,8), %rsi
-               	movq	(%rsi), %r14
-               	leaq	-0x110(%rbp), %r8
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x2, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r14
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	addq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x2, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r15
+               	leaq	-0x68(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	-0x208(%rbp), %r8
+               	movq	%rdi, %rsi
+               	addq	%r8, %rsi
+               	leaq	-0x80(%rbp), %r8
                	movq	%r8, -0x1b0(%rbp)
                	movq	-0x1b0(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%r14, %rsi
-               	callq	*%r12
+               	movq	-0x1a8(%rbp), %r8
+               	callq	*%r8
                	movq	-0x1b0(%rbp), %r8
                	movq	-0x1b0(%rbp), %r8
                	movq	(%r8), %rsi
                	movq	-0x1b0(%rbp), %r8
                	movq	0x8(%r8), %rdi
-               	movq	-0x1b0(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L20>
+<L21>:
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	movq	-0x1e8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x270(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movq	-0x128(%rbp), %r8
+               	leaq	(%r8,%r15,8), %r12
+               	movq	(%r12), %r15
+               	leaq	-0xf8(%rbp), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x1a0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x1a0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	-0x218(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	-0x220(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x210(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x210(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	callq	*%r15
+               	movq	%rax, %r15
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L26>
+<L26>:
+               	movq	%rax, %r15
+               	movq	(%r12), %rbx
+               	movq	-0x148(%rbp), %r8
+               	leaq	(%r8,%r14,8), %rsi
+               	movq	(%rsi), %r12
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r8,%r13,8), %rsi
+               	movq	(%rsi), %r14
+               	leaq	-0x110(%rbp), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	*%r12
+               	movq	-0x240(%rbp), %r8
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x240(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x240(%rbp), %r8
                	movq	0x10(%r8), %r12
                	movq	%rsi, (%rsp)
                	movq	%rdi, 0x8(%rsp)
                	movq	%r12, 0x10(%rsp)
-               	movq	-0x1f8(%rbp), %r8
-               	callq	*%r8
+               	callq	*%rbx
                	movq	%rax, %rsi
                	movq	%r15, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rbx
+               	callq	 <L27>
+<L27>:
+               	movq	%rax, %rsi
                	addq	$0x1, %r13
+               	movq	%rsi, %r8
+               	movq	%r8, -0x238(%rbp)
                	cmpq	$0x8, %r13
                	jb	 <L19>
-<L25>:
-               	movq	%rbx, %r8
-               	movq	%r8, -0x1b8(%rbp)
+<L28>:
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x248(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L26>
-               	jmp	 <L71>
-<L26>:
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x1c0(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x120(%rbp), %r8
-               	movq	%rsi, %r13
+               	jb	 <L29>
+               	jmp	 <L42>
+<L29>:
+               	movq	-0x180(%rbp), %r8
+               	movq	-0x268(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	-0x150(%rbp), %r8
+               	movq	%rdi, %r13
                	addq	%r8, %r13
                	movl	%r13d, %r14d
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
+               	movq	%r13, %rsi
+               	andq	$0xfff, %rsi            # imm = 0xFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L28>
-<L27>:
+               	jl	 <L30>
+               	cvtsi2sd	%r11, %xmm14
+               	jmp	 <L31>
+<L30>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L28>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x8c5>
-               	movsd	%xmm14, -0x208(%rbp)
-               	movb	%r13b, %r15b
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm14
+               	addsd	%xmm14, %xmm14
+<L31>:
+               	movsd	%xmm14, -0x280(%rbp)
+               	movsd	-0x280(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xb85>
+               	movb	%r13b, %r8b
+               	movq	%r8, -0x258(%rbp)
+               	movq	%r13, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L30>:
-               	movss	%xmm14, -0x218(%rbp)
+<L33>:
+               	movss	%xmm14, -0x290(%rbp)
                	movq	%r13, %r8
                	imulq	$0x3, %r8, %r8
-               	movq	%r8, -0x220(%rbp)
+               	movq	%r8, -0x260(%rbp)
                	movq	%r13, %rsi
                	andq	$0xffff, %rsi           # imm = 0xFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L31>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L32>
-<L31>:
+               	jl	 <L34>
+               	cvtsi2sd	%r11, %xmm14
+               	jmp	 <L35>
+<L34>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L32>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x963>
-               	movsd	%xmm14, -0x230(%rbp)
-               	movw	%r13w, %bx
-               	movq	%r13, %r12
-               	xorq	$-0x1, %r12
+               	cvtsi2sd	%r11, %xmm14
+               	addsd	%xmm14, %xmm14
+<L35>:
+               	movsd	%xmm14, -0x2a0(%rbp)
+               	movsd	-0x2a0(%rbp), %xmm2
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xc2d>
+               	movw	%r13w, %r8w
+               	movq	%r8, -0x250(%rbp)
+               	movq	%r13, %r15
+               	xorq	$-0x1, %r15
                	movq	%r13, %rsi
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L33>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L34>
-<L33>:
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L34>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0x9bb>
-               	movss	%xmm14, -0x240(%rbp)
-               	movq	-0x188(%rbp), %r9
-               	movq	%r13, %r8
-               	xorq	%r9, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L37>
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
 <L37>:
-               	movq	%rax, %rdi
-               	movsd	-0x208(%rbp), %xmm0
+               	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
+               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xc83>
+               	movss	%xmm14, -0x2b0(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r13, %rbx
+               	xorq	%r8, %rbx
+               	movq	%r15, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r13, %rdi
+               	movl	%r14d, %esi
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x290(%rbp), %xmm1
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rcx
+               	movl	%r14d, %r8d
+               	movq	-0x250(%rbp), %r9
+               	movss	-0x2b0(%rbp), %xmm3
                	callq	 <L38>
 <L38>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	%rax, %rsi
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %rdi
-               	movss	-0x218(%rbp), %xmm0
+               	movq	%rax, %r12
+               	movsd	-0x280(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.call.call_indirect.checksum+0xd00>
+               	movsd	-0x2a0(%rbp), %xmm2
+               	divsd	, %xmm2 <corpus.cases.call.call_indirect.checksum+0xd10>
+               	movq	%r15, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r13, %rdi
+               	movl	%r14d, %esi
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x290(%rbp), %xmm1
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rcx
+               	movl	%r14d, %r8d
+               	movq	-0x250(%rbp), %r9
+               	movss	-0x2b0(%rbp), %xmm3
                	callq	 <L40>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0x220(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rsi
+               	movq	%r12, %rdi
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movsd	-0x230(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movss	-0x240(%rbp), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L47>
-<L47>:
                	movq	%rax, %rsi
-               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x268(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x1d0(%rbp), %r8
-               	movl	%r13d, %r12d
-               	movq	%r13, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L49>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L50>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xaed>
-               	movsd	%xmm14, -0x250(%rbp)
-               	movb	%r13b, %r14b
-               	movq	%r13, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L51>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L52>
-<L51>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L52>:
-               	movss	%xmm14, -0x260(%rbp)
-               	movq	%r13, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	%r13, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L53>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L54>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xb84>
-               	movsd	%xmm14, -0x270(%rbp)
-               	movw	%r13w, %r8w
-               	movq	%r8, -0x278(%rbp)
-               	movq	%r13, %rbx
-               	xorq	$-0x1, %rbx
-               	movq	%r13, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L55>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L56>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_indirect.checksum+0xbe3>
-               	movss	%xmm14, -0x288(%rbp)
-               	movq	-0x188(%rbp), %r9
-               	movq	%r13, %r8
-               	xorq	%r9, %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movsd	-0x250(%rbp), %xmm0
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movss	-0x260(%rbp), %xmm0
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
-               	movsd	-0x270(%rbp), %xmm0
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	-0x278(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movss	-0x288(%rbp), %xmm0
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rcx
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1b8(%rbp)
+               	addq	$0x1, %rdi
                	movq	%rsi, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L26>
-<L71>:
-               	movq	-0x1b8(%rbp), %r8
+               	jb	 <L29>
+<L42>:
+               	movq	-0x248(%rbp), %r8
                	movq	%r8, %rax
-               	movq	-0x298(%rbp), %rbx
-               	movq	-0x2a0(%rbp), %r12
-               	movq	-0x2a8(%rbp), %r13
-               	movq	-0x2b0(%rbp), %r14
-               	movq	-0x2b8(%rbp), %r15
+               	movq	-0x2b8(%rbp), %rbx
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_int_regs.dis
+++ b/test/golden/x86_64-linux/call/call_int_regs.dis
@@ -20,110 +20,375 @@ Disassembly of section .text:
                	movq	%r13, -0x78(%rbp)
                	movq	%r14, -0x80(%rbp)
                	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	movq	%rdx, %r13
-               	movq	%rcx, %r14
-               	movl	%r8d, %r15d
+               	movq	%rcx, %rax
+               	movl	%r8d, %ebx
                	movl	%r9d, %r8d
-               	movq	%r8, -0x50(%rbp)
-               	movq	0x10(%rbp), %r8
                	movq	%r8, -0x58(%rbp)
+               	movq	0x10(%rbp), %r8
+               	movq	%r8, -0x50(%rbp)
                	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x30(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x40(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x50(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	0x58(%rbp), %r8
+               	movq	0x20(%rbp), %r8
                	movq	%r8, -0x48(%rbp)
-               	callq	 <L0>
+               	movq	0x28(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x30(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%dil, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movsbq	%sil, %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L4>
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L5>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L6>
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L13>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L14>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
                	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
+               	movzbq	%r8b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x28(%rbp), %r8
+               	movslq	%r8d, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x68(%rbp), %rbx
                	movq	-0x70(%rbp), %r12
                	movq	-0x78(%rbp), %r13
@@ -136,121 +401,116 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.take16n>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	movq	%rdx, %r13
-               	movq	%rcx, %r14
-               	movq	%r8, %r15
-               	movq	%r9, %r8
-               	movq	%r8, -0x50(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	movq	%rsi, %rbx
+               	movq	%rdx, %r12
+               	movq	%rcx, %r13
+               	movq	%r8, %r14
+               	movq	%r9, %r15
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	0x30(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x28(%rbp)
-               	movq	0x40(%rbp), %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	0x48(%rbp), %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	0x50(%rbp), %r8
                	movq	%r8, -0x40(%rbp)
-               	movq	0x58(%rbp), %r8
+               	movq	0x18(%rbp), %r8
                	movq	%r8, -0x48(%rbp)
+               	movq	0x20(%rbp), %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	0x28(%rbp), %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	0x30(%rbp), %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	0x40(%rbp), %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	0x48(%rbp), %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	0x50(%rbp), %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	0x58(%rbp), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movzbq	%dil, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movzbq	%bl, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
+               	movsbq	%r12b, %rsi
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
+               	movsbq	%r13b, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	%r14, %rsi
+               	movzwq	%r14w, %rsi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movzwq	%r15w, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x40(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L6>
 <L6>:
+               	movq	-0x48(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
+               	movq	-0x50(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
+               	movq	-0x8(%rbp), %r8
+               	movsbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
+               	movq	-0x20(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
+               	movq	-0x28(%rbp), %r8
+               	movsbq	%r8b, %rsi
                	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L13>
 <L13>:
+               	movq	-0x30(%rbp), %r8
+               	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
+               	movq	-0x38(%rbp), %r8
+               	movswq	%r8w, %rsi
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -258,820 +518,551 @@ Disassembly of section .text:
 <corpus.cases.call.call_int_regs.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x390, %rsp            # imm = 0x390
-               	movq	%rbx, -0x368(%rbp)
-               	movq	%r12, -0x370(%rbp)
-               	movq	%r13, -0x378(%rbp)
-               	movq	%r14, -0x380(%rbp)
-               	movq	%r15, -0x388(%rbp)
+               	subq	$0x3c0, %rsp            # imm = 0x3C0
+               	movq	%rbx, -0x348(%rbp)
+               	movq	%r12, -0x350(%rbp)
+               	movq	%r13, -0x358(%rbp)
+               	movq	%r14, -0x360(%rbp)
+               	movq	%r15, -0x368(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	leaq	-0xa0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xa0, %rdx
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0xa0, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x14, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x210(%rbp)
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x14, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x188(%rbp)
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-               	jmp	 <L41>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L8>
+<L3>:
                	movq	%r15, %rax
                	imulq	$0x7, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	leaq	(%r12), %rax
-               	movq	(%rax), %rdx
-               	movb	%dl, %r8b
-               	movq	%r8, -0x2f0(%rbp)
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x2f8(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
                	movq	%r8, -0xa8(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r9
-               	movq	%rdi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0xd8(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0xe0(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xe8(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0xf0(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0xf8(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x330(%rbp)
+               	movq	-0x330(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
                	movq	%r8, -0x100(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r9
-               	movq	%rdi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x108(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x110(%rbp)
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0x2f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x2f8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
+               	leaq	0x8(%r12), %r8
+               	movq	%r8, -0xb0(%rbp)
                	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x110(%rbp)
+               	leaq	0x10(%r12), %r8
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x118(%rbp)
+               	leaq	0x18(%r12), %r8
+               	movq	%r8, -0xc0(%rbp)
                	movq	-0xc0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0xc8(%rbp)
+               	leaq	0x20(%r12), %r8
+               	movq	%r8, -0xd0(%rbp)
                	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0xd8(%rbp)
+               	leaq	0x28(%r12), %r8
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0xf0(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rcx
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rcx
+               	leaq	0x38(%r12), %r8
+               	movq	%r8, -0xf8(%rbp)
                	movq	-0xf8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rdi
+               	leaq	0x40(%r12), %r8
+               	movq	%r8, -0x108(%rbp)
                	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rsi
+               	movb	%sil, %dl
+               	leaq	0x48(%r12), %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x128(%rbp)
+               	leaq	0x50(%r12), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movw	%si, %r8w
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x58(%r12), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movw	%si, %r8w
+               	movq	%r8, -0x148(%rbp)
+               	leaq	0x60(%r12), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	leaq	0x68(%r12), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x168(%rbp)
+               	leaq	0x70(%r12), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rsi
+               	leaq	0x78(%r12), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	%rcx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rdx, 0x10(%rsp)
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rsi, 0x40(%rsp)
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
                	movq	-0x110(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	-0x210(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x300(%rbp)
-               	movq	-0x300(%rbp), %r8
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x308(%rbp)
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x118(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x120(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x128(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x130(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x138(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x140(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x148(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r8
-               	addq	%r8, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x150(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x158(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x160(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x168(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x2e8(%rbp), %r8
-               	addq	%r8, %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x310(%rbp)
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0x308(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
                	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x148(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x150(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movq	-0x310(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	movq	-0x300(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L40>
-<L40>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0x210(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %r14
-               	cmpq	$0x3, %r15
-               	jb	 <L4>
-<L41>:
-               	leaq	(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %bl
-               	leaq	0x8(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r15b
-               	leaq	0x10(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x320(%rbp)
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x328(%rbp)
-               	leaq	0x20(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x330(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x188(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x1b0(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x1b8(%rbp)
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x1c8(%rbp)
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	movq	-0x328(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	movq	-0x330(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe8(%rbp), %r9
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rsi
                	movq	-0x188(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r13
+               	movq	-0x330(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %di
+               	movq	-0xf8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %si
+               	movq	-0x108(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rax
+               	movb	%al, %dl
+               	movq	-0x120(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %cl
+               	movq	-0x130(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %r8b
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0xa8(%rbp), %r8
+               	addq	%r8, %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdx, 0x10(%rsp)
+               	movq	%rcx, 0x18(%rsp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
                	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
                	movq	-0x1a8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
                	movq	-0x1b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdx
                	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L58>
-<L58>:
-               	movb	%al, %r8b
-               	movq	%r8, -0x240(%rbp)
-               	leaq	0x8(%r12), %rax
+               	movq	%r8, %rcx
+               	movq	-0x190(%rbp), %r8
+               	movq	-0x198(%rbp), %r9
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r14
+               	movq	%r13, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L7>
+<L7>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x188(%rbp)
+               	cmpq	$0x3, %r15
+               	jb	 <L3>
+<L8>:
+               	leaq	(%r12), %rax
                	movq	(%rax), %rcx
                	movb	%cl, %r8b
-               	movq	%r8, -0x268(%rbp)
-               	leaq	0x10(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x278(%rbp)
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movw	%dx, %r8w
-               	movq	%r8, -0x288(%rbp)
-               	movl	%r14d, %r8d
+               	movq	%r8, -0x1f0(%rbp)
+               	leaq	0x8(%r12), %rbx
+               	movq	(%rbx), %rax
+               	movb	%al, %r8b
                	movq	%r8, -0x220(%rbp)
-               	leaq	0x28(%r12), %r8
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	-0x1f8(%rbp), %r8
+               	leaq	0x10(%r12), %r13
+               	movq	(%r13), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x230(%rbp)
+               	leaq	0x18(%r12), %r15
+               	movq	(%r15), %rax
+               	movw	%ax, %r8w
+               	movq	%r8, -0x238(%rbp)
+               	leaq	0x20(%r12), %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x338(%rbp), %r8
                	movq	(%r8), %rdi
                	movl	%edi, %r8d
-               	movq	%r8, -0x230(%rbp)
-               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	leaq	0x28(%r12), %r8
                	movq	%r8, -0x200(%rbp)
-               	movq	-0x200(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	leaq	0x38(%r12), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x1e8(%rbp), %r9
-               	movq	(%r9), %r8
-               	movq	%r8, -0x1f0(%rbp)
-               	leaq	0x80(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, -0x338(%rbp)
-               	leaq	0x88(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x208(%rbp)
-               	movq	-0x208(%rbp), %r8
-               	movb	%r8b, %r13b
-               	leaq	0x90(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x218(%rbp)
-               	movq	-0x218(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x340(%rbp)
-               	leaq	0x98(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x228(%rbp)
-               	movq	-0x228(%rbp), %r8
-               	movb	%r8b, %r14b
-               	leaq	0x20(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x238(%rbp)
-               	movq	-0x238(%rbp), %r8
-               	movw	%r8w, %bx
-               	movq	-0x1f8(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x248(%rbp)
                	movq	-0x200(%rbp), %r8
                	movq	(%r8), %rdi
-               	movw	%di, %r8w
-               	movq	%r8, -0x250(%rbp)
-               	movq	-0x1e8(%rbp), %r8
+               	movl	%edi, %r8d
+               	movq	%r8, -0x208(%rbp)
+               	leaq	0x30(%r12), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
                	movq	(%r8), %rdi
-               	movw	%di, %r8w
+               	leaq	0x38(%r12), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	leaq	0x40(%r12), %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	-0x228(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %cl
+               	leaq	0x48(%r12), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x248(%rbp)
+               	leaq	0x50(%r12), %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
                	movq	%r8, -0x258(%rbp)
-               	leaq	0x40(%r12), %rdi
-               	movq	(%rdi), %r8
+               	leaq	0x58(%r12), %r8
                	movq	%r8, -0x260(%rbp)
                	movq	-0x260(%rbp), %r8
-               	movb	%r8b, %r15b
-               	leaq	0x48(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x268(%rbp)
+               	leaq	0x60(%r12), %r8
                	movq	%r8, -0x270(%rbp)
-               	movq	-0x270(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x348(%rbp)
-               	leaq	0x50(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x278(%rbp)
+               	leaq	0x68(%r12), %r8
                	movq	%r8, -0x280(%rbp)
-               	movq	-0x280(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x350(%rbp)
-               	leaq	0x58(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x288(%rbp)
+               	leaq	0x70(%r12), %r8
                	movq	%r8, -0x290(%rbp)
-               	movq	-0x290(%rbp), %r9
-               	movw	%r9w, %r8w
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rdx
+               	leaq	0x78(%r12), %r8
                	movq	%r8, -0x298(%rbp)
-               	leaq	0x60(%r12), %rdi
-               	movq	(%rdi), %r8
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
                	movq	%r8, -0x2a0(%rbp)
-               	movq	-0x2a0(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x2a8(%rbp)
-               	leaq	0x68(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2b0(%rbp)
-               	movq	-0x2b0(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x2b8(%rbp)
-               	leaq	0x70(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2c0(%rbp)
-               	movq	-0x2c0(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x2c8(%rbp)
-               	leaq	0x78(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x2d0(%rbp)
-               	movq	-0x2d0(%rbp), %r9
-               	movw	%r9w, %r8w
-               	movq	%r8, -0x2d8(%rbp)
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movq	-0x338(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movq	-0x340(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
                	movq	-0x248(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	-0x250(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rdi
+               	movq	%r8, 0x18(%rsp)
                	movq	-0x258(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rdx, 0x40(%rsp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x220(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	movq	-0x348(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	movq	-0x350(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x1f8(%rbp), %r8
+               	movq	-0x208(%rbp), %r9
+               	callq	 <L9>
+<L9>:
+               	movq	%rax, %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	(%rbx), %rcx
+               	movb	%cl, %r8b
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	(%r13), %rcx
+               	movw	%cx, %r8w
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	(%r15), %rcx
+               	movw	%cx, %r15w
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movl	%ecx, %r14d
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %r13
+               	leaq	0x80(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x88(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2d8(%rbp)
+               	leaq	0x90(%r12), %rcx
+               	movq	(%rcx), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x2e0(%rbp)
+               	leaq	0x98(%r12), %rdx
+               	movq	(%rdx), %r12
+               	movb	%r12b, %r8b
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x338(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %di
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %si
+               	movq	-0x228(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %cl
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %al
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r12w
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movb	%dl, %r8b
+               	movq	%r8, -0x308(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x310(%rbp)
                	movq	-0x298(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movq	-0x2a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movq	-0x2b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	movq	-0x2c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
+               	movq	(%r8), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x318(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
+               	movq	%rax, 0x18(%rsp)
+               	movq	%r12, 0x20(%rsp)
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x300(%rbp), %r8
+               	movq	%r8, 0x30(%rsp)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, 0x40(%rsp)
+               	movq	-0x318(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x2d0(%rbp), %r8
+               	movq	%r8, %rdi
                	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L75>
-<L75>:
-               	movb	%al, %bl
-               	leaq	0x48(%r12), %rax
-               	movq	(%rax), %rcx
-               	movb	%cl, %r13b
-               	leaq	0x50(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r14w
-               	leaq	0x58(%r12), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r15w
-               	leaq	0x60(%r12), %rax
-               	movq	(%rax), %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x358(%rbp)
-               	leaq	0x68(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x360(%rbp)
-               	leaq	0x70(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x2e0(%rbp)
-               	leaq	0x78(%r12), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rdi
-               	movq	-0x240(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rdi
-               	movq	-0x268(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rdi
-               	movq	-0x278(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x288(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movq	-0x220(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movq	-0x230(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-               	movq	-0x1f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L84>
-<L84>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %rdi
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L89>
-<L89>:
-               	movq	%rax, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L90>
-<L90>:
-               	movq	%rax, %rdi
                	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x2f0(%rbp), %r9
+               	callq	 <L10>
+<L10>:
+               	movb	%al, %cl
+               	movq	-0x240(%rbp), %r8
+               	movq	(%r8), %rax
+               	movb	%al, %dl
+               	movq	-0x250(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %si
+               	movq	-0x260(%rbp), %r8
+               	movq	(%r8), %rax
+               	movw	%ax, %di
+               	movq	-0x270(%rbp), %r8
+               	movq	(%r8), %rax
+               	movl	%eax, %r12d
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x290(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x298(%rbp), %r9
+               	movq	(%r9), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	%rbx, (%rsp)
+               	movq	%r13, 0x8(%rsp)
+               	movq	%rcx, 0x10(%rsp)
+               	movq	%rdx, 0x18(%rsp)
+               	movq	%rsi, 0x20(%rsp)
+               	movq	%rdi, 0x28(%rsp)
+               	movq	%r12, 0x30(%rsp)
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, 0x38(%rsp)
+               	movq	%rax, 0x40(%rsp)
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, 0x48(%rsp)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x2b8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x210(%rbp), %r8
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	%r15, %rcx
+               	movq	-0x2b0(%rbp), %r8
+               	movl	%r14d, %r9d
+               	callq	 <L11>
+<L11>:
+               	movq	-0x188(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x368(%rbp), %rbx
-               	movq	-0x370(%rbp), %r12
-               	movq	-0x378(%rbp), %r13
-               	movq	-0x380(%rbp), %r14
-               	movq	-0x388(%rbp), %r15
+               	callq	 <L12>
+<L12>:
+               	movq	-0x348(%rbp), %rbx
+               	movq	-0x350(%rbp), %r12
+               	movq	-0x358(%rbp), %r13
+               	movq	-0x360(%rbp), %r14
+               	movq	-0x368(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_mixed.dis
+++ b/test/golden/x86_64-linux/call/call_mixed.dis
@@ -56,260 +56,584 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.mixed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1a0, %rsp            # imm = 0x1A0
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%r15, -0x198(%rbp)
-               	movq	%rdi, %r10
-               	movq	%r10, -0x78(%rbp)
-               	movss	%xmm0, -0xa8(%rbp)
-               	movl	%esi, %r12d
-               	movsd	%xmm1, -0xb8(%rbp)
-               	movups	%xmm2, -0xd0(%rbp)
-               	movq	%rdx, %r13
-               	movss	%xmm3, -0xe0(%rbp)
-               	movq	%rcx, %r14
-               	movsd	%xmm5, -0xf0(%rbp)
-               	movq	%r8, %r10
+               	subq	$0x1d0, %rsp            # imm = 0x1D0
+               	movq	%rbx, -0x1a8(%rbp)
+               	movq	%r12, -0x1b0(%rbp)
+               	movq	%r13, -0x1b8(%rbp)
+               	movq	%r14, -0x1c0(%rbp)
+               	movq	%r15, -0x1c8(%rbp)
+               	movq	%rdi, %rbx
+               	movss	%xmm0, -0x120(%rbp)
+               	movl	%esi, %r10d
+               	movq	%r10, -0xa0(%rbp)
+               	movsd	%xmm1, -0x130(%rbp)
+               	movups	%xmm2, -0x140(%rbp)
+               	movq	%rdx, %r10
                	movq	%r10, -0x98(%rbp)
-               	movss	%xmm6, -0x100(%rbp)
-               	movq	%r9, %r8
-               	movq	%r8, -0x90(%rbp)
-               	movsd	%xmm7, -0x110(%rbp)
-               	movsd	0x10(%rbp), %xmm0
-               	movq	0x18(%rbp), %r8
-               	movq	%r8, -0x118(%rbp)
+               	movss	%xmm3, -0x150(%rbp)
+               	movq	%rcx, %r10
+               	movq	%r10, -0x90(%rbp)
+               	movsd	%xmm5, -0x160(%rbp)
+               	movq	%r8, %r12
+               	movss	%xmm6, -0x170(%rbp)
+               	movq	%r9, %r13
+               	movsd	%xmm7, -0x180(%rbp)
+               	movsd	0x10(%rbp), %xmm7
+               	movq	0x18(%rbp), %r14
                	movq	0x20(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
-               	movq	0x28(%rbp), %r8
-               	movq	%r8, -0x88(%rbp)
+               	movq	%r11, -0x190(%rbp)
+               	movq	0x28(%rbp), %r15
                	movq	0x30(%rbp), %r11
-               	movq	%r11, -0x138(%rbp)
+               	movq	%r11, -0x1a0(%rbp)
                	movq	0x38(%rbp), %r8
-               	movq	%r8, -0x80(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r8, -0x78(%rbp)
+               	leaq	-0xc(%rbp), %r8
+               	movq	%r8, -0xa8(%rbp)
                	leaq	-0x20(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	leaq	-0x28(%rbp), %r15
-               	movups	-0xd0(%rbp), %xmm14
+               	movq	%r8, -0x80(%rbp)
+               	leaq	-0x28(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	movups	-0x140(%rbp), %xmm14
                	movups	%xmm14, -0x38(%rbp)
-               	movq	-0x38(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x30(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x38(%rbp), %rax
+               	movq	-0xa8(%rbp), %r8
+               	movq	%rax, (%r8)
+               	movl	-0x30(%rbp), %eax
+               	movq	-0xa8(%rbp), %r8
+               	movl	%eax, 0x8(%r8)
+               	movq	-0x80(%rbp), %r8
                	movups	%xmm4, (%r8)
-               	movsd	%xmm0, (%r15)
-               	callq	 <L0>
+               	movq	-0x88(%rbp), %r8
+               	movsd	%xmm7, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L1>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L2>
+               	movl	-0x120(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xb0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	-0xb8(%rbp), %xmm0
-               	callq	 <L4>
+               	movq	-0xa0(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L6>
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L7>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	movq	-0xa8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xc8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
+               	movq	-0xa8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0xa8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movl	-0x150(%rbp), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xe0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x90(%rbp), %r9
+               	movzwq	%r9w, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xf0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x80(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movl	-0x170(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movzbq	%r13b, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movq	-0x180(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	movq	%rax, %rdi
                	movq	%r14, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L37>
+<L37>:
+               	movl	-0x190(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r11d
-               	movl	%r11d, -0x150(%rbp)
-               	movss	-0x150(%rbp), %xmm0
-               	callq	 <L11>
-<L11>:
+               	callq	 <L38>
+<L38>:
+               	movslq	%r15d, %rsi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r11d
-               	movl	%r11d, -0x160(%rbp)
-               	movss	-0x160(%rbp), %xmm0
-               	callq	 <L12>
-<L12>:
+               	callq	 <L39>
+<L39>:
+               	movq	-0x1a0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L13>
-<L13>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movsd	-0xf0(%rbp), %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movsd	-0x110(%rbp), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0x170(%rbp)
-               	movss	-0x170(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0x128(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movsd	-0x138(%rbp), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	-0x118(%rbp), %r9
-               	movq	%r8, %rcx
-               	imulq	%r9, %rcx
                	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%rcx, %rdx
+               	movq	%r8, %rsi
+               	callq	 <L41>
+<L41>:
+               	imulq	%r14, %r12
+               	addq	%r12, %rbx
+               	movq	-0x78(%rbp), %r8
+               	subq	%r8, %rbx
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L42>
+<L42>:
+               	movss	-0x150(%rbp), %xmm4
+               	mulss	-0x170(%rbp), %xmm4
+               	movss	-0x120(%rbp), %xmm2
+               	addss	%xmm4, %xmm2
+               	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
+               	subss	-0x190(%rbp), %xmm4
+               	movd	%xmm4, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movsd	-0x160(%rbp), %xmm2
+               	mulsd	-0x180(%rbp), %xmm2
+               	movsd	-0x130(%rbp), %xmm3
+               	addsd	%xmm2, %xmm3
+               	movsd	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1]
+               	subsd	-0x1a0(%rbp), %xmm0
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	-0x44(%rbp), %rdx
                	movq	-0x80(%rbp), %r8
-               	subq	%r8, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movss	-0xe0(%rbp), %xmm0
-               	mulss	-0x100(%rbp), %xmm0
-               	movss	-0xa8(%rbp), %xmm2
-               	addss	%xmm0, %xmm2
-               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
-               	subss	-0x128(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0xf0(%rbp), %xmm0
-               	mulsd	-0x110(%rbp), %xmm0
-               	movsd	-0xb8(%rbp), %xmm2
-               	addsd	%xmm0, %xmm2
-               	movsd	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1]
-               	subsd	-0x138(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	leaq	-0x44(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	-0x150(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	-0x160(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	-0x170(%rbp), %r11d
-               	movl	%r11d, (%rdx)
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x80(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
                	movq	$0x0, -0x54(%rbp)
                	movq	$0x0, -0x4c(%rbp)
-               	movq	(%rcx), %rdx
-               	movq	%rdx, -0x54(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0x4c(%rbp)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x54(%rbp)
+               	movl	0x8(%rdx), %esi
+               	movl	%esi, -0x4c(%rbp)
                	movups	-0x54(%rbp), %xmm0
-               	movaps	-0xd0(%rbp), %xmm14
+               	movaps	-0x140(%rbp), %xmm14
                	addps	%xmm0, %xmm14
                	movaps	%xmm14, %xmm1
                	leaq	-0x60(%rbp), %rbx
                	movups	%xmm1, -0x70(%rbp)
-               	movq	-0x70(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x68(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
+               	movq	-0x70(%rbp), %rdx
+               	movq	%rdx, (%rbx)
+               	movl	-0x68(%rbp), %edx
+               	movl	%edx, 0x8(%rbx)
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
+               	callq	 <L45>
+<L45>:
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
-               	movq	-0x198(%rbp), %r15
+               	callq	 <L46>
+<L46>:
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
+               	movq	-0x1a8(%rbp), %rbx
+               	movq	-0x1b0(%rbp), %r12
+               	movq	-0x1b8(%rbp), %r13
+               	movq	-0x1c0(%rbp), %r14
+               	movq	-0x1c8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -324,68 +648,66 @@ Disassembly of section .text:
                	movq	%r14, -0x380(%rbp)
                	movq	%r15, -0x388(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	leaq	-0xd8(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rcx
 <L0>:
-               	leaq	-0xc0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xc0, %rdx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	movq	%rax, %rcx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rcx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x18, %rcx
-               	jb	 <L2>
-<L3>:
-               	movq	%rax, %r13
+               	addq	%r11, %rcx
+               	addq	%rbx, %rcx
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	%rcx, (%rdx)
+               	addq	$0x1, %rax
+               	cmpq	$0x18, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-               	jmp	 <L36>
-<L4>:
+               	jb	 <L3>
+               	jmp	 <L35>
+<L3>:
                	movq	%r15, %rax
                	imulq	$0xb, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
                	movq	%r8, -0x190(%rbp)
-               	leaq	-0xcc(%rbp), %rax
+               	leaq	-0xc(%rbp), %rax
                	leaq	0x80(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
+<L5>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x136>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x135>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x142>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x141>
                	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x88(%r12), %rdx
@@ -393,21 +715,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L7>
+               	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
-<L7>:
+               	jmp	 <L7>
+<L6>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L8>:
+<L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x193>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x192>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x19f>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x19e>
                	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x90(%r12), %rdx
@@ -415,21 +737,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L9>
+<L8>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L10>:
+<L9>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f1>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f0>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1fd>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1fc>
                	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movq	$0x0, -0xe8(%rbp)
@@ -446,21 +768,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L11>
+               	jl	 <L10>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L12>
-<L11>:
+               	jmp	 <L11>
+<L10>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L12>:
+<L11>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x28f>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x28e>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x29b>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x29a>
                	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa0(%r12), %rdx
@@ -468,21 +790,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L13>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L14>
-<L13>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L14>:
+<L13>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2ec>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2eb>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2f8>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2f7>
                	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa8(%r12), %rdx
@@ -490,21 +812,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L15>
+               	jl	 <L14>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L16>
-<L15>:
+               	jmp	 <L15>
+<L14>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L16>:
+<L15>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x34a>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x349>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x356>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x355>
                	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xb0(%r12), %rdx
@@ -512,21 +834,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L16>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L18>:
+<L17>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a8>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a7>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3b4>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3b3>
                	leaq	0xc(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rax), %xmm14
@@ -538,21 +860,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rsi            # imm = 0xFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L19>
+               	jl	 <L18>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
-<L19>:
+               	jmp	 <L19>
+<L18>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L20>:
+<L19>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x420>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x41f>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x42c>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x42b>
                	movq	-0x1b8(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
@@ -563,8 +885,8 @@ Disassembly of section .text:
                	movq	-0x190(%rbp), %r8
                	addq	%r8, %rsi
                	movq	%rsi, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L20>
+<L20>:
                	movq	-0x1b8(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movss	%xmm0, (%rsi)
@@ -579,8 +901,8 @@ Disassembly of section .text:
                	movq	%r8, -0x1d8(%rbp)
                	leaq	0x8(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L22>
-<L22>:
+               	callq	 <L21>
+<L21>:
                	movss	%xmm0, -0x1e8(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rsi
@@ -591,29 +913,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L23>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L24>
-<L23>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L24>:
+<L23>:
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-               	subsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x50d>
+               	subsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x50c>
                	movsd	%xmm5, %xmm14           # xmm14 = xmm5[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x51b>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x51a>
                	movsd	%xmm14, -0x200(%rbp)
                	leaq	0x20(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x138(%rbp)
                	leaq	0x28(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L24>
+<L24>:
                	movss	%xmm0, -0x210(%rbp)
                	leaq	0x30(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -624,29 +946,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm6
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm6
                	addsd	%xmm6, %xmm6
-<L27>:
+<L26>:
                	movsd	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1]
-               	subsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x5a2>
+               	subsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x5a1>
                	movsd	%xmm7, %xmm14           # xmm14 = xmm7[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5b0>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5af>
                	movsd	%xmm14, -0x220(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x148(%rbp)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L28>
-<L28>:
+               	callq	 <L27>
+<L27>:
                	movss	%xmm0, -0x230(%rbp)
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -657,29 +979,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdi          # imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L29>
+               	jl	 <L28>
                	cvtsi2sd	%r11, %xmm8
-               	jmp	 <L30>
-<L29>:
+               	jmp	 <L29>
+<L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm8
                	addsd	%xmm8, %xmm8
-<L30>:
+<L29>:
                	movsd	%xmm8, %xmm9            # xmm9 = xmm8[0],xmm9[1]
-               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x639>
+               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x638>
                	movsd	%xmm9, %xmm14           # xmm14 = xmm9[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x647>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x646>
                	movsd	%xmm14, -0x240(%rbp)
                	leaq	0x60(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x158(%rbp)
                	leaq	0x68(%r12), %rsi
                	movq	(%rsi), %rdi
-               	callq	 <L31>
-<L31>:
+               	callq	 <L30>
+<L30>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x70(%r12), %rsi
                	movq	(%rsi), %rdi
@@ -690,21 +1012,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L31>
                	cvtsi2sd	%r11, %xmm10
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm10
                	addsd	%xmm10, %xmm10
-<L33>:
+<L32>:
                	movsd	%xmm10, %xmm11          # xmm11 = xmm10[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x6cd>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x6cc>
                	movsd	%xmm11, %xmm10          # xmm10 = xmm11[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x6db>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x6da>
                	leaq	0x8(%r12), %rsi
                	movq	(%rsi), %rdi
                	movq	-0x190(%rbp), %r8
@@ -736,38 +1058,38 @@ Disassembly of section .text:
                	movss	-0x230(%rbp), %xmm6
                	movq	-0x150(%rbp), %r9
                	movsd	-0x240(%rbp), %xmm7
-               	callq	 <L34>
-<L34>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L4>
-<L36>:
-               	leaq	-0xd8(%rbp), %rax
+               	jb	 <L3>
+<L35>:
+               	leaq	-0x18(%rbp), %rax
                	movq	%r14, %rcx
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L37>
+               	jl	 <L36>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L38>
-<L37>:
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L38>:
+<L37>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x804>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x800>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x810>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x80c>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%r12), %rcx
@@ -775,21 +1097,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L40>:
+<L39>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x85e>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x85a>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x86a>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x866>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%r12), %rcx
@@ -797,21 +1119,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L41>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L41>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b9>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8b5>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8c5>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8c1>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -828,21 +1150,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L43>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x954>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x950>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x960>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x95c>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%r12), %rcx
@@ -850,21 +1172,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L45>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9ae>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9aa>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9ba>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9b6>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%r12), %rcx
@@ -872,21 +1194,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L47>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa09>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa05>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa15>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa11>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%r12), %rcx
@@ -894,21 +1216,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L49>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa64>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa60>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa70>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa6c>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm14
@@ -919,27 +1241,27 @@ Disassembly of section .text:
                	andq	$0xfff, %rcx            # imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L51>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xad2>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xace>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xade>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xada>
                	leaq	(%rbx), %rax
                	movss	%xmm0, (%rax)
                	leaq	0x48(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L52>
+<L52>:
                	leaq	0x4(%rbx), %rax
                	movss	%xmm0, (%rax)
                	movq	(%rbx), %r11
@@ -948,8 +1270,8 @@ Disassembly of section .text:
                	movq	(%rax), %rbx
                	leaq	0x8(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L53>
+<L53>:
                	movss	%xmm0, -0x280(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rcx
@@ -959,29 +1281,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L55>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L56>
-<L55>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L56>:
+<L55>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xb72>
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xb6e>
                	movsd	%xmm2, %xmm14           # xmm14 = xmm2[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xb80>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xb7c>
                	movsd	%xmm14, -0x298(%rbp)
                	leaq	0x20(%r12), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x288(%rbp)
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L56>
+<L56>:
                	movss	%xmm0, -0x2a8(%rbp)
                	leaq	0x30(%r12), %rax
                	movq	(%rax), %rdx
@@ -992,29 +1314,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L58>
+               	jl	 <L57>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L59>
-<L58>:
+               	jmp	 <L58>
+<L57>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L59>:
+<L58>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc07>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc03>
                	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc15>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc11>
                	movsd	%xmm14, -0x2c0(%rbp)
                	leaq	0x40(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x168(%rbp)
                	leaq	0x48(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L59>
+<L59>:
                	movss	%xmm0, -0x2d0(%rbp)
                	leaq	0x50(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -1025,29 +1347,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L60>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L61>
+<L60>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L62>:
+<L61>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc9b>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xc97>
                	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xca9>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xca5>
                	movsd	%xmm14, -0x2e8(%rbp)
                	leaq	0x60(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x2d8(%rbp)
                	leaq	0x68(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L62>
+<L62>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	leaq	0x70(%r12), %rdx
                	movq	(%rdx), %rdi
@@ -1058,21 +1380,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %rdx          # imm = 0xFFFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L64>
+               	jl	 <L63>
                	cvtsi2sd	%r11, %xmm4
-               	jmp	 <L65>
-<L64>:
+               	jmp	 <L64>
+<L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm4
                	addsd	%xmm4, %xmm4
-<L65>:
+<L64>:
                	movsd	%xmm4, %xmm11           # xmm11 = xmm4[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xd2d>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xd29>
                	movsd	%xmm11, %xmm4           # xmm4 = xmm11[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd3a>
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd36>
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %rdi
                	movq	-0x270(%rbp), %r11
@@ -1100,13 +1422,13 @@ Disassembly of section .text:
                	movss	-0x2d0(%rbp), %xmm6
                	movq	-0x170(%rbp), %r9
                	movsd	-0x2e8(%rbp), %xmm7
-               	callq	 <L66>
-<L66>:
+               	callq	 <L65>
+<L65>:
                	movq	%rax, %rbx
                	leaq	0x18(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L67>
-<L67>:
+               	callq	 <L66>
+<L66>:
                	movss	%xmm0, -0x2f8(%rbp)
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rcx
@@ -1116,29 +1438,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L68>
+               	jl	 <L67>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L69>
-<L68>:
+               	jmp	 <L68>
+<L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L69>:
+<L68>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe4b>
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe47>
                	movsd	%xmm2, %xmm14           # xmm14 = xmm2[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xe59>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xe55>
                	movsd	%xmm14, -0x310(%rbp)
                	leaq	0x48(%r12), %rax
                	movq	(%rax), %r8
                	movq	%r8, -0x300(%rbp)
                	leaq	0x58(%r12), %rax
                	movq	(%rax), %rdi
-               	callq	 <L70>
-<L70>:
+               	callq	 <L69>
+<L69>:
                	movss	%xmm0, -0x320(%rbp)
                	leaq	0x68(%r12), %rax
                	movq	(%rax), %rdx
@@ -1149,29 +1471,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L71>
+               	jl	 <L70>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L71>
+<L70>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L72>:
+<L71>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xee0>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xedc>
                	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xeee>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xeea>
                	movsd	%xmm14, -0x338(%rbp)
                	leaq	0x88(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x180(%rbp)
                	leaq	0x98(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L72>
+<L72>:
                	movss	%xmm0, -0x348(%rbp)
                	leaq	0xa8(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -1182,29 +1504,29 @@ Disassembly of section .text:
                	andq	$0xfffff, %rsi          # imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L74>
+               	jl	 <L73>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L75>
-<L74>:
+               	jmp	 <L74>
+<L73>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L75>:
+<L74>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xf80>
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xf7c>
                	movsd	%xmm4, %xmm14           # xmm14 = xmm4[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf8e>
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf8a>
                	movsd	%xmm14, -0x360(%rbp)
                	leaq	0x10(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x350(%rbp)
                	leaq	0x20(%r12), %rdx
                	movq	(%rdx), %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L75>
+<L75>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	leaq	0x30(%r12), %rdx
                	movq	(%rdx), %rdi
@@ -1214,21 +1536,21 @@ Disassembly of section .text:
                	andq	$0xfffff, %r12          # imm = 0xFFFFF
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L77>
+               	jl	 <L76>
                	cvtsi2sd	%r11, %xmm4
-               	jmp	 <L78>
-<L77>:
+               	jmp	 <L77>
+<L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm4
                	addsd	%xmm4, %xmm4
-<L78>:
+<L77>:
                	movsd	%xmm4, %xmm11           # xmm11 = xmm4[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x100a>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x1006>
                	movsd	%xmm11, %xmm4           # xmm4 = xmm11[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1017>
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1013>
                	movq	-0x270(%rbp), %r11
                	movq	%r11, (%rsp)
                	movq	-0x350(%rbp), %r8
@@ -1253,12 +1575,12 @@ Disassembly of section .text:
                	movss	-0x348(%rbp), %xmm6
                	movq	-0x188(%rbp), %r9
                	movsd	-0x360(%rbp), %xmm7
-               	callq	 <L79>
-<L79>:
+               	callq	 <L78>
+<L78>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L80>
-<L80>:
+               	callq	 <L79>
+<L79>:
                	movq	-0x368(%rbp), %rbx
                	movq	-0x370(%rbp), %r12
                	movq	-0x378(%rbp), %r13

--- a/test/golden/x86_64-linux/call/call_rec_edge.dis
+++ b/test/golden/x86_64-linux/call/call_rec_edge.dis
@@ -18,36 +18,75 @@ Disassembly of section .text:
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x18(%rbp), %rbx
-               	leaq	-0x10(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0xf(%rbp), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, (%rbx)
-               	callq	 <L0>
+               	leaq	-0x18(%rbp), %rax
+               	leaq	-0x10(%rbp), %rdx
+               	movzbl	(%rdx), %esi
+               	leaq	-0xf(%rbp), %rdx
+               	movq	(%rdx), %rbx
+               	movq	%rbx, (%rax)
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L1>
-               	jmp	 <L3>
-<L1>:
-               	leaq	(%rbx,%r13), %rax
-               	movzbl	(%rax), %esi
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
                	movq	%r12, %rdi
-               	callq	 <L2>
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L1>
+               	leaq	(%rax,%rdx), %rsi
+               	movzbl	(%rsi), %ebx
+               	movzbq	%bl, %rsi
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%r12, %rax
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -55,30 +94,85 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.fold_e12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -88,19 +182,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -109,19 +240,57 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movsd	%xmm1, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm1
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -130,19 +299,56 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -154,39 +360,78 @@ Disassembly of section .text:
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	-0x11(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r14, -0x40(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	-0x11(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rbx
+               	movb	0x10(%rax), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	leaq	(%rdx), %rax
+               	movzbl	(%rax), %esi
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L1>
-               	jmp	 <L3>
-<L1>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
                	movq	%r12, %rdi
-               	callq	 <L2>
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L2>
+               	jmp	 <L5>
 <L2>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L1>
+               	leaq	0x1(%rdx), %rsi
+               	leaq	(%rsi,%rax), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	%rdi, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%r12, %rax
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x10, %rax
+               	jb	 <L2>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -194,55 +439,91 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x9, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x9, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L3>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0xc, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x11, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x10, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x11, %rsi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
@@ -250,11 +531,11 @@ Disassembly of section .text:
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
@@ -262,9 +543,21 @@ Disassembly of section .text:
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L20>
+<L20>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -272,497 +565,435 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.take_edge>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            # imm = 0x290
-               	movq	%rbx, -0x268(%rbp)
-               	movq	%r12, -0x270(%rbp)
-               	movq	%r13, -0x278(%rbp)
-               	movq	%r14, -0x280(%rbp)
-               	movq	%r15, -0x288(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x2a0, %rsp            # imm = 0x2A0
+               	movq	%rbx, -0x258(%rbp)
+               	movq	%r12, -0x260(%rbp)
+               	movq	%r13, -0x268(%rbp)
+               	movq	%r14, -0x270(%rbp)
+               	movq	%r15, -0x278(%rbp)
+               	movq	%rdi, %r10
+               	movq	%r10, -0x190(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	movl	%ecx, %r12d
+               	movl	%ecx, %ebx
                	movq	%r8, -0x20(%rbp)
                	movq	%r9, -0x18(%rbp)
-               	movsd	%xmm0, -0x208(%rbp)
-               	leaq	0x10(%rbp), %rcx
+               	movsd	%xmm0, -0x200(%rbp)
+               	leaq	0x10(%rbp), %rdx
                	movsd	%xmm1, -0x30(%rbp)
                	movsd	%xmm2, -0x28(%rbp)
-               	leaq	0x20(%rbp), %rdx
-               	movq	0x30(%rbp), %r13
-               	leaq	0x38(%rbp), %rsi
+               	leaq	0x20(%rbp), %rsi
+               	movq	0x30(%rbp), %r12
+               	leaq	0x38(%rbp), %rdi
                	leaq	0x50(%rbp), %r8
-               	movq	%r8, -0x188(%rbp)
+               	movq	%r8, -0x1b8(%rbp)
                	leaq	0x60(%rbp), %r8
                	movq	%r8, -0x1b0(%rbp)
                	leaq	0x70(%rbp), %r8
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x80(%rbp), %r8
-               	movq	%r8, -0x138(%rbp)
-               	movss	%xmm3, -0x218(%rbp)
-               	movq	0x98(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	leaq	-0x38(%rbp), %r8
-               	movq	%r8, -0x148(%rbp)
-               	leaq	-0x40(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	leaq	-0x48(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	leaq	-0x50(%rbp), %r8
-               	movq	%r8, -0x160(%rbp)
-               	leaq	-0x58(%rbp), %r8
-               	movq	%r8, -0x168(%rbp)
-               	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x170(%rbp)
-               	leaq	-0x10(%rbp), %r15
-               	movzbl	(%r15), %r8d
-               	movq	%r8, -0x180(%rbp)
-               	leaq	-0xf(%rbp), %r15
-               	movq	(%r15), %rdi
-               	movq	-0x148(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	leaq	-0x20(%rbp), %rdi
-               	movl	(%rdi), %r15d
-               	leaq	-0x1c(%rbp), %rdi
-               	movl	(%rdi), %r8d
-               	movq	%r8, -0x190(%rbp)
-               	leaq	-0x18(%rbp), %rdi
-               	movl	(%rdi), %r8d
-               	movq	%r8, -0x198(%rbp)
-               	leaq	(%rcx), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x8(%rcx), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x228(%rbp)
-               	leaq	-0x30(%rbp), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x238(%rbp)
-               	leaq	-0x28(%rbp), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x248(%rbp)
-               	leaq	(%rdx), %rdi
-               	movq	(%rdi), %r8
                	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x8(%rdx), %rdi
-               	movq	(%rdi), %r11
-               	movq	%r11, -0x258(%rbp)
-               	leaq	-0x71(%rbp), %r8
-               	movq	%r8, -0x220(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %r14
-               	movb	0x10(%rsi), %r8b
-               	movq	%r8, -0x1b8(%rbp)
-               	movq	-0x220(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x220(%rbp), %r8
-               	movq	%r14, 0x8(%r8)
-               	movq	-0x220(%rbp), %r8
-               	movq	-0x1b8(%rbp), %r9
-               	movb	%r9b, 0x10(%r8)
-               	movq	-0x188(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzbl	(%rsi), %r14d
-               	movq	-0x188(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movq	(%rsi), %rdi
-               	movq	-0x150(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	leaq	0x80(%rbp), %r8
                	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movss	%xmm3, -0x210(%rbp)
+               	movq	0x98(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	leaq	-0x39(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x10(%rbp), %r15
+               	movb	-0x8(%rbp), %r14b
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x1a0(%rbp), %r8
+               	movb	%r14b, 0x8(%r8)
+               	leaq	-0x48(%rbp), %r14
+               	movq	-0x20(%rbp), %r15
+               	movl	-0x18(%rbp), %r13d
+               	movq	%r15, (%r14)
+               	movl	%r13d, 0x8(%r14)
+               	leaq	-0x58(%rbp), %r13
+               	movq	(%rdx), %r15
+               	movq	0x8(%rdx), %rax
+               	movq	%r15, (%r13)
+               	movq	%rax, 0x8(%r13)
+               	leaq	-0x30(%rbp), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x228(%rbp)
+               	leaq	-0x28(%rbp), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x238(%rbp)
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %r15
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x248(%rbp)
+               	leaq	-0x69(%rbp), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	(%rdi), %rdx
+               	movq	0x8(%rdi), %rsi
+               	movb	0x10(%rdi), %r8b
                	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1b0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1d8(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	leaq	-0x82(%rbp), %r8
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	-0x138(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x138(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x138(%rbp), %r9
-               	movb	0x10(%r9), %r8b
-               	movq	%r8, -0x1f0(%rbp)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0x1e8(%rbp), %r8
-               	movq	-0x1f0(%rbp), %r9
+               	movq	-0x218(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x218(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x218(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r9
                	movb	%r9b, 0x10(%r8)
+               	leaq	-0x72(%rbp), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movb	0x8(%r8), %sil
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1d0(%rbp), %r8
+               	movb	%sil, 0x8(%r8)
+               	leaq	-0x80(%rbp), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1b0(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1d8(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	leaq	-0x90(%rbp), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	leaq	-0xa1(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	(%r8), %rdx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x1c0(%rbp), %r8
+               	movb	0x10(%r8), %dil
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%rdx, (%r8)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x1e8(%rbp), %r8
+               	movb	%dil, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	leaq	-0xcc(%rbp), %rdx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1a0(%rbp), %r8
+               	movb	0x8(%r8), %dil
+               	movq	%rsi, (%rdx)
+               	movb	%dil, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0xd8(%rbp)
+               	movb	0x8(%rdx), %dil
+               	movb	%dil, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %rdx
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	-0x148(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x158(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x168(%rbp), %r8
-               	movq	%rsi, (%r8)
                	movq	%rax, %rdi
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
+               	movl	%ebx, %esi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r8
-               	movq	%r8, -0x260(%rbp)
-               	movq	-0x260(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
-               	jmp	 <L5>
+               	movq	%rax, %rdi
+               	leaq	-0xe4(%rbp), %rdx
+               	movq	(%r14), %rsi
+               	movl	0x8(%r14), %ebx
+               	movq	%rsi, (%rdx)
+               	movl	%ebx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0xf0(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %rdx
+               	callq	 <L3>
 <L3>:
-               	movq	-0x168(%rbp), %r8
-               	movq	-0x260(%rbp), %r9
-               	leaq	(%r8,%r9), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x1f8(%rbp)
-               	movq	%rbx, %rdi
-               	movq	-0x1f8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rdi
+               	movq	-0x200(%rbp), %rsi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rbx
-               	movq	-0x260(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x260(%rbp)
-               	movq	-0x260(%rbp), %r8
-               	cmpq	$0x8, %r8
-               	jb	 <L3>
+               	movq	%rax, %rdi
+               	leaq	-0x100(%rbp), %rdx
+               	movq	(%r13), %rsi
+               	movq	0x8(%r13), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L5>
 <L5>:
-               	movq	%rbx, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L6>
+               	movq	%rax, %rdx
+               	movq	-0x228(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
+               	movq	-0x238(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x198(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x208(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x228(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	movq	-0x248(%rbp), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movsd	-0x238(%rbp), %xmm0
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x248(%rbp), %xmm0
+               	movq	%rdx, %rdi
+               	movq	%r12, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0x111(%rbp), %rdx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movb	0x10(%rdx), %r12b
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movsd	-0x258(%rbp), %xmm0
+               	leaq	-0x11a(%rbp), %rdx
+               	movq	-0x1d0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1d0(%rbp), %r8
+               	movb	0x8(%r8), %bl
+               	movq	%rsi, (%rdx)
+               	movb	%bl, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x128(%rbp)
+               	movb	0x8(%rdx), %bl
+               	movb	%bl, -0x128(%rbp)
+               	movq	-0x128(%rbp), %rdx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
+               	leaq	-0x134(%rbp), %rdx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1d8(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movq	%rsi, (%rdx)
+               	movl	%ebx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x140(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0x140(%rbp)
+               	movq	-0x140(%rbp), %rdx
                	callq	 <L17>
 <L17>:
-               	leaq	-0xd7(%rbp), %rcx
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x220(%rbp), %r8
-               	movb	0x10(%r8), %bl
-               	movq	%rsi, (%rcx)
-               	movq	%rdi, 0x8(%rcx)
-               	movb	%bl, 0x10(%rcx)
-               	leaq	-0xe8(%rbp), %rbx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rsi, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
                	movq	%rax, %rdi
+               	leaq	-0x150(%rbp), %rdx
+               	movq	-0x1e0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rbx, %rdx
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L20>
-<L20>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L19>
-<L21>:
-               	movq	-0x150(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x160(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0x160(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x170(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x8, %r12
-               	jb	 <L23>
-               	jmp	 <L25>
-<L23>:
-               	movq	-0x170(%rbp), %r8
-               	leaq	(%r8,%r12), %rax
-               	movzbl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L24>
-<L24>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x8, %r12
-               	jb	 <L23>
-<L25>:
-               	movq	%rbx, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
                	movq	%rax, %rdi
-               	movq	-0x1c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x1d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x1e0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	leaq	-0xf9(%rbp), %rcx
+               	leaq	-0x161(%rbp), %rdx
                	movq	-0x1e8(%rbp), %r8
                	movq	(%r8), %rsi
                	movq	-0x1e8(%rbp), %r8
-               	movq	0x8(%r8), %rdi
-               	movq	-0x1e8(%rbp), %r8
-               	movb	0x10(%r8), %bl
-               	movq	%rsi, (%rcx)
-               	movq	%rdi, 0x8(%rcx)
-               	movb	%bl, 0x10(%rcx)
-               	leaq	-0x10a(%rbp), %rbx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movb	0x10(%rcx), %r12b
-               	movq	%rsi, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L32>
-               	jmp	 <L34>
-<L32>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L32>
-<L34>:
-               	movq	%r12, %rdi
-               	movss	-0x218(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L36>
-<L36>:
-               	leaq	-0x11b(%rbp), %rcx
-               	leaq	-0x12c(%rbp), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0x220(%rbp), %r8
                	movq	0x8(%r8), %rbx
-               	movq	-0x220(%rbp), %r8
+               	movq	-0x1e8(%rbp), %r8
                	movb	0x10(%r8), %r12b
-               	movq	%rdi, (%rsi)
-               	movq	%rbx, 0x8(%rsi)
-               	movb	%r12b, 0x10(%rsi)
-               	movq	(%rsi), %rdi
-               	movq	0x8(%rsi), %rbx
-               	movb	0x10(%rsi), %r12b
-               	movq	%rdi, (%rcx)
-               	movq	%rbx, 0x8(%rcx)
-               	movb	%r12b, 0x10(%rcx)
-               	leaq	(%rcx), %rsi
-               	movzbl	(%rsi), %edi
-               	addl	$0x1, %edi
-               	movb	%dil, (%rsi)
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movb	0x10(%rdx), %r12b
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movl	-0x210(%rbp), %edx
+               	movl	%edx, %esi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %rdi
+               	leaq	-0x172(%rbp), %rdx
+               	leaq	-0x183(%rbp), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %r12
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r13b
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movb	%r13b, 0x10(%rsi)
+               	movq	(%rsi), %rbx
+               	movq	0x8(%rsi), %r12
+               	movb	0x10(%rsi), %r13b
+               	movq	%rbx, (%rdx)
+               	movq	%r12, 0x8(%rdx)
+               	movb	%r13b, 0x10(%rdx)
+               	leaq	(%rdx), %rsi
+               	movzbl	(%rsi), %ebx
+               	addl	$0x1, %ebx
+               	movb	%bl, (%rsi)
                	movq	$0x0, %rsi
                	cmpq	$0x10, %rsi
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
-               	leaq	0x1(%rcx), %rdi
-               	leaq	(%rdi,%rsi), %rbx
-               	movzbl	(%rbx), %edi
-               	movb	%sil, %r12b
-               	addl	%r12d, %edi
-               	addl	$0x1, %edi
-               	movb	%dil, (%rbx)
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	leaq	0x1(%rdx), %rbx
+               	leaq	(%rbx,%rsi), %r12
+               	movzbl	(%r12), %ebx
+               	movb	%sil, %r13b
+               	addl	%r13d, %ebx
+               	addl	$0x1, %ebx
+               	movb	%bl, (%r12)
                	addq	$0x1, %rsi
                	cmpq	$0x10, %rsi
-               	jb	 <L37>
-<L38>:
-               	leaq	-0x93(%rbp), %rsi
-               	movq	(%rcx), %rdi
-               	movq	0x8(%rcx), %rbx
-               	movb	0x10(%rcx), %r12b
-               	movq	%rdi, (%rsi)
-               	movq	%rbx, 0x8(%rsi)
-               	movb	%r12b, 0x10(%rsi)
-               	leaq	-0xa4(%rbp), %rbx
-               	movq	(%rsi), %rcx
-               	movq	0x8(%rsi), %rdi
+               	jb	 <L22>
+<L23>:
+               	leaq	-0xb2(%rbp), %rsi
+               	movq	(%rdx), %rbx
+               	movq	0x8(%rdx), %r12
+               	movb	0x10(%rdx), %r13b
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movb	%r13b, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rbx
                	movb	0x10(%rsi), %r12b
-               	movq	%rcx, (%rbx)
-               	movq	%rdi, 0x8(%rbx)
-               	movb	%r12b, 0x10(%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movb	%r12b, 0x10(%rsp)
+               	callq	 <L24>
+<L24>:
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L40>
-               	jmp	 <L42>
-<L40>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L41>
-<L41>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L40>
-<L42>:
-               	leaq	-0xb5(%rbp), %rax
-               	movq	-0x220(%rbp), %r8
-               	movq	(%r8), %rcx
-               	movq	-0x220(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x220(%rbp), %r8
-               	movb	0x10(%r8), %dil
-               	movq	%rcx, (%rax)
-               	movq	%rsi, 0x8(%rax)
-               	movb	%dil, 0x10(%rax)
-               	leaq	-0xc6(%rbp), %rbx
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movb	0x10(%rax), %sil
-               	movq	%rcx, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movb	%sil, 0x10(%rbx)
-               	leaq	(%rbx), %rax
-               	movzbl	(%rax), %esi
-               	movq	%r12, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
-               	jb	 <L44>
-               	jmp	 <L46>
-<L44>:
-               	leaq	0x1(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%r12, %rdi
-               	callq	 <L45>
-<L45>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x10, %r13
-               	jb	 <L44>
-<L46>:
-               	movq	%r12, %rax
-               	movq	-0x268(%rbp), %rbx
-               	movq	-0x270(%rbp), %r12
-               	movq	-0x278(%rbp), %r13
-               	movq	-0x280(%rbp), %r14
-               	movq	-0x288(%rbp), %r15
+               	leaq	-0xc3(%rbp), %rdx
+               	movq	-0x218(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x218(%rbp), %r8
+               	movq	0x8(%r8), %rbx
+               	movq	-0x218(%rbp), %r8
+               	movb	0x10(%r8), %r12b
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movb	%r12b, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movb	0x10(%rdx), %bl
+               	movq	%rax, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movb	%bl, 0x10(%rsp)
+               	callq	 <L25>
+<L25>:
+               	movq	-0x258(%rbp), %rbx
+               	movq	-0x260(%rbp), %r12
+               	movq	-0x268(%rbp), %r13
+               	movq	-0x270(%rbp), %r14
+               	movq	-0x278(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1009,46 +1240,85 @@ Disassembly of section .text:
                	movq	%r14, -0x370(%rbp)
                	movq	%r15, -0x378(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x9, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0xc, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x10, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x10, %rsi
-               	callq	 <L5>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
                	movq	%rax, %rdi
-               	movq	$0x11, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x11, %rsi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
@@ -1056,19 +1326,19 @@ Disassembly of section .text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x1, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
@@ -1080,24 +1350,32 @@ Disassembly of section .text:
                	callq	 <L17>
 <L17>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L18>
 <L18>:
-               	leaq	-0x60(%rbp), %r12
+               	movq	%rax, %rdi
+               	movq	$0x8, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x88(%rbp), %r12
                	leaq	(%r12), %rdx
                	addq	$0x0, %rdx
                	movq	$0x60, %rsi
-<L19>:
+<L21>:
                	movq	$0x0, (%rdx)
                	addq	$0x8, %rdx
                	subq	$0x8, %rsi
                	cmpq	$0x0, %rsi
-               	jne	 <L19>
+               	jne	 <L21>
                	movq	$0x0, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-               	jmp	 <L21>
-<L20>:
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
                	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rsi
@@ -1108,15 +1386,15 @@ Disassembly of section .text:
                	movq	%rsi, (%rdi)
                	addq	$0x1, %rdx
                	cmpq	$0xc, %rdx
-               	jb	 <L20>
-<L21>:
+               	jb	 <L22>
+<L23>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L22>
-               	jmp	 <L43>
-<L22>:
+               	jb	 <L24>
+               	jmp	 <L45>
+<L24>:
                	movq	%r15, %rax
                	imulq	$0x11, %rax, %rax
                	movq	%rax, %r8
@@ -1131,7 +1409,7 @@ Disassembly of section .text:
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x228(%rbp)
-               	leaq	-0x69(%rbp), %r8
+               	leaq	-0x9(%rbp), %r8
                	movq	%r8, -0x230(%rbp)
                	movq	-0x230(%rbp), %r8
                	movq	$0x0, (%r8)
@@ -1144,9 +1422,9 @@ Disassembly of section .text:
                	movb	%sil, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-               	jmp	 <L24>
-<L23>:
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
                	movq	%rax, %rsi
                	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1162,9 +1440,9 @@ Disassembly of section .text:
                	movb	%dil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L23>
-<L24>:
-               	leaq	-0x72(%rbp), %r8
+               	jb	 <L25>
+<L26>:
+               	leaq	-0x12(%rbp), %r8
                	movq	%r8, -0x240(%rbp)
                	movq	-0x230(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1180,7 +1458,7 @@ Disassembly of section .text:
                	movq	%r8, -0x238(%rbp)
                	leaq	0x18(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x90(%rbp), %r8
+               	leaq	-0x94(%rbp), %r8
                	movq	%r8, -0x258(%rbp)
                	movl	%esi, %edi
                	movq	-0x258(%rbp), %r8
@@ -1202,17 +1480,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L25>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L26>:
+<L28>:
                	leaq	0x28(%r12), %rax
                	movq	(%rax), %rsi
                	movq	-0x220(%rbp), %r8
@@ -1235,25 +1513,6 @@ Disassembly of section .text:
                	andq	$0xffff, %rax           # imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L28>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x415>
-               	movq	-0x250(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movsd	%xmm2, (%rax)
-               	andq	$0xfff, %rdi            # imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
                	jl	 <L29>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L30>
@@ -1266,7 +1525,26 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L30>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x462>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4f2>
+               	movq	-0x250(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movsd	%xmm2, (%rax)
+               	andq	$0xfff, %rdi            # imm = 0xFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L32>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x53f>
                	movq	-0x250(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1282,19 +1560,19 @@ Disassembly of section .text:
                	andq	$0x3ffff, %rdi          # imm = 0x3FFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L31>
+               	jl	 <L33>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L32>
-<L31>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L32>:
+<L34>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4dd>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x5ba>
                	movq	-0x268(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movsd	%xmm2, (%rdx)
@@ -1321,9 +1599,9 @@ Disassembly of section .text:
                	movb	%al, (%rsi)
                	movq	$0x0, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
                	movq	%rax, %rsi
                	imulq	$0x4, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1339,8 +1617,8 @@ Disassembly of section .text:
                	movb	%dil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L33>
-<L34>:
+               	jb	 <L35>
+<L36>:
                	leaq	-0x122(%rbp), %r8
                	movq	%r8, -0x280(%rbp)
                	movq	-0x278(%rbp), %r8
@@ -1371,9 +1649,9 @@ Disassembly of section .text:
                	movb	%dil, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-               	jmp	 <L36>
-<L35>:
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
                	movq	%rax, %rdi
                	imulq	$0x8, %rdi, %rdi
                	movq	%rdi, %rcx
@@ -1389,8 +1667,8 @@ Disassembly of section .text:
                	movb	%sil, (%rdx)
                	addq	$0x1, %rax
                	cmpq	$0x8, %rax
-               	jb	 <L35>
-<L36>:
+               	jb	 <L37>
+<L38>:
                	leaq	-0x156(%rbp), %r8
                	movq	%r8, -0x298(%rbp)
                	movq	-0x290(%rbp), %r8
@@ -1452,9 +1730,9 @@ Disassembly of section .text:
                	movb	%dl, (%rax)
                	movq	$0x0, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-               	jmp	 <L38>
-<L37>:
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
                	movq	%rax, %rdx
                	imulq	$0x4, %rdx, %rdx
                	movq	%rdx, %rcx
@@ -1470,8 +1748,8 @@ Disassembly of section .text:
                	movb	%dil, (%rsi)
                	addq	$0x1, %rax
                	cmpq	$0x10, %rax
-               	jb	 <L37>
-<L38>:
+               	jb	 <L39>
+<L40>:
                	leaq	-0x1c2(%rbp), %rax
                	movq	-0x2b8(%rbp), %r8
                	movq	(%r8), %rdx
@@ -1487,17 +1765,17 @@ Disassembly of section .text:
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L39>
+               	jl	 <L41>
                	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L40>
-<L39>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm3
                	addss	%xmm3, %xmm3
-<L40>:
+<L42>:
                	leaq	0x18(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x2e0(%rbp)
@@ -1582,19 +1860,19 @@ Disassembly of section .text:
                	movl	%r8d, %ecx
                	movq	-0x2c8(%rbp), %r8
                	movq	-0x2d0(%rbp), %r9
-               	callq	 <L41>
-<L41>:
+               	callq	 <L43>
+<L43>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L42>
-<L42>:
+               	callq	 <L44>
+<L44>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L22>
-<L43>:
-               	leaq	-0x7b(%rbp), %rax
+               	jb	 <L24>
+<L45>:
+               	leaq	-0x1b(%rbp), %rax
                	movq	$0x0, (%rax)
                	movb	$0x0, 0x8(%rax)
                	movb	%r14b, %dl
@@ -1602,9 +1880,9 @@ Disassembly of section .text:
                	movb	%dl, (%rsi)
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-               	jmp	 <L45>
-<L44>:
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
                	movq	%rdx, %rsi
                	imulq	$0x8, %rsi, %rsi
                	movq	%rsi, %rcx
@@ -1618,9 +1896,9 @@ Disassembly of section .text:
                	movb	%dil, (%rbx)
                	addq	$0x1, %rdx
                	cmpq	$0x8, %rdx
-               	jb	 <L44>
-<L45>:
-               	leaq	-0x84(%rbp), %r8
+               	jb	 <L46>
+<L47>:
+               	leaq	-0x24(%rbp), %r8
                	movq	%r8, -0x2f0(%rbp)
                	movq	(%rax), %rsi
                	movb	0x8(%rax), %dil
@@ -1630,7 +1908,7 @@ Disassembly of section .text:
                	movb	%dil, 0x8(%r8)
                	movl	%r14d, %r8d
                	movq	%r8, -0x2e8(%rbp)
-               	leaq	-0x9c(%rbp), %r8
+               	leaq	-0xa0(%rbp), %r8
                	movq	%r8, -0x318(%rbp)
                	movl	%r14d, %edi
                	movq	-0x318(%rbp), %r8
@@ -1652,17 +1930,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdi            # imm = 0x3FF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L48>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L47>:
+<L49>:
                	leaq	-0xc0(%rbp), %r8
                	movq	%r8, -0x300(%rbp)
                	movq	-0x300(%rbp), %r8
@@ -1680,26 +1958,6 @@ Disassembly of section .text:
                	andq	$0xffff, %r15           # imm = 0xFFFF
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L49>
-<L48>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L49>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc12>
-               	movq	-0x308(%rbp), %r8
-               	leaq	(%r8), %r15
-               	movsd	%xmm2, (%r15)
-               	movq	%r14, %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
                	jl	 <L50>
                	cvtsi2sd	%r11, %xmm1
                	jmp	 <L51>
@@ -1712,7 +1970,27 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L51>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc63>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xcec>
+               	movq	-0x308(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movsd	%xmm2, (%r15)
+               	movq	%r14, %r15
+               	andq	$0xfff, %r15            # imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L52>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L53>
+<L52>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L53>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xd3d>
                	movq	-0x308(%rbp), %r8
                	leaq	0x8(%r8), %r15
                	movsd	%xmm2, (%r15)
@@ -1727,19 +2005,19 @@ Disassembly of section .text:
                	andq	$0x3ffff, %rax          # imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L52>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L53>
-<L52>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L53>:
+<L55>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xcda>
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xdb4>
                	movq	-0x310(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
@@ -1757,9 +2035,9 @@ Disassembly of section .text:
                	movb	%dil, (%rdx)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-               	jmp	 <L55>
-<L54>:
+               	jb	 <L56>
+               	jmp	 <L57>
+<L56>:
                	movq	%rdx, %rdi
                	imulq	$0x4, %rdi, %rdi
                	movq	%rdi, %rcx
@@ -1773,8 +2051,8 @@ Disassembly of section .text:
                	movb	%bl, (%r15)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L54>
-<L55>:
+               	jb	 <L56>
+<L57>:
                	leaq	-0x144(%rbp), %r8
                	movq	%r8, -0x320(%rbp)
                	movq	(%rax), %rdi
@@ -1796,9 +2074,9 @@ Disassembly of section .text:
                	movb	%bl, (%r15)
                	movq	$0x0, %rbx
                	cmpq	$0x8, %rbx
-               	jb	 <L56>
-               	jmp	 <L57>
-<L56>:
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
                	movq	%rbx, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
@@ -1812,8 +2090,8 @@ Disassembly of section .text:
                	movb	%sil, (%rdx)
                	addq	$0x1, %rbx
                	cmpq	$0x8, %rbx
-               	jb	 <L56>
-<L57>:
+               	jb	 <L58>
+<L59>:
                	leaq	-0x168(%rbp), %r8
                	movq	%r8, -0x328(%rbp)
                	movq	(%rax), %rsi
@@ -1866,9 +2144,9 @@ Disassembly of section .text:
                	movb	%dl, (%r15)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-               	jmp	 <L59>
-<L58>:
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
                	movq	%rdx, %r15
                	imulq	$0x4, %r15, %r15
                	movq	%r15, %rcx
@@ -1882,8 +2160,8 @@ Disassembly of section .text:
                	movb	%sil, (%rax)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
-               	jb	 <L58>
-<L59>:
+               	jb	 <L60>
+<L61>:
                	leaq	-0x1fa(%rbp), %rax
                	movq	(%rdi), %rdx
                	movq	0x8(%rdi), %rsi
@@ -1896,17 +2174,17 @@ Disassembly of section .text:
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L62>
                	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L63>
+<L62>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm3
                	addss	%xmm3, %xmm3
-<L61>:
+<L63>:
                	leaq	0x20(%r12), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x348(%rbp)
@@ -1986,12 +2264,12 @@ Disassembly of section .text:
                	movl	%r8d, %ecx
                	movq	%r12, %r8
                	movq	%r15, %r9
-               	callq	 <L62>
-<L62>:
+               	callq	 <L64>
+<L64>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L65>
+<L65>:
                	movq	-0x358(%rbp), %rbx
                	movq	-0x360(%rbp), %r12
                	movq	-0x368(%rbp), %r13

--- a/test/golden/x86_64-linux/call/call_rec_large.dis
+++ b/test/golden/x86_64-linux/call/call_rec_large.dis
@@ -14,28 +14,81 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.fold_l24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -43,26 +96,80 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.fold_l24f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movsd	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movsd	(%rdx), %xmm2
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -71,34 +178,105 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
                	movl	(%rdx), %ebx
-               	leaq	0x14(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	callq	 <L0>
+               	leaq	0x14(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L2>
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
+               	movl	%ebx, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -110,32 +288,101 @@ Disassembly of section .text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r14, -0x20(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r12
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r13
-               	callq	 <L0>
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -148,32 +395,64 @@ Disassembly of section .text:
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	leaq	(%rdx), %rsi
                	movq	(%rsi), %rbx
                	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r12
-               	leaq	0x10(%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %r13
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r14
-               	movq	%rbx, %rsi
-               	callq	 <L0>
+               	movq	(%rsi), %rdx
+               	leaq	0x10(%rax), %rsi
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %r12
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%r12, %rsi
+               	callq	 <L4>
+<L4>:
                	movq	%rax, %rdi
                	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
-<L3>:
+               	callq	 <L5>
+<L5>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
@@ -262,20 +541,20 @@ Disassembly of section .text:
                	movq	(%rdx), %r14
                	callq	 <L0>
 <L0>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movl	%ebx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	movl	%r12d, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
@@ -371,484 +650,714 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.take_large>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1f0, %rsp            # imm = 0x1F0
-               	movq	%rbx, -0x1c8(%rbp)
-               	movq	%r12, -0x1d0(%rbp)
-               	movq	%r13, -0x1d8(%rbp)
-               	movq	%r14, -0x1e0(%rbp)
-               	movq	%r15, -0x1e8(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x28(%rbp), %rdi
+               	subq	$0x340, %rsp            # imm = 0x340
+               	movq	%rbx, -0x2f8(%rbp)
+               	movq	%r12, -0x300(%rbp)
+               	movq	%r13, -0x308(%rbp)
+               	movq	%r14, -0x310(%rbp)
+               	movq	%r15, -0x318(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	leaq	0x10(%rbp), %rdi
+               	leaq	0x28(%rbp), %rbx
                	leaq	0x40(%rbp), %r12
                	movl	%esi, %r13d
                	leaq	0x58(%rbp), %rsi
-               	leaq	0x78(%rbp), %r14
-               	movsd	%xmm0, -0x140(%rbp)
-               	leaq	0x98(%rbp), %r15
+               	leaq	0x78(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movsd	%xmm0, -0x268(%rbp)
+               	leaq	0x98(%rbp), %r8
+               	movq	%r8, -0x120(%rbp)
                	leaq	0xc8(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r8, -0x118(%rbp)
                	leaq	0xf8(%rbp), %r8
-               	movq	%r8, -0x10(%rbp)
+               	movq	%r8, -0xf0(%rbp)
                	leaq	0x110(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	leaq	0x130(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	movss	%xmm1, -0x150(%rbp)
+               	movq	%r8, -0x100(%rbp)
+               	movss	%xmm1, -0x278(%rbp)
                	movq	%rdx, %r8
-               	movq	%r8, -0x28(%rbp)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x30(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x38(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x158(%rbp)
-               	leaq	(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x168(%rbp)
-               	leaq	0x8(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x178(%rbp)
-               	leaq	0x10(%rdi), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x188(%rbp)
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x40(%rbp)
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x198(%rbp)
-               	leaq	0x10(%r12), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	0x14(%r12), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x50(%rbp)
-               	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x10(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x60(%rbp)
-               	leaq	0x18(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x68(%rbp)
-               	leaq	(%r14), %rdx
-               	leaq	(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x70(%rbp)
-               	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0x10(%r14), %rsi
-               	leaq	(%rsi), %rdi
+               	movq	%r8, -0x108(%rbp)
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x280(%rbp)
                	movq	(%rdi), %r14
+               	movq	0x8(%rdi), %rax
+               	movq	0x10(%rdi), %r15
+               	movq	-0x280(%rbp), %r8
+               	movq	%r14, (%r8)
+               	movq	-0x280(%rbp), %r8
+               	movq	%rax, 0x8(%r8)
+               	movq	-0x280(%rbp), %r8
+               	movq	%r15, 0x10(%r8)
+               	leaq	(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x290(%rbp)
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2a0(%rbp)
+               	leaq	0x10(%rbx), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2b0(%rbp)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %r11
+               	movq	%r11, -0x2c0(%rbp)
+               	leaq	0x10(%r12), %rax
+               	movl	(%rax), %r14d
+               	leaq	0x14(%r12), %rax
+               	movl	(%rax), %r12d
+               	leaq	-0x38(%rbp), %r15
+               	movq	(%rsi), %rax
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	0x18(%rsi), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	%rax, (%r15)
+               	movq	%rdi, 0x8(%r15)
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, 0x10(%r15)
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, 0x18(%r15)
+               	movq	-0x110(%rbp), %r8
+               	leaq	(%r8), %rax
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x8(%rax), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	-0x110(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x140(%rbp)
                	leaq	0x8(%rsi), %rdi
                	movq	(%rdi), %r8
-               	movq	%r8, -0x78(%rbp)
-               	leaq	(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x80(%rbp)
-               	leaq	0x8(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x10(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x90(%rbp)
-               	leaq	0x18(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x98(%rbp)
-               	leaq	0x20(%r15), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x28(%r15), %rsi
-               	movq	(%rsi), %r15
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x120(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x118(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %r11
-               	movq	%r11, -0x1a8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r11, -0x2d0(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x14(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x18(%r8), %rsi
                	movq	(%rsi), %r11
-               	movq	%r11, -0x1b8(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r11, -0x2e0(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xc0(%rbp)
-               	movq	-0x8(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x118(%rbp), %r8
                	leaq	0x28(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xf0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1a8(%rbp), %r8
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xf8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0xf8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x1c0(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x1c8(%rbp), %r9
+               	movq	%r9, 0x18(%r8)
+               	movq	-0x100(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0x10(%rbp), %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0x18(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x18(%rbp), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x18(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	0x18(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	-0x20(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x20(%rbp), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x100(%rbp), %r8
                	leaq	0x28(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x130(%rbp)
+               	movq	%r8, -0x1f8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	-0x200(%rbp), %r8
+               	leaq	-0x88(%rbp), %rsi
+               	movq	-0x280(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x280(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x280(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
+               	movq	%rax, %rdx
+               	movq	-0x290(%rbp), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x220(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L3>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x228(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x228(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L4>
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x238(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x168(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x230(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x238(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x238(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x178(%rbp), %xmm0
-               	callq	 <L6>
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movsd	-0x188(%rbp), %xmm0
-               	callq	 <L7>
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x248(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	-0x248(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movsd	-0x198(%rbp), %xmm0
-               	callq	 <L9>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x250(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L11>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %rdx
+               	xorq	%rbx, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L12>
+               	movl	%r14d, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
+               	movl	%r12d, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
+               	movl	%r13d, %edx
+               	movq	%rsi, %rdi
+               	movq	%rdx, %rsi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %rbx
+               	movq	0x10(%r15), %r12
+               	movq	0x18(%r15), %r13
+               	movq	%rsi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	%rsi, (%rsp)
+               	movq	%rbx, 0x8(%rsp)
+               	movq	%r12, 0x10(%rsp)
+               	movq	%r13, 0x18(%rsp)
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L19>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
-               	callq	 <L21>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x2e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	%rdx, %rdi
+               	movq	-0x140(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L22>
 <L22>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L23>
 <L23>:
+               	movq	-0x268(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L24>
 <L24>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L25>
 <L25>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L26>
 <L26>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L27>
 <L27>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L28>
 <L28>:
                	movq	%rax, %rdi
-               	movsd	-0x1a8(%rbp), %xmm0
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L29>
 <L29>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L30>
 <L30>:
                	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L31>
 <L31>:
+               	movq	-0x2d0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x1b8(%rbp), %xmm0
                	callq	 <L32>
 <L32>:
+               	movq	-0x188(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L33>
 <L33>:
+               	movq	-0x190(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L34>
 <L34>:
+               	movq	-0x2e0(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0x198(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L37>
 <L37>:
+               	leaq	-0xc0(%rbp), %rdx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	0x10(%r8), %rbx
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%rbx, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %rbx
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rbx, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L38>
 <L38>:
+               	leaq	-0xe0(%rbp), %rdx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x10(%r8), %rbx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	0x18(%r8), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%rbx, 0x10(%rdx)
+               	movq	%r12, 0x18(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %rbx
+               	movq	0x18(%rdx), %r12
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%rbx, 0x10(%rsp)
+               	movq	%r12, 0x18(%rsp)
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L39>
 <L39>:
                	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
+               	movq	-0x1d0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L40>
 <L40>:
                	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x1d8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x1e0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x1e8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
                	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x1f0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L44>
 <L44>:
                	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x1f8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L45>
 <L45>:
+               	movl	-0x278(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x108(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L47>
 <L47>:
-               	movq	%rax, %rdi
-               	movss	-0x150(%rbp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L49>
-<L49>:
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	addq	$0x1, %rsi
-               	movq	%r15, %rbx
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rbx
                	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
                	xorq	%r11, %rbx
                	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %rdi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rdi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L54>
 <L54>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L55>
 <L55>:
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L57>
 <L57>:
                	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L58>
 <L58>:
                	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
+               	movq	-0x178(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L59>
 <L59>:
-               	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x1c8(%rbp), %rbx
-               	movq	-0x1d0(%rbp), %r12
-               	movq	-0x1d8(%rbp), %r13
-               	movq	-0x1e0(%rbp), %r14
-               	movq	-0x1e8(%rbp), %r15
+               	movq	-0x2f8(%rbp), %rbx
+               	movq	-0x300(%rbp), %r12
+               	movq	-0x308(%rbp), %r13
+               	movq	-0x310(%rbp), %r14
+               	movq	-0x318(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1218,6 +1727,8 @@ Disassembly of section .text:
                	movq	%r14, -0x500(%rbp)
                	movq	%r15, -0x508(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x18, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -1229,7 +1740,7 @@ Disassembly of section .text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -1237,7 +1748,7 @@ Disassembly of section .text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x30, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
@@ -1245,7 +1756,7 @@ Disassembly of section .text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x30, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
@@ -1257,7 +1768,7 @@ Disassembly of section .text:
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
@@ -1265,44 +1776,40 @@ Disassembly of section .text:
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x14, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x14, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movq	$0x28, %rsi
-               	callq	 <L17>
-<L17>:
-               	leaq	-0x60(%rbp), %r12
+               	leaq	-0x90(%rbp), %r12
                	leaq	(%r12), %rcx
                	addq	$0x0, %rcx
                	movq	$0x60, %rdx
-<L18>:
+<L17>:
                	movq	$0x0, (%rcx)
                	addq	$0x8, %rcx
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L18>
+               	jne	 <L17>
                	movq	$0x0, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-               	jmp	 <L20>
-<L19>:
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
                	movq	%rcx, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
@@ -1313,16 +1820,16 @@ Disassembly of section .text:
                	movq	%rdx, (%rsi)
                	addq	$0x1, %rcx
                	cmpq	$0xc, %rcx
-               	jb	 <L19>
-<L20>:
+               	jb	 <L18>
+<L19>:
                	movq	%rax, %r8
                	movq	%r8, -0x3c0(%rbp)
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L21>
-               	jmp	 <L37>
-<L21>:
+               	jb	 <L20>
+               	jmp	 <L36>
+<L20>:
                	movq	%r15, %rax
                	imulq	$0x13, %rax, %rax
                	movq	%rax, %r8
@@ -1336,7 +1843,7 @@ Disassembly of section .text:
                	movq	%r8, -0x498(%rbp)
                	leaq	0x8(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x78(%rbp), %r8
+               	leaq	-0x18(%rbp), %r8
                	movq	%r8, -0x4b0(%rbp)
                	movq	-0x4b0(%rbp), %r8
                	leaq	(%r8), %rdi
@@ -1359,19 +1866,19 @@ Disassembly of section .text:
                	andq	$0xffff, %rdi           # imm = 0xFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L22>
+               	jl	 <L21>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L23>
-<L22>:
+               	jmp	 <L22>
+<L21>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L23>:
+<L22>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2a9>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2ae>
                	movq	-0x4b8(%rbp), %r8
                	leaq	(%r8), %rdi
                	movsd	%xmm1, (%rdi)
@@ -1379,38 +1886,38 @@ Disassembly of section .text:
                	andq	$0xfff, %rdi            # imm = 0xFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L24>
+<L23>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
+<L24>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2f9>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2fe>
                	movq	-0x4b8(%rbp), %r8
                	leaq	0x8(%r8), %rdi
                	movsd	%xmm1, (%rdi)
                	andq	$0x3ffff, %rsi          # imm = 0x3FFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L27>
-<L26>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L27>:
+<L26>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x347>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x34c>
                	movq	-0x4b8(%rbp), %r8
                	leaq	0x10(%r8), %rsi
                	movsd	%xmm1, (%rsi)
@@ -1428,19 +1935,19 @@ Disassembly of section .text:
                	andq	$0x7fff, %rsi           # imm = 0x7FFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L29>:
+<L28>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3d0>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x3d5>
                	movq	-0x350(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movsd	%xmm1, (%rsi)
@@ -1548,17 +2055,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rdi            # imm = 0x3FF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L30>
+               	jl	 <L29>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L31>
-<L30>:
+               	jmp	 <L30>
+<L29>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L31>:
+<L30>:
                	movsd	%xmm14, -0x4a8(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
@@ -1607,8 +2114,8 @@ Disassembly of section .text:
                	movq	%r13, %rdi
                	movq	-0x3b8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L31>
+<L31>:
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x3d0(%rbp)
@@ -1703,17 +2210,17 @@ Disassembly of section .text:
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L33>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L34>
-<L33>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L34>:
+<L33>:
                	leaq	0x10(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x3f8(%rbp)
@@ -1856,21 +2363,21 @@ Disassembly of section .text:
                	movsd	-0x4a8(%rbp), %xmm0
                	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L35>
-<L35>:
+               	callq	 <L34>
+<L34>:
                	movq	%rax, %r14
                	movq	-0x3c0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r14, %rsi
-               	callq	 <L36>
-<L36>:
+               	callq	 <L35>
+<L35>:
                	addq	$0x1, %r15
                	movq	%rax, %r8
                	movq	%r8, -0x3c0(%rbp)
                	cmpq	$0x3, %r15
-               	jb	 <L21>
-<L37>:
-               	leaq	-0x90(%rbp), %rbx
+               	jb	 <L20>
+<L36>:
+               	leaq	-0x30(%rbp), %rbx
                	leaq	(%rbx), %rax
                	movq	%r14, (%rax)
                	movq	%r14, %rax
@@ -1887,57 +2394,57 @@ Disassembly of section .text:
                	andq	$0xffff, %rax           # imm = 0xFFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L38>
+               	jl	 <L37>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L39>
-<L38>:
+               	jmp	 <L38>
+<L37>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L39>:
+<L38>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xce4>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xce6>
                	leaq	(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r14, %rax
                	andq	$0xfff, %rax            # imm = 0xFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L40>
+               	jl	 <L39>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
+               	jmp	 <L40>
+<L39>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L41>:
+<L40>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd2e>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd30>
                	leaq	0x8(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r14, %rax
                	andq	$0x3ffff, %rax          # imm = 0x3FFFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L42>
+               	jl	 <L41>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L43>
-<L42>:
+               	jmp	 <L42>
+<L41>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L43>:
+<L42>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd78>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd7a>
                	leaq	0x10(%r13), %rax
                	movsd	%xmm1, (%rax)
                	leaq	-0xf0(%rbp), %r15
@@ -1947,19 +2454,19 @@ Disassembly of section .text:
                	andq	$0x7fff, %rax           # imm = 0x7FFF
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L44>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L45>
-<L44>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L45>:
+<L44>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xdcf>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xdd1>
                	leaq	0x8(%r15), %rax
                	movsd	%xmm1, (%rax)
                	movl	%r14d, %eax
@@ -2042,17 +2549,17 @@ Disassembly of section .text:
                	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L46>
+               	jl	 <L45>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L47>
-<L46>:
+               	jmp	 <L46>
+<L45>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L47>:
+<L46>:
                	movsd	%xmm14, -0x4c8(%rbp)
                	leaq	-0x240(%rbp), %r8
                	movq	%r8, -0x4e0(%rbp)
@@ -2090,8 +2597,8 @@ Disassembly of section .text:
                	movq	-0x458(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r14, %rsi
-               	callq	 <L48>
-<L48>:
+               	callq	 <L47>
+<L47>:
                	movq	-0x458(%rbp), %r8
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %r8
@@ -2187,17 +2694,17 @@ Disassembly of section .text:
                	andq	$0xff, %rdi
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L50>:
+<L49>:
                	leaq	0x18(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x490(%rbp)
@@ -2324,13 +2831,13 @@ Disassembly of section .text:
                	movsd	-0x4c8(%rbp), %xmm0
                	movq	-0x490(%rbp), %r8
                	movq	%r8, %rdx
-               	callq	 <L51>
-<L51>:
+               	callq	 <L50>
+<L50>:
                	movq	-0x3c0(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%rax, %rsi
-               	callq	 <L52>
-<L52>:
+               	callq	 <L51>
+<L51>:
                	movq	-0x4e8(%rbp), %rbx
                	movq	-0x4f0(%rbp), %r12
                	movq	-0x4f8(%rbp), %r13

--- a/test/golden/x86_64-linux/call/call_rec_small.dis
+++ b/test/golden/x86_64-linux/call/call_rec_small.dis
@@ -14,12 +14,34 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r1>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -29,18 +51,57 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0x7(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0x7(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -48,28 +109,84 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0x7(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x6(%rbp), %rcx
-               	movzwl	(%rcx), %r12d
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0x7(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x6(%rbp), %rax
+               	movzwl	(%rax), %ebx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzwq	%bx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -77,29 +194,84 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.fold_r8>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x4(%rbp), %rcx
-               	movzwl	(%rcx), %ebx
-               	leaq	-0x2(%rbp), %rcx
-               	movzbl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0x4(%rbp), %rax
+               	movzwl	(%rax), %esi
+               	leaq	-0x2(%rbp), %rax
+               	movzbl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzwq	%si, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -107,57 +279,169 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x1, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L3>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x2, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x4, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L7>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L8>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x2, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movq	$0x4, %rsi
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L9>
-<L9>:
+               	callq	 <L15>
+<L15>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rdi
                	movq	$0x2, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L11>
-<L11>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rdi
                	movq	$0x6, %rsi
-               	callq	 <L12>
-<L12>:
+               	callq	 <L19>
+<L19>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -165,237 +449,247 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.take_small>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            # imm = 0x100
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
-               	movq	%r15, -0xf8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x160, %rsp            # imm = 0x160
+               	movq	%rbx, -0x138(%rbp)
+               	movq	%r12, -0x140(%rbp)
+               	movq	%r13, -0x148(%rbp)
+               	movq	%r14, -0x150(%rbp)
+               	movq	%r15, -0x158(%rbp)
+               	movq	%rdi, %r10
+               	movq	%r10, -0xb0(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	movl	%edx, %r12d
+               	movl	%edx, %ebx
                	movq	%rcx, -0x10(%rbp)
-               	movsd	%xmm0, -0xb0(%rbp)
+               	movsd	%xmm0, -0x110(%rbp)
                	movq	%r8, -0x18(%rbp)
-               	movq	%r9, %r13
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x18(%rbp), %r8
-               	movq	%r8, -0x20(%rbp)
-               	leaq	0x20(%rbp), %rsi
-               	leaq	0x28(%rbp), %rdi
-               	leaq	0x30(%rbp), %r14
-               	movss	%xmm1, -0xc0(%rbp)
-               	movq	0x38(%rbp), %r15
-               	leaq	-0x8(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x28(%rbp)
-               	leaq	-0x10(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x30(%rbp)
-               	leaq	-0xf(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x38(%rbp)
-               	leaq	-0x18(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x40(%rbp)
-               	leaq	-0x17(%rbp), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x48(%rbp)
-               	leaq	-0x16(%rbp), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x50(%rbp)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x58(%rbp)
-               	leaq	0x4(%rcx), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x60(%rbp)
-               	leaq	0x6(%rcx), %rdx
-               	movzbl	(%rdx), %r8d
+               	movq	%r9, %r12
+               	leaq	0x10(%rbp), %rdx
+               	leaq	0x18(%rbp), %rsi
+               	leaq	0x20(%rbp), %r8
+               	movq	%r8, -0xd0(%rbp)
+               	leaq	0x28(%rbp), %r8
                	movq	%r8, -0xc8(%rbp)
-               	movq	-0x20(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x68(%rbp)
+               	leaq	0x30(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movss	%xmm1, -0x120(%rbp)
+               	movq	0x38(%rbp), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %r8d
+               	movq	%r8, -0xb8(%rbp)
+               	leaq	-0x1a(%rbp), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movw	-0x10(%rbp), %r14w
+               	movq	-0x128(%rbp), %r8
+               	movw	%r14w, (%r8)
+               	leaq	-0x1e(%rbp), %r14
+               	movl	-0x18(%rbp), %r13d
+               	movl	%r13d, (%r14)
+               	leaq	-0x28(%rbp), %r13
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%r13)
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x70(%rbp)
-               	leaq	0x1(%rsi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x78(%rbp)
-               	leaq	(%rdi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x80(%rbp)
-               	leaq	0x1(%rdi), %rdx
-               	movzbl	(%rdx), %r8d
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x2(%rdi), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0x90(%rbp)
-               	leaq	(%r14), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x98(%rbp)
-               	leaq	0x4(%r14), %rdx
-               	movzwl	(%rdx), %r8d
-               	movq	%r8, -0xa0(%rbp)
-               	leaq	0x6(%r14), %rdx
-               	movzbl	(%rdx), %r14d
+               	movq	%r8, -0xd8(%rbp)
+               	leaq	-0x2a(%rbp), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	movw	(%r8), %si
+               	movq	-0x130(%rbp), %r8
+               	movw	%si, (%r8)
+               	leaq	-0x2e(%rbp), %r15
+               	movq	-0xc8(%rbp), %r8
+               	movl	(%r8), %esi
+               	movl	%esi, (%r15)
+               	leaq	-0x38(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xc0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xe8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	movq	-0xb8(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
+               	movq	-0x100(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L2>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
+               	movl	%ebx, %esi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	-0x3a(%rbp), %rsi
+               	movq	-0x128(%rbp), %r8
+               	movw	(%r8), %bx
+               	movw	%bx, (%rsi)
+               	movq	$0x0, -0x48(%rbp)
+               	movw	(%rsi), %ax
+               	movw	%ax, -0x48(%rbp)
+               	movq	-0x48(%rbp), %rsi
                	callq	 <L4>
 <L4>:
+               	movq	-0x110(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
+               	leaq	-0x4c(%rbp), %rsi
+               	movl	(%r14), %edi
+               	movl	%edi, (%rsi)
+               	movq	$0x0, -0x58(%rbp)
+               	movl	(%rsi), %edi
+               	movl	%edi, -0x58(%rbp)
+               	movq	-0x58(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0xb0(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r12, %rsi
                	callq	 <L7>
 <L7>:
+               	leaq	-0x60(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rbx
                	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
+               	movq	-0xd8(%rbp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L10>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
 <L10>:
+               	leaq	-0x62(%rbp), %rsi
+               	movq	-0x130(%rbp), %r8
+               	movw	(%r8), %di
+               	movw	%di, (%rsi)
+               	movq	$0x0, -0x70(%rbp)
+               	movw	(%rsi), %dx
+               	movw	%dx, -0x70(%rbp)
+               	movq	-0x70(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
                	callq	 <L11>
 <L11>:
+               	leaq	-0x74(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x80(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x80(%rbp)
+               	movq	-0x80(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
+               	leaq	-0x88(%rbp), %rdx
+               	movq	-0xe8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L13>
 <L13>:
+               	movl	-0x120(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
+               	leaq	-0x90(%rbp), %rdx
+               	leaq	-0x98(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edi
+               	addl	$0x2, %edi
+               	movw	%di, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movzbl	(%rsi), %edi
+               	addl	$0x3, %edi
+               	movb	%dil, (%rsi)
+               	leaq	-0xa0(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdx
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rdx, %rsi
                	callq	 <L16>
 <L16>:
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r13), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %edx
-               	addl	$0x1, %edx
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %ebx
-               	addl	$0x2, %ebx
-               	movq	-0xc8(%rbp), %r8
-               	movl	%r8d, %r12d
-               	addl	$0x3, %r12d
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
-               	movq	-0xf8(%rbp), %r15
+               	movq	-0x138(%rbp), %rbx
+               	movq	-0x140(%rbp), %r12
+               	movq	-0x148(%rbp), %r13
+               	movq	-0x150(%rbp), %r14
+               	movq	-0x158(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -487,349 +781,438 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1c0, %rsp            # imm = 0x1C0
-               	movq	%rbx, -0x168(%rbp)
-               	movq	%r12, -0x170(%rbp)
-               	movq	%r13, -0x178(%rbp)
-               	movq	%r14, -0x180(%rbp)
-               	movq	%r15, -0x188(%rbp)
+               	subq	$0x1e0, %rsp            # imm = 0x1E0
+               	movq	%rbx, -0x188(%rbp)
+               	movq	%r12, -0x190(%rbp)
+               	movq	%r13, -0x198(%rbp)
+               	movq	%r14, -0x1a0(%rbp)
+               	movq	%r15, -0x1a8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x1, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x4, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L5>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x2, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L14>
+<L14>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L9>
-<L9>:
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rdi
                	movq	$0x2, %rsi
-               	callq	 <L11>
-<L11>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
-               	callq	 <L12>
-<L12>:
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %rdi
                	movq	$0x6, %rsi
-               	callq	 <L13>
-<L13>:
-               	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L14>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L14>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-               	jmp	 <L16>
-<L15>:
-               	movq	%rcx, %rdx
+               	callq	 <L19>
+<L19>:
+               	leaq	-0x68(%rbp), %r12
+               	leaq	(%r12), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rsi
+<L20>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L20>
+               	movq	$0x0, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L15>
-<L16>:
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0xc, %rdx
+               	jb	 <L21>
+<L22>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
-               	jb	 <L17>
-               	jmp	 <L24>
-<L17>:
+               	jb	 <L23>
+               	jmp	 <L30>
+<L23>:
                	movq	%r15, %rax
                	imulq	$0xd, %rax, %rax
                	addq	%rbx, %rax
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rdx, %r8
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rsi, %r8
                	addq	%rax, %r8
                	movq	%r8, -0xe0(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x61(%rbp), %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movb	%sil, %dil
-               	movq	-0xe8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movb	%dil, (%rsi)
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	-0x1(%rbp), %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movb	%dil, %sil
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movb	%sil, (%rdi)
                	leaq	0x10(%r12), %rsi
                	movq	(%rsi), %rdi
                	movl	%edi, %r8d
-               	movq	%r8, -0xd8(%rbp)
+               	movq	%r8, -0xe8(%rbp)
                	leaq	0x18(%r12), %rsi
                	movq	(%rsi), %rdi
-               	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0xf0(%rbp)
+               	leaq	-0x6a(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
                	movb	%dil, %dl
-               	movq	-0xf0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%dl, (%rcx)
+               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dl, (%rsi)
                	shrq	$0x8, %rdi
-               	movb	%dil, %cl
-               	movq	-0xf0(%rbp), %r8
-               	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0x3ff, %rdx            # imm = 0x3FF
-               	movq	%rdx, %r11
+               	movb	%dil, %dl
+               	movq	-0xf8(%rbp), %r8
+               	leaq	0x1(%r8), %rsi
+               	movb	%dl, (%rsi)
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0x3ff, %rsi            # imm = 0x3FF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L18>
+               	jl	 <L24>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L19>
-<L18>:
+               	jmp	 <L25>
+<L24>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L19>:
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x6a(%rbp), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movb	%dl, %dil
-               	movq	-0x108(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	movq	%rdx, %rsi
-               	shrq	$0x8, %rsi
+<L25>:
+               	leaq	0x28(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	-0x70(%rbp), %r8
+               	movq	%r8, -0x100(%rbp)
                	movb	%sil, %dil
-               	movq	-0x108(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %si
-               	movq	-0x108(%rbp), %r8
-               	leaq	0x2(%r8), %rdx
-               	movw	%si, (%rdx)
+               	movq	-0x100(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movb	%dil, (%rdx)
+               	movq	%rsi, %rdx
+               	shrq	$0x8, %rdx
+               	movb	%dl, %dil
+               	movq	-0x100(%rbp), %r8
+               	leaq	0x1(%r8), %rdx
+               	movb	%dil, (%rdx)
+               	shrq	$0x10, %rsi
+               	movw	%si, %dx
+               	movq	-0x100(%rbp), %r8
+               	leaq	0x2(%r8), %rsi
+               	movw	%dx, (%rsi)
                	leaq	0x30(%r12), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0xf8(%rbp)
+               	movq	%r8, -0x108(%rbp)
                	leaq	0x38(%r12), %rdx
                	movq	(%rdx), %rsi
                	addq	%rax, %rsi
-               	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x110(%rbp)
+               	leaq	-0x7c(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
                	movl	%esi, %edx
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	(%r8), %rdi
                	movl	%edx, (%rdi)
                	movq	%rsi, %rdx
                	shrq	$0x20, %rdx
                	movw	%dx, %di
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movw	%di, (%rdx)
                	shrq	$0x30, %rsi
                	movb	%sil, %dl
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	leaq	0x6(%r8), %rsi
                	movb	%dl, (%rsi)
                	leaq	0x40(%r12), %rdx
                	movq	(%rdx), %rsi
-               	leaq	-0x81(%rbp), %r8
-               	movq	%r8, -0x100(%rbp)
+               	leaq	-0x85(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
                	movb	%sil, %dil
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	leaq	(%r8), %rsi
                	movb	%dil, (%rsi)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	leaq	-0x84(%rbp), %r8
-               	movq	%r8, -0x118(%rbp)
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x120(%rbp)
                	movb	%dil, %dl
-               	movq	-0x118(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movb	%dl, (%rcx)
+               	movq	-0x120(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movb	%dl, (%rax)
                	shrq	$0x8, %rdi
-               	movb	%dil, %cl
-               	movq	-0x118(%rbp), %r8
+               	movb	%dil, %al
+               	movq	-0x120(%rbp), %r8
                	leaq	0x1(%r8), %rdx
-               	movb	%cl, (%rdx)
-               	leaq	0x50(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0x8a(%rbp), %rcx
-               	movb	%dl, %dil
-               	leaq	(%rcx), %rax
-               	movb	%dil, (%rax)
-               	movq	%rdx, %rax
-               	shrq	$0x8, %rax
-               	movb	%al, %dil
-               	leaq	0x1(%rcx), %rax
-               	movb	%dil, (%rax)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %ax
-               	leaq	0x2(%rcx), %rdx
-               	movw	%ax, (%rdx)
-               	leaq	0x58(%r12), %rax
+               	movb	%al, (%rdx)
+               	leaq	0x50(%r12), %rax
                	movq	(%rax), %rdx
-               	leaq	-0x98(%rbp), %rax
-               	movl	%edx, %edi
-               	leaq	(%rax), %rsi
-               	movl	%edi, (%rsi)
+               	leaq	-0x8e(%rbp), %r8
+               	movq	%r8, -0x128(%rbp)
+               	movb	%dl, %dil
+               	movq	-0x128(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dil, (%rsi)
                	movq	%rdx, %rsi
-               	shrq	$0x20, %rsi
-               	movw	%si, %di
-               	leaq	0x4(%rax), %rsi
-               	movw	%di, (%rsi)
-               	shrq	$0x30, %rdx
-               	movb	%dl, %sil
-               	leaq	0x6(%rax), %rdx
-               	movb	%sil, (%rdx)
-               	leaq	(%r12), %rdx
+               	shrq	$0x8, %rsi
+               	movb	%sil, %dil
+               	movq	-0x128(%rbp), %r8
+               	leaq	0x1(%r8), %rsi
+               	movb	%dil, (%rsi)
+               	shrq	$0x10, %rdx
+               	movw	%dx, %si
+               	movq	-0x128(%rbp), %r8
+               	leaq	0x2(%r8), %rdx
+               	movw	%si, (%rdx)
+               	leaq	0x58(%r12), %rdx
                	movq	(%rdx), %rsi
+               	leaq	-0x9c(%rbp), %rdx
+               	movl	%esi, %edi
+               	leaq	(%rdx), %rax
+               	movl	%edi, (%rax)
+               	movq	%rsi, %rax
+               	shrq	$0x20, %rax
+               	movw	%ax, %di
+               	leaq	0x4(%rdx), %rax
+               	movw	%di, (%rax)
+               	shrq	$0x30, %rsi
+               	movb	%sil, %al
+               	leaq	0x6(%rdx), %rsi
+               	movb	%al, (%rsi)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
                	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L20>
+               	jl	 <L26>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L21>
-<L20>:
+               	jmp	 <L27>
+<L26>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L21>:
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movq	$0x0, -0xa0(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xa0(%rbp)
-               	movq	-0xa0(%rbp), %rdx
+<L27>:
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rsi
                	movq	$0x0, -0xa8(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movw	(%r8), %di
-               	movw	%di, -0xa8(%rbp)
-               	movq	-0xa8(%rbp), %r8
-               	movq	%r8, -0x120(%rbp)
+               	movb	(%r8), %al
+               	movb	%al, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %rax
                	movq	$0x0, -0xb0(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	movl	(%r8), %edi
-               	movl	%edi, -0xb0(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	movw	(%r8), %di
+               	movw	%di, -0xb0(%rbp)
                	movq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x110(%rbp), %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, -0xb8(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	movl	(%r8), %edi
+               	movl	%edi, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x118(%rbp), %r8
                	movq	(%r8), %rdi
                	movq	%rdi, (%rsp)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	movb	(%r8), %dil
                	movb	%dil, 0x8(%rsp)
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x120(%rbp), %r8
                	movw	(%r8), %di
                	movw	%di, 0x10(%rsp)
-               	movl	(%rcx), %edi
+               	movq	-0x128(%rbp), %r8
+               	movl	(%r8), %edi
                	movl	%edi, 0x18(%rsp)
-               	movq	(%rax), %rcx
-               	movq	%rcx, 0x20(%rsp)
+               	movq	(%rdx), %rdi
+               	movq	%rdi, 0x20(%rsp)
                	movq	%rsi, 0x28(%rsp)
                	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%rdx, %rsi
-               	movq	-0xd8(%rbp), %r8
+               	movq	%rax, %rsi
+               	movq	-0xe8(%rbp), %r8
                	movl	%r8d, %edx
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	-0x128(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	callq	 <L22>
-<L22>:
+               	movq	-0x138(%rbp), %r8
+               	movq	-0x108(%rbp), %r9
+               	callq	 <L28>
+<L28>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L23>
-<L23>:
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
-               	jb	 <L17>
-<L24>:
-               	leaq	-0x62(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	movb	%r14b, %cl
-               	movq	-0x140(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movb	%cl, (%rdx)
+               	jb	 <L23>
+<L30>:
+               	leaq	-0x2(%rbp), %r8
+               	movq	%r8, -0x150(%rbp)
+               	movb	%r14b, %dl
+               	movq	-0x150(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movb	%dl, (%rsi)
                	movl	%r14d, %r8d
-               	movq	%r8, -0x130(%rbp)
-               	leaq	-0x66(%rbp), %r8
-               	movq	%r8, -0x148(%rbp)
-               	movb	%r14b, %sil
-               	movq	-0x148(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movb	%sil, (%rdi)
-               	movq	%r14, %rsi
-               	shrq	$0x8, %rsi
-               	movb	%sil, %dil
-               	movq	-0x148(%rbp), %r8
-               	leaq	0x1(%r8), %rsi
-               	movb	%dil, (%rsi)
-               	movq	%r14, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L25>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L26>
-<L25>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L26>:
-               	leaq	-0x6e(%rbp), %r8
+               	movq	%r8, -0x140(%rbp)
+               	leaq	-0x6c(%rbp), %r8
                	movq	%r8, -0x158(%rbp)
                	movb	%r14b, %dil
                	movq	-0x158(%rbp), %r8
@@ -842,141 +1225,172 @@ Disassembly of section .text:
                	leaq	0x1(%r8), %rdi
                	movb	%bl, (%rdi)
                	movq	%r14, %rdi
-               	shrq	$0x10, %rdi
-               	movw	%di, %bx
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x2(%r8), %rdi
-               	movw	%bx, (%rdi)
-               	leaq	0x30(%r12), %rdi
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x138(%rbp)
-               	leaq	-0x80(%rbp), %rdi
-               	movl	%r14d, %r15d
-               	leaq	(%rdi), %rcx
-               	movl	%r15d, (%rcx)
-               	movq	%r14, %rcx
-               	shrq	$0x20, %rcx
-               	movw	%cx, %r15w
-               	leaq	0x4(%rdi), %rcx
-               	movw	%r15w, (%rcx)
-               	movq	%r14, %rcx
-               	shrq	$0x30, %rcx
-               	movb	%cl, %r15b
-               	leaq	0x6(%rdi), %rcx
-               	movb	%r15b, (%rcx)
-               	leaq	0x40(%r12), %rcx
-               	movq	(%rcx), %r15
-               	leaq	-0x82(%rbp), %r8
-               	movq	%r8, -0x150(%rbp)
-               	movb	%r15b, %bl
-               	movq	-0x150(%rbp), %r8
+               	andq	$0x3ff, %rdi            # imm = 0x3FF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L32>
+<L31>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L32>:
+               	leaq	-0x74(%rbp), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movb	%r14b, %bl
+               	movq	-0x168(%rbp), %r8
                	leaq	(%r8), %r15
                	movb	%bl, (%r15)
-               	leaq	0x48(%r12), %rbx
-               	movq	(%rbx), %r15
-               	leaq	-0x86(%rbp), %rbx
-               	movb	%r15b, %al
-               	leaq	(%rbx), %rdx
-               	movb	%al, (%rdx)
-               	shrq	$0x8, %r15
-               	movb	%r15b, %al
-               	leaq	0x1(%rbx), %rdx
-               	movb	%al, (%rdx)
-               	leaq	0x50(%r12), %rax
-               	movq	(%rax), %rdx
-               	leaq	-0x8e(%rbp), %rax
-               	movb	%dl, %r15b
-               	leaq	(%rax), %rcx
-               	movb	%r15b, (%rcx)
-               	movq	%rdx, %rcx
-               	shrq	$0x8, %rcx
-               	movb	%cl, %r15b
-               	leaq	0x1(%rax), %rcx
-               	movb	%r15b, (%rcx)
-               	shrq	$0x10, %rdx
-               	movw	%dx, %cx
-               	leaq	0x2(%rax), %rdx
-               	movw	%cx, (%rdx)
-               	leaq	0x58(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	-0xb8(%rbp), %rcx
-               	movl	%edx, %r15d
-               	leaq	(%rcx), %rsi
-               	movl	%r15d, (%rsi)
-               	movq	%rdx, %rsi
-               	shrq	$0x20, %rsi
-               	movw	%si, %r15w
-               	leaq	0x4(%rcx), %rsi
-               	movw	%r15w, (%rsi)
+               	movq	%r14, %rbx
+               	shrq	$0x8, %rbx
+               	movb	%bl, %r15b
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x1(%r8), %rbx
+               	movb	%r15b, (%rbx)
+               	movq	%r14, %rbx
+               	shrq	$0x10, %rbx
+               	movw	%bx, %r15w
+               	movq	-0x168(%rbp), %r8
+               	leaq	0x2(%r8), %rbx
+               	movw	%r15w, (%rbx)
+               	leaq	0x30(%r12), %rbx
+               	movq	(%rbx), %r8
+               	movq	%r8, -0x148(%rbp)
+               	leaq	-0x84(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movl	%r14d, %edx
+               	movq	-0x170(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movl	%edx, (%r15)
+               	movq	%r14, %rdx
+               	shrq	$0x20, %rdx
+               	movw	%dx, %r15w
+               	movq	-0x170(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movw	%r15w, (%rdx)
+               	movq	%r14, %rdx
                	shrq	$0x30, %rdx
-               	movb	%dl, %sil
-               	leaq	0x6(%rcx), %rdx
+               	movb	%dl, %r15b
+               	movq	-0x170(%rbp), %r8
+               	leaq	0x6(%r8), %rdx
+               	movb	%r15b, (%rdx)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %r15
+               	leaq	-0x86(%rbp), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movb	%r15b, %al
+               	movq	-0x160(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movb	%al, (%r15)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %r15
+               	leaq	-0x8a(%rbp), %rax
+               	movb	%r15b, %sil
+               	leaq	(%rax), %rdx
                	movb	%sil, (%rdx)
-               	leaq	(%r12), %rdx
+               	shrq	$0x8, %r15
+               	movb	%r15b, %dl
+               	leaq	0x1(%rax), %rsi
+               	movb	%dl, (%rsi)
+               	leaq	0x50(%r12), %rdx
                	movq	(%rdx), %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
+               	leaq	-0x92(%rbp), %rdx
+               	movb	%sil, %r15b
+               	leaq	(%rdx), %rdi
+               	movb	%r15b, (%rdi)
+               	movq	%rsi, %rdi
+               	shrq	$0x8, %rdi
+               	movb	%dil, %r15b
+               	leaq	0x1(%rdx), %rdi
+               	movb	%r15b, (%rdi)
+               	shrq	$0x10, %rsi
+               	movw	%si, %di
+               	leaq	0x2(%rdx), %rsi
+               	movw	%di, (%rsi)
+               	leaq	0x58(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	-0xc0(%rbp), %rsi
+               	movl	%edi, %r15d
+               	leaq	(%rsi), %rbx
+               	movl	%r15d, (%rbx)
+               	movq	%rdi, %rbx
+               	shrq	$0x20, %rbx
+               	movw	%bx, %r15w
+               	leaq	0x4(%rsi), %rbx
+               	movw	%r15w, (%rbx)
+               	shrq	$0x30, %rdi
+               	movb	%dil, %bl
+               	leaq	0x6(%rsi), %rdi
+               	movb	%bl, (%rdi)
+               	leaq	(%r12), %rdi
+               	movq	(%rdi), %rbx
+               	andq	$0xff, %rbx
+               	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L33>
                	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L28>:
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movq	$0x0, -0xc0(%rbp)
-               	movq	-0x140(%rbp), %r8
-               	movb	(%r8), %dl
-               	movb	%dl, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %rdx
+<L34>:
+               	leaq	0x10(%r12), %rdi
+               	movq	(%rdi), %rbx
                	movq	$0x0, -0xc8(%rbp)
-               	movq	-0x148(%rbp), %r8
-               	movw	(%r8), %r12w
-               	movw	%r12w, -0xc8(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	movb	(%r8), %dil
+               	movb	%dil, -0xc8(%rbp)
                	movq	-0xc8(%rbp), %r12
                	movq	$0x0, -0xd0(%rbp)
                	movq	-0x158(%rbp), %r8
-               	movl	(%r8), %r15d
-               	movl	%r15d, -0xd0(%rbp)
+               	movw	(%r8), %di
+               	movw	%di, -0xd0(%rbp)
                	movq	-0xd0(%rbp), %r15
-               	movq	(%rdi), %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, -0xd8(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	movl	(%r8), %edi
+               	movl	%edi, -0xd8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, (%rsp)
                	movq	-0x160(%rbp), %r8
-               	movq	%r8, (%rsp)
-               	movq	-0x150(%rbp), %r8
                	movb	(%r8), %dil
                	movb	%dil, 0x8(%rsp)
-               	movw	(%rbx), %di
+               	movw	(%rax), %di
                	movw	%di, 0x10(%rsp)
-               	movl	(%rax), %edi
-               	movl	%edi, 0x18(%rsp)
-               	movq	(%rcx), %rax
+               	movl	(%rdx), %eax
+               	movl	%eax, 0x18(%rsp)
+               	movq	(%rsi), %rax
                	movq	%rax, 0x20(%rsp)
-               	movq	%rsi, 0x28(%rsp)
+               	movq	%rbx, 0x28(%rsp)
                	movq	%r14, %rdi
-               	movq	%rdx, %rsi
-               	movq	-0x130(%rbp), %r8
+               	movq	%r12, %rsi
+               	movq	-0x140(%rbp), %r8
                	movl	%r8d, %edx
-               	movq	%r12, %rcx
-               	movq	%r15, %r8
-               	movq	-0x138(%rbp), %r9
-               	callq	 <L29>
-<L29>:
+               	movq	%r15, %rcx
+               	movq	-0x178(%rbp), %r8
+               	movq	-0x148(%rbp), %r9
+               	callq	 <L35>
+<L35>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x168(%rbp), %rbx
-               	movq	-0x170(%rbp), %r12
-               	movq	-0x178(%rbp), %r13
-               	movq	-0x180(%rbp), %r14
-               	movq	-0x188(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x188(%rbp), %rbx
+               	movq	-0x190(%rbp), %r12
+               	movq	-0x198(%rbp), %r13
+               	movq	-0x1a0(%rbp), %r14
+               	movq	-0x1a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_recursive.dis
+++ b/test/golden/x86_64-linux/call/call_recursive.dis
@@ -14,12 +14,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.descend>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x70, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%r13, -0x58(%rbp)
-               	movq	%r14, -0x60(%rbp)
-               	movq	%r15, -0x68(%rbp)
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -35,14 +35,14 @@ Disassembly of section .text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rsi, %rdi
-               	imulq	%rcx, %rdi
-               	addq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %r13
-               	movq	%rdi, (%r13)
-               	movq	%rcx, %rax
+               	movq	%rax, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r13
+               	imulq	%rdi, %r13
+               	addq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %r14
+               	movq	%r13, (%r14)
+               	movq	%rdi, %rax
                	cmpq	$0x8, %rax
                	jb	 <L0>
 <L1>:
@@ -62,34 +62,87 @@ Disassembly of section .text:
 <L3>:
                	movq	%rax, %r14
 <L4>:
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L9>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %r12
-               	movq	-0x58(%rbp), %r13
-               	movq	-0x60(%rbp), %r14
-               	movq	-0x68(%rbp), %r15
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r14, %rax
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -97,11 +150,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.ping>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
                	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x20(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -113,13 +167,13 @@ Disassembly of section .text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	%rsi, %rdi
-               	addq	%rcx, %rdi
-               	addq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	%rdi, (%rcx)
+               	movq	%rax, %rdi
+               	imulq	$0x7, %rdi, %rdi
+               	movq	%rsi, %r13
+               	addq	%rdi, %r13
+               	addq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %rdi
+               	movq	%r13, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x4, %rax
                	jb	 <L0>
@@ -137,30 +191,66 @@ Disassembly of section .text:
 <L3>:
                	movq	%rax, %r13
 <L4>:
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
+               	movq	$0x0, %rax
+               	cmpq	$0x4, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%r13, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L5>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	imulq	$0x2, %rbx, %rbx
-               	movq	%r13, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r13
+               	cmpq	$0x4, %rax
+               	jb	 <L5>
 <L8>:
+               	imulq	$0x2, %rbx, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	%r13, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
                	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -168,12 +258,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.pong>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
-               	movq	%r14, -0x50(%rbp)
-               	movq	%r15, -0x58(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
@@ -187,13 +277,13 @@ Disassembly of section .text:
                	jb	 <L0>
                	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rsi, %rdi
-               	imulq	%rcx, %rdi
-               	subq	%rbx, %rdi
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	%rdi, (%rcx)
+               	movq	%rax, %rdi
+               	addq	$0x3, %rdi
+               	movq	%rsi, %r13
+               	imulq	%rdi, %r13
+               	subq	%rbx, %r13
+               	leaq	(%r12,%rax,8), %rdi
+               	movq	%r13, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x6, %rax
                	jb	 <L0>
@@ -213,31 +303,274 @@ Disassembly of section .text:
 <L3>:
                	movq	%rax, %r14
 <L4>:
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
                	jb	 <L5>
-               	jmp	 <L7>
+               	jmp	 <L8>
 <L5>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
+               	leaq	(%r12,%rax,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x6, %r15
-               	jb	 <L5>
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L8>
+               	addq	$0x1, %rax
+               	movq	%rdx, %r14
+               	cmpq	$0x6, %rax
+               	jb	 <L5>
 <L8>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
                	imulq	$0x3, %rbx, %rbx
                	addq	$0x1, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	movq	%r14, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_recursive.tree>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %rsi
+               	movq	%rsi, %r12
+               	addq	%rbx, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %r11
+               	cmpq	%rbx, %r11
+               	jb	 <L2>
+               	movq	%rdx, %r13
+               	jmp	 <L7>
+<L2>:
+               	movq	%rbx, %rdi
+               	subq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	addq	$0x1, %rsi
+               	callq	 <L3>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L9>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	subq	$0x1, %rbx
+               	movq	%r12, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	movq	%rbx, %rdi
+               	movq	%rax, %rdx
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r13
+<L7>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r12, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
+               	movq	%r13, %rax
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.call.call_recursive.tail>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x28(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	%rdi, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	xorq	%r12, %r13
+               	leaq	(%rax,%rbx,8), %r12
+               	movq	%r13, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rbx
+               	movq	%rdx, %r12
+               	cmpq	$0x4, %rbx
+               	jb	 <L2>
+               	jmp	 <L5>
+<L2>:
+               	leaq	(%rax,%rbx,8), %rdx
+               	movq	(%rdx), %r13
+               	movq	%r12, %rdx
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+<L4>:
+               	addq	$0x1, %rbx
+               	movq	%rdx, %r12
+               	cmpq	$0x4, %rbx
+               	jb	 <L2>
+<L5>:
+               	cmpq	$0x0, %rdi
+               	je	 <L7>
+               	subq	$0x1, %rdi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0x5, %rax, %rax
+               	addq	$0x3, %rax
+               	movq	%rax, %rsi
+               	movq	%r12, %rdx
+               	callq	 <L6>
+<L6>:
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13
@@ -246,403 +579,13 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-
-<corpus.cases.call.call_recursive.tree>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0xa0, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%r12, -0x80(%rbp)
-               	movq	%r13, -0x88(%rbp)
-               	movq	%r14, -0x90(%rbp)
-               	movq	%r15, -0x98(%rbp)
-               	movq	%rdi, %rbx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	movq	%rsi, %r12
-               	addq	%rbx, %r12
-               	movq	%rdx, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L0>
-<L0>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L1>
-               	movq	%rax, %r13
-               	jmp	 <L41>
-<L1>:
-               	movq	%rbx, %r14
-               	subq	$0x1, %r14
-               	movq	%r12, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r15
-               	addq	%r14, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	$0x0, %r11
-               	cmpq	%r14, %r11
-               	jb	 <L3>
-               	movq	%rax, %r8
-               	movq	%r8, -0x58(%rbp)
-               	jmp	 <L19>
-<L3>:
-               	movq	%r14, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	%r15, %rsi
-               	addq	$0x1, %rsi
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	movq	-0x50(%rbp), %r9
-               	movq	%rsi, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	-0x50(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L5>
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-               	jmp	 <L9>
-<L5>:
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x18(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
 <L7>:
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x10(%rbp)
-<L9>:
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L11>
-<L11>:
-               	subq	$0x1, %r14
-               	movq	%r15, %rdx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rdx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rdx
-               	movq	%rdx, %r8
-               	addq	%r14, %r8
-               	movq	%r8, -0x20(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	$0x0, %r11
-               	cmpq	%r14, %r11
-               	jb	 <L13>
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	jmp	 <L17>
-<L13>:
-               	subq	$0x1, %r14
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%r14, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	%r14, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-<L17>:
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x58(%rbp)
-<L19>:
-               	movq	-0x58(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L21>
-<L21>:
-               	subq	$0x1, %rbx
-               	movq	%r12, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L23>
-               	movq	%rax, %r15
-               	jmp	 <L39>
-<L23>:
-               	movq	%rbx, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	%r14, %rdx
-               	addq	$0x1, %rdx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rdx
-               	movq	-0x60(%rbp), %r9
-               	movq	%rdx, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x30(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x60(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L25>
-               	movq	%rax, %r8
-               	movq	%r8, -0x38(%rbp)
-               	jmp	 <L29>
-<L25>:
-               	movq	-0x60(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x38(%rbp)
-<L29>:
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x30(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L31>
-<L31>:
-               	subq	$0x1, %rbx
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	$0x0, %r11
-               	cmpq	%rbx, %r11
-               	jb	 <L33>
-               	movq	%rax, %r8
-               	movq	%r8, -0x68(%rbp)
-               	jmp	 <L37>
-<L33>:
-               	subq	$0x1, %rbx
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	$0x1, %rsi
-               	movq	%rbx, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rsi
-               	movq	%rbx, %rdi
-               	movq	%rax, %rdx
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x68(%rbp)
-<L37>:
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r15
-<L39>:
-               	movq	%r15, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r13
-<L41>:
-               	movq	%r13, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %r12
-               	movq	-0x88(%rbp), %r13
-               	movq	-0x90(%rbp), %r14
-               	movq	-0x98(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-
-<corpus.cases.call.call_recursive.tail>:
-               	pushq	%rbp
-               	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rdi, %rbx
-               	movq	%rsi, %r12
-               	leaq	-0x20(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, 0x18(%r13)
-               	movq	$0x0, %rax
-               	cmpq	$0x4, %rax
-               	jb	 <L0>
-               	jmp	 <L1>
-<L0>:
-               	movq	%rax, %rcx
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rcx
-               	addq	%rbx, %rcx
-               	movq	%r12, %rsi
-               	xorq	%rcx, %rsi
-               	leaq	(%r13,%rax,8), %rcx
-               	movq	%rsi, (%rcx)
-               	addq	$0x1, %rax
-               	cmpq	$0x4, %rax
-               	jb	 <L0>
-<L1>:
-               	movq	$0x0, %r14
-               	movq	%rdx, %r15
-               	cmpq	$0x4, %r14
-               	jb	 <L2>
-               	jmp	 <L4>
-<L2>:
-               	leaq	(%r13,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r15, %rdi
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r15
-               	cmpq	$0x4, %r14
-               	jb	 <L2>
-<L4>:
-               	cmpq	$0x0, %rbx
-               	je	 <L6>
-               	subq	$0x1, %rbx
-               	imulq	$0x5, %r12, %r12
-               	addq	$0x3, %r12
-               	movq	%rbx, %rdi
-               	movq	%r12, %rsi
-               	movq	%r15, %rdx
-               	callq	 <L5>
-<L5>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
-               	movq	%rbp, %rsp
-               	popq	%rbp
-               	retq
-<L6>:
-               	movq	%r15, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r12, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -742,130 +685,178 @@ Disassembly of section .text:
 <corpus.cases.call.call_recursive.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x68(%rbp)
-               	movq	%r12, -0x70(%rbp)
-               	movq	%r13, -0x78(%rbp)
-               	movq	%r14, -0x80(%rbp)
-               	movq	%r15, -0x88(%rbp)
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x78(%rbp)
+               	movq	%r12, -0x80(%rbp)
+               	movq	%r13, -0x88(%rbp)
+               	movq	%r14, -0x90(%rbp)
+               	movq	%r15, -0x98(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x30(%rbp), %r12
+               	leaq	-0x48(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
                	addq	%rbx, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
+               	leaq	(%r12,%rax,8), %rsi
                	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L1>
-<L2>:
+               	addq	$0x1, %rax
+               	cmpq	$0x6, %rax
+               	jb	 <L0>
+<L1>:
                	movq	$0x28, %rdi
                	addq	%rbx, %rdi
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
+               	movq	$0x21, %r13
+               	addq	%rbx, %r13
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%r13, %rdi
                	movq	%rax, %rdx
                	callq	 <L3>
 <L3>:
-               	movq	$0x21, %r13
-               	addq	%rbx, %r13
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x10(%r12), %rdx
+               	movq	(%rdx), %rsi
                	movq	%r13, %rdi
                	movq	%rax, %rdx
                	callq	 <L4>
 <L4>:
-               	leaq	0x10(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%r13, %rdi
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	movq	$0x8, %rdi
                	movq	%rax, %rdx
                	callq	 <L5>
 <L5>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	movq	$0x8, %rdi
-               	movq	%rdx, %rsi
+               	movq	$0x30, %rdi
+               	addq	%rbx, %rdi
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdx
                	callq	 <L6>
 <L6>:
-               	movq	$0x30, %rdi
-               	addq	%rbx, %rdi
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdx
-               	callq	 <L7>
-<L7>:
                	movq	$0x18, %r13
                	addq	%rbx, %r13
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L8>
-               	jmp	 <L13>
-<L8>:
+               	jb	 <L7>
+               	jmp	 <L15>
+<L7>:
                	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x48(%rbp), %r8
-               	movq	%r8, -0x50(%rbp)
-               	movq	-0x50(%rbp), %r8
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
                	movq	%r13, %rsi
-               	movq	%rcx, %rdx
-               	callq	 <L9>
-<L9>:
-               	movq	-0x50(%rbp), %r8
-               	movq	-0x50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x58(%rbp)
-               	movq	-0x50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
+               	callq	 <L8>
+<L8>:
+               	movq	-0x68(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %r8
                	movq	%r8, -0x60(%rbp)
-               	movq	%r14, %rdi
-               	callq	 <L10>
-<L10>:
+               	movq	-0x68(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x68(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x50(%rbp)
+               	movq	%r14, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
                	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x58(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
 <L12>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L8>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L13>
+               	jmp	 <L14>
 <L13>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L13>
+<L14>:
+               	addq	$0x1, %r15
+               	movq	%rdx, %r14
+               	cmpq	$0x4, %r15
+               	jb	 <L7>
+<L15>:
                	movq	%r14, %rax
-               	movq	-0x68(%rbp), %rbx
-               	movq	-0x70(%rbp), %r12
-               	movq	-0x78(%rbp), %r13
-               	movq	-0x80(%rbp), %r14
-               	movq	-0x88(%rbp), %r15
+               	movq	-0x78(%rbp), %rbx
+               	movq	-0x80(%rbp), %r12
+               	movq	-0x88(%rbp), %r13
+               	movq	-0x90(%rbp), %r14
+               	movq	-0x98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_ret_large.dis
+++ b/test/golden/x86_64-linux/call/call_ret_large.dis
@@ -14,44 +14,134 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold20>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r15, -0x28(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movl	(%rdx), %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movl	(%rdx), %ebx
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movl	(%rdx), %r12d
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movl	(%rdx), %r13d
-               	leaq	0x10(%rcx), %rdx
-               	movl	(%rdx), %r14d
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%ebx, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L4>
+               	movl	%r12d, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movl	%r13d, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -59,28 +149,81 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold24>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x10, %rsp
+               	subq	$0x20, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r13, -0x18(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	callq	 <L0>
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -88,26 +231,80 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold24f>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movsd	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movsd	(%rdx), %xmm2
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L2>
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -119,32 +316,101 @@ Disassembly of section .text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r14, -0x20(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	(%rdx), %rbx
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r12
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r13
-               	callq	 <L0>
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r13
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -152,50 +418,68 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold40m>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x30, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x10(%rax), %rdx
+               	movl	(%rdx), %ebx
+               	leaq	0x14(%rax), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x18(%rax), %rdx
                	movq	(%rdx), %r11
                	movq	%r11, -0x10(%rbp)
-               	leaq	0x10(%rcx), %rdx
-               	movl	(%rdx), %ebx
-               	leaq	0x14(%rcx), %rdx
-               	movl	(%rdx), %r12d
-               	leaq	0x18(%rcx), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	leaq	0x20(%rcx), %rdx
+               	leaq	0x20(%rax), %rdx
                	movq	(%rdx), %r13
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %r14
+               	xorq	%rdx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
+               	movq	%xmm0, %rsi
                	callq	 <L2>
 <L2>:
+               	movl	%ebx, %esi
                	movq	%rax, %rdi
-               	movl	%r12d, %esi
                	callq	 <L3>
 <L3>:
+               	movl	%r12d, %esi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
+               	movq	%rax, %rdi
+               	movq	%r13, %rsi
+               	callq	 <L6>
+<L6>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -256,54 +540,62 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.fold_nest>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
-               	leaq	0x8(%rcx), %rdx
-               	leaq	(%rdx), %rbx
-               	movq	(%rbx), %r12
-               	leaq	0x8(%rdx), %rbx
-               	movq	(%rbx), %r13
-               	leaq	0x10(%rdx), %rbx
-               	movq	(%rbx), %r14
-               	leaq	0x20(%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r15
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	-0x30(%rbp), %rbx
+               	movq	(%rax), %rcx
+               	movq	0x8(%rax), %rdx
+               	movq	0x10(%rax), %rsi
+               	movq	0x18(%rax), %r12
+               	movq	0x20(%rax), %r13
+               	movq	0x28(%rax), %r14
+               	movq	%rcx, (%rbx)
+               	movq	%rdx, 0x8(%rbx)
+               	movq	%rsi, 0x10(%rbx)
+               	movq	%r12, 0x18(%rbx)
+               	movq	%r13, 0x20(%rbx)
+               	movq	%r14, 0x28(%rbx)
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
                	callq	 <L0>
 <L0>:
+               	leaq	0x8(%rbx), %rcx
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rdi
+               	movq	0x10(%rcx), %r12
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	(%rdx), %rcx
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rcx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
                	callq	 <L1>
 <L1>:
+               	leaq	0x20(%rbx), %r12
+               	leaq	(%r12), %rcx
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L2>
 <L2>:
+               	leaq	0x8(%r12), %rcx
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movq	%r14, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -913,38 +1205,45 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.take_two>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x60, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%r12, -0x40(%rbp)
-               	movq	%r13, -0x48(%rbp)
-               	movq	%r14, -0x50(%rbp)
-               	movq	%r15, -0x58(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	0x40(%rbp), %rdx
+               	subq	$0xa0, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%r12, -0x60(%rbp)
+               	movq	%r13, -0x68(%rbp)
+               	movq	%r14, -0x70(%rbp)
+               	movq	%r15, -0x78(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	0x40(%rbp), %rcx
                	movq	%rdi, %rbx
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %r12
-               	leaq	0x8(%rcx), %rsi
-               	movq	(%rsi), %r13
-               	leaq	0x10(%rcx), %rsi
-               	movq	(%rsi), %r14
-               	leaq	0x18(%rcx), %rsi
-               	movq	(%rsi), %r15
-               	leaq	0x20(%rcx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x8(%rbp)
-               	leaq	0x28(%rcx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x20(%rbp)
-               	leaq	(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x10(%rbp)
-               	leaq	0x8(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x18(%rbp)
-               	leaq	0x10(%rdx), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x28(%rbp)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x38(%rbp)
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %r12
+               	leaq	0x10(%rax), %rdx
+               	movq	(%rdx), %r13
+               	leaq	0x18(%rax), %rdx
+               	movq	(%rdx), %r14
+               	leaq	0x20(%rax), %rdx
+               	movq	(%rdx), %r15
+               	leaq	0x28(%rax), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x50(%rbp)
+               	leaq	-0x18(%rbp), %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	(%rcx), %rdi
+               	movq	0x8(%rcx), %rsi
+               	movq	0x10(%rcx), %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x48(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x48(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x48(%rbp), %r8
+               	movq	-0x40(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -964,39 +1263,38 @@ Disassembly of section .text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
+               	movq	-0x50(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
+               	leaq	-0x30(%rbp), %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x48(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x48(%rbp), %r8
+               	movq	0x10(%r8), %r12
+               	movq	%rsi, (%rcx)
+               	movq	%rdi, 0x8(%rcx)
+               	movq	%r12, 0x10(%rcx)
+               	movq	(%rcx), %rdx
+               	movq	0x8(%rcx), %rsi
+               	movq	0x10(%rcx), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
                	movq	%rax, %rdi
-               	movq	-0x20(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rbx, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	-0x38(%rbp), %rbx
-               	movq	-0x40(%rbp), %r12
-               	movq	-0x48(%rbp), %r13
-               	movq	-0x50(%rbp), %r14
-               	movq	-0x58(%rbp), %r15
+               	movq	-0x58(%rbp), %rbx
+               	movq	-0x60(%rbp), %r12
+               	movq	-0x68(%rbp), %r13
+               	movq	-0x70(%rbp), %r14
+               	movq	-0x78(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1004,18 +1302,19 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x790, %rsp            # imm = 0x790
-               	movq	%rbx, -0x738(%rbp)
-               	movq	%r12, -0x740(%rbp)
-               	movq	%r13, -0x748(%rbp)
-               	movq	%r14, -0x750(%rbp)
-               	movq	%r15, -0x758(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x508(%rbp)
+               	subq	$0xa80, %rsp            # imm = 0xA80
+               	movq	%rbx, -0xa28(%rbp)
+               	movq	%r12, -0xa30(%rbp)
+               	movq	%r13, -0xa38(%rbp)
+               	movq	%r14, -0xa40(%rbp)
+               	movq	%r15, -0xa48(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x14, %rsi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movq	$0x14, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
@@ -1023,15 +1322,15 @@ Disassembly of section .text:
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x28, %rsi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x30, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
@@ -1039,18 +1338,14 @@ Disassembly of section .text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	$0x30, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x20, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	$0x20, %rsi
-               	callq	 <L9>
-<L9>:
-               	leaq	-0x1c0(%rbp), %r12
+               	leaq	-0x2d8(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -1059,119 +1354,197 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-               	jmp	 <L11>
-<L10>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x508(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L10>
-<L11>:
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+<L10>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L12>
-               	jmp	 <L51>
-<L12>:
+               	jb	 <L11>
+               	jmp	 <L57>
+<L11>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x508(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
                	movl	%r15d, %eax
-               	movq	%r15, %rcx
-               	shrq	$0x8, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x610(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x10, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4a8(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x18, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4b0(%rbp)
-               	movq	%r15, %rcx
-               	shrq	$0x20, %rcx
-               	movl	%ecx, %r8d
-               	movq	%r8, -0x4b8(%rbp)
-               	movq	%r13, %rdi
-               	movl	%eax, %esi
-               	callq	 <L13>
+               	movq	%r15, %rdx
+               	shrq	$0x8, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x650(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x10, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x648(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x18, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x638(%rbp)
+               	movq	%r15, %rdx
+               	shrq	$0x20, %rdx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x640(%rbp)
+               	movl	%eax, %r8d
+               	movq	%r8, -0x658(%rbp)
+               	movq	%r13, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x658(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	-0x610(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L14>
+               	movq	-0x650(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x660(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	-0x4a8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L15>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x660(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x4b0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
+               	movq	-0x648(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x668(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movq	-0x4b8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L17>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x668(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movq	%r15, %r8
-               	movq	%r8, -0x618(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x618(%rbp)
+               	movq	-0x638(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x670(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x640(%rbp), %r8
+               	movl	%r8d, %edx
+               	movq	%rax, %r8
+               	movq	%r8, -0x678(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x678(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	-0x390(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
                	movq	%r15, %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	%rdx, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x4c0(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x618(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x4c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L21>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L22>
 <L22>:
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x2c6>
-               	movq	%r15, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
+               	movq	%r15, %rdx
+               	andq	$0xffff, %rdx           # imm = 0xFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L23>
                	cvtsi2sd	%r11, %xmm0
@@ -1184,12 +1557,11 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L24>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	subsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x30a>
-               	movsd	%xmm14, -0x628(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x475>
+               	movq	%r15, %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L25>
                	cvtsi2sd	%r11, %xmm0
@@ -1202,76 +1574,127 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L26>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x357>
-               	movsd	%xmm14, -0x638(%rbp)
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movsd	-0x628(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0x638(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%r15, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x640(%rbp)
-               	movq	%r15, %r8
-               	imulq	$0x5, %r8, %r8
-               	movq	%r8, -0x648(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x640(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x648(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movq	-0x4c8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%r15, %rcx
-               	andq	$0x1fff, %rcx           # imm = 0x1FFF
-               	movq	%rcx, %r11
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_ret_large.checksum+0x4b7>
+               	movq	%r15, %rdx
+               	andq	$0x3ffff, %rdx          # imm = 0x3FFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L34>
+               	jl	 <L27>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L35>
-<L34>:
+               	jmp	 <L28>
+<L27>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
+<L28>:
+               	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.call.call_ret_large.checksum+0x4f9>
+               	movq	%xmm1, %r8
+               	movq	%r8, -0x680(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	%xmm2, %r8
+               	movq	%r8, -0x688(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x688(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+<L32>:
+               	movq	%xmm3, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x690(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L33>
+<L34>:
+               	leaq	-0x4a0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	imulq	$0x5, %rdx, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x18(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x698(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L35>
 <L35>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x442>
-               	movsd	%xmm14, -0x658(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0x660(%rbp)
                	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x4d0(%rbp)
-               	movq	%r15, %rdx
-               	andq	$0x1ffff, %rdx          # imm = 0x1FFFF
+               	andq	$0x1fff, %rdx           # imm = 0x1FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L36>
@@ -1285,95 +1708,1053 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
 <L37>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_large.checksum+0x6ea>
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x980(%rbp)
+               	movq	%r15, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x6a0(%rbp)
+               	movq	%r15, %rsi
+               	andq	$0x1ffff, %rsi          # imm = 0x1FFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L38>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L39>
+<L38>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L39>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x4aa>
-               	movsd	%xmm14, -0x670(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_ret_large.checksum+0x749>
+               	movsd	%xmm14, -0x990(%rbp)
                	movq	%r15, %r8
                	imulq	$0x7, %r8, %r8
-               	movq	%r8, -0x678(%rbp)
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movsd	-0x658(%rbp), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movq	-0x660(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L40>
+               	movq	%r8, -0x6a8(%rbp)
+               	movq	%rax, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0x4d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L41>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rdi
-               	movsd	-0x670(%rbp), %xmm0
+               	movq	%xmm1, %rsi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L42>
 <L42>:
+               	movq	-0x980(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	-0x678(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L43>
 <L43>:
-               	movq	%r15, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x680(%rbp)
-               	movq	%r15, %r8
-               	addq	$0x2, %r8
-               	movq	%r8, -0x688(%rbp)
-               	movq	%r15, %r8
-               	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x4d8(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	movq	%r15, %r8
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %r8
-               	movq	%r8, -0x4e8(%rbp)
+               	movq	-0x6a0(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
                	callq	 <L44>
 <L44>:
+               	movq	-0x990(%rbp), %rsi
                	movq	%rax, %rdi
-               	movq	-0x680(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L45>
 <L45>:
                	movq	%rax, %rdi
-               	movq	-0x688(%rbp), %r8
+               	movq	-0x6a8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
+               	movq	%r15, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x998(%rbp)
+               	movq	%r15, %r8
+               	addq	$0x2, %r8
+               	movq	%r8, -0x6b8(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x9, %r8, %r8
+               	movq	%r8, -0x6c0(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	xorq	$-0x1, %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	movq	%r15, %r8
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %r8
+               	movq	%r8, -0x6d0(%rbp)
                	movq	%rax, %rdi
-               	movq	-0x4d8(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r15, %rsi
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rdi
-               	movq	-0x4e0(%rbp), %r8
+               	movq	-0x998(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rdi
-               	movq	-0x4e8(%rbp), %r8
+               	movq	-0x6b8(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
+               	movq	%rax, %rdi
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %rdi
+               	movq	-0x6c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L51>
+<L51>:
+               	movq	%rax, %rdi
+               	movq	-0x6d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %r8
-               	movq	%r8, -0x4f0(%rbp)
-               	movq	-0x4f0(%rbp), %r8
-               	leaq	-0x478(%rbp), %r8
-               	movq	%r8, -0x4f8(%rbp)
-               	movl	%r15d, %edx
-               	movq	-0x4f8(%rbp), %r8
+               	movq	%r8, -0x6d8(%rbp)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	-0x5c0(%rbp), %r8
+               	movq	%r8, -0x6e0(%rbp)
+               	movl	%r15d, %esi
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%esi, (%rdi)
+               	leaq	-0x5d8(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	%r15, (%rdi)
+               	movq	%r15, %rdi
+               	xorq	$-0x1, %rdi
+               	leaq	0x8(%rsi), %rax
+               	movq	%rdi, (%rax)
+               	movq	%r15, %rax
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	0x10(%rsi), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	%rdi, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	movq	-0x6e8(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	leaq	-0x5e8(%rbp), %rax
+               	movq	%r15, %rdx
+               	imulq	$0xb, %rdx, %rdx
+               	leaq	(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	xorq	$-0x1, %r15
+               	leaq	0x8(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	leaq	-0x618(%rbp), %r15
+               	movq	-0x6e0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x10(%r8), %rsi
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x18(%r8), %rdi
+               	movq	-0x6e0(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x6e0(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x6f8(%rbp)
+               	movq	%rax, (%r15)
+               	movq	%rdx, 0x8(%r15)
+               	movq	%rsi, 0x10(%r15)
+               	movq	%rdi, 0x18(%r15)
+               	movq	-0x6f0(%rbp), %r8
+               	movq	%r8, 0x20(%r15)
+               	movq	-0x6f8(%rbp), %r8
+               	movq	%r8, 0x28(%r15)
+               	leaq	(%r15), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %esi
+               	movq	-0x6d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L53>
+<L53>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	leaq	0x8(%r15), %rdx
+               	leaq	-0x630(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %rax
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x708(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	%rax, 0x8(%rsi)
+               	movq	-0x708(%rbp), %r8
+               	movq	%r8, 0x10(%rsi)
+               	movq	(%rsi), %rax
+               	movq	0x8(%rsi), %rdx
+               	movq	0x10(%rsi), %rdi
+               	movq	%rax, (%rsp)
+               	movq	%rdx, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L54>
+<L54>:
+               	leaq	0x20(%r15), %r8
+               	movq	%r8, -0x9a0(%rbp)
+               	movq	-0x9a0(%rbp), %r8
                	leaq	(%r8), %rsi
-               	movl	%edx, (%rsi)
-               	leaq	-0x490(%rbp), %rdx
+               	movq	(%rsi), %r15
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L55>
+<L55>:
+               	movq	-0x9a0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L56>
+<L56>:
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L11>
+<L57>:
+               	leaq	-0x18(%rbp), %r14
+               	movq	%rbx, %rax
+               	addq	$0x1, %rax
+               	leaq	-0x1d0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	%rax, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	imulq	$0x3, %rax, %rax
+               	addq	$0x1, %rax
+               	leaq	0x10(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L58>
+               	jmp	 <L60>
+<L58>:
+               	leaq	(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x718(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x720(%rbp)
+               	leaq	0x10(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x710(%rbp)
+               	leaq	(%r12,%r15,8), %rax
+               	movq	(%rax), %rdi
+               	leaq	-0x1e8(%rbp), %rax
+               	movq	-0x718(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%rdi, %rdx
+               	leaq	(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	-0x720(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rdi, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	-0x710(%rbp), %r8
+               	movq	-0x718(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	leaq	-0x200(%rbp), %rax
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %rsi
+               	movq	0x10(%r14), %rdi
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	%r13, %rdi
+               	callq	 <L59>
+<L59>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L58>
+<L60>:
+               	leaq	-0x48(%rbp), %r14
+               	movq	%rbx, %rax
+               	addq	$0x2, %rax
+               	leaq	-0x230(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	%rax, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rax, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rax
+               	leaq	0x28(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x728(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x730(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	%r15, 0x18(%r14)
+               	movq	-0x728(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x730(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L61>
+               	jmp	 <L69>
+<L61>:
+               	leaq	-0x78(%rbp), %rax
+               	movq	(%r14), %rdx
+               	movq	0x8(%r14), %rsi
+               	movq	0x10(%r14), %rdi
+               	movq	0x18(%r14), %r8
+               	movq	%r8, -0x738(%rbp)
+               	movq	0x20(%r14), %r8
+               	movq	%r8, -0x740(%rbp)
+               	movq	0x28(%r14), %r8
+               	movq	%r8, -0x748(%rbp)
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	-0x740(%rbp), %r8
+               	movq	%r8, 0x20(%rax)
+               	movq	-0x748(%rbp), %r8
+               	movq	%r8, 0x28(%rax)
+               	leaq	(%r12,%r15,8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x750(%rbp)
+               	leaq	-0xa8(%rbp), %r8
+               	movq	%r8, -0x9a8(%rbp)
+               	movq	(%rax), %rdi
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x758(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x760(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x768(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x770(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	-0x758(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x760(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x768(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x770(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x750(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L62>
+<L62>:
+               	movq	-0x9a8(%rbp), %r8
+               	movq	-0x9a8(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x9a8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	-0x9a8(%rbp), %r8
+               	movq	0x10(%r8), %rdi
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x778(%rbp)
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	-0x9a8(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	-0x778(%rbp), %r8
+               	movq	%r8, 0x18(%r14)
+               	movq	-0x780(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x788(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	leaq	(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9b0(%rbp)
+               	leaq	0x10(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x18(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0x20(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0x28(%r14), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x7a8(%rbp)
+               	movq	%r13, %rdi
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	movq	-0x9b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rdi
+               	movq	-0x790(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rdi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movq	-0x7a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rdi
+               	movq	-0x7a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L68>
+<L68>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L61>
+<L69>:
+               	leaq	-0x168(%rbp), %r14
+               	leaq	(%r14), %rax
+               	addq	$0x0, %rax
+               	movq	$0xc0, %rdx
+<L70>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L70>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+               	jmp	 <L72>
+<L71>:
+               	movq	-0x7b0(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	leaq	-0x250(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%rsi, %rdi
+               	addq	$0x1, %rdi
+               	leaq	0x8(%rdx), %r15
+               	movq	%rdi, (%r15)
+               	movq	%rsi, %rdi
+               	imulq	$0x5, %rdi, %rdi
+               	leaq	0x10(%rdx), %r15
+               	movq	%rdi, (%r15)
+               	xorq	$-0x1, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r14,%rsi), %rdi
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r15
+               	movq	0x10(%rdx), %rax
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x7b8(%rbp)
+               	movq	%rsi, (%rdi)
+               	movq	%r15, 0x8(%rdi)
+               	movq	%rax, 0x10(%rdi)
+               	movq	-0x7b8(%rbp), %r8
+               	movq	%r8, 0x18(%rdi)
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L71>
+<L72>:
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L73>
+               	jmp	 <L75>
+<L73>:
+               	movq	%r15, %rax
+               	imulq	$0x20, %rax, %rax
+               	leaq	(%r14,%rax), %rdx
+               	leaq	-0x188(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x7c8(%rbp)
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, 0x10(%rax)
+               	movq	-0x7c8(%rbp), %r8
+               	movq	%r8, 0x18(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x7d0(%rbp)
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x7d0(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	%r13, %rdi
+               	callq	 <L74>
+<L74>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r13
+               	cmpq	$0x6, %r15
+               	jb	 <L73>
+<L75>:
+               	leaq	-0x1b8(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	leaq	(%rax), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movq	%rbx, %rdx
+               	addq	$0x3, %rdx
+               	movq	%rdx, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	xorq	$-0x1, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	%rdx, %rdi
+               	imulq	$0x3, %rdi, %rdi
+               	movq	%rdi, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	(%r12), %r14
+               	movq	(%r14), %r15
+               	leaq	-0x2f0(%rbp), %r14
+               	movq	%rdx, %rdi
+               	addq	%r15, %rdi
+               	leaq	(%r14), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%r15, %rsi
+               	leaq	0x8(%r14), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x7d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%rdx, %rsi
+               	leaq	0x10(%r14), %rdx
+               	movq	%rsi, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	(%r14), %rsi
+               	movq	0x8(%r14), %rdi
+               	movq	0x10(%r14), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r15, 0x10(%rdx)
+               	leaq	-0x300(%rbp), %rdx
+               	leaq	0x8(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	leaq	0x20(%rax), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r14
+               	movq	%rdi, (%rsi)
+               	movq	%r14, 0x8(%rsi)
+               	leaq	-0x330(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	0x10(%rax), %r14
+               	movq	0x18(%rax), %r15
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x7e8(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x7f0(%rbp)
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
+               	movq	%r15, 0x18(%rdx)
+               	movq	-0x7e8(%rbp), %r8
+               	movq	%r8, 0x20(%rdx)
+               	movq	-0x7f0(%rbp), %r8
+               	movq	%r8, 0x28(%rdx)
+               	leaq	-0x3c0(%rbp), %r14
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	0x18(%rdx), %r15
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	%rax, (%r14)
+               	movq	%rsi, 0x8(%r14)
+               	movq	%rdi, 0x10(%r14)
+               	movq	%r15, 0x18(%r14)
+               	movq	-0x7f8(%rbp), %r8
+               	movq	%r8, 0x20(%r14)
+               	movq	-0x800(%rbp), %r8
+               	movq	%r8, 0x28(%r14)
+               	leaq	(%r14), %rax
+               	movl	(%rax), %edx
+               	movl	%edx, %esi
+               	movq	%r13, %rdi
+               	callq	 <L76>
+<L76>:
+               	leaq	0x8(%r14), %rdx
+               	leaq	-0x3d8(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r13
+               	movq	0x10(%rdx), %r15
+               	movq	%rdi, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movq	%r15, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r13
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r13, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
+               	leaq	0x20(%r14), %r13
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L79>
+<L79>:
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x4, %r14
+               	jb	 <L80>
+               	jmp	 <L106>
+<L80>:
+               	leaq	(%r12,%r14,8), %rax
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
+               	leaq	-0x268(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	%r15, (%rdx)
+               	movq	%r15, %rdx
+               	xorq	$-0x1, %rdx
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%r15, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x1, %rdx
+               	leaq	0x10(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	leaq	-0x298(%rbp), %r8
+               	movq	%r8, -0x9b8(%rbp)
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x808(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x808(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L81>
+<L81>:
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	-0x360(%rbp), %rax
+               	leaq	(%rax), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rax), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x378(%rbp), %r8
+               	movq	%r8, -0x9c0(%rbp)
+               	movq	(%rax), %rdi
+               	movq	0x8(%rax), %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	0x10(%rax), %r8
+               	movq	%r8, -0x818(%rbp)
+               	movq	0x18(%rax), %r8
+               	movq	%r8, -0x820(%rbp)
+               	movq	0x20(%rax), %r8
+               	movq	%r8, -0x828(%rbp)
+               	movq	0x28(%rax), %r8
+               	movq	%r8, -0x830(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x810(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x818(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x820(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x828(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x830(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L82>
+<L82>:
+               	movq	-0x9c0(%rbp), %r8
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x838(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x840(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x848(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x850(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x20(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x858(%rbp)
+               	movq	-0x9b8(%rbp), %r8
+               	leaq	0x28(%r8), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x9d0(%rbp)
+               	leaq	-0x3f0(%rbp), %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	movq	-0x9c0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9c0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x860(%rbp)
+               	movq	-0x9c0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	-0x860(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	-0x868(%rbp), %r9
+               	movq	%r9, 0x10(%r8)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	-0x838(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L83>
+<L83>:
+               	movq	%rax, %rdi
+               	movq	-0x840(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L84>
+<L84>:
+               	movq	%rax, %rdi
+               	movq	-0x848(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L85>
+<L85>:
+               	movq	%rax, %rdi
+               	movq	-0x850(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L86>
+<L86>:
+               	movq	%rax, %rdi
+               	movq	-0x858(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L87>
+<L87>:
+               	movq	%rax, %rdi
+               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L88>
+<L88>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x870(%rbp)
+               	movq	-0x870(%rbp), %r8
+               	leaq	-0x408(%rbp), %rdx
+               	movq	-0x9c8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x9c8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x9c8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x878(%rbp)
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	-0x878(%rbp), %r8
+               	movq	%r8, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %rdi
+               	movq	%rax, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movq	-0x870(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L90>
+<L90>:
+               	movq	%r13, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x9d8(%rbp)
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	-0x438(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x450(%rbp), %r8
+               	movq	%r8, -0x9e0(%rbp)
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x880(%rbp)
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x888(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x890(%rbp)
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x898(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x880(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x888(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x890(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x898(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x8a0(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x9e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L92>
+<L92>:
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	-0x480(%rbp), %r8
+               	movq	%r8, -0x9e8(%rbp)
+               	movq	-0x9e0(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9e0(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	-0x9e0(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8a8(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8b0(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L93>
+<L93>:
+               	movq	-0x9e8(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	%rax, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L95>
+<L95>:
+               	movq	%rax, %rdi
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L96>
+<L96>:
+               	movq	%rax, %rdi
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L97>
+<L97>:
+               	movq	%rax, %rdi
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L98>
+<L98>:
+               	movq	%rax, %rdi
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L99>
+<L99>:
+               	movq	%rax, %r8
+               	movq	%r8, -0xa00(%rbp)
+               	movq	-0xa00(%rbp), %r8
+               	leaq	-0x4b8(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movq	%r15, (%rsi)
                	movq	%r15, %rsi
@@ -1385,910 +2766,211 @@ Disassembly of section .text:
                	addq	$0x1, %rsi
                	leaq	0x10(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movq	-0x4f8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
+               	leaq	-0x4e8(%rbp), %r8
+               	movq	%r8, -0x9f8(%rbp)
                	movq	(%rdx), %rdi
-               	movq	0x8(%rdx), %rax
-               	movq	0x10(%rdx), %rcx
-               	movq	%rdi, (%rsi)
-               	movq	%rax, 0x8(%rsi)
-               	movq	%rcx, 0x10(%rsi)
-               	leaq	-0x4a0(%rbp), %rax
-               	movq	%r15, %rcx
-               	imulq	$0xb, %rcx, %rcx
-               	leaq	(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	xorq	$-0x1, %r15
-               	leaq	0x8(%rax), %rcx
-               	movq	%r15, (%rcx)
-               	movq	-0x4f8(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	-0x4f8(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x8(%r8), %rcx
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x10(%r8), %rdx
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x18(%r8), %rsi
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x20(%r8), %rdi
-               	movq	-0x4f8(%rbp), %r8
-               	movq	0x28(%r8), %r15
-               	movq	%rax, (%rsp)
-               	movq	%rcx, 0x8(%rsp)
-               	movq	%rdx, 0x10(%rsp)
-               	movq	%rsi, 0x18(%rsp)
-               	movq	%rdi, 0x20(%rsp)
-               	movq	%r15, 0x28(%rsp)
-               	movq	-0x4f0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L50>
-<L50>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x8, %r14
-               	jb	 <L12>
-<L51>:
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rax, %rdx
-               	imulq	$0x3, %rdx, %rdx
-               	addq	$0x1, %rdx
-               	movq	$0x0, %r14
-               	movq	%rax, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x698(%rbp)
-               	movq	%rdx, %r8
-               	movq	%r8, -0x6a0(%rbp)
-               	cmpq	$0x8, %r14
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
-               	leaq	(%r12,%r14,8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%r15, %r8
-               	addq	%rsi, %r8
-               	movq	%r8, -0x690(%rbp)
-               	movq	-0x698(%rbp), %r9
-               	movq	%r9, %r8
-               	xorq	%rsi, %r8
-               	movq	%r8, -0x500(%rbp)
-               	movq	-0x6a0(%rbp), %r8
-               	movq	%r8, %rbx
-               	addq	%r15, %rbx
-               	movq	%r13, %rdi
-               	movq	-0x690(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	-0x500(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-               	addq	$0x1, %r14
-               	movq	%rsi, %r13
-               	movq	-0x690(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	-0x500(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x698(%rbp)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x6a0(%rbp)
-               	cmpq	$0x8, %r14
-               	jb	 <L52>
-<L56>:
-               	leaq	-0x30(%rbp), %rbx
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x2, %rax
-               	leaq	-0x1f0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	%rax, %rdx
-               	addq	$0x1, %rdx
-               	leaq	0x8(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	addq	$0x2, %rdx
-               	leaq	0x10(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	imulq	$0x9, %rdx, %rdx
-               	leaq	0x18(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	xorq	$-0x1, %rdx
-               	leaq	0x20(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rcx), %rdx
-               	movq	%rax, (%rdx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %rdi
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	%rax, (%rbx)
-               	movq	%rdx, 0x8(%rbx)
-               	movq	%rsi, 0x10(%rbx)
-               	movq	%rdi, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
-               	movq	%r15, 0x28(%rbx)
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
-               	jb	 <L57>
-               	jmp	 <L65>
-<L57>:
-               	leaq	-0x60(%rbp), %rax
-               	movq	(%rbx), %rcx
-               	movq	0x8(%rbx), %rdx
-               	movq	0x10(%rbx), %rsi
-               	movq	0x18(%rbx), %rdi
-               	movq	0x20(%rbx), %r15
-               	movq	0x28(%rbx), %r8
-               	movq	%r8, -0x510(%rbp)
-               	movq	%rcx, (%rax)
-               	movq	%rdx, 0x8(%rax)
-               	movq	%rsi, 0x10(%rax)
-               	movq	%rdi, 0x18(%rax)
-               	movq	%r15, 0x20(%rax)
-               	movq	-0x510(%rbp), %r8
-               	movq	%r8, 0x28(%rax)
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x518(%rbp)
-               	leaq	-0x90(%rbp), %r15
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %rsi
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x520(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x528(%rbp)
-               	movq	%rcx, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	%rsi, 0x18(%rsp)
-               	movq	-0x520(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x528(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	%r15, %rdi
-               	movq	-0x518(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	(%r15), %rax
-               	movq	0x8(%r15), %rcx
-               	movq	0x10(%r15), %rdx
-               	movq	0x18(%r15), %rsi
-               	movq	0x20(%r15), %rdi
-               	movq	0x28(%r15), %r8
-               	movq	%r8, -0x530(%rbp)
-               	movq	%rax, (%rbx)
-               	movq	%rcx, 0x8(%rbx)
-               	movq	%rdx, 0x10(%rbx)
-               	movq	%rsi, 0x18(%rbx)
-               	movq	%rdi, 0x20(%rbx)
-               	movq	-0x530(%rbp), %r8
-               	movq	%r8, 0x28(%rbx)
-               	leaq	(%rbx), %rax
-               	movq	(%rax), %rsi
-               	leaq	0x8(%rbx), %rax
-               	movq	(%rax), %r15
-               	leaq	0x10(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6a8(%rbp)
-               	leaq	0x18(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6b0(%rbp)
-               	leaq	0x20(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x538(%rbp)
-               	leaq	0x28(%rbx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x540(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	movq	-0x6a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	movq	-0x6b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	-0x538(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	movq	-0x540(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L64>
-<L64>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x8, %r14
-               	jb	 <L57>
-<L65>:
-               	leaq	-0x150(%rbp), %rbx
-               	leaq	(%rbx), %rax
-               	addq	$0x0, %rax
-               	movq	$0xc0, %rcx
-<L66>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L66>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x508(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0x210(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rdx, %rsi
-               	addq	$0x1, %rsi
-               	leaq	0x8(%rcx), %rdi
-               	movq	%rsi, (%rdi)
-               	movq	%rdx, %rsi
-               	imulq	$0x5, %rsi, %rsi
-               	leaq	0x10(%rcx), %rdi
-               	movq	%rsi, (%rdi)
-               	xorq	$-0x1, %rdx
-               	leaq	0x18(%rcx), %rsi
-               	movq	%rdx, (%rsi)
-               	movq	%rax, %rdx
-               	imulq	$0x20, %rdx, %rdx
-               	leaq	(%rbx,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
-               	movq	0x10(%rcx), %r14
-               	movq	0x18(%rcx), %r15
-               	movq	%rdx, (%rsi)
-               	movq	%rdi, 0x8(%rsi)
-               	movq	%r14, 0x10(%rsi)
-               	movq	%r15, 0x18(%rsi)
-               	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L67>
-<L68>:
-               	movq	$0x0, %r14
-               	cmpq	$0x6, %r14
-               	jb	 <L69>
-               	jmp	 <L74>
-<L69>:
-               	movq	%r14, %rax
-               	imulq	$0x20, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movq	(%rax), %rsi
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r15
-               	leaq	0x10(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6b8(%rbp)
-               	leaq	0x18(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6c0(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movq	-0x6b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movq	-0x6c0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x6, %r14
-               	jb	 <L69>
-<L74>:
-               	leaq	-0x180(%rbp), %rax
-               	movq	$0x0, (%rax)
-               	movq	$0x0, 0x8(%rax)
-               	movq	$0x0, 0x10(%rax)
-               	movq	$0x0, 0x18(%rax)
-               	movq	$0x0, 0x20(%rax)
-               	movq	$0x0, 0x28(%rax)
-               	leaq	(%rax), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movq	-0x508(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rdx
-               	xorq	$-0x1, %rdx
-               	movq	%rcx, %rsi
-               	imulq	$0x3, %rsi, %rsi
-               	addq	$0x1, %rsi
-               	leaq	(%r12), %rdi
-               	movq	(%rdi), %rbx
-               	leaq	-0x270(%rbp), %rdi
-               	movq	%rcx, %r14
-               	addq	%rbx, %r14
-               	leaq	(%rdi), %r15
-               	movq	%r14, (%r15)
-               	xorq	%rbx, %rdx
-               	leaq	0x8(%rdi), %rbx
-               	movq	%rdx, (%rbx)
-               	addq	%rcx, %rsi
-               	leaq	0x10(%rdi), %rcx
-               	movq	%rsi, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rdi), %rdx
-               	movq	0x8(%rdi), %rsi
-               	movq	0x10(%rdi), %rbx
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%rbx, 0x10(%rcx)
-               	leaq	-0x280(%rbp), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%rcx), %rdx
-               	movq	%rsi, (%rdx)
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	%rsi, (%rdx)
-               	leaq	0x20(%rax), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	leaq	-0x2b0(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %rbx
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%rdi, 0x10(%rcx)
-               	movq	%rbx, 0x18(%rcx)
-               	movq	%r14, 0x20(%rcx)
-               	movq	%r15, 0x28(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %rdi
-               	movq	0x20(%rcx), %rbx
-               	movq	0x28(%rcx), %r14
-               	movq	%rax, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rsi, 0x10(%rsp)
-               	movq	%rdi, 0x18(%rsp)
-               	movq	%rbx, 0x20(%rsp)
-               	movq	%r14, 0x28(%rsp)
-               	movq	%r13, %rdi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L76>
-               	jmp	 <L109>
-<L76>:
-               	leaq	(%r12,%r13,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x508(%rbp), %r8
-               	movq	%rcx, %r14
-               	addq	%r8, %r14
-               	leaq	-0x228(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x258(%rbp), %r15
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	%rcx, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movq	%rsi, 0x10(%rsp)
-               	movq	%r15, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	-0x2e0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x2f8(%rbp), %r8
-               	movq	%r8, -0x6c8(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x548(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x550(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x558(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x548(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x550(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x558(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x6c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6d0(%rbp)
-               	leaq	0x8(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x560(%rbp)
-               	leaq	0x10(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x568(%rbp)
-               	leaq	0x18(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x570(%rbp)
-               	leaq	0x20(%r15), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x578(%rbp)
-               	leaq	0x28(%r15), %rax
-               	movq	(%rax), %r15
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x580(%rbp)
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x588(%rbp)
-               	movq	-0x6c8(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x6d8(%rbp)
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x6d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movq	-0x560(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movq	-0x568(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movq	-0x570(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-               	movq	-0x578(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L84>
-<L84>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rdi
-               	movq	-0x580(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %rdi
-               	movq	-0x588(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rdi
-               	movq	-0x6d8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L89>
-<L89>:
-               	movq	%rbx, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L90>
-<L90>:
-               	movq	%rax, %r15
-               	leaq	-0x328(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x6e0(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x590(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x598(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x5a0(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x590(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x598(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x5a0(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x6e0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	-0x6e0(%rbp), %r8
-               	leaq	-0x370(%rbp), %r8
-               	movq	%r8, -0x6e8(%rbp)
-               	movq	-0x6e0(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x6e0(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x6e0(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x6e8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x6e8(%rbp), %r8
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x6f0(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5a8(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5b0(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x20(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x5b8(%rbp)
-               	movq	-0x6e8(%rbp), %r8
-               	leaq	0x28(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x6f8(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %rdi
-               	movq	-0x6f0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %rdi
-               	movq	-0x5a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %rdi
-               	movq	-0x5b0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rdi
-               	movq	-0x5b8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %rdi
-               	movq	-0x6f8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r15
-               	leaq	-0x388(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x3b8(%rbp), %r8
-               	movq	%r8, -0x700(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x700(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	-0x700(%rbp), %r8
-               	leaq	-0x3d0(%rbp), %r8
-               	movq	%r8, -0x708(%rbp)
-               	movq	-0x700(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x700(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x700(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	-0x700(%rbp), %r9
-               	movq	0x18(%r9), %r8
-               	movq	%r8, -0x5c0(%rbp)
-               	movq	-0x700(%rbp), %r9
-               	movq	0x20(%r9), %r8
-               	movq	%r8, -0x5c8(%rbp)
-               	movq	-0x700(%rbp), %r9
-               	movq	0x28(%r9), %r8
-               	movq	%r8, -0x5d0(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5c0(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x5c8(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x5d0(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x708(%rbp), %r8
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8e0(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8e8(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x9f8(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L100>
 <L100>:
-               	movq	-0x708(%rbp), %r8
-               	movq	-0x708(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x708(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x710(%rbp)
-               	movq	-0x708(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x718(%rbp)
-               	movq	%r15, %rdi
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	-0x500(%rbp), %r8
+               	movq	%r8, -0xa08(%rbp)
+               	movq	-0x9f8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x9f8(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x910(%rbp)
+               	movq	%rdi, (%rsp)
+               	movq	-0x8f0(%rbp), %r8
+               	movq	%r8, 0x8(%rsp)
+               	movq	-0x8f8(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x908(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x910(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0xa08(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L101>
 <L101>:
-               	movq	%rax, %rdi
-               	movq	-0x710(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa08(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0xa08(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0xa08(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x918(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x918(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0xa00(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L102>
 <L102>:
-               	movq	%rax, %rdi
-               	movq	-0x718(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xa10(%rbp)
+               	movq	-0xa10(%rbp), %r8
+               	leaq	-0x530(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	addq	$0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	addq	$0x2, %rsi
+               	leaq	0x10(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	leaq	0x18(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x20(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
+               	xorq	%r11, %rsi
+               	leaq	0x28(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x560(%rbp), %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	0x18(%rdx), %r8
+               	movq	%r8, -0x930(%rbp)
+               	movq	0x20(%rdx), %r8
+               	movq	%r8, -0x938(%rbp)
+               	movq	0x28(%rdx), %r8
+               	movq	%r8, -0x940(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x928(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x930(%rbp), %r8
+               	movq	%r8, 0x18(%rsp)
+               	movq	-0x938(%rbp), %r8
+               	movq	%r8, 0x20(%rsp)
+               	movq	-0x940(%rbp), %r8
+               	movq	%r8, 0x28(%rsp)
+               	movq	-0x920(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
                	callq	 <L103>
 <L103>:
-               	movq	%rax, %r15
-               	leaq	-0x400(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	%r14, (%rcx)
-               	movq	%r14, %rcx
-               	addq	$0x1, %rcx
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x10(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	0x18(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	xorq	$-0x1, %rcx
-               	leaq	0x20(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movq	%r14, %rcx
-               	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rcx
-               	leaq	0x28(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0x430(%rbp), %r8
-               	movq	%r8, -0x720(%rbp)
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %rdi
-               	movq	0x18(%rax), %r8
-               	movq	%r8, -0x5d8(%rbp)
-               	movq	0x20(%rax), %r8
-               	movq	%r8, -0x5e0(%rbp)
-               	movq	0x28(%rax), %r8
-               	movq	%r8, -0x5e8(%rbp)
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5d8(%rbp), %r8
+               	movq	-0x920(%rbp), %r8
+               	leaq	-0x578(%rbp), %r8
+               	movq	%r8, -0xa18(%rbp)
+               	movq	-0x920(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x920(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x920(%rbp), %r9
+               	movq	0x10(%r9), %r8
+               	movq	%r8, -0x948(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x18(%r9), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x20(%r9), %r8
+               	movq	%r8, -0x958(%rbp)
+               	movq	-0x920(%rbp), %r9
+               	movq	0x28(%r9), %r8
+               	movq	%r8, -0x960(%rbp)
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movq	-0x948(%rbp), %r8
+               	movq	%r8, 0x10(%rsp)
+               	movq	-0x950(%rbp), %r8
                	movq	%r8, 0x18(%rsp)
-               	movq	-0x5e0(%rbp), %r8
+               	movq	-0x958(%rbp), %r8
                	movq	%r8, 0x20(%rsp)
-               	movq	-0x5e8(%rbp), %r8
+               	movq	-0x960(%rbp), %r8
                	movq	%r8, 0x28(%rsp)
-               	movq	-0x720(%rbp), %r8
+               	movq	-0xa18(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	%r14, %rsi
                	callq	 <L104>
 <L104>:
-               	movq	-0x720(%rbp), %r8
-               	leaq	-0x448(%rbp), %r8
-               	movq	%r8, -0x728(%rbp)
-               	movq	-0x720(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	-0x720(%rbp), %r8
-               	movq	0x8(%r8), %rsi
-               	movq	-0x720(%rbp), %r8
-               	movq	0x10(%r8), %rdi
-               	movq	-0x720(%rbp), %r9
-               	movq	0x18(%r9), %r8
-               	movq	%r8, -0x5f0(%rbp)
-               	movq	-0x720(%rbp), %r9
-               	movq	0x20(%r9), %r8
-               	movq	%r8, -0x5f8(%rbp)
-               	movq	-0x720(%rbp), %r9
-               	movq	0x28(%r9), %r8
-               	movq	%r8, -0x600(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x968(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x978(%rbp)
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x970(%rbp)
+               	leaq	-0x590(%rbp), %rsi
+               	movq	-0x968(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	%r15, %rdx
+               	leaq	(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	-0x978(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%r15, %rdx
+               	leaq	0x8(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	-0x970(%rbp), %r8
+               	movq	-0x968(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	leaq	0x10(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movq	0x10(%rsi), %r15
                	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movq	%rdi, 0x10(%rsp)
-               	movq	-0x5f0(%rbp), %r8
-               	movq	%r8, 0x18(%rsp)
-               	movq	-0x5f8(%rbp), %r8
-               	movq	%r8, 0x20(%rsp)
-               	movq	-0x600(%rbp), %r8
-               	movq	%r8, 0x28(%rsp)
-               	movq	-0x728(%rbp), %r8
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r15, 0x10(%rsp)
+               	movq	-0xa10(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L105>
 <L105>:
-               	movq	-0x728(%rbp), %r8
-               	movq	-0x728(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x728(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	-0x728(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movq	(%rcx), %rax
-               	movq	%rdx, %rcx
-               	addq	%r14, %rcx
-               	movq	%rsi, %r8
-               	xorq	%r14, %r8
-               	movq	%r8, -0x608(%rbp)
-               	movq	%rax, %r14
-               	addq	%rdx, %r14
-               	movq	%r15, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L106>
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x4, %r14
+               	jb	 <L80>
 <L106>:
-               	movq	%rax, %rdi
-               	movq	-0x608(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L108>
-<L108>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	cmpq	$0x4, %r13
-               	jb	 <L76>
-<L109>:
-               	movq	%rbx, %rax
-               	movq	-0x738(%rbp), %rbx
-               	movq	-0x740(%rbp), %r12
-               	movq	-0x748(%rbp), %r13
-               	movq	-0x750(%rbp), %r14
-               	movq	-0x758(%rbp), %r15
+               	movq	%r13, %rax
+               	movq	-0xa28(%rbp), %rbx
+               	movq	-0xa30(%rbp), %r12
+               	movq	-0xa38(%rbp), %r13
+               	movq	-0xa40(%rbp), %r14
+               	movq	-0xa48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_ret_small.dis
+++ b/test/golden/x86_64-linux/call/call_ret_small.dis
@@ -292,19 +292,57 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x4(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0x4(%rbp), %rax
+               	movl	(%rax), %esi
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -313,18 +351,58 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x8(%rbp), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	-0x4(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0x18(%rbp)
-               	callq	 <L0>
+               	leaq	-0x8(%rbp), %rax
+               	movss	(%rax), %xmm0
+               	leaq	-0x4(%rbp), %rax
+               	movss	(%rax), %xmm1
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x18(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movd	%xmm1, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -332,30 +410,85 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.fold12>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movl	(%rcx), %r12d
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movl	(%rax), %ebx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -365,19 +498,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rsi, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rbx
+               	xorq	%rdx, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -386,19 +556,57 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movsd	%xmm1, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm1
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -407,19 +615,56 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movsd	%xmm0, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x20(%rbp)
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rax), %rdx
+               	leaq	-0x8(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -429,19 +674,57 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	movsd	%xmm0, -0x10(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movsd	(%rax), %xmm0
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rdx
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -449,19 +732,31 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.layout>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	movq	$0x1, %rsi
-               	callq	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x2, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x2, %rsi
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -469,11 +764,11 @@ Disassembly of section .text:
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	$0xc, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0xc, %rsi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
@@ -488,6 +783,10 @@ Disassembly of section .text:
                	movq	$0x10, %rsi
                	callq	 <L9>
 <L9>:
+               	movq	%rax, %rdi
+               	movq	$0x10, %rsi
+               	callq	 <L10>
+<L10>:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -495,12 +794,12 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.regain>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x130, %rsp            # imm = 0x130
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%r15, -0x128(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x8(%rbp)
                	movsd	%xmm0, -0x20(%rbp)
@@ -511,102 +810,96 @@ Disassembly of section .text:
                	movq	%r8, -0x38(%rbp)
                	movq	%r9, -0x48(%rbp)
                	movsd	%xmm3, -0x50(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	leaq	-0x20(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x70(%rbp)
-               	leaq	-0x18(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x80(%rbp)
-               	leaq	-0x30(%rbp), %rcx
-               	movq	(%rcx), %r13
-               	leaq	-0x28(%rbp), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x90(%rbp)
-               	leaq	-0x40(%rbp), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	-0x3c(%rbp), %rcx
-               	movl	(%rcx), %r15d
-               	leaq	-0x38(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x98(%rbp)
-               	leaq	-0x48(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x58(%rbp)
-               	leaq	-0x44(%rbp), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x60(%rbp)
-               	leaq	-0x50(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0xa8(%rbp)
-               	leaq	-0x4c(%rbp), %rcx
-               	movl	(%rcx), %r11d
-               	movl	%r11d, -0xb8(%rbp)
+               	leaq	-0x60(%rbp), %rax
+               	movq	-0x10(%rbp), %rcx
+               	movq	-0x8(%rbp), %rdx
+               	movq	%rcx, (%rax)
+               	movq	%rdx, 0x8(%rax)
+               	leaq	-0x70(%rbp), %rbx
+               	movq	-0x20(%rbp), %rcx
+               	movq	-0x18(%rbp), %rdx
+               	movq	%rcx, (%rbx)
+               	movq	%rdx, 0x8(%rbx)
+               	leaq	-0x80(%rbp), %r12
+               	movq	-0x30(%rbp), %rcx
+               	movq	-0x28(%rbp), %rdx
+               	movq	%rcx, (%r12)
+               	movq	%rdx, 0x8(%r12)
+               	leaq	-0x8c(%rbp), %r13
+               	movq	-0x40(%rbp), %rcx
+               	movl	-0x38(%rbp), %edx
+               	movq	%rcx, (%r13)
+               	movl	%edx, 0x8(%r13)
+               	leaq	-0x94(%rbp), %r14
+               	movq	-0x48(%rbp), %rcx
+               	movq	%rcx, (%r14)
+               	leaq	-0x9c(%rbp), %r15
+               	movq	-0x50(%rbp), %rcx
+               	movq	%rcx, (%r15)
+               	leaq	-0xb0(%rbp), %rcx
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
+               	leaq	-0xc0(%rbp), %rcx
+               	movq	(%rbx), %rdx
+               	movq	0x8(%rbx), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movsd	(%rcx), %xmm0
+               	movsd	0x8(%rcx), %xmm1
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
                	callq	 <L1>
 <L1>:
+               	leaq	-0xd0(%rbp), %rcx
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %rsi
+               	movq	%rdx, (%rcx)
+               	movq	%rsi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movsd	0x8(%rcx), %xmm0
                	movq	%rax, %rdi
-               	movq	%r12, %rsi
                	callq	 <L2>
 <L2>:
+               	leaq	-0xdc(%rbp), %rcx
+               	movq	(%r13), %rdx
+               	movl	0x8(%r13), %esi
+               	movq	%rdx, (%rcx)
+               	movl	%esi, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	$0x0, -0xe8(%rbp)
+               	movl	0x8(%rcx), %edx
+               	movl	%edx, -0xe8(%rbp)
+               	movq	-0xe8(%rbp), %rdx
                	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
+               	leaq	-0xf0(%rbp), %rcx
+               	movq	(%r14), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
+               	leaq	-0xf8(%rbp), %rcx
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	(%rcx), %rdx
+               	movq	%rdx, -0x100(%rbp)
+               	movsd	-0x100(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x98(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x58(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movss	-0xa8(%rbp), %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
+               	movq	-0x128(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -614,21 +907,34 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_small.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x240, %rsp            # imm = 0x240
-               	movq	%rbx, -0x218(%rbp)
-               	movq	%r12, -0x220(%rbp)
-               	movq	%r13, -0x228(%rbp)
-               	movq	%r14, -0x230(%rbp)
-               	movq	%r15, -0x238(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x140(%rbp)
-               	callq	 <L0>
+               	subq	$0x360, %rsp            # imm = 0x360
+               	movq	%rbx, -0x338(%rbp)
+               	movq	%r12, -0x340(%rbp)
+               	movq	%r13, -0x348(%rbp)
+               	movq	%r14, -0x350(%rbp)
+               	movq	%r15, -0x358(%rbp)
+               	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L1>
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
                	movq	$0x2, %rsi
                	callq	 <L2>
 <L2>:
@@ -664,7 +970,7 @@ Disassembly of section .text:
                	movq	$0x10, %rsi
                	callq	 <L10>
 <L10>:
-               	leaq	-0xe8(%rbp), %r12
+               	leaq	-0x130(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -673,144 +979,196 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
                	jmp	 <L12>
 <L11>:
-               	movq	%rcx, %rdx
+               	movq	%rdx, %rsi
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdx
+               	imulq	%r11, %rsi
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
-               	addq	%r11, %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	addq	%r11, %rsi
+               	addq	%rbx, %rsi
+               	leaq	(%r12,%rdx,8), %rdi
+               	movq	%rsi, (%rdi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L11>
 <L12>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
                	jb	 <L13>
-               	jmp	 <L44>
+               	jmp	 <L39>
 <L13>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movb	%r15b, %sil
+               	movq	(%rax), %rdx
+               	movq	%rdx, %r15
+               	addq	%rbx, %r15
+               	movb	%r15b, %al
+               	movzbq	%al, %rsi
                	movq	%r13, %rdi
                	callq	 <L14>
 <L14>:
-               	movw	%r15w, %si
+               	movw	%r15w, %dx
+               	movzwq	%dx, %rsi
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movl	%r15d, %ecx
+               	movl	%r15d, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
-               	movl	%r15d, %ecx
-               	movq	%r15, %rdx
-               	shrq	$0x20, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x110(%rbp)
+               	leaq	-0x184(%rbp), %rdx
+               	movl	%r15d, %esi
+               	leaq	(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movq	%r15, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
+               	leaq	-0x240(%rbp), %rdx
+               	movq	%r15, %rsi
+               	andq	$0xfff, %rsi            # imm = 0xFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L18>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L19>
 <L18>:
-               	movq	%r15, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L19>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L20>
+               	addss	%xmm0, %xmm0
 <L19>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L20>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x237>
-               	movq	%r15, %rcx
-               	andq	$0xff, %rcx
-               	movq	%rcx, %r11
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x273>
+               	leaq	(%rdx), %rsi
+               	movss	%xmm1, (%rsi)
+               	movq	%r15, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L21>
+               	jl	 <L20>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
+               	jmp	 <L21>
+<L20>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L22>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x27b>
-               	movss	%xmm14, -0x158(%rbp)
+<L21>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x2bc>
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm1, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x248(%rbp)
+               	movsd	-0x248(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	callq	 <L22>
+<L22>:
+               	leaq	-0x254(%rbp), %rdx
+               	movl	%r15d, %esi
+               	leaq	(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movq	%r15, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	%r15, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %edi
+               	leaq	0x8(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x260(%rbp)
+               	movl	0x8(%rdx), %edi
+               	movl	%edi, -0x260(%rbp)
+               	movq	-0x260(%rbp), %rdx
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
+               	leaq	-0x270(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	%r15, (%rsi)
+               	movq	%r15, %rsi
+               	xorq	$-0x1, %rsi
+               	leaq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x298(%rbp)
                	movq	%rax, %rdi
-               	movss	-0x158(%rbp), %xmm0
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L24>
 <L24>:
-               	movl	%r15d, %ecx
-               	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x20, %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x120(%rbp)
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
-               	movq	%r15, %r8
-               	movq	%r8, -0x160(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x160(%rbp)
-               	movq	%rax, %rdi
+               	leaq	-0x280(%rbp), %rdx
                	movq	%r15, %rsi
-               	callq	 <L28>
+               	andq	$0xffff, %rsi           # imm = 0xFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L25>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L26>
+<L25>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L26>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x3b5>
+               	leaq	(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movq	%r15, %rsi
+               	andq	$0x3ffff, %rsi          # imm = 0x3FFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L27>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L28>
+<L27>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L28>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x3fe>
+               	leaq	0x8(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movsd	(%rdx), %xmm0
+               	movsd	0x8(%rdx), %xmm1
                	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
                	callq	 <L29>
 <L29>:
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
+               	leaq	-0x290(%rbp), %rdx
+               	movq	%r15, %rsi
+               	imulq	$0x3, %rsi, %rsi
+               	addq	$0x1, %rsi
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	%r15, %rsi
+               	andq	$0x7fff, %rsi           # imm = 0x7FFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L30>
                	cvtsi2sd	%r11, %xmm0
@@ -824,440 +1182,530 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L31>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x367>
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L32>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L33>
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x471>
+               	leaq	0x8(%rdx), %rsi
+               	movsd	%xmm1, (%rsi)
+               	movq	(%rdx), %rsi
+               	movsd	0x8(%rdx), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L33>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x3ab>
-               	movsd	%xmm14, -0x170(%rbp)
-               	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movsd	-0x170(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%r15, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x1, %rcx
                	movq	%r15, %rdx
-               	andq	$0x7fff, %rdx           # imm = 0x7FFF
+               	andq	$0x1fff, %rdx           # imm = 0x1FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L36>
+               	jl	 <L33>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L37>
-<L36>:
+               	jmp	 <L34>
+<L33>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L37>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x41f>
-               	movsd	%xmm14, -0x180(%rbp)
-               	movq	%rax, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movsd	-0x180(%rbp), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%r15, %rcx
-               	andq	$0x1fff, %rcx           # imm = 0x1FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L40>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L41>
-<L40>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L41>:
+<L34>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x485>
-               	xorq	$0x12345678, %r15       # imm = 0x12345678
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x4cb>
+               	movq	%r15, %r8
+               	xorq	$0x12345678, %r8        # imm = 0x12345678
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	%xmm1, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L43>
-<L43>:
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x8, %r14
                	jb	 <L13>
-<L44>:
+<L39>:
                	leaq	-0x48(%rbp), %r14
                	leaq	(%r14), %rax
                	addq	$0x0, %rax
-               	movq	$0x48, %rcx
-<L45>:
+               	movq	$0x48, %rdx
+<L40>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L45>
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L40>
                	leaq	-0xa8(%rbp), %r15
                	leaq	(%r15), %rax
                	addq	$0x0, %rax
-               	movq	$0x60, %rcx
-<L46>:
+               	movq	$0x60, %rdx
+<L41>:
                	movq	$0x0, (%rax)
                	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L46>
-               	movq	$0x0, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0xf4(%rbp), %rcx
-               	movl	%edx, %esi
-               	leaq	(%rcx), %rdi
-               	movl	%esi, (%rdi)
-               	movq	%rdx, %rsi
-               	shrq	$0x10, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L41>
+               	movq	$0x0, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x2a8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	-0x2a8(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rdx
+               	movq	(%rdx), %rsi
+               	addq	%rbx, %rsi
+               	leaq	-0xdc(%rbp), %rdx
                	movl	%esi, %edi
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edi, (%rsi)
-               	shrq	$0x20, %rdx
-               	movl	%edx, %esi
-               	leaq	0x8(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movq	%rax, %rdx
-               	imulq	$0xc, %rdx, %rdx
-               	leaq	(%r14,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movl	0x8(%rcx), %edi
-               	movq	%rdx, (%rsi)
+               	leaq	(%rdx), %rax
+               	movl	%edi, (%rax)
+               	movq	%rsi, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %edi
+               	leaq	0x4(%rdx), %rax
+               	movl	%edi, (%rax)
+               	shrq	$0x20, %rsi
+               	movl	%esi, %eax
+               	leaq	0x8(%rdx), %rsi
+               	movl	%eax, (%rsi)
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rax
+               	imulq	$0xc, %rax, %rax
+               	leaq	(%r14,%rax), %rsi
+               	movq	(%rdx), %rax
+               	movl	0x8(%rdx), %edi
+               	movq	%rax, (%rsi)
                	movl	%edi, 0x8(%rsi)
-               	leaq	(%r12,%rax,8), %rcx
-               	movq	(%rcx), %rdx
+               	movq	-0x2a8(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rax
+               	movq	(%rax), %rdx
                	imulq	$0x3, %rdx, %rdx
-               	movq	-0x140(%rbp), %r8
-               	addq	%r8, %rdx
-               	leaq	-0x108(%rbp), %rcx
+               	addq	%rbx, %rdx
+               	leaq	-0x140(%rbp), %rax
                	movq	%rdx, %rsi
                	imulq	$0x3, %rsi, %rsi
                	addq	$0x1, %rsi
-               	leaq	(%rcx), %rdi
+               	leaq	(%rax), %rdi
                	movq	%rsi, (%rdi)
                	andq	$0x7fff, %rdx           # imm = 0x7FFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L48>
+               	jl	 <L43>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L49>
-<L48>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L49>:
+<L44>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x5e0>
-               	leaq	0x8(%rcx), %rdx
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x6de>
+               	leaq	0x8(%rax), %rdx
                	movsd	%xmm1, (%rdx)
-               	movq	%rax, %rdx
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rdi
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rdi
                	movq	%rdx, (%rsi)
                	movq	%rdi, 0x8(%rsi)
-               	addq	$0x1, %rax
-               	cmpq	$0x6, %rax
-               	jb	 <L47>
-<L50>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x188(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L51>
-               	jmp	 <L57>
-<L51>:
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r14,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x128(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x190(%rbp)
-               	movq	%r13, %rdi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x128(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x188(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r15,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r11
-               	movq	%r11, -0x1a0(%rbp)
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movsd	-0x1a0(%rbp), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rcx
-               	movq	-0x188(%rbp), %r8
+               	movq	-0x2a8(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r13
                	movq	%rax, %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x188(%rbp), %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	-0x2a8(%rbp), %r8
                	cmpq	$0x6, %r8
-               	jb	 <L51>
-<L57>:
+               	jb	 <L42>
+<L45>:
+               	movq	$0x0, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L46>
+               	jmp	 <L49>
+<L46>:
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0xc, %rdx, %rdx
+               	leaq	(%r14,%rdx), %rsi
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	(%rsi), %rdi
+               	movl	0x8(%rsi), %edx
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x2b0(%rbp), %r8
+               	movl	%edx, 0x8(%r8)
+               	movq	-0x2b0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	$0x0, -0xc0(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	movl	0x8(%r8), %edx
+               	movl	%edx, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %rdx
+               	movq	%r13, %rdi
+               	callq	 <L47>
+<L47>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x2b8(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r15,%rdx), %rsi
+               	leaq	-0xd0(%rbp), %r8
+               	movq	%r8, -0x2c0(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x2c0(%rbp), %r8
+               	movq	%rdx, 0x8(%r8)
+               	movq	-0x2c0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2c0(%rbp), %r8
+               	movsd	0x8(%r8), %xmm0
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %r13
+               	movq	-0x320(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L46>
+<L49>:
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L58>
-               	jmp	 <L84>
-<L58>:
+               	jb	 <L50>
+               	jmp	 <L68>
+<L50>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x140(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movq	%r15, %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0xffff, %rcx           # imm = 0xFFFF
-               	movq	%rcx, %r11
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	%rdx, (%rsi)
+               	movq	%rdx, %rsi
+               	xorq	$-0x1, %rsi
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movq	%rsi, (%rdi)
+               	leaq	-0x150(%rbp), %r8
+               	movq	%r8, -0x2d0(%rbp)
+               	movq	%rdx, %rdi
+               	andq	$0xffff, %rdi           # imm = 0xFFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L51>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L52>
+<L51>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L52>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x902>
+               	movq	-0x2d0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movsd	%xmm1, (%rdi)
+               	movq	%rdx, %rdi
+               	andq	$0x3ffff, %rdi          # imm = 0x3FFFF
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L53>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L54>
+<L53>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L54>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x952>
+               	movq	-0x2d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movsd	%xmm1, (%rdi)
+               	leaq	-0x160(%rbp), %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	%rdx, %r15
+               	imulq	$0x3, %r15, %r15
+               	addq	$0x1, %r15
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movq	%r15, (%rax)
+               	movq	%rdx, %rax
+               	andq	$0x7fff, %rax           # imm = 0x7FFF
+               	movq	%rax, %r11
+               	testq	%r11, %r11
+               	jl	 <L55>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L56>
+<L55>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L56>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0x9c9>
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movsd	%xmm1, (%rax)
+               	leaq	-0x16c(%rbp), %rax
+               	movl	%edx, %r15d
+               	leaq	(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movq	%rdx, %rsi
+               	shrq	$0x10, %rsi
+               	movl	%esi, %r15d
+               	leaq	0x4(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movq	%rdx, %rsi
+               	shrq	$0x20, %rsi
+               	movl	%esi, %r15d
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	leaq	-0x174(%rbp), %r8
+               	movq	%r8, -0x2e0(%rbp)
+               	movl	%edx, %r15d
+               	movq	-0x2e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%r15d, (%rdi)
+               	movq	%rdx, %rdi
+               	shrq	$0x20, %rdi
+               	movl	%edi, %r15d
+               	movq	-0x2e0(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movl	%r15d, (%rdi)
+               	leaq	-0x17c(%rbp), %r8
+               	movq	%r8, -0x2e8(%rbp)
+               	movq	%rdx, %r15
+               	andq	$0xfff, %r15            # imm = 0xFFF
+               	movq	%r15, %r11
+               	testq	%r11, %r11
+               	jl	 <L57>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L58>
+<L57>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L58>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xa90>
+               	movq	-0x2e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm1, (%r15)
+               	andq	$0xff, %rdx
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L59>
-               	cvtsi2sd	%r11, %xmm0
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L60>
 <L59>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L60>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x782>
-               	movsd	%xmm14, -0x1b8(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L61>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L62>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_ret_small.checksum+0xade>
+               	movq	-0x2e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x198(%rbp), %rdx
+               	movq	-0x2c8(%rbp), %r8
+               	movq	(%r8), %r15
+               	movq	-0x2c8(%rbp), %r8
+               	movq	0x8(%r8), %rsi
+               	movq	%r15, (%rdx)
+               	movq	%rsi, 0x8(%rdx)
+               	leaq	-0x1a8(%rbp), %r15
+               	movq	-0x2d0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	%rsi, (%r15)
+               	movq	%rdi, 0x8(%r15)
+               	leaq	-0x1b8(%rbp), %r8
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2d8(%rbp), %r8
+               	movq	0x8(%r8), %rdi
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%rdi, 0x8(%r8)
+               	leaq	-0x1c4(%rbp), %r8
+               	movq	%r8, -0x2f8(%rbp)
+               	movq	(%rax), %rsi
+               	movl	0x8(%rax), %edi
+               	movq	-0x2f8(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%edi, 0x8(%r8)
+               	leaq	-0x1cc(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x2e0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x328(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	leaq	-0x1d4(%rbp), %r8
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x2e8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x300(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	leaq	-0x1e8(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r8
+               	movq	%r8, -0x308(%rbp)
+               	movq	%rdi, (%rsi)
+               	movq	-0x308(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r8
+               	movq	%r8, -0x310(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	%rdx, %rsi
+               	movq	-0x310(%rbp), %r8
+               	movq	%r8, %rdx
+               	callq	 <L61>
 <L61>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
+               	leaq	-0x1f8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	0x8(%r15), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movsd	(%rdx), %xmm0
+               	movsd	0x8(%rdx), %xmm1
+               	movq	-0x318(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L62>
 <L62>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x7cf>
-               	movsd	%xmm14, -0x1c8(%rbp)
-               	movq	%r15, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x1d0(%rbp)
-               	movq	%r15, %rcx
-               	andq	$0x7fff, %rcx           # imm = 0x7FFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L63>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L64>
+               	movq	%rax, %rdi
+               	leaq	-0x208(%rbp), %rdx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2f0(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%r15, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movsd	0x8(%rdx), %xmm0
+               	callq	 <L63>
 <L63>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%rax, %rdi
+               	leaq	-0x214(%rbp), %rdx
+               	movq	-0x2f8(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2f8(%rbp), %r8
+               	movl	0x8(%r8), %r15d
+               	movq	%rsi, (%rdx)
+               	movl	%r15d, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	$0x0, -0x220(%rbp)
+               	movl	0x8(%rdx), %r15d
+               	movl	%r15d, -0x220(%rbp)
+               	movq	-0x220(%rbp), %rdx
+               	callq	 <L64>
 <L64>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x831>
-               	movsd	%xmm14, -0x1e0(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0x1e8(%rbp)
-               	movq	%r15, %rsi
-               	shrq	$0x10, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x130(%rbp)
-               	movq	%r15, %rsi
-               	shrq	$0x20, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x138(%rbp)
-               	movl	%r15d, %ebx
-               	movq	%r15, %rsi
-               	shrq	$0x20, %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x148(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L66>
+               	movq	%rax, %rdi
+               	leaq	-0x228(%rbp), %rdx
+               	movq	-0x328(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	callq	 <L65>
 <L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	leaq	-0x230(%rbp), %rdx
+               	movq	-0x300(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	movq	%rsi, -0x238(%rbp)
+               	movsd	-0x238(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L66>
 <L66>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x8be>
-               	movss	%xmm14, -0x1f8(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xff, %rsi
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L68>
-<L67>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L68>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_ret_small.checksum+0x90b>
-               	movss	%xmm14, -0x208(%rbp)
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	movsd	-0x1b8(%rbp), %xmm0
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rdi
-               	movsd	-0x1c8(%rbp), %xmm0
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	movq	-0x1d0(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
-               	movsd	-0x1e0(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rdi
-               	movq	-0x1e8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L76>
-<L76>:
-               	movq	%rax, %rdi
-               	movq	-0x130(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rdi
-               	movq	-0x138(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L78>
-<L78>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rdi
-               	movq	-0x148(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L80>
-<L80>:
-               	movq	%rax, %rdi
-               	movss	-0x1f8(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movss	-0x208(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L67>
+<L67>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L58>
-<L84>:
+               	jb	 <L50>
+<L68>:
                	movq	%r13, %rax
-               	movq	-0x218(%rbp), %rbx
-               	movq	-0x220(%rbp), %r12
-               	movq	-0x228(%rbp), %r13
-               	movq	-0x230(%rbp), %r14
-               	movq	-0x238(%rbp), %r15
+               	movq	-0x338(%rbp), %rbx
+               	movq	-0x340(%rbp), %r12
+               	movq	-0x348(%rbp), %r13
+               	movq	-0x350(%rbp), %r14
+               	movq	-0x358(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/call/call_variadic.dis
+++ b/test/golden/x86_64-linux/call/call_variadic.dis
@@ -14,77 +14,96 @@ Disassembly of section .text:
 <corpus.cases.call.call_variadic.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1a0, %rsp            # imm = 0x1A0
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%r15, -0x198(%rbp)
+               	subq	$0x2e0, %rsp            # imm = 0x2E0
+               	movq	%rbx, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
                	movq	%rdi, %r8
-               	movq	%r8, -0x80(%rbp)
-               	callq	 <L0>
-<L0>:
+               	movq	%r8, -0x68(%rbp)
                	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rdx
+               	jne	 <L0>
+               	movq	$0x0, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rax, %rdx
                	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
-               	movq	-0x80(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	addq	%r8, %rdx
-               	leaq	(%r12,%rcx,8), %rsi
+               	leaq	(%r12,%rax,8), %rsi
                	movq	%rdx, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L2>
+               	addq	$0x1, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L1>
+<L2>:
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L4>
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L5>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L6>
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
                	movq	%rax, %r13
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L7>
-               	jmp	 <L91>
-<L7>:
+               	jb	 <L9>
+               	jmp	 <L106>
+<L9>:
                	leaq	(%r12,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	movq	-0x80(%rbp), %r8
-               	movq	%rcx, %r15
+               	movq	(%rax), %rdx
+               	movq	-0x68(%rbp), %r8
+               	movq	%rdx, %r15
                	addq	%r8, %r15
                	movb	%r15b, %r8b
-               	movq	%r8, -0xe0(%rbp)
+               	movq	%r8, -0x228(%rbp)
                	movw	%r15w, %r8w
-               	movq	%r8, -0xe8(%rbp)
-               	movl	%r15d, %r8d
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%r8, -0x230(%rbp)
+               	movl	%r15d, %ebx
                	movq	%r15, %rsi
                	shrq	$0x7, %rsi
                	movb	%sil, %r8b
-               	movq	%r8, -0x68(%rbp)
+               	movq	%r8, -0x88(%rbp)
                	movq	%r15, %rsi
                	shrq	$0x3, %rsi
                	movw	%si, %r8w
@@ -95,24 +114,6 @@ Disassembly of section .text:
                	movq	%r8, -0x78(%rbp)
                	movq	%r15, %rsi
                	andq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L8>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L9>
-<L8>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L9>:
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x19b>
-               	movss	%xmm14, -0x100(%rbp)
-               	movq	%r15, %rsi
-               	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L10>
@@ -127,10 +128,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x1e8>
-               	movss	%xmm14, -0x110(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x205>
+               	movss	%xmm14, -0x240(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x3ff, %rsi            # imm = 0x3FF
+               	andq	$0xff, %rsi
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L12>
@@ -145,10 +146,10 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L13>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x235>
-               	movss	%xmm14, -0x120(%rbp)
+               	subss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x252>
+               	movss	%xmm14, -0x250(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x1ff, %rsi            # imm = 0x1FF
+               	andq	$0x3ff, %rsi            # imm = 0x3FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L14>
@@ -163,28 +164,28 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L15>:
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x282>
-               	movss	%xmm14, -0x130(%rbp)
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x29f>
+               	movss	%xmm14, -0x260(%rbp)
                	movq	%r15, %rsi
-               	andq	$0xffff, %rsi           # imm = 0xFFFF
+               	andq	$0x1ff, %rsi            # imm = 0x1FF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L16>
-               	cvtsi2sd	%r11, %xmm0
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L17>
 <L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L17>:
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x2cf>
-               	movsd	%xmm14, -0x140(%rbp)
+               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
+               	divss	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x2ec>
+               	movss	%xmm14, -0x270(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x3ffff, %rsi          # imm = 0x3FFFF
+               	andq	$0xffff, %rsi           # imm = 0xFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L18>
@@ -199,10 +200,10 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L19>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x31c>
-               	movsd	%xmm14, -0x150(%rbp)
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x339>
+               	movsd	%xmm14, -0x280(%rbp)
                	movq	%r15, %rsi
-               	andq	$0x1fff, %rsi           # imm = 0x1FFF
+               	andq	$0x3ffff, %rsi          # imm = 0x3FFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L20>
@@ -217,297 +218,665 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L21>:
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x369>
-               	movsd	%xmm14, -0x160(%rbp)
-               	movq	%r15, %rbx
-               	imulq	$0x3, %rbx, %rbx
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x386>
+               	movsd	%xmm14, -0x290(%rbp)
                	movq	%r15, %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movslq	%r8d, %rsi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	addq	%r15, %rbx
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x88(%rbp)
-               	leaq	0x10(%r12), %rsi
-               	movq	(%rsi), %r8
+               	andq	$0x1fff, %rsi           # imm = 0x1FFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L22>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L23>
+<L22>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L23>:
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_variadic.checksum+0x3d3>
+               	movsd	%xmm14, -0x2a0(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x3, %r8, %r8
+               	movq	%r8, -0x80(%rbp)
+               	movq	-0x228(%rbp), %r9
+               	movzbq	%r9b, %r8
                	movq	%r8, -0x90(%rbp)
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %r8
+               	movq	%r13, %r8
                	movq	%r8, -0x98(%rbp)
-               	leaq	0x20(%r12), %rsi
-               	movq	(%rsi), %r8
+               	movq	$0x0, %r8
                	movq	%r8, -0xa0(%rbp)
-               	leaq	0x28(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xa8(%rbp)
-               	leaq	0x30(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xb0(%rbp)
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xb8(%rbp)
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xc0(%rbp)
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd0(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	%rbx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
+               	movq	-0xa0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x90(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0xa0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L24>
+<L25>:
+               	movq	-0x230(%rbp), %r9
+               	movswq	%r9w, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0x98(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xb8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L26>
+<L27>:
+               	movl	%ebx, %r8d
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xb0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xc0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L28>
+<L29>:
+               	movq	-0xc8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L30>
+<L31>:
+               	movq	-0x88(%rbp), %r9
+               	movzbq	%r9b, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xd8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L32>
+<L33>:
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rsi
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L34>
 <L34>:
                	movq	%rax, %rdi
-               	movq	-0xa0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x78(%rbp), %r8
+               	movslq	%r8d, %rsi
                	callq	 <L35>
 <L35>:
                	movq	%rax, %rdi
-               	movq	-0xa8(%rbp), %r8
+               	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
                	callq	 <L36>
 <L36>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %rdi
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L38>
+               	movq	%rax, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	leaq	(%r12), %rdi
+               	movq	(%rdi), %rsi
+               	movq	%rsi, %r8
+               	addq	%r15, %r8
+               	movq	%r8, -0x160(%rbp)
+               	leaq	0x8(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x108(%rbp)
+               	leaq	0x10(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x110(%rbp)
+               	leaq	0x18(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x118(%rbp)
+               	leaq	0x20(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x120(%rbp)
+               	leaq	0x28(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x128(%rbp)
+               	leaq	0x30(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x130(%rbp)
+               	leaq	0x38(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x138(%rbp)
+               	leaq	0x40(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x140(%rbp)
+               	leaq	0x48(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x148(%rbp)
+               	leaq	0x50(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x150(%rbp)
+               	leaq	0x58(%r12), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movq	%rax, %rdi
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L39>
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L38>
 <L39>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L40>
+               	movq	-0x168(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
+               	jmp	 <L41>
 <L40>:
-               	movq	%rax, %rdi
-               	movq	-0xd0(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L41>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L40>
 <L41>:
-               	movq	%rax, %rdi
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L42>
+               	movq	-0x178(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	%rax, %rdi
-               	movq	$0xc, %rsi
-               	callq	 <L43>
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L42>
 <L43>:
-               	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
-               	callq	 <L44>
+               	movq	-0x188(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
+               	jmp	 <L45>
 <L44>:
-               	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
-               	callq	 <L45>
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L44>
 <L45>:
-               	movq	%rax, %rdi
-               	movss	-0x110(%rbp), %xmm0
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rdi
-               	movsd	-0x150(%rbp), %xmm0
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x5, %rbx, %rbx
-               	movq	%r15, %rsi
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L49>
 <L49>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L50>
 <L50>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L51>
 <L51>:
                	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L52>
 <L52>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movq	$0xc, %rsi
                	callq	 <L54>
 <L54>:
-               	movq	%rax, %rdi
-               	movq	$0x6, %rsi
-               	callq	 <L55>
+               	movq	%rax, %rsi
+               	movl	-0x240(%rbp), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
+               	jmp	 <L56>
 <L55>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x7, %rbx, %rbx
-               	movq	%r15, %rsi
-               	callq	 <L56>
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1b8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L55>
 <L56>:
-               	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	addq	%r15, %rsi
-               	callq	 <L57>
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x1b0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
+               	jmp	 <L58>
 <L57>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	addq	%r15, %rsi
-               	callq	 <L58>
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L57>
 <L58>:
-               	movq	%rax, %rdi
-               	addq	%r15, %rbx
-               	movq	%rbx, %rsi
+               	movl	-0x250(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L59>
 <L59>:
                	movq	%rax, %rdi
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rsi
-               	addq	%r15, %rsi
+               	movq	-0x290(%rbp), %rsi
                	callq	 <L60>
 <L60>:
                	movq	%rax, %rdi
                	movq	$0x4, %rsi
                	callq	 <L61>
 <L61>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L62>
+               	movq	%rax, %rsi
+               	movq	%r15, %r8
+               	imulq	$0x5, %r8, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+               	jmp	 <L63>
 <L62>:
-               	movq	%rax, %rdi
-               	movss	-0x120(%rbp), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	%r15, %rsi
-               	addq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L62>
+<L63>:
+               	movl	-0x240(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L64>
 <L64>:
                	movq	%rax, %rdi
-               	movsd	-0x160(%rbp), %xmm0
+               	movl	%ebx, %esi
                	callq	 <L65>
 <L65>:
                	movq	%rax, %rdi
-               	movq	$0x3, %rsi
+               	movq	-0x280(%rbp), %rsi
                	callq	 <L66>
 <L66>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
-               	movzbq	%r8b, %rsi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L67>
 <L67>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	$0x6, %rsi
                	callq	 <L69>
 <L69>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L70>
+               	movq	%rax, %rsi
+               	movq	%r15, %r8
+               	imulq	$0x7, %r8, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
+               	jmp	 <L71>
 <L70>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L71>
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r15, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x210(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L70>
 <L71>:
-               	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x228(%rbp), %r8
                	movzbq	%r8b, %rsi
+               	addq	%r15, %rsi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L72>
 <L72>:
                	movq	%rax, %rdi
-               	movq	-0xe8(%rbp), %r8
-               	movswq	%r8w, %rsi
+               	movl	%ebx, %esi
+               	addq	%r15, %rsi
                	callq	 <L73>
 <L73>:
                	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%r15, %rsi
                	callq	 <L74>
 <L74>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rsi
+               	addq	%r15, %rsi
                	callq	 <L75>
 <L75>:
                	movq	%rax, %rdi
@@ -519,53 +888,42 @@ Disassembly of section .text:
                	callq	 <L77>
 <L77>:
                	movq	%rax, %rdi
-               	movss	-0x100(%rbp), %xmm0
+               	movl	-0x260(%rbp), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L78>
 <L78>:
                	movq	%rax, %rdi
-               	movsd	-0x140(%rbp), %xmm0
+               	movq	%r15, %rsi
+               	addq	%r15, %rsi
                	callq	 <L79>
 <L79>:
                	movq	%rax, %rdi
-               	movq	$0x3, %rsi
+               	movq	-0x2a0(%rbp), %rsi
                	callq	 <L80>
 <L80>:
                	movq	%rax, %rdi
-               	movq	%r15, %rbx
-               	imulq	$0x7, %rbx, %rbx
-               	movq	%r15, %r8
-               	imulq	$0x3, %r8, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x3, %rsi
                	callq	 <L81>
 <L81>:
                	movq	%rax, %rdi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x228(%rbp), %r8
                	movzbq	%r8b, %rsi
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rsi
                	callq	 <L82>
 <L82>:
-               	movq	-0xf0(%rbp), %r8
-               	movl	%r8d, %esi
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rsi
                	movq	%rax, %rdi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L83>
 <L83>:
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rbx
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
+               	movl	%ebx, %esi
                	callq	 <L84>
 <L84>:
-               	movq	-0x70(%rbp), %r8
-               	movzwq	%r8w, %rdx
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %rdx
                	movq	%rax, %rdi
-               	movq	%rdx, %rsi
+               	movq	%r15, %rsi
                	callq	 <L85>
 <L85>:
                	movq	%rax, %rdi
@@ -573,32 +931,116 @@ Disassembly of section .text:
                	callq	 <L86>
 <L86>:
                	movq	%rax, %rdi
-               	movq	%r15, %rsi
+               	movq	-0x228(%rbp), %r8
+               	movzbq	%r8b, %rsi
                	callq	 <L87>
 <L87>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	-0x230(%rbp), %r8
+               	movswq	%r8w, %rsi
                	callq	 <L88>
 <L88>:
                	movq	%rax, %rdi
-               	movss	-0x130(%rbp), %xmm0
+               	movl	%ebx, %esi
                	callq	 <L89>
 <L89>:
                	movq	%rax, %rdi
-               	movq	$0x1, %rsi
+               	movq	%r15, %rsi
                	callq	 <L90>
 <L90>:
+               	movq	%rax, %rdi
+               	movq	$0x4, %rsi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L92>
+<L92>:
+               	movq	%rax, %rdi
+               	movl	-0x240(%rbp), %edx
+               	movl	%edx, %esi
+               	callq	 <L93>
+<L93>:
+               	movq	%rax, %rdi
+               	movq	-0x280(%rbp), %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	%rax, %rdi
+               	movq	$0x3, %rsi
+               	callq	 <L95>
+<L95>:
+               	movq	%rax, %rdi
+               	movq	%r15, %r8
+               	imulq	$0x7, %r8, %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	%r15, %r8
+               	imulq	$0x3, %r8, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L96>
+<L96>:
+               	movq	%rax, %rdi
+               	movq	-0x228(%rbp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rsi
+               	callq	 <L97>
+<L97>:
+               	movl	%ebx, %esi
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L98>
+<L98>:
+               	movq	-0x2a8(%rbp), %r8
+               	movq	-0x220(%rbp), %r9
+               	movq	%r8, %rdx
+               	addq	%r9, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L99>
+<L99>:
+               	movq	-0x70(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	movq	-0x220(%rbp), %r8
+               	addq	%r8, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L100>
+<L100>:
+               	movq	%rax, %rdi
+               	movq	$0x4, %rsi
+               	callq	 <L101>
+<L101>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L102>
+<L102>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L103>
+<L103>:
+               	movl	-0x270(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L104>
+<L104>:
+               	movq	%rax, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L105>
+<L105>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L7>
-<L91>:
+               	jb	 <L9>
+<L106>:
                	movq	%r13, %rax
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
-               	movq	-0x198(%rbp), %r15
+               	movq	-0x2b8(%rbp), %rbx
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -798,18 +1240,21 @@ Disassembly of section .text:
                	movsd	%xmm1, -0x10(%rbp)
                	movss	%xmm2, -0x20(%rbp)
                	movsd	%xmm3, -0x30(%rbp)
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
+               	movq	-0x10(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movl	-0x20(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movq	-0x30(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x30(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -834,20 +1279,21 @@ Disassembly of section .text:
                	movq	%r8, %r13
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movl	%ebx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	movswq	%r12w, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
@@ -931,17 +1377,18 @@ Disassembly of section .text:
                	movq	%rbx, %rsi
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	addq	%rbx, %r12
+               	movq	%rax, %rdi
                	movq	%r12, %rsi
                	callq	 <L2>
 <L2>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
@@ -1036,12 +1483,13 @@ Disassembly of section .text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
@@ -1122,6 +1570,8 @@ Disassembly of section .text:
 <corpus.cases.call.call_variadic.fold_pack$pack$f32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
@@ -1177,12 +1627,13 @@ Disassembly of section .text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
@@ -1201,12 +1652,13 @@ Disassembly of section .text:
                	movsd	%xmm1, -0x20(%rbp)
                	callq	 <L0>
 <L0>:
+               	movl	-0x10(%rbp), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movq	-0x20(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi

--- a/test/golden/x86_64-linux/cmp/branch_nest.dis
+++ b/test/golden/x86_64-linux/cmp/branch_nest.dis
@@ -5,162 +5,196 @@ Disassembly of section .text:
 <corpus.cases.cmp.branch_nest.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movq	%r15, -0x28(%rbp)
+               	movl	%edi, %eax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	cmpl	$0x14, %esi
+               	jb	 <L0>
+               	jmp	 <L43>
 <L0>:
-               	movl	%ebx, %r12d
-               	movq	%rax, %rbx
-               	movl	$0x0, %r13d
-               	cmpl	$0x14, %r13d
-               	jb	 <L1>
-               	jmp	 <L42>
+               	movl	%esi, %edi
+               	addl	%eax, %edi
+               	cmpl	$0x4, %edi
+               	jb	 <L31>
+               	cmpl	$0x8, %edi
+               	jb	 <L23>
+               	cmpl	$0xc, %edi
+               	jb	 <L15>
+               	cmpl	$0x10, %edi
+               	jb	 <L7>
+               	cmpl	$0x10, %edi
+               	je	 <L5>
+               	cmpl	$0x11, %edi
+               	je	 <L3>
+               	cmpl	$0x12, %edi
+               	je	 <L1>
+               	movl	$0x1f7, %ebx            # imm = 0x1F7
+               	jmp	 <L2>
 <L1>:
-               	movl	%r13d, %r14d
-               	addl	%r12d, %r14d
-               	cmpl	$0x4, %r14d
-               	jb	 <L32>
-               	cmpl	$0x8, %r14d
-               	jb	 <L24>
-               	cmpl	$0xc, %r14d
-               	jb	 <L16>
-               	cmpl	$0x10, %r14d
-               	jb	 <L8>
-               	cmpl	$0x10, %r14d
-               	je	 <L6>
-               	cmpl	$0x11, %r14d
-               	je	 <L4>
-               	cmpl	$0x12, %r14d
-               	je	 <L2>
-               	movl	$0x1f7, %eax            # imm = 0x1F7
-               	jmp	 <L3>
+               	movl	$0x1f6, %ebx            # imm = 0x1F6
 <L2>:
-               	movl	$0x1f6, %eax            # imm = 0x1F6
+               	jmp	 <L4>
 <L3>:
-               	jmp	 <L5>
+               	movl	$0x1f5, %ebx            # imm = 0x1F5
 <L4>:
-               	movl	$0x1f5, %eax            # imm = 0x1F5
+               	jmp	 <L6>
 <L5>:
-               	jmp	 <L7>
+               	movl	$0x1f4, %ebx            # imm = 0x1F4
 <L6>:
-               	movl	$0x1f4, %eax            # imm = 0x1F4
-<L7>:
-               	jmp	 <L15>
-<L8>:
-               	cmpl	$0xe, %r14d
-               	jb	 <L11>
-               	cmpl	$0xe, %r14d
-               	je	 <L9>
-               	movl	$0x193, %ecx            # imm = 0x193
-               	jmp	 <L10>
-<L9>:
-               	movl	$0x192, %ecx            # imm = 0x192
-<L10>:
                	jmp	 <L14>
-<L11>:
-               	cmpl	$0xc, %r14d
-               	je	 <L12>
-               	movl	$0x191, %edx            # imm = 0x191
+<L7>:
+               	cmpl	$0xe, %edi
+               	jb	 <L10>
+               	cmpl	$0xe, %edi
+               	je	 <L8>
+               	movl	$0x193, %r12d           # imm = 0x193
+               	jmp	 <L9>
+<L8>:
+               	movl	$0x192, %r12d           # imm = 0x192
+<L9>:
                	jmp	 <L13>
+<L10>:
+               	cmpl	$0xc, %edi
+               	je	 <L11>
+               	movl	$0x191, %r13d           # imm = 0x191
+               	jmp	 <L12>
+<L11>:
+               	movl	$0x190, %r13d           # imm = 0x190
 <L12>:
-               	movl	$0x190, %edx            # imm = 0x190
+               	movq	%r13, %r12
 <L13>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rbx
 <L14>:
-               	movq	%rcx, %rax
-<L15>:
-               	jmp	 <L23>
-<L16>:
-               	cmpl	$0x8, %r14d
-               	je	 <L21>
-               	cmpl	$0x9, %r14d
-               	je	 <L19>
-               	cmpl	$0xa, %r14d
-               	je	 <L17>
-               	movl	$0x12f, %ecx            # imm = 0x12F
-               	jmp	 <L18>
-<L17>:
-               	movl	$0x12e, %ecx            # imm = 0x12E
-<L18>:
-               	jmp	 <L20>
-<L19>:
-               	movl	$0x12d, %ecx            # imm = 0x12D
-<L20>:
                	jmp	 <L22>
+<L15>:
+               	cmpl	$0x8, %edi
+               	je	 <L20>
+               	cmpl	$0x9, %edi
+               	je	 <L18>
+               	cmpl	$0xa, %edi
+               	je	 <L16>
+               	movl	$0x12f, %r12d           # imm = 0x12F
+               	jmp	 <L17>
+<L16>:
+               	movl	$0x12e, %r12d           # imm = 0x12E
+<L17>:
+               	jmp	 <L19>
+<L18>:
+               	movl	$0x12d, %r12d           # imm = 0x12D
+<L19>:
+               	jmp	 <L21>
+<L20>:
+               	movl	$0x12c, %r12d           # imm = 0x12C
 <L21>:
-               	movl	$0x12c, %ecx            # imm = 0x12C
+               	movq	%r12, %rbx
 <L22>:
-               	movq	%rcx, %rax
-<L23>:
-               	jmp	 <L31>
-<L24>:
-               	cmpl	$0x6, %r14d
-               	jb	 <L27>
-               	cmpl	$0x6, %r14d
-               	je	 <L25>
-               	movl	$0xcb, %ecx
-               	jmp	 <L26>
-<L25>:
-               	movl	$0xca, %ecx
-<L26>:
                	jmp	 <L30>
-<L27>:
-               	cmpl	$0x4, %r14d
-               	je	 <L28>
-               	movl	$0xc9, %edx
+<L23>:
+               	cmpl	$0x6, %edi
+               	jb	 <L26>
+               	cmpl	$0x6, %edi
+               	je	 <L24>
+               	movl	$0xcb, %r12d
+               	jmp	 <L25>
+<L24>:
+               	movl	$0xca, %r12d
+<L25>:
                	jmp	 <L29>
+<L26>:
+               	cmpl	$0x4, %edi
+               	je	 <L27>
+               	movl	$0xc9, %r13d
+               	jmp	 <L28>
+<L27>:
+               	movl	$0xc8, %r13d
 <L28>:
-               	movl	$0xc8, %edx
+               	movq	%r13, %r12
 <L29>:
-               	movq	%rdx, %rcx
+               	movq	%r12, %rbx
 <L30>:
-               	movq	%rcx, %rax
-<L31>:
-               	jmp	 <L39>
-<L32>:
-               	cmpl	$0x0, %r14d
-               	je	 <L37>
-               	cmpl	$0x1, %r14d
-               	je	 <L35>
-               	cmpl	$0x2, %r14d
-               	je	 <L33>
-               	movl	$0x67, %ecx
-               	jmp	 <L34>
-<L33>:
-               	movl	$0x66, %ecx
-<L34>:
-               	jmp	 <L36>
-<L35>:
-               	movl	$0x65, %ecx
-<L36>:
                	jmp	 <L38>
+<L31>:
+               	cmpl	$0x0, %edi
+               	je	 <L36>
+               	cmpl	$0x1, %edi
+               	je	 <L34>
+               	cmpl	$0x2, %edi
+               	je	 <L32>
+               	movl	$0x67, %r12d
+               	jmp	 <L33>
+<L32>:
+               	movl	$0x66, %r12d
+<L33>:
+               	jmp	 <L35>
+<L34>:
+               	movl	$0x65, %r12d
+<L35>:
+               	jmp	 <L37>
+<L36>:
+               	movl	$0x64, %r12d
 <L37>:
-               	movl	$0x64, %ecx
+               	movq	%r12, %rbx
 <L38>:
-               	movq	%rcx, %rax
+               	movl	%ebx, %r12d
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
+               	jmp	 <L40>
 <L39>:
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L40>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L39>
 <L40>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L41>
+               	movl	%edi, %r12d
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x14, %r13d
-               	jb	 <L1>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L41>
 <L42>:
-               	movq	%rbx, %rax
+               	addl	$0x1, %esi
+               	movq	%rbx, %rdx
+               	cmpl	$0x14, %esi
+               	jb	 <L0>
+<L43>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/cmp/cmp_i32.dis
+++ b/test/golden/x86_64-linux/cmp/cmp_i32.dis
@@ -5,137 +5,240 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%rdi, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %r13
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%r13)
-               	movq	%rsi, 0x8(%r13)
-               	movq	%rdi, 0x10(%r13)
-               	movl	%r14d, 0x18(%r13)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%rbx,%r15,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r8d
-               	addl	%r12d, %r8d
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x78(%rbp)
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %r8d
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     # imm = 0x7FFFFFFF
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movl	0x18(%rsi), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rsi
+               	leaq	-0x70(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     # imm = 0xFFFFFFFF
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     # imm = 0x80000000
+               	leaq	0x10(%rdi), %rbx
+               	movl	$0x7fffffff, (%rbx)     # imm = 0x7FFFFFFF
+               	leaq	0x14(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     # imm = 0x80000000
+               	movq	(%rdi), %rbx
+               	movq	0x8(%rdi), %r12
+               	movq	0x10(%rdi), %r13
+               	movl	0x18(%rdi), %r14d
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movl	%r14d, 0x18(%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
                	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
+               	addl	%r8d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	cmpl	%r14d, %r13d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	cmpl	%r13d, %r14d
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	cmpl	%r14d, %r13d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/cmp/cmp_i64.dis
+++ b/test/golden/x86_64-linux/cmp/cmp_i64.dis
@@ -11,149 +11,250 @@ Disassembly of section .text:
                	movq	%r13, -0x118(%rbp)
                	movq	%r14, -0x120(%rbp)
                	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	movq	%rdi, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %r12
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movq	%rdi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
-               	movq	%r15, 0x28(%r12)
-               	movq	%rax, 0x30(%r12)
-               	leaq	-0xa8(%rbp), %r13
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	0x18(%rax), %rdi
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%r13)
-               	movq	%rdx, 0x8(%r13)
-               	movq	%rsi, 0x10(%r13)
-               	movq	%rdi, 0x18(%r13)
-               	movq	%r14, 0x20(%r13)
-               	movq	%r15, 0x28(%r13)
+               	leaq	-0x70(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	0x20(%rdx), %r14
+               	movq	0x28(%rdx), %r15
+               	movq	0x30(%rdx), %rdi
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%r13)
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rdx
+               	leaq	-0xe0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x10(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	leaq	0x20(%rsi), %rdi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdi)
+               	leaq	0x28(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movq	0x18(%rsi), %r13
+               	movq	0x20(%rsi), %r14
+               	movq	0x28(%rsi), %r15
+               	movq	0x30(%rsi), %rax
+               	movq	%rdi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	%r14, 0x20(%rdx)
+               	movq	%r15, 0x28(%rdx)
+               	movq	%rax, 0x30(%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0xf8(%rbp)
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	-0xe8(%rbp), %r8
+               	addq	%r8, %rbx
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %r12
+               	cmpq	%r12, %rbx
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r13
                	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setl	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setle	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
+               	movq	%r8, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	cmpq	%r12, %rbx
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpq	%r12, %rbx
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpq	%rbx, %r12
+               	setl	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
+               	cmpq	%r12, %rbx
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rbx, %r12
+               	setle	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13

--- a/test/golden/x86_64-linux/cmp/cmp_u32.dis
+++ b/test/golden/x86_64-linux/cmp/cmp_u32.dis
@@ -5,137 +5,240 @@ Disassembly of section .text:
 <corpus.cases.cmp.cmp_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x1c(%rbp), %rbx
-               	leaq	-0x38(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r13d
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%rdi, 0x10(%rbx)
-               	movl	%r13d, 0x18(%rbx)
-               	leaq	-0x54(%rbp), %r13
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	leaq	0x10(%rcx), %rdx
-               	movl	$0x7fffffff, (%rdx)     # imm = 0x7FFFFFFF
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rcx), %rdx
-               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movl	0x18(%rcx), %r14d
-               	movq	%rdx, (%r13)
-               	movq	%rsi, 0x8(%r13)
-               	movq	%rdi, 0x10(%r13)
-               	movl	%r14d, 0x18(%r13)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%rbx,%r15,4), %rax
-               	movl	(%rax), %ecx
-               	movl	%ecx, %r8d
-               	addl	%r12d, %r8d
+               	subq	$0xc0, %rsp
+               	movq	%rbx, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x78(%rbp)
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %r8d
+               	leaq	-0x1c(%rbp), %r8
+               	movq	%r8, -0x88(%rbp)
+               	leaq	-0x38(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0xc(%rsi), %rdi
+               	movl	$0x7fffffff, (%rdi)     # imm = 0x7FFFFFFF
+               	leaq	0x10(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	leaq	0x14(%rsi), %rdi
+               	movl	$0xffffffff, (%rdi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rsi), %rdi
+               	movl	$0x80000000, (%rdi)     # imm = 0x80000000
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movl	0x18(%rsi), %r13d
+               	movq	-0x88(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0x88(%rbp), %r8
+               	movl	%r13d, 0x18(%r8)
+               	leaq	-0x54(%rbp), %rsi
+               	leaq	-0x70(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     # imm = 0xFFFFFFFF
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     # imm = 0x80000000
+               	leaq	0x10(%rdi), %rbx
+               	movl	$0x7fffffff, (%rbx)     # imm = 0x7FFFFFFF
+               	leaq	0x14(%rdi), %rbx
+               	movl	$0xffffffff, (%rbx)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rdi), %rbx
+               	movl	$0x80000000, (%rbx)     # imm = 0x80000000
+               	movq	(%rdi), %rbx
+               	movq	0x8(%rdi), %r12
+               	movq	0x10(%rdi), %r13
+               	movl	0x18(%rdi), %r14d
+               	movq	%rbx, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movq	%r13, 0x10(%rsi)
+               	movl	%r14d, 0x18(%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x80(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0x88(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
                	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
+               	addl	%r8d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r14d, %r13d
+               	sete	%r12b
+               	movzbq	%r12b, %r12
+               	movzbq	%r12b, %r15
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L1>
+<L2>:
+               	cmpl	%r14d, %r13d
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	cmpl	%r14d, %r13d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
                	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	-0x80(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movq	-0x78(%rbp), %r9
-               	cmpl	%r9d, %r8d
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	cmpl	%r13d, %r14d
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	cmpl	%r14d, %r13d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpl	%r13d, %r14d
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r12, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rbx
+               	movq	%r12, %r8
+               	movq	%r8, -0x80(%rbp)
+               	cmpq	$0x7, %rbx
+               	jb	 <L0>
+<L13>:
+               	movq	-0x80(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/cmp/cmp_u64.dis
+++ b/test/golden/x86_64-linux/cmp/cmp_u64.dis
@@ -11,149 +11,250 @@ Disassembly of section .text:
                	movq	%r13, -0x118(%rbp)
                	movq	%r14, -0x120(%rbp)
                	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
+               	movq	%rdi, %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	leaq	-0x38(%rbp), %r12
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x20(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x28(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x30(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %rdi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	0x28(%rcx), %r15
-               	movq	0x30(%rcx), %rax
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movq	%rdi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
-               	movq	%r15, 0x28(%r12)
-               	movq	%rax, 0x30(%r12)
-               	leaq	-0xa8(%rbp), %r13
-               	leaq	-0xe0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x10(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x18(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x20(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x28(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x30(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movq	(%rax), %rcx
-               	movq	0x8(%rax), %rdx
-               	movq	0x10(%rax), %rsi
-               	movq	0x18(%rax), %rdi
-               	movq	0x20(%rax), %r14
-               	movq	0x28(%rax), %r15
-               	movq	0x30(%rax), %r8
+               	leaq	-0x38(%rbp), %r8
                	movq	%r8, -0xf0(%rbp)
-               	movq	%rcx, (%r13)
-               	movq	%rdx, 0x8(%r13)
-               	movq	%rsi, 0x10(%r13)
-               	movq	%rdi, 0x18(%r13)
-               	movq	%r14, 0x20(%r13)
-               	movq	%r15, 0x28(%r13)
+               	leaq	-0x70(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rsi)
+               	leaq	0x20(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	leaq	0x28(%rdx), %rsi
+               	movq	$-0x1, (%rsi)
+               	leaq	0x30(%rdx), %rsi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rsi)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
+               	movq	0x10(%rdx), %r12
+               	movq	0x18(%rdx), %r13
+               	movq	0x20(%rdx), %r14
+               	movq	0x28(%rdx), %r15
+               	movq	0x30(%rdx), %rdi
                	movq	-0xf0(%rbp), %r8
-               	movq	%r8, 0x30(%r13)
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x7, %r15
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rcx
-               	movq	%rcx, %r8
-               	addq	%rbx, %r8
+               	movq	%rsi, (%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rbx, 0x8(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r12, 0x10(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r13, 0x18(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r14, 0x20(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%r15, 0x28(%r8)
+               	movq	-0xf0(%rbp), %r8
+               	movq	%rdi, 0x30(%r8)
+               	leaq	-0xa8(%rbp), %rdx
+               	leaq	-0xe0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x10(%rsi), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	0x18(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	leaq	0x20(%rsi), %rdi
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdi)
+               	leaq	0x28(%rsi), %rdi
+               	movq	$-0x1, (%rdi)
+               	leaq	0x30(%rsi), %rdi
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdi)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rbx
+               	movq	0x10(%rsi), %r12
+               	movq	0x18(%rsi), %r13
+               	movq	0x20(%rsi), %r14
+               	movq	0x28(%rsi), %r15
+               	movq	0x30(%rsi), %rax
+               	movq	%rdi, (%rdx)
+               	movq	%rbx, 0x8(%rdx)
+               	movq	%r12, 0x10(%rdx)
+               	movq	%r13, 0x18(%rdx)
+               	movq	%r14, 0x20(%rdx)
+               	movq	%r15, 0x28(%rdx)
+               	movq	%rax, 0x30(%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0xf8(%rbp)
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+               	jmp	 <L13>
+<L0>:
+               	movq	-0xf0(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	-0xe8(%rbp), %r8
+               	addq	%r8, %rbx
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %r12
+               	cmpq	%r12, %rbx
+               	sete	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r13
                	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setb	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	-0xf8(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0xf8(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x7, %r15
+               	movq	%r8, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	cmpq	%r12, %rbx
+               	setne	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	cmpq	%r12, %rbx
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L5>
+<L6>:
+               	cmpq	%rbx, %r12
+               	setb	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
 <L8>:
-               	movq	%r14, %rax
+               	cmpq	%r12, %rbx
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %r13
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rax, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rax
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L9>
+<L10>:
+               	cmpq	%rbx, %r12
+               	setbe	%al
+               	movzbq	%al, %rax
+               	movzbq	%al, %rbx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rax, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	cmpq	$0x7, %rsi
+               	jb	 <L0>
+<L13>:
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rax
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13

--- a/test/golden/x86_64-linux/cmp/loop_shapes.dis
+++ b/test/golden/x86_64-linux/cmp/loop_shapes.dis
@@ -5,155 +5,242 @@ Disassembly of section .text:
 <corpus.cases.cmp.loop_shapes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movq	%rax, %rbx
-               	movl	$0x0, %r13d
-               	movq	%r12, %r14
-               	cmpl	$0x10, %r13d
-               	jb	 <L1>
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movl	$0x0, %esi
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rdi
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	%r13d, %eax
-               	imull	$0x3, %eax, %eax
-               	movl	%r14d, %ecx
-               	addl	%eax, %ecx
-               	movl	%ecx, %r14d
-               	addl	$0x1, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r13d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r13d
+<L0>:
+               	movl	%esi, %ebx
+               	imull	$0x3, %ebx, %ebx
+               	movl	%edi, %r12d
+               	addl	%ebx, %r12d
+               	addl	$0x1, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rdx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-<L3>:
-               	movl	$0x62, %eax
-               	addl	%r12d, %eax
-               	movq	%rax, %r13
-               	movl	$0x0, %r11d
-               	cmpl	%r13d, %r11d
-               	jb	 <L4>
-               	jmp	 <L6>
-<L4>:
-               	subl	$0x7, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rbx
-               	movl	$0x0, %r11d
-               	cmpl	%r13d, %r11d
-               	jb	 <L4>
-<L6>:
-               	movl	$0x0, %r13d
-               	cmpl	$0x6, %r13d
-               	jb	 <L7>
-               	jmp	 <L13>
-<L7>:
-               	movl	%r13d, %r14d
-               	imull	$0x6, %r14d, %r14d
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
                	movq	%rbx, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8(%rbp)
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %esi
+               	movq	%r13, %rdx
+               	movq	%r12, %rdi
+               	cmpl	$0x10, %esi
+               	jb	 <L0>
+<L3>:
                	movq	-0x8(%rbp), %r8
-               	cmpl	$0x6, %r8d
+               	movl	$0x62, %eax
+               	addl	%r8d, %eax
+               	movl	$0x0, %r11d
+               	cmpl	%eax, %r11d
+               	jb	 <L4>
+               	jmp	 <L7>
+<L4>:
+               	movl	%eax, %esi
+               	subl	$0x7, %esi
+               	movl	%esi, %edi
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+<L6>:
+               	movq	%rbx, %rdx
+               	movq	%rsi, %rax
+               	movl	$0x0, %r11d
+               	cmpl	%eax, %r11d
+               	jb	 <L4>
+<L7>:
+               	movl	$0x0, %eax
+               	cmpl	$0x6, %eax
                	jb	 <L8>
-               	jmp	 <L12>
+               	jmp	 <L15>
 <L8>:
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x3, %r8d
-               	je	 <L10>
-               	movq	-0x8(%rbp), %r8
-               	movl	%r14d, %ecx
-               	addl	%r8d, %ecx
-               	addl	%r12d, %ecx
-               	movq	%r15, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movl	%eax, %r8d
+               	imull	$0x6, %r8d, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rdx, %rdi
+               	movl	$0x0, %ebx
+               	cmpl	$0x6, %ebx
+               	jb	 <L9>
+               	jmp	 <L14>
 <L9>:
-               	movq	%rax, %r15
+               	cmpl	$0x3, %ebx
+               	je	 <L12>
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	addl	%ebx, %r12d
                	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
+               	addl	%r8d, %r12d
+               	movl	%r12d, %r13d
+               	movq	%rdi, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
 <L11>:
-               	movq	-0x8(%rbp), %r8
-               	cmpl	$0x6, %r8d
-               	jb	 <L8>
+               	addl	$0x1, %ebx
+               	movq	%r12, %rdi
+               	jmp	 <L13>
 <L12>:
-               	addl	$0x1, %r13d
-               	movq	%r15, %rbx
-               	cmpl	$0x6, %r13d
-               	jb	 <L7>
+               	addl	$0x1, %ebx
 <L13>:
-               	movl	$0x9, %r13d
-               	addl	%r12d, %r13d
-               	movq	%r12, %r14
-               	cmpl	$0xf4240, %r14d         # imm = 0xF4240
-               	jb	 <L14>
-               	jmp	 <L16>
+               	cmpl	$0x6, %ebx
+               	jb	 <L9>
 <L14>:
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L15>
+               	addl	$0x1, %eax
+               	movq	%rdi, %rdx
+               	cmpl	$0x6, %eax
+               	jb	 <L8>
 <L15>:
-               	cmpl	%r13d, %r14d
-               	je	 <L17>
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0xf4240, %r14d         # imm = 0xF4240
-               	jb	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9, %eax
+               	addl	%r8d, %eax
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	cmpl	$0xf4240, %esi          # imm = 0xF4240
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
+               	movl	%esi, %edi
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
                	jmp	 <L18>
 <L17>:
-               	movq	%rax, %rbx
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L17>
 <L18>:
-               	movl	$0x1, %eax
-               	addl	%r12d, %eax
-               	movq	%rax, %r12
-               	movl	$0x1, %r13d
-               	movl	$0x0, %r14d
-               	cmpl	$0x14, %r14d
-               	jb	 <L19>
-               	jmp	 <L21>
+               	cmpl	%eax, %esi
+               	je	 <L20>
+               	addl	$0x1, %esi
+               	movq	%rbx, %rdx
+               	cmpl	$0xf4240, %esi          # imm = 0xF4240
+               	jb	 <L16>
 <L19>:
-               	movl	%r12d, %r15d
-               	addl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r13, %r12
-               	movq	%r15, %r13
-               	cmpl	$0x14, %r14d
-               	jb	 <L19>
+               	movq	%rbx, %rdx
 <L21>:
-               	movq	%rbx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x1, %eax
+               	addl	%r8d, %eax
+               	movq	%rax, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x1, %esi
+               	movl	$0x0, %edi
+               	cmpl	$0x14, %edi
+               	jb	 <L22>
+               	jmp	 <L25>
+<L22>:
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %ebx
+               	addl	%esi, %ebx
+               	movl	%ebx, %r12d
+               	movq	%rdx, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L23>
+<L24>:
+               	addl	$0x1, %edi
+               	movq	%r13, %rdx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	%rbx, %rsi
+               	cmpl	$0x14, %edi
+               	jb	 <L22>
+<L25>:
+               	movq	%rdx, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/cmp/short_circuit.dis
+++ b/test/golden/x86_64-linux/cmp/short_circuit.dis
@@ -40,42 +40,96 @@ Disassembly of section .text:
 <corpus.cases.cmp.short_circuit.fold_state>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.fold_state+0x1f>
-               	callq	 <L0>
+               	movq	%r15, -0x28(%rbp)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.fold_state+0x23>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.fold_state+0x2b>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.fold_state+0x32>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L1>
-               	jmp	 <L4>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L2>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.fold_state+0x7c>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.fold_state+0x83>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+               	jmp	 <L7>
 <L2>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L3>
+               	leaq	(%rax,%rsi,8), %rbx
+               	movq	(%rbx), %r12
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L1>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%r13, %rax
+               	leaq	(%rdx,%rsi,8), %r12
+               	movq	(%r12), %r13
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L5>
+<L6>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdi
+               	cmpq	$0x4, %rsi
+               	jb	 <L2>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -83,580 +137,524 @@ Disassembly of section .text:
 <corpus.cases.cmp.short_circuit.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
+               	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movb	%bl, %r12b
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x32>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x39>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x40>
+               	movb	%dil, %bl
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x1e>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x25>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2c>
                	movq	$0x0, %rsi
                	cmpq	$0x4, %rsi
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	leaq	(%rcx,%rsi,8), %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	leaq	(%rax,%rsi,8), %rdi
                	movq	$0x0, (%rdi)
                	leaq	(%rdx,%rsi,8), %rdi
                	movq	$0x0, (%rdi)
                	addq	$0x1, %rsi
                	cmpq	$0x4, %rsi
-               	jb	 <L1>
-<L2>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x81>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x93>
-               	movq	(%rcx), %rdx
+               	jb	 <L0>
+<L1>:
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x78>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7f>
+               	movq	(%rax), %rdx
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0xa4>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0xab>
-               	movq	%rcx, (%rdx)
-               	movq	%rax, %rdi
-               	movq	$0x0, %rsi
-               	callq	 <L3>
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x90>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x97>
+               	movq	%rax, (%rdx)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x0, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0xc4>
-               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0xd3>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0xda>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x10a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x111>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x118>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
-               	jmp	 <L8>
+               	jmp	 <L6>
 <L5>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L6>
-<L6>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
                	jb	 <L5>
+<L6>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x15b>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x166>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x16d>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x17e>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x185>
+               	movq	%rdx, (%rsi)
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x196>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x1a1>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1a8>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1b9>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x1c0>
+               	movq	%rsi, (%rdi)
+               	cmpb	$0x1, %dl
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x12e>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x135>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x13c>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
-               	jmp	 <L10>
+               	movq	%rax, %rdi
+               	callq	 <L9>
 <L9>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L9>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x237>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x23e>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x245>
+               	movq	$0x0, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x17d>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x188>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x18f>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1a0>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a7>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %eax
-               	xorl	%r12d, %eax
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b9>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1cb>
-               	movq	(%rcx), %rdx
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	leaq	(%rsi,%rdi,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rdi
+               	cmpq	$0x4, %rdi
+               	jb	 <L10>
+<L11>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x288>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1dc>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1e3>
-               	movq	%rcx, (%rdx)
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x293>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x29a>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2ab>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2b2>
+               	movq	%rdx, (%rsi)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x1, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x321>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x328>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x32f>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L17>
+<L17>:
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L18>
+               	movl	$0x1, %eax
+               	xorl	%ebx, %eax
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x39c>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x3a7>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x3ae>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x3bf>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x3c6>
+               	movq	%rsi, (%rdi)
                	cmpb	$0x1, %al
                	sete	%sil
                	movzbq	%sil, %rsi
-               	movq	%r14, %rdi
-               	callq	 <L11>
-<L11>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x200>
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20f>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x216>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L13>
-               	jmp	 <L16>
-<L13>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L13>
-<L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x26a>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x271>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x278>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
-               	jmp	 <L18>
-<L17>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L17>
+               	jmp	 <L19>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b9>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c4>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2cb>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2dc>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2e3>
-               	movq	%rax, (%rcx)
-               	movq	%r14, %rdi
-               	movq	$0x1, %rsi
-               	callq	 <L19>
+               	movq	%rdx, %rsi
 <L19>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2fc>
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x30b>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x312>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L21>
-               	jmp	 <L24>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
+               	movq	%r12, %rdi
                	callq	 <L22>
 <L22>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x448>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x44f>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x456>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L21>
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L23>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x366>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x36d>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x374>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L25>
-<L26>:
                	movq	$0x0, %rdi
                	movq	$0x0, %rsi
-               	callq	 <L27>
-<L27>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movl	$0x1, %eax
-               	xorl	%r12d, %eax
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3e2>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3ed>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3f4>
-               	movq	(%rdx), %rsi
-               	addq	$0x1, %rsi
-               	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x405>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x40c>
-               	movq	%rdx, (%rsi)
+               	callq	 <L25>
+<L25>:
                	cmpb	$0x1, %al
                	sete	%dl
                	movzbq	%dl, %rdx
-               	jmp	 <L29>
-<L28>:
-               	movq	%rcx, %rdx
-<L29>:
-               	movq	%r14, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x433>
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x442>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x449>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L32>
-               	jmp	 <L35>
-<L32>:
-               	leaq	(%rbx,%r15,8), %rax
+               	testb	%dl, %dl
+               	jne	 <L26>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4bc>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4c7>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4ce>
                	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L33>
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4df>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x4e6>
+               	movq	%rax, (%rsi)
+               	movq	$0x1, %rax
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rax
+<L27>:
+               	testb	%al, %al
+               	jne	 <L28>
+               	jmp	 <L31>
+<L28>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x50c>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x517>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x51e>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x52f>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x536>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %bl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L29>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x552>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x55d>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x564>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x575>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x57c>
+               	movq	%rsi, (%rdi)
+               	movq	$0x1, %rsi
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdx, %rsi
+<L30>:
+               	movq	%rsi, %rax
+<L31>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
 <L33>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
+               	movq	%r12, %rdi
                	callq	 <L34>
 <L34>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L32>
-<L35>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x49d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4a4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4ab>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
-               	jmp	 <L37>
-<L36>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L36>
-<L37>:
-               	movq	$0x0, %rdi
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x5fd>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x604>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x60b>
                	movq	$0x0, %rsi
-               	callq	 <L38>
-<L38>:
-               	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L39>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x511>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51c>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x523>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x534>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x53b>
-               	movq	%rax, (%rdx)
-               	movq	$0x1, %rax
-               	jmp	 <L40>
-<L39>:
-               	movq	%rcx, %rax
-<L40>:
-               	testb	%al, %al
-               	jne	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x561>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x56c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x573>
-               	movq	(%rcx), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x584>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x58b>
-               	movq	%rcx, (%rdx)
-               	cmpb	$0x1, %r12b
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L42>
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5a8>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5b3>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5ba>
-               	movq	(%rdx), %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
                	addq	$0x1, %rsi
-               	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5cb>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5d2>
-               	movq	%rdx, (%rsi)
-               	movq	$0x1, %rdx
-               	jmp	 <L43>
-<L42>:
-               	movq	%rcx, %rdx
-<L43>:
-               	movq	%rdx, %rax
-<L44>:
-               	movq	%r14, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5f9>
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x608>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x60f>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L47>
-               	jmp	 <L50>
-<L47>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L48>
-<L48>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L47>
-<L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x663>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x66a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x671>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-               	jmp	 <L52>
-<L51>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L51>
-<L52>:
+               	cmpq	$0x4, %rsi
+               	jb	 <L35>
+<L36>:
                	movq	$0x0, %rdi
                	movq	$0x1, %rsi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L37>
+<L37>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L54>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d7>
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L38>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x671>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6e2>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6e9>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6fa>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x701>
-               	movq	%rax, (%rdx)
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x67c>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x683>
+               	movq	(%rax), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x694>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x69b>
+               	movq	%rax, (%rsi)
                	movq	$0x1, %rax
-               	jmp	 <L55>
-<L54>:
-               	movq	%rcx, %rax
-<L55>:
+               	jmp	 <L39>
+<L38>:
+               	movq	%rdx, %rax
+<L39>:
                	testb	%al, %al
-               	jne	 <L56>
-               	jmp	 <L57>
-<L56>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x727>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x732>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x739>
-               	movq	(%rcx), %rdx
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6c1>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x74a>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x751>
-               	movq	%rcx, (%rdx)
-               	movl	$0x1, %ecx
-               	xorl	%r12d, %ecx
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x763>
-               	addq	$0x1, %rdx
-               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x76e>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x775>
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x6cc>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6d3>
                	movq	(%rdx), %rsi
                	addq	$0x1, %rsi
                	movq	%rsi, (%rdx)
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x786>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x78d>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6e4>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x6eb>
                	movq	%rdx, (%rsi)
-               	cmpb	$0x1, %cl
-               	sete	%dl
-               	movzbq	%dl, %rdx
-               	movq	%rdx, %rax
-<L57>:
-               	movq	%r14, %rdi
+               	movl	$0x1, %edx
+               	xorl	%ebx, %edx
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x6fc>
+               	addq	$0x1, %rsi
+               	movq	%rsi,  <corpus.cases.cmp.short_circuit.checksum+0x707>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x70e>
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, (%rsi)
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x71f>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x726>
+               	movq	%rsi, (%rdi)
+               	cmpb	$0x1, %dl
+               	sete	%sil
+               	movzbq	%sil, %rsi
+               	movq	%rsi, %rax
+<L41>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+               	jmp	 <L43>
+<L42>:
                	movq	%rax, %rsi
-               	callq	 <L58>
-<L58>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7af>
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7be>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x7c5>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L60>
-               	jmp	 <L63>
-<L60>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L60>
-<L63>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x819>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x827>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-               	jmp	 <L65>
-<L64>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L64>
-<L65>:
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L42>
+<L43>:
+               	movq	%r12, %rdi
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %r12
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x7a3>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7aa>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x7b1>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L45>
+               	jmp	 <L46>
+<L45>:
+               	leaq	(%rax,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	$0x0, (%rdi)
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L45>
+<L46>:
                	movq	$0x0, %rdi
                	movq	$0x0, %rsi
-               	callq	 <L66>
-<L66>:
+               	callq	 <L47>
+<L47>:
                	cmpb	$0x1, %al
-               	sete	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L67>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L48>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x817>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x898>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x89f>
-               	movq	(%rax), %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8b0>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8b7>
-               	movq	%rax, (%rdx)
-               	cmpb	$0x1, %r12b
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x822>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x829>
+               	movq	(%rax), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x83a>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x841>
+               	movq	%rax, (%rsi)
+               	cmpb	$0x1, %bl
                	sete	%al
                	movzbq	%al, %rax
-               	jmp	 <L68>
-<L67>:
-               	movq	%rcx, %rax
-<L68>:
+               	jmp	 <L49>
+<L48>:
+               	movq	%rdx, %rax
+<L49>:
                	testb	%al, %al
-               	jne	 <L69>
-               	jmp	 <L70>
-<L69>:
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8e1>
-               	addq	$0x1, %rcx
-               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8ec>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f3>
-               	movq	(%rcx), %rdx
+               	jne	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x86a>
                	addq	$0x1, %rdx
-               	movq	%rdx, (%rcx)
-               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x904>
-               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x90b>
-               	movq	%rcx, (%rdx)
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x875>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x87c>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x894>
+               	movq	%rdx, (%rsi)
                	movq	$0x1, %rax
-<L70>:
-               	movq	%r14, %rdi
+<L51>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
                	movq	%rax, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x927>
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x936>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x93d>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L73>
-               	jmp	 <L76>
-<L73>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r13
-               	cmpq	$0x4, %r14
-               	jb	 <L73>
-<L76>:
-               	movq	%r13, %rax
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L52>
+<L53>:
+               	movq	%r12, %rdi
+               	callq	 <L54>
+<L54>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/comptime/ct_runtime_agree.dis
+++ b/test/golden/x86_64-linux/comptime/ct_runtime_agree.dis
@@ -32,549 +32,808 @@ Disassembly of section .text:
 <corpus.cases.comptime.ct_runtime_agree.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x100, %rsp            # imm = 0x100
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
-               	movq	%r15, -0xf8(%rbp)
+               	subq	$0x120, %rsp            # imm = 0x120
+               	movq	%rbx, -0xf8(%rbp)
+               	movq	%r12, -0x100(%rbp)
+               	movq	%r13, -0x108(%rbp)
+               	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	$0x12345678, %r12       # imm = 0x12345678
-               	addq	%rbx, %r12
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	%rcx, %r13
-               	addq	$0x7, %r13
-               	movq	%r13, %rcx
-               	shlq	$0xd, %rcx
-               	movq	%rcx, %r14
-               	movabsq	$0xf0f0f0f0f, %r11      # imm = 0xF0F0F0F0F
-               	xorq	%r11, %r14
-               	movq	%r14, %rcx
-               	shrq	$0x7, %rcx
-               	movq	%r14, %r15
-               	xorq	%rcx, %r15
-               	movq	%r15, %r8
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	andq	%r11, %r8
-               	movq	%r8, -0x48(%rbp)
-               	movq	-0x48(%rbp), %r9
-               	movq	%r9, %r8
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %r8
+               	movq	$0x12345678, %r8        # imm = 0x12345678
+               	addq	%rbx, %r8
                	movq	%r8, -0x50(%rbp)
-               	movq	-0x50(%rbp), %r9
-               	movq	%r9, %r8
-               	shrq	$0x11, %r8
-               	movq	%r8, -0x38(%rbp)
-               	movq	-0x38(%rbp), %r9
-               	movq	-0x48(%rbp), %r10
-               	movq	%r9, %r8
-               	addq	%r10, %r8
-               	movq	%r8, -0x40(%rbp)
-               	movq	$0x12345678, %rsi       # imm = 0x12345678
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	$0x369d036f, %rsi       # imm = 0x369D036F
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movabsq	$0x6dcaf62ef0f, %rsi    # imm = 0x6DCAF62EF0F
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movabsq	$0x6d1163c2ad1, %rsi    # imm = 0x6D1163C2AD1
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	$0x163c2ad1, %rsi       # imm = 0x163C2AD1
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	movq	%rdx, %r8
+               	addq	$0x7, %r8
+               	movq	%r8, -0x48(%rbp)
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
+               	shlq	$0xd, %rsi
+               	movq	%rsi, %r8
+               	movabsq	$0xf0f0f0f0f, %r11      # imm = 0xF0F0F0F0F
+               	xorq	%r11, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	$0x7, %rdi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %r12
+               	xorq	%rdi, %r12
+               	movq	%r12, %r13
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	andq	%r11, %r13
+               	movq	%r13, %r14
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %r14
+               	movq	%r14, %r15
+               	shrq	$0x11, %r15
+               	movq	%r15, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rsi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x12345678, %rdx       # imm = 0x12345678
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rsi
                	movq	%rax, %rdi
-               	movabsq	$0xdbdf3ec00bd6381, %rsi # imm = 0xDBDF3EC00BD6381
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
                	movq	-0x50(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$0x369d036f, %rdx       # imm = 0x369D036F
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0x6dcaf62ef0f, %rdx    # imm = 0x6DCAF62EF0F
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x6d1163c2ad1, %rsi    # imm = 0x6D1163C2AD1
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movabsq	$0x6def9f6005e, %rsi    # imm = 0x6DEF9F6005E
+               	movq	%r12, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	$0x163c2ad1, %rsi       # imm = 0x163C2AD1
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movabsq	$0x6df10322b2f, %rsi    # imm = 0x6DF10322B2F
+               	movq	%r13, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
+               	movabsq	$0xdbdf3ec00bd6381, %rsi # imm = 0xDBDF3EC00BD6381
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L17>
+<L17>:
+               	movq	%rax, %rdi
+               	movabsq	$0x6def9f6005e, %rsi    # imm = 0x6DEF9F6005E
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movabsq	$0x6df10322b2f, %rsi    # imm = 0x6DF10322B2F
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L17>
+               	jl	 <L22>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L18>
-<L17>:
+               	jmp	 <L23>
+<L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L18>:
-               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1e6>
+<L23>:
+               	movsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x38f>
                	addsd	%xmm0, %xmm1
                	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
-               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x1f8>
-               	movsd	%xmm14, -0x60(%rbp)
-               	movsd	-0x60(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x20b>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	subsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x219>
-               	movsd	%xmm14, -0x70(%rbp)
-               	movsd	-0x70(%rbp), %xmm14
-               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x22e>
-               	movsd	%xmm14, -0x80(%rbp)
-               	movsd	-0x80(%rbp), %xmm0
-               	mulsd	-0x80(%rbp), %xmm0
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x60(%rbp), %xmm14
-               	movsd	%xmm14, -0x90(%rbp)
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x25a>
-               	callq	 <L19>
-<L19>:
+               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3a1>
+               	movsd	%xmm14, -0x78(%rbp)
+               	movsd	-0x78(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3b4>
+               	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
+               	subsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3c2>
+               	movsd	%xmm14, -0x88(%rbp)
+               	movsd	-0x88(%rbp), %xmm14
+               	divsd	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3dd>
+               	movsd	%xmm14, -0x98(%rbp)
+               	movsd	-0x98(%rbp), %xmm3
+               	mulsd	-0x98(%rbp), %xmm3
+               	movsd	%xmm3, %xmm14           # xmm14 = xmm3[0],xmm14[1]
+               	addsd	-0x78(%rbp), %xmm14
+               	movsd	%xmm14, -0xa8(%rbp)
+               	movabsq	$0x3fd5555555555555, %rsi # imm = 0x3FD5555555555555
                	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x277>
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x294>
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L24>
 <L24>:
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2b1>
                	callq	 <L25>
 <L25>:
+               	movabsq	$0x3fd5555555555550, %rsi # imm = 0x3FD5555555555550
                	movq	%rax, %rdi
-               	movsd	-0x90(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
+               	movq	-0x88(%rbp), %rsi
                	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movabsq	$0x3fd364d9364d9360, %rsi # imm = 0x3FD364D9364D9360
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	-0x98(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movabsq	$0x3fdb35d5373e4baf, %rsi # imm = 0x3FDB35D5373E4BAF
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movq	-0xa8(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L27>
+               	jl	 <L32>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L28>
-<L27>:
+               	jmp	 <L33>
+<L32>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L28>:
-               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x2fd>
+<L33>:
+               	movss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4bf>
                	addss	%xmm0, %xmm1
                	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
-               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x30f>
-               	movss	%xmm14, -0xa0(%rbp)
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x328>
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	subss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x336>
-               	movss	%xmm14, -0xb0(%rbp)
-               	movss	-0xb0(%rbp), %xmm14
-               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x351>
-               	movss	%xmm14, -0xc0(%rbp)
-               	movss	-0xc0(%rbp), %xmm0
-               	mulss	-0xc0(%rbp), %xmm0
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	addss	-0xa0(%rbp), %xmm14
-               	movss	%xmm14, -0xd0(%rbp)
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x389>
-               	callq	 <L29>
-<L29>:
+               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4d1>
+               	movss	%xmm14, -0xb8(%rbp)
+               	movss	-0xb8(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4ea>
+               	movss	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1,2,3]
+               	subss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x4f8>
+               	movss	%xmm14, -0xc8(%rbp)
+               	movss	-0xc8(%rbp), %xmm14
+               	divss	, %xmm14 <corpus.cases.comptime.ct_runtime_agree.checksum+0x513>
+               	movss	%xmm14, -0xd8(%rbp)
+               	movss	-0xd8(%rbp), %xmm3
+               	mulss	-0xd8(%rbp), %xmm3
+               	movss	%xmm3, %xmm14           # xmm14 = xmm3[0],xmm14[1,2,3]
+               	addss	-0xb8(%rbp), %xmm14
+               	movss	%xmm14, -0xe8(%rbp)
+               	movl	$0x3eaaaaab, %edx       # imm = 0x3EAAAAAB
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xa0(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3a9>
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	movss	-0xb0(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3c9>
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L34>
 <L34>:
+               	movl	-0xb8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.comptime.ct_runtime_agree.checksum+0x3e9>
                	callq	 <L35>
 <L35>:
+               	movl	$0x3eaaaab0, %edx       # imm = 0x3EAAAAB0
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L36>
 <L36>:
+               	movl	-0xc8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x9e3779b1, %rsi       # imm = 0x9E3779B1
                	callq	 <L37>
 <L37>:
+               	movl	$0x3e9b26ce, %edx       # imm = 0x3E9B26CE
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x1449114a2, %rsi      # imm = 0x1449114A2
                	callq	 <L38>
 <L38>:
+               	movl	-0xd8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x517154775, %rsi      # imm = 0x517154775
                	callq	 <L39>
 <L39>:
+               	movl	$0x3ed9aead, %edx       # imm = 0x3ED9AEAD
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0xc5255662a, %rsi      # imm = 0xC5255662A
                	callq	 <L40>
 <L40>:
+               	movl	-0xe8(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movabsq	$0x1f7ae2da45, %rsi     # imm = 0x1F7AE2DA45
                	callq	 <L41>
 <L41>:
                	movq	%rax, %rdi
-               	movabsq	$0x39954428ca, %rsi     # imm = 0x39954428CA
+               	movabsq	$0x9e3779b1, %rsi       # imm = 0x9E3779B1
                	callq	 <L42>
 <L42>:
-               	leaq	-0x30(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
+               	movq	%rax, %rdi
+               	movabsq	$0x1449114a2, %rsi      # imm = 0x1449114A2
+               	callq	 <L43>
+<L43>:
+               	movq	%rax, %rdi
+               	movabsq	$0x517154775, %rsi      # imm = 0x517154775
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %rdi
+               	movabsq	$0xc5255662a, %rsi      # imm = 0xC5255662A
+               	callq	 <L45>
+<L45>:
+               	movq	%rax, %rdi
+               	movabsq	$0x1f7ae2da45, %rsi     # imm = 0x1F7AE2DA45
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rdi
+               	movabsq	$0x39954428ca, %rsi     # imm = 0x39954428CA
+               	callq	 <L47>
+<L47>:
+               	leaq	-0x30(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movq	$0x0, 0x10(%rdx)
+               	movq	$0x0, 0x18(%rdx)
+               	movq	$0x0, 0x20(%rdx)
+               	movq	$0x0, 0x28(%rdx)
                	movq	$0x1, %rsi
                	addq	%rbx, %rsi
-               	leaq	(%r12), %rdi
+               	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x3, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x8(%r12), %rdi
+               	leaq	0x8(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x7, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x10(%r12), %rdi
+               	leaq	0x10(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0xf, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x18(%r12), %rdi
+               	leaq	0x18(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x1f, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x20(%r12), %rdi
+               	leaq	0x20(%rdx), %rdi
                	movq	%rsi, (%rdi)
                	movq	$0x3f, %rsi
                	addq	%rbx, %rsi
-               	leaq	0x28(%r12), %rdi
+               	leaq	0x28(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L43>
-               	jmp	 <L45>
-<L43>:
-               	leaq	(%r12,%r15,8), %rax
-               	movq	(%rax), %rsi
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rsi
-               	xorq	%rsi, %r14
-               	movq	%r13, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L44>
-<L44>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L43>
-<L45>:
-               	movq	%r13, %rdi
-               	movq	$0xb, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %r12
-               	movq	-0x40(%rbp), %r8
-               	movq	-0x50(%rbp), %r9
-               	cmpq	%r9, %r8
+               	movq	%rax, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x58(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x6, %rdi
                	jb	 <L48>
-               	movq	%r12, %rdi
-               	movq	$0x16, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r13
-               	jmp	 <L50>
+               	jmp	 <L51>
 <L48>:
-               	movq	%r12, %rdi
-               	movq	$0xb, %rsi
-               	callq	 <L49>
+               	leaq	(%rdx,%rdi,8), %r12
+               	movq	(%r12), %r15
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %r15
+               	movq	-0x58(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%r15, %r8
+               	movq	%r8, -0x68(%rbp)
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L49>
+               	jmp	 <L50>
 <L49>:
-               	movq	%rax, %r13
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	-0x68(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%r15, %r12
+               	xorq	%rax, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L49>
 <L50>:
-               	movq	%r13, %rdi
-               	movq	$0x21, %rsi
-               	callq	 <L51>
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
+               	movq	%r8, -0x60(%rbp)
+               	movq	-0x68(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x58(%rbp)
+               	cmpq	$0x6, %rdi
+               	jb	 <L48>
 <L51>:
-               	movq	%rax, %r12
-               	movq	-0x48(%rbp), %r8
-               	movq	$0xffff, %r11           # imm = 0xFFFF
-               	cmpq	%r8, %r11
-               	jb	 <L53>
-               	movq	%r12, %rdi
-               	movq	$0x2c, %rsi
-               	callq	 <L52>
+               	movq	-0x60(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
+               	jmp	 <L53>
 <L52>:
-               	movq	%rax, %r13
-               	jmp	 <L55>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0xb, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L52>
 <L53>:
-               	movq	%r12, %rdi
-               	movq	$0x21, %rsi
-               	callq	 <L54>
+               	movq	-0x38(%rbp), %r8
+               	cmpq	%r14, %r8
+               	jb	 <L56>
+               	movq	%rax, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
 <L54>:
-               	movq	%rax, %r13
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x16, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
 <L55>:
+               	jmp	 <L59>
+<L56>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0xb, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L57>
+<L58>:
+               	movq	%rax, %rdx
+<L59>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x21, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L60>
+<L61>:
+               	movq	$0xffff, %r11           # imm = 0xFFFF
+               	cmpq	%r13, %r11
+               	jb	 <L64>
+               	movq	%rdx, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x2c, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+<L63>:
+               	jmp	 <L67>
+<L64>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	$0x21, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L65>
+<L66>:
+               	movq	%rdx, %rax
+<L67>:
                	movb	%bl, %r12b
                	movl	$0x1, %ebx
                	addl	%r12d, %ebx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rax
-               	shrq	$0x1d, %rax
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	xorq	%rax, %rdx
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdx
-               	movq	%r13, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L56>
-<L56>:
-               	cmpb	$0x0, %r12b
-               	je	 <L59>
-               	cmpb	$0x1, %r12b
-               	je	 <L57>
-               	movq	$0x0, %rdx
-               	jmp	 <L58>
-<L57>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shlq	$0x11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rsi
-               	addq	$0x3039, %rsi           # imm = 0x3039
-               	movq	%rsi, %rdx
-<L58>:
-               	jmp	 <L60>
-<L59>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x1d, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rsi, %rdi
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L60>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdx
-               	shlq	$0x11, %rdx
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x2f, %rsi
-               	orq	%rsi, %rdx
-               	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L62>
-<L62>:
-               	cmpb	$0x0, %bl
-               	je	 <L65>
-               	cmpb	$0x1, %bl
-               	je	 <L63>
-               	movq	$0x0, %rdx
-               	jmp	 <L64>
-<L63>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shlq	$0x11, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	shrq	$0x2f, %rdi
-               	orq	%rdi, %rsi
-               	addq	$0x3039, %rsi           # imm = 0x3039
-               	movq	%rsi, %rdx
-<L64>:
-               	jmp	 <L66>
-<L65>:
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rsi
-               	shrq	$0x1d, %rsi
-               	movq	-0x40(%rbp), %r8
-               	movq	%r8, %rdi
-               	xorq	%rsi, %rdi
-               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rdi
-               	movq	%rdi, %rdx
-<L66>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x1d, %rdx
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	xorq	%rdx, %rsi
                	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
                	imulq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	cmpb	$0x0, %r12b
-               	je	 <L71>
-               	cmpb	$0x1, %r12b
-               	je	 <L69>
                	movq	$0x0, %rdx
-               	jmp	 <L70>
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
+               	jmp	 <L69>
+<L68>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L68>
 <L69>:
-               	movq	-0x48(%rbp), %r8
+               	cmpb	$0x0, %r12b
+               	je	 <L72>
+               	cmpb	$0x1, %r12b
+               	je	 <L70>
+               	movq	$0x0, %rdx
+               	jmp	 <L71>
+<L70>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	addq	$0x3039, %rsi           # imm = 0x3039
                	movq	%rsi, %rdx
-<L70>:
-               	jmp	 <L72>
 <L71>:
-               	movq	-0x48(%rbp), %r8
+               	jmp	 <L73>
+<L72>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x1d, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	xorq	%rsi, %rdi
                	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
                	imulq	%r11, %rdi
                	movq	%rdi, %rdx
-<L72>:
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L73>
 <L73>:
-               	movq	-0x48(%rbp), %r8
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L74>
+<L75>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdx
                	shlq	$0x11, %rdx
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x2f, %rsi
                	orq	%rsi, %rdx
                	addq	$0x3039, %rdx           # imm = 0x3039
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
-               	callq	 <L74>
-<L74>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+<L77>:
                	cmpb	$0x0, %bl
-               	je	 <L77>
+               	je	 <L80>
                	cmpb	$0x1, %bl
-               	je	 <L75>
+               	je	 <L78>
                	movq	$0x0, %rdx
-               	jmp	 <L76>
-<L75>:
-               	movq	-0x48(%rbp), %r8
+               	jmp	 <L79>
+<L78>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x48(%rbp), %r8
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	addq	$0x3039, %rsi           # imm = 0x3039
                	movq	%rsi, %rdx
-<L76>:
-               	jmp	 <L78>
-<L77>:
-               	movq	-0x48(%rbp), %r8
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	-0x38(%rbp), %r8
                	movq	%r8, %rsi
                	shrq	$0x1d, %rsi
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rcx
-               	xorq	%rsi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
                	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
-               	imulq	%r11, %rcx
-               	movq	%rcx, %rdx
-<L78>:
+               	imulq	%r11, %rdi
+               	movq	%rdi, %rdx
+<L81>:
                	movq	%rax, %rdi
                	movq	%rdx, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
-               	movq	-0xf8(%rbp), %r15
+               	callq	 <L82>
+<L82>:
+               	movq	%r13, %rdx
+               	shrq	$0x1d, %rdx
+               	movq	%r13, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L83>
+<L83>:
+               	cmpb	$0x0, %r12b
+               	je	 <L86>
+               	cmpb	$0x1, %r12b
+               	je	 <L84>
+               	movq	$0x0, %rdx
+               	jmp	 <L85>
+<L84>:
+               	movq	%r13, %rsi
+               	shlq	$0x11, %rsi
+               	movq	%r13, %rdi
+               	shrq	$0x2f, %rdi
+               	orq	%rdi, %rsi
+               	addq	$0x3039, %rsi           # imm = 0x3039
+               	movq	%rsi, %rdx
+<L85>:
+               	jmp	 <L87>
+<L86>:
+               	movq	%r13, %rsi
+               	shrq	$0x1d, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	%rdi, %rdx
+<L87>:
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L88>
+<L88>:
+               	movq	%r13, %rdx
+               	shlq	$0x11, %rdx
+               	movq	%r13, %rsi
+               	shrq	$0x2f, %rsi
+               	orq	%rsi, %rdx
+               	addq	$0x3039, %rdx           # imm = 0x3039
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L89>
+<L89>:
+               	cmpb	$0x0, %bl
+               	je	 <L92>
+               	cmpb	$0x1, %bl
+               	je	 <L90>
+               	movq	$0x0, %rdx
+               	jmp	 <L91>
+<L90>:
+               	movq	%r13, %rsi
+               	shlq	$0x11, %rsi
+               	movq	%r13, %rdi
+               	shrq	$0x2f, %rdi
+               	orq	%rdi, %rsi
+               	addq	$0x3039, %rsi           # imm = 0x3039
+               	movq	%rsi, %rdx
+<L91>:
+               	jmp	 <L93>
+<L92>:
+               	movq	%r13, %rsi
+               	shrq	$0x1d, %rsi
+               	xorq	%rsi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	movq	%r13, %rdx
+<L93>:
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L94>
+<L94>:
+               	movq	-0xf8(%rbp), %rbx
+               	movq	-0x100(%rbp), %r12
+               	movq	-0x108(%rbp), %r13
+               	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/bitcast.dis
+++ b/test/golden/x86_64-linux/convert/bitcast.dis
@@ -5,65 +5,235 @@ Disassembly of section .text:
 <corpus.cases.convert.bitcast.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movl	%edi, %eax
+               	xorl	$0xc0490fdb, %eax       # imm = 0xC0490FDB
+               	movd	%eax, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%eax, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	xorl	$0xc0490fdb, %ecx       # imm = 0xC0490FDB
-               	movl	%ecx, -0x10(%rbp)
-               	movl	-0x10(%rbp), %r12d
-               	movl	%ecx, %esi
-               	callq	 <L1>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rbx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm0
-               	callq	 <L2>
+               	movd	%xmm0, %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rax, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movabsq	$0x400921fb54442d18, %r11 # imm = 0x400921FB54442D18
-               	xorq	%r11, %rbx
-               	movq	%rbx, -0x20(%rbp)
-               	movq	-0x20(%rbp), %r12
-               	movq	%rbx, %rsi
-               	callq	 <L4>
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movabsq	$0x400921fb54442d18, %r11 # imm = 0x400921FB54442D18
+               	xorq	%r11, %rdi
+               	movq	%rdi, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	$0x40490fdb, %ecx       # imm = 0x40490FDB
-               	movl	%ecx, -0x30(%rbp)
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movss	-0x30(%rbp), %xmm0
-               	callq	 <L8>
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movabsq	$0x4005bf0a8b145769, %rsi # imm = 0x4005BF0A8B145769
-               	movq	%rsi, -0x40(%rbp)
-               	callq	 <L9>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L10>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	-0x48(%rbp), %rbx
-               	movq	-0x50(%rbp), %r12
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	movl	$0x40490fdb, %edx       # imm = 0x40490FDB
+               	movd	%edx, %xmm0
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movabsq	$0x4005bf0a8b145769, %rdx # imm = 0x4005BF0A8B145769
+               	movq	%rdx, %xmm0
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/ext_sign.dis
+++ b/test/golden/x86_64-linux/convert/ext_sign.dis
@@ -11,99 +11,337 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movl	%r12d, %r13d
-               	xorl	$-0x1, %r13d
-               	movw	%bx, %cx
-               	movl	%ecx, %r14d
-               	orl	$0x8000, %r14d          # imm = 0x8000
-               	movl	%r14d, %r15d
-               	xorl	$-0x1, %r15d
-               	movl	%ebx, %ecx
-               	movl	%ecx, %ebx
-               	orl	$0x80000000, %ebx       # imm = 0x80000000
-               	movl	%ebx, %r8d
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movl	%eax, %edx
+               	xorl	$-0x1, %edx
+               	movw	%di, %si
+               	orl	$0x8000, %esi           # imm = 0x8000
+               	movl	%esi, %ebx
+               	xorl	$-0x1, %ebx
+               	movl	%edi, %r12d
+               	movl	%r12d, %r8d
+               	orl	$0x80000000, %r8d       # imm = 0x80000000
+               	movq	%r8, -0x10(%rbp)
+               	movq	-0x10(%rbp), %r9
+               	movl	%r9d, %r8d
                	movq	%r8, -0x8(%rbp)
                	xorl	$-0x1, %r8d
                	movq	%r8, -0x8(%rbp)
-               	movsbl	%r12b, %esi
-               	callq	 <L1>
+               	movsbl	%al, %r13d
+               	movswq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movsbl	%r13b, %esi
-               	callq	 <L2>
+               	movsbl	%dl, %edi
+               	movswq	%di, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movsbl	%r12b, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movsbl	%r13b, %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
+               	movsbl	%al, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movsbq	%r12b, %r8
-               	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movsbq	%r13b, %r12
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movsbl	%dl, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movswl	%r14w, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movswl	%r15w, %esi
-               	callq	 <L8>
+               	movsbq	%al, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movswq	%r14w, %r13
-               	movq	%r13, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movswq	%r15w, %r14
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	movsbq	%dl, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movslq	%ebx, %r15
-               	movq	%r15, %rsi
-               	callq	 <L11>
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movslq	%r8d, %rbx
-               	movq	%rbx, %rsi
-               	callq	 <L12>
+               	movswl	%si, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%r13, %rdx
-               	addq	%r15, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	addq	%r14, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	callq	 <L14>
+               	movswl	%bx, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movswq	%si, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movswq	%bx, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L18>
+<L19>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movsbq	%al, %rdi
+               	movswq	%si, %rax
+               	addq	%rax, %rdi
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %rax
+               	addq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movsbq	%dl, %rax
+               	movswq	%bx, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movslq	%r8d, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/convert/ext_zero.dis
+++ b/test/golden/x86_64-linux/convert/ext_zero.dis
@@ -11,98 +11,335 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movl	$0xff, %r13d
-               	subl	%r12d, %r13d
-               	movw	%bx, %cx
-               	movl	%ecx, %r14d
-               	orl	$0x8000, %r14d          # imm = 0x8000
-               	movl	$0xffff, %r15d          # imm = 0xFFFF
-               	subl	%r14d, %r15d
-               	movl	%ebx, %ecx
-               	movl	%ecx, %ebx
-               	orl	$0x80000000, %ebx       # imm = 0x80000000
-               	movl	$0xffffffff, %r8d       # imm = 0xFFFFFFFF
-               	subl	%ebx, %r8d
-               	movq	%r8, -0x8(%rbp)
-               	movzbl	%r12b, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movzbl	%r13b, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movzbl	%r12b, %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movzbl	%r13b, %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movzbq	%r12b, %r8
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movl	$0xff, %edx
+               	subl	%eax, %edx
+               	movw	%di, %si
+               	orl	$0x8000, %esi           # imm = 0x8000
+               	movl	$0xffff, %r8d           # imm = 0xFFFF
+               	subl	%esi, %r8d
                	movq	%r8, -0x10(%rbp)
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movl	%edi, %r12d
+               	orl	$0x80000000, %r12d      # imm = 0x80000000
+               	movl	$0xffffffff, %r8d       # imm = 0xFFFFFFFF
+               	subl	%r12d, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movzbl	%al, %r13d
+               	movzwq	%r13w, %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+<L1>:
+               	movzbl	%dl, %edi
+               	movzwq	%di, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+<L3>:
+               	movzbl	%al, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movzbq	%r13b, %r12
-               	movq	%r12, %rsi
-               	callq	 <L6>
+               	movzbl	%dl, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movzwl	%r14w, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movzwl	%r15w, %esi
-               	callq	 <L8>
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movzwq	%r14w, %r13
-               	movq	%r13, %rsi
-               	callq	 <L9>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movzwq	%r15w, %r14
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	movzbq	%dl, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r15d
-               	movq	%r15, %rsi
-               	callq	 <L11>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %ebx
-               	movq	%rbx, %rsi
-               	callq	 <L12>
+               	movzwl	%si, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	%r13, %rdx
-               	addq	%r15, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	addq	%r14, %r12
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	callq	 <L14>
+               	movq	-0x10(%rbp), %r8
+               	movzwl	%r8w, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L14>
+<L15>:
+               	movzwq	%si, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movl	%r12d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movzbq	%al, %rdi
+               	movzwq	%si, %rax
+               	addq	%rax, %rdi
+               	movl	%r12d, %eax
+               	addq	%rax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdi, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movzbq	%dl, %rax
+               	movq	-0x10(%rbp), %r8
+               	movzwq	%r8w, %rdx
+               	addq	%rdx, %rax
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %edx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/convert/f2f.dis
+++ b/test/golden/x86_64-linux/convert/f2f.dis
@@ -5,98 +5,265 @@ Disassembly of section .text:
 <corpus.cases.convert.f2f.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm14
-               	addsd	%xmm14, %xmm14
-<L2>:
-               	movsd	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
+               	cvtsi2ss	%r11, %xmm1
+               	addss	%xmm1, %xmm1
+<L3>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x6c>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movss	%xmm14, -0x20(%rbp)
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0x8b>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x30(%rbp)
-               	movss	-0x30(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	callq	 <L5>
-<L5>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movss	-0x30(%rbp), %xmm0
-               	callq	 <L6>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	movd	%xmm3, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
                	movq	%rax, %rdi
-               	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L7>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0xd6>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movss	-0x50(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	callq	 <L8>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movss	-0x50(%rbp), %xmm0
-               	callq	 <L9>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L10>
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x191>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm3
+               	cvtss2sd	%xmm3, %xmm4
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.convert.f2f.checksum+0x121>
-               	addsd	-0x10(%rbp), %xmm0
-               	cvtsd2ss	%xmm0, %xmm14
-               	movss	%xmm14, -0x70(%rbp)
-               	callq	 <L11>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movss	-0x70(%rbp), %xmm0
-               	callq	 <L12>
+               	movd	%xmm3, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x14e>
-               	addss	-0x20(%rbp), %xmm0
-               	cvtss2sd	%xmm0, %xmm14
-               	movsd	%xmm14, -0x80(%rbp)
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movsd	-0x80(%rbp), %xmm0
-               	callq	 <L14>
+               	movq	%xmm4, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	-0x88(%rbp), %rbx
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2f.checksum+0x2ac>
+               	addsd	%xmm0, %xmm2
+               	cvtsd2ss	%xmm2, %xmm0
+               	movq	%xmm2, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movss	, %xmm0 <corpus.cases.convert.f2f.checksum+0x36c>
+               	addss	%xmm1, %xmm0
+               	cvtss2sd	%xmm0, %xmm1
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	%xmm1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movq	%rdx, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/f2i.dis
+++ b/test/golden/x86_64-linux/convert/f2i.dis
@@ -5,128 +5,394 @@ Disassembly of section .text:
 <corpus.cases.convert.f2i.fold_pos>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movss	%xmm0, -0x10(%rbp)
-               	movsd	%xmm1, -0x20(%rbp)
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	cvttss2si	%xmm0, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	cvttss2si	%xmm0, %r11
+               	movw	%r11w, %ax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x65>
-               	jb	 <L3>
-               	movaps	%xmm14, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x78>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L4>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	cvttss2si	%xmm14, %r11
+               	cvttss2si	%xmm0, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r11, %rsi
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movss	-0x10(%rbp), %xmm14
+               	ucomiss	, %xmm0 <corpus.cases.convert.f2i.fold_pos+0x12c>
+               	jb	 <L6>
+               	movaps	%xmm0, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x13f>
                	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	callq	 <L9>
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L7>
+<L6>:
+               	cvttss2si	%xmm0, %r11
+<L7>:
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	callq	 <L10>
+               	cvttss2si	%xmm0, %r11d
+               	movb	%r11b, %al
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	callq	 <L11>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	cvttss2si	%xmm0, %r11d
+               	movw	%r11w, %ax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x14e>
-               	jb	 <L13>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x161>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm0, %r11d
+               	movl	%r11d, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	cvttsd2si	%xmm1, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	cvttsd2si	%xmm1, %r11
+               	movw	%r11w, %ax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm1, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	ucomisd	, %xmm1 <corpus.cases.convert.f2i.fold_pos+0x445>
+               	jb	 <L24>
+               	movaps	%xmm1, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.fold_pos+0x458>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L14>
-<L13>:
-               	cvttsd2si	%xmm14, %r11
-<L14>:
-               	movq	%r11, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movsd	-0x20(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	callq	 <L19>
-<L19>:
+               	jmp	 <L25>
+<L24>:
+               	cvttsd2si	%xmm1, %r11
+<L25>:
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	cvttsd2si	%xmm1, %r11d
+               	movb	%r11b, %al
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	cvttsd2si	%xmm1, %r11d
+               	movw	%r11w, %ax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm1, %r11d
+               	movl	%r11d, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm1, %r11
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -139,51 +405,55 @@ Disassembly of section .text:
                	movsd	%xmm1, -0x20(%rbp)
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %al
+               	movsbq	%al, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %cx
+               	movswq	%cx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
-               	movl	%ecx, %esi
+               	movslq	%ecx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	movss	-0x10(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %cl
+               	movsbq	%cl, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %cx
+               	movswq	%cx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
                	movl	%r11d, %ecx
-               	movl	%ecx, %esi
+               	movslq	%ecx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rdi
                	movsd	-0x20(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
                	movq	%rbp, %rsp
@@ -193,260 +463,529 @@ Disassembly of section .text:
 <corpus.cases.convert.f2i.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x58(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
+<L1>:
                	movss	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
-<L4>:
+<L3>:
                	movsd	%xmm14, -0x20(%rbp)
-               	movss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x86>
-               	addss	-0x10(%rbp), %xmm14
-               	movss	%xmm14, -0x30(%rbp)
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x9b>
-               	addsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7a>
+               	addss	-0x10(%rbp), %xmm2
+               	movsd	, %xmm3 <corpus.cases.convert.f2i.checksum+0x87>
+               	addsd	-0x20(%rbp), %xmm3
+               	cvttss2si	%xmm2, %r11
+               	movb	%r11b, %al
+               	movzbq	%al, %rdx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	cvttss2si	%xmm2, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movss	-0x30(%rbp), %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.convert.f2i.checksum+0xfa>
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L8>
-               	movaps	%xmm14, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x10d>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L9>
 <L8>:
-               	cvttss2si	%xmm14, %r11
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movss	-0x30(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movss	-0x30(%rbp), %xmm14
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x1b6>
+               	jb	 <L10>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1c9>
                	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L11>
+<L10>:
+               	cvttss2si	%xmm2, %r11
+<L11>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	cvttss2si	%xmm2, %r11d
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L16>
+               	cvttss2si	%xmm2, %r11d
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movsd	-0x40(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1e3>
+               	cvttss2si	%xmm2, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x1f6>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	cvttss2si	%xmm2, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	cvttsd2si	%xmm3, %r11
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	cvttsd2si	%xmm3, %r11
+               	movw	%r11w, %dx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	cvttsd2si	%xmm3, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	ucomisd	, %xmm3 <corpus.cases.convert.f2i.checksum+0x4cf>
+               	jb	 <L28>
+               	movaps	%xmm3, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x4e2>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L19>
-<L18>:
-               	cvttsd2si	%xmm14, %r11
-<L19>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L23>
-<L23>:
-               	movsd	-0x40(%rbp), %xmm14
-               	cvttsd2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x280>
-               	xorps	, %xmm2 <corpus.cases.convert.f2i.checksum+0x287>
+               	jmp	 <L29>
+<L28>:
+               	cvttsd2si	%xmm3, %r11
+<L29>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	cvttsd2si	%xmm3, %r11d
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L32>
+<L33>:
+               	cvttsd2si	%xmm3, %r11d
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	cvttsd2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L36>
+<L37>:
+               	cvttsd2si	%xmm3, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+<L39>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x6cf>
+               	xorps	, %xmm2 <corpus.cases.convert.f2i.checksum+0x6d6>
                	movss	%xmm2, %xmm14           # xmm14 = xmm2[0],xmm14[1,2,3]
                	subss	-0x10(%rbp), %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x2a1>
+               	movss	%xmm14, -0x30(%rbp)
+               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x6f0>
                	subsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	movss	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x40(%rbp)
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L40>
+<L40>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L41>
+<L41>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L27>
-<L27>:
-               	movss	-0x50(%rbp), %xmm14
+               	callq	 <L42>
+<L42>:
+               	movss	-0x30(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L43>
+<L43>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L44>
+<L44>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movw	%r11w, %si
+               	movw	%r11w, %dx
+               	movswq	%dx, %rsi
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L45>
+<L45>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L31>
-<L31>:
-               	movsd	-0x60(%rbp), %xmm14
+               	callq	 <L46>
+<L46>:
+               	movsd	-0x40(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x36b>
+               	callq	 <L47>
+<L47>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7cc>
                	addss	-0x10(%rbp), %xmm2
                	cvttss2si	%xmm2, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x388>
+               	callq	 <L48>
+<L48>:
+               	movss	, %xmm2 <corpus.cases.convert.f2i.checksum+0x7ed>
                	addss	-0x10(%rbp), %xmm2
                	cvttss2si	%xmm2, %r11
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x3a6>
+               	callq	 <L49>
+<L49>:
+               	movsd	, %xmm14 <corpus.cases.convert.f2i.checksum+0x80f>
                	addsd	-0x20(%rbp), %xmm14
-               	movsd	%xmm14, -0x70(%rbp)
-               	movsd	-0x70(%rbp), %xmm14
+               	movsd	%xmm14, -0x50(%rbp)
+               	movsd	-0x50(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movsd	-0x70(%rbp), %xmm14
+               	callq	 <L50>
+<L50>:
+               	movsd	-0x50(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x3e6>
+               	callq	 <L51>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2i.checksum+0x857>
                	subsd	-0x20(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11d
-               	movb	%r11b, %sil
+               	movb	%r11b, %dl
+               	movsbq	%dl, %rsi
                	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x78(%rbp), %rbx
+               	callq	 <L52>
+<L52>:
+               	movq	-0x58(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/f2u_high.dis
+++ b/test/golden/x86_64-linux/convert/f2u_high.dis
@@ -5,11 +5,33 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.f32_u32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
                	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L0>
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -17,11 +39,33 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.f64_u32>:
                	pushq	%rbp
                	movq	%rsp, %rbp
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
                	cvttsd2si	%xmm0, %r11
-               	movl	%r11d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L0>
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+<L1>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -29,10 +73,12 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.f32_u64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.f32_u64+0xb>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	ucomiss	, %xmm0 <corpus.cases.convert.f2u_high.f32_u64+0x13>
                	jb	 <L0>
                	movaps	%xmm0, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x1e>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.f32_u64+0x26>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -40,9 +86,29 @@ Disassembly of section .text:
 <L0>:
                	cvttss2si	%xmm0, %r11
 <L1>:
-               	movq	%r11, %rsi
-               	callq	 <L2>
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -50,10 +116,12 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.f64_u64>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.f64_u64+0xc>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.f64_u64+0x14>
                	jb	 <L0>
                	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x1f>
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.f64_u64+0x27>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -61,9 +129,29 @@ Disassembly of section .text:
 <L0>:
                	cvttsd2si	%xmm0, %r11
 <L1>:
-               	movq	%r11, %rsi
-               	callq	 <L2>
+               	movq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -71,176 +159,291 @@ Disassembly of section .text:
 <corpus.cases.convert.f2u_high.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x10, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%rdi, %r11
+               	testq	%r11, %r11
+               	jl	 <L0>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L1>
 <L0>:
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L1>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x10(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
-               	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jl	 <L2>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm14
-               	addsd	%xmm14, %xmm14
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L3>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6c>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movsd	%xmm14, -0x20(%rbp)
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x82>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xa1>
-               	addss	-0x10(%rbp), %xmm2
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xde>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xc0>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xdf>
-               	addss	-0x10(%rbp), %xmm2
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x146>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0xfe>
-               	addss	-0x10(%rbp), %xmm2
-               	cvttss2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x11d>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
-<L10>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x13c>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
-<L11>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x15b>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
-<L12>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x17a>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x199>
-               	addsd	-0x20(%rbp), %xmm2
-               	cvttsd2si	%xmm2, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
-<L14>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1b8>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1c4>
-               	jb	 <L15>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x1d7>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L16>
-<L15>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x1ae>
+               	addss	%xmm0, %xmm2
                	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x216>
+               	addss	%xmm0, %xmm2
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x27e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2e6>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x206>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x212>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x34e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L18>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x225>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L19>
 <L18>:
-               	cvttss2si	%xmm2, %r11
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x3b6>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x254>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x260>
-               	jb	 <L21>
-               	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x273>
-               	cvttss2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L22>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
 <L21>:
-               	cvttss2si	%xmm2, %r11
+               	movsd	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x41e>
+               	addsd	%xmm1, %xmm2
+               	cvttsd2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2a2>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2ae>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x486>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x491>
                	jb	 <L24>
                	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x2c1>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x4a4>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
@@ -248,113 +451,334 @@ Disassembly of section .text:
 <L24>:
                	cvttss2si	%xmm2, %r11
 <L25>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L26>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2f0>
-               	addss	-0x10(%rbp), %xmm2
-               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x2fc>
-               	jb	 <L27>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x51d>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x528>
+               	jb	 <L28>
                	movaps	%xmm2, %xmm14
-               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x30f>
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x53b>
                	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L28>
-<L27>:
-               	cvttss2si	%xmm2, %r11
+               	jmp	 <L29>
 <L28>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
+               	cvttss2si	%xmm2, %r11
 <L29>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x33e>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x34b>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L30>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x35e>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
                	jmp	 <L31>
 <L30>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
 <L31>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x38d>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x39a>
-               	jb	 <L33>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x3ad>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5b4>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x5bf>
+               	jb	 <L32>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x5d2>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L34>
+               	jmp	 <L33>
+<L32>:
+               	cvttss2si	%xmm2, %r11
 <L33>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
 <L35>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3dc>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x3e9>
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x64b>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x656>
                	jb	 <L36>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x3fc>
-               	cvttsd2si	%xmm14, %r11
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x669>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
                	jmp	 <L37>
 <L36>:
-               	cvttsd2si	%xmm0, %r11
+               	cvttss2si	%xmm2, %r11
 <L37>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L38>
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x42b>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x438>
-               	jb	 <L39>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x44b>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L40>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L38>
 <L39>:
-               	cvttsd2si	%xmm0, %r11
-<L40>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x47a>
-               	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x487>
-               	jb	 <L42>
-               	movaps	%xmm0, %xmm14
-               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x49a>
-               	cvttsd2si	%xmm14, %r11
+               	movss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6e2>
+               	addss	%xmm0, %xmm2
+               	ucomiss	, %xmm2 <corpus.cases.convert.f2u_high.checksum+0x6ed>
+               	jb	 <L40>
+               	movaps	%xmm2, %xmm14
+               	subss	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x700>
+               	cvttss2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
+               	jmp	 <L41>
+<L40>:
+               	cvttss2si	%xmm2, %r11
+<L41>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L42>
                	jmp	 <L43>
 <L42>:
-               	cvttsd2si	%xmm0, %r11
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L42>
 <L43>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x779>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x785>
+               	jb	 <L44>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x798>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L45>
 <L44>:
-               	movq	-0x28(%rbp), %rbx
+               	cvttsd2si	%xmm0, %r11
+<L45>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L46>
+               	jmp	 <L47>
+<L46>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L46>
+<L47>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x811>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x81d>
+               	jb	 <L48>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x830>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L49>
+<L48>:
+               	cvttsd2si	%xmm0, %r11
+<L49>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L50>
+               	jmp	 <L51>
+<L50>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L50>
+<L51>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8a9>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x8b5>
+               	jb	 <L52>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x8c8>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L53>
+<L52>:
+               	cvttsd2si	%xmm0, %r11
+<L53>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+<L55>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x941>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x94d>
+               	jb	 <L56>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x960>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L57>
+<L56>:
+               	cvttsd2si	%xmm0, %r11
+<L57>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L58>
+               	jmp	 <L59>
+<L58>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L58>
+<L59>:
+               	movsd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9d9>
+               	addsd	%xmm1, %xmm0
+               	ucomisd	, %xmm0 <corpus.cases.convert.f2u_high.checksum+0x9e5>
+               	jb	 <L60>
+               	movaps	%xmm0, %xmm14
+               	subsd	, %xmm14 <corpus.cases.convert.f2u_high.checksum+0x9f8>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L61>
+<L60>:
+               	cvttsd2si	%xmm0, %r11
+<L61>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+               	jmp	 <L63>
+<L62>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L62>
+<L63>:
+               	movq	-0x8(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/i2f.dis
+++ b/test/golden/x86_64-linux/convert/i2f.dis
@@ -11,124 +11,423 @@ Disassembly of section .text:
                	movq	%r13, -0x38(%rbp)
                	movq	%r14, -0x40(%rbp)
                	movq	%r15, -0x48(%rbp)
-               	movq	%rsi, %rbx
-               	movq	%rdx, %r12
-               	movl	%ecx, %r13d
-               	movq	%r8, %r14
-               	movq	%r9, %r15
+               	movl	%ecx, %eax
+               	movq	%r8, %rbx
+               	movq	%r9, %r8
+               	movq	%r8, -0x20(%rbp)
                	movq	0x10(%rbp), %r8
-               	movq	%r8, -0x8(%rbp)
+               	movq	%r8, -0x18(%rbp)
                	movq	0x18(%rbp), %r8
                	movq	%r8, -0x10(%rbp)
                	movq	0x20(%rbp), %r8
-               	movq	%r8, -0x18(%rbp)
-               	movzbq	%bl, %r11
+               	movq	%r8, -0x8(%rbp)
+               	movzbq	%sil, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L0>
+               	movd	%xmm0, %r15d
+               	movl	%r15d, %r14d
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzbq	%bl, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L1>
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r14, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r15
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movzwq	%r12w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L2>
+               	movzbq	%sil, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movzwq	%r12w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r11d
+               	movzwq	%dx, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L4>
+               	movd	%xmm0, %esi
+               	movl	%esi, %r12d
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %r11d
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L5>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	%r14, %r11
-               	testq	%r11, %r11
-               	jl	 <L6>
-               	cvtsi2ss	%r11, %xmm0
+               	movzwq	%dx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
                	jmp	 <L7>
 <L6>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+<L7>:
+               	movl	%eax, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movl	%eax, %r11d
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L12>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L7>:
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %r11
+<L13>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L9>
+               	jl	 <L16>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L10>
-<L9>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L10>:
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movsbq	%r15b, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movsbq	%r15b, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movswq	%r8w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movswq	%r8w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movsbq	%r8b, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
                	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x18(%rbp), %r8
+               	movswq	%r8w, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movq	-0x10(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2ss	%r11, %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x8(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
-               	callq	 <L19>
-<L19>:
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
@@ -141,179 +440,482 @@ Disassembly of section .text:
 <corpus.cases.convert.i2f.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movb	%bl, %cl
-               	movl	%ecx, %r12d
-               	orl	$0x80, %r12d
-               	movw	%bx, %cx
-               	movl	%ecx, %r13d
-               	orl	$0x8000, %r13d          # imm = 0x8000
-               	movl	%ebx, %ecx
-               	movl	%ecx, %r14d
-               	orl	$0x80000000, %r14d      # imm = 0x80000000
-               	movq	%rbx, %r15
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %al
+               	orl	$0x80, %eax
+               	movw	%di, %dx
+               	orl	$0x8000, %edx           # imm = 0x8000
+               	movl	%edi, %esi
+               	orl	$0x80000000, %esi       # imm = 0x80000000
+               	movq	%rdi, %r8
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	orq	%r11, %r15
-               	movzbq	%r12b, %r11
+               	orq	%r11, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movzbq	%al, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L1>
+               	movd	%xmm0, %r12d
+               	movl	%r12d, %r13d
+               	movabsq	$-0x340d631b7bdddcdb, %r12 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rbx
+               	xorq	%r15, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r14
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L0>
 <L1>:
-               	movzbq	%r12b, %r11
+               	movzbq	%al, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L2>
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movzwq	%r13w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L3>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L2>
 <L3>:
-               	movzwq	%r13w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L4>
+               	movzwq	%dx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
 <L5>:
-               	movl	%r14d, %r11d
+               	movzwq	%dx, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L7>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L8>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L6>
 <L7>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
+               	movl	%esi, %r11d
                	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L8>
 <L9>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L10>
+               	movl	%esi, %r11d
                	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movsbq	%r12b, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	movsbq	%r12b, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	movswq	%r13w, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	movswq	%r13w, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movslq	%r14d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	movslq	%r14d, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%r15, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%r15, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	orq	$0x1, %rbx
-               	movq	$0x0, %r12
-               	subq	%rbx, %r12
-               	movq	%rbx, %r11
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L21>
+               	jl	 <L12>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L22>
-<L21>:
+               	jmp	 <L13>
+<L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L22>:
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	%rbx, %r11
+<L13>:
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L24>
+               	jl	 <L16>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L25>
-<L24>:
+               	jmp	 <L17>
+<L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L25>:
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%r12, %r11
+<L17>:
+               	movq	%xmm0, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+<L19>:
+               	movsbq	%al, %r11
                	cvtsi2ss	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	%r12, %r11
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r13d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r13, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r12, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movsbq	%al, %r11
                	cvtsi2sd	%r11, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rax, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movswq	%dx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %ebx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rax
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movswq	%dx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movslq	%esi, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rax
+               	movq	%r13, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
+               	movslq	%esi, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L32>
+<L33>:
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L34>
+<L35>:
+               	movq	%rdi, %rbx
+               	orq	$0x1, %rbx
+               	movq	$0x0, %r13
+               	subq	%rbx, %r13
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L36>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L37>
+<L36>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L37>:
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
+               	movq	%r12, %rdi
+               	callq	 <L38>
+<L38>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L39>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L40>
+<L39>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L40>:
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	%r13, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	movq	%r13, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%xmm0, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/convert/trunc.dis
+++ b/test/golden/x86_64-linux/convert/trunc.dis
@@ -11,67 +11,204 @@ Disassembly of section .text:
                	movq	%r13, -0x28(%rbp)
                	movq	%r14, -0x30(%rbp)
                	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
-               	xorq	%r11, %rbx
-               	orq	$0x1, %rbx
-               	movl	%ebx, %r12d
-               	movw	%bx, %r13w
-               	movb	%bl, %r14b
-               	movl	%r12d, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	xorl	$0x55555555, %ecx       # imm = 0x55555555
-               	movw	%cx, %bx
-               	movb	%cl, %r15b
-               	movq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	xorl	$0x5555, %ecx           # imm = 0x5555
-               	movb	%cl, %r8b
+               	xorq	%r11, %rdi
+               	orq	$0x1, %rdi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x10(%rbp)
+               	movw	%di, %dx
+               	movb	%dil, %r8b
                	movq	%r8, -0x8(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %rbx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L0>
+<L1>:
+               	movzwq	%dx, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+<L3>:
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L6>
+               	movzbq	%r8b, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+<L5>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %edi
+               	xorl	$0x55555555, %edi       # imm = 0x55555555
+               	movw	%di, %r12w
+               	movb	%dil, %r13b
+               	movzwq	%r12w, %rdi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	movzwq	%r13w, %rsi
-               	addq	%rsi, %rcx
-               	movzbq	%r14b, %rsi
-               	addq	%rsi, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L7>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rdi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rbx, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rbx
+               	cmpq	$0x8, %r14
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movzwq	%bx, %rcx
-               	movzbq	%r15b, %rsi
-               	addq	%rsi, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	addq	%rsi, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L8>
+               	movzbq	%r13b, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+<L9>:
+               	movl	%edx, %esi
+               	xorl	$0x5555, %esi           # imm = 0x5555
+               	movb	%sil, %dil
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rsi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rbx, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %rbx
+               	cmpq	$0x8, %r14
+               	jb	 <L10>
+<L11>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	movzwq	%dx, %rsi
+               	addq	%rsi, %rax
+               	movq	-0x8(%rbp), %r8
+               	movzbq	%r8b, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdx
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movzwq	%r12w, %rax
+               	movzbq	%r13b, %rdx
+               	addq	%rdx, %rax
+               	movzbq	%dil, %rdx
+               	addq	%rdx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	%rbx, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13

--- a/test/golden/x86_64-linux/float/arith_f32.dis
+++ b/test/golden/x86_64-linux/float/arith_f32.dis
@@ -12,27 +12,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -44,138 +83,69 @@ Disassembly of section .text:
                	movq	%rbx, -0x108(%rbp)
                	movq	%r12, -0x110(%rbp)
                	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
-               	movl	%ebx, %r13d
+               	movl	%edi, %ebx
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%r13d, %eax
+               	addl	%ebx, %eax
                	movl	%eax, -0x30(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x49>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x35>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x10(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x5e>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4a>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x20(%rbp)
                	movss	-0x10(%rbp), %xmm0
                	addss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
-<L2>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rbx
-<L4>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movss	-0x10(%rbp), %xmm0
                	subss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rdi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
-<L6>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %r12
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movss	-0x20(%rbp), %xmm0
                	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
-<L10>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rbx
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L2>
+<L2>:
                	movss	-0x10(%rbp), %xmm0
                	mulss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
-<L14>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %r12
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	movss	-0x10(%rbp), %xmm0
                	divss	-0x20(%rbp), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	movss	-0x20(%rbp), %xmm0
                	divss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movss	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1a6>
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd5>
                	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm14, %xmm14
                	subss	-0x10(%rbp), %xmm14
                	movss	%xmm14, -0x40(%rbp)
                	movq	%rax, %rdi
                	movss	-0x40(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movss	-0x10(%rbp), %xmm0
                	subss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movss	-0x40(%rbp), %xmm0
                	addss	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1f8>
+               	callq	 <L9>
+<L9>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x127>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x50(%rbp)
                	movss	-0x30(%rbp), %xmm14
@@ -183,13 +153,13 @@ Disassembly of section .text:
                	movss	%xmm14, -0x60(%rbp)
                	movq	%rax, %rdi
                	movss	-0x60(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movss	-0x60(%rbp), %xmm0
                	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movss	-0x30(%rbp), %xmm0
                	subss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
@@ -197,24 +167,24 @@ Disassembly of section .text:
                	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
                	subss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x266>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x195>
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27b>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1aa>
                	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x28b>
+               	callq	 <L14>
+<L14>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1ba>
                	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x2a1>
+               	callq	 <L15>
+<L15>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1d0>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x70(%rbp)
                	movss	-0x70(%rbp), %xmm14
@@ -222,1306 +192,1109 @@ Disassembly of section .text:
                	movss	%xmm14, -0x80(%rbp)
                	movq	%rax, %rdi
                	movss	-0x80(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movss	-0x80(%rbp), %xmm0
                	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movss	-0x30(%rbp), %xmm0
                	addss	-0x30(%rbp), %xmm0
                	movss	-0x70(%rbp), %xmm5
                	addss	%xmm0, %xmm5
                	movq	%rax, %rdi
                	movss	%xmm5, %xmm0            # xmm0 = xmm5[0],xmm0[1,2,3]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movss	-0x70(%rbp), %xmm0
                	subss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movss	-0x80(%rbp), %xmm0
                	subss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulss	-0x30(%rbp), %xmm0
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
                	movsd	%xmm0, -0xa0(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x18, %r12d
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	movl	$0x0, %r13d
+               	cmpl	$0x18, %r13d
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movss	-0xa0(%rbp), %xmm0
                	addss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x364>
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x293>
                	movss	%xmm14, -0x90(%rbp)
-               	movss	-0x90(%rbp), %xmm14
-               	ucomiss	-0x90(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
-               	movq	%rbx, %rdi
+               	movq	%r12, %rdi
                	movss	-0x90(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r14
-               	jmp	 <L38>
-<L36>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
-<L38>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
+               	callq	 <L22>
+<L22>:
+               	addl	$0x1, %r13d
+               	movq	%rax, %r12
                	movq	-0x90(%rbp), %r11
                	movq	%r11, -0xa0(%rbp)
-               	cmpl	$0x18, %r12d
-               	jb	 <L34>
-<L39>:
+               	cmpl	$0x18, %r13d
+               	jb	 <L21>
+<L23>:
                	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
+               	addl	%ebx, %eax
                	movl	%eax, -0xb0(%rbp)
-               	movss	-0xb0(%rbp), %xmm14
-               	ucomiss	-0xb0(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
-               	movq	%rbx, %rdi
-               	movss	-0xb0(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r12
-               	jmp	 <L43>
-<L41>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r12
-<L43>:
-               	movss	-0xb0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x448>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
                	movq	%r12, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rbx
-               	jmp	 <L47>
-<L45>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rbx
-<L47>:
+               	movss	-0xb0(%rbp), %xmm0
+               	callq	 <L24>
+<L24>:
+               	movss	-0xb0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x2f8>
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	movss	-0xb0(%rbp), %xmm0
                	addss	-0xb0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%rbx, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r12
-               	jmp	 <L51>
-<L49>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %r12
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	movss	-0xb0(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4dc>
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x32a>
                	movss	%xmm14, -0xc0(%rbp)
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
                	movss	-0xc0(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm0, %xmm0
                	subss	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movss	-0xb0(%rbp), %xmm0
                	mulss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movss	-0xb0(%rbp), %xmm0
                	subss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movl	$0x800000, %ecx         # imm = 0x800000
-               	addl	%r13d, %ecx
+               	addl	%ebx, %ecx
                	movl	%ecx, -0xd0(%rbp)
                	movl	$0x1, %ecx
-               	addl	%r13d, %ecx
+               	addl	%ebx, %ecx
                	movl	%ecx, -0xe0(%rbp)
                	movss	-0xd0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x564>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3b0>
                	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movss	-0xd0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57c>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x3c8>
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movss	-0xd0(%rbp), %xmm0
                	subss	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movss	-0xd0(%rbp), %xmm0
                	mulss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movss	-0xe0(%rbp), %xmm0
                	addss	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5d9>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x425>
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5f1>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x43d>
                	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movss	-0xe0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x609>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x455>
                	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movss	-0xe0(%rbp), %xmm0
                	divss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x635>
+               	callq	 <L39>
+<L39>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x47e>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0xf0(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x64d>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x496>
                	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x100(%rbp)
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movss	-0xf0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x693>
-               	movss	-0xf0(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movss	-0xf0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x4dc>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	movss	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomiss	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	-0xf0(%rbp), %xmm0
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xf0(%rbp), %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	-0x100(%rbp), %xmm4
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm4, %xmm4
                	subss	-0x100(%rbp), %xmm4
-<L72>:
+<L47>:
                	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x75c>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x5a5>
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-<L73>:
+<L48>:
                	ucomiss	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-<L74>:
+<L49>:
                	ucomiss	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomiss	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
-<L79>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7e2>
+<L54>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x62b>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L74>
-<L80>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f4>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x63d>
+               	jmp	 <L48>
+<L56>:
                	movss	-0xf0(%rbp), %xmm0
                	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	mulss	-0x100(%rbp), %xmm4
                	movss	-0xf0(%rbp), %xmm9
                	subss	%xmm4, %xmm9
-<L82>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rdi
+<L57>:
+               	movq	%rax, %rdi
                	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r12
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subss	-0xf0(%rbp), %xmm0
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8b0>
-               	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x6c7>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm4, %xmm4
-               	subss	%xmm0, %xmm4
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	-0x100(%rbp), %xmm5
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm5, %xmm5
                	subss	-0x100(%rbp), %xmm5
-<L94>:
+<L66>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x95a>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x771>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L95>:
+<L67>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9e1>
+<L73>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x7f8>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L96>
-<L102>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9f3>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x80a>
+               	jmp	 <L67>
+<L75>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	-0x100(%rbp), %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	-0x100(%rbp), %xmm5
                	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
-<L104>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%r12, %rdi
+<L76>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subss	-0x100(%rbp), %xmm0
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movss	-0xf0(%rbp), %xmm4
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaa2>
-               	movss	-0xf0(%rbp), %xmm14
-               	ucomiss	%xmm4, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movss	-0xf0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x887>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm4, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	movss	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomiss	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	-0xf0(%rbp), %xmm4
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm4, %xmm4
-               	subss	-0xf0(%rbp), %xmm4
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0xf0(%rbp), %xmm4
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm5, %xmm5
                	subss	%xmm0, %xmm5
-<L116>:
+<L85>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb5f>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x944>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L117>:
+<L86>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbe6>
+<L92>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9cb>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L118>
-<L124>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbf8>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9dd>
+               	jmp	 <L86>
+<L94>:
                	movss	-0xf0(%rbp), %xmm4
                	divss	%xmm0, %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm0, %xmm5
                	movss	-0xf0(%rbp), %xmm10
                	subss	%xmm5, %xmm10
-<L126>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rdi
+<L95>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r12
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subss	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
                	subss	-0x100(%rbp), %xmm2
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm2
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xcae>
-               	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa61>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
-               	testb	%cl, %cl
-               	jne	 <L147>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm4, %xmm4
-               	subss	%xmm0, %xmm4
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	%xmm2, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L137>
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm2, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-               	jmp	 <L138>
-<L137>:
+               	jmp	 <L104>
+<L103>:
                	xorps	%xmm5, %xmm5
                	subss	%xmm2, %xmm5
-<L138>:
+<L104>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd4c>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xaff>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L139>:
+<L105>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L146>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
                	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L140>:
+<L106>:
                	ucomiss	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
                	testb	%cl, %cl
-               	jne	 <L143>
-               	testb	%al, %al
-               	jne	 <L141>
+               	jne	 <L107>
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L142>
-<L141>:
+               	jmp	 <L108>
+<L107>:
                	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
-               	xorps	, %xmm10 <L142>
-<L142>:
-               	jmp	 <L148>
-<L143>:
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
                	ucomiss	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L144>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L145>
-<L144>:
+               	jmp	 <L111>
+<L110>:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
-<L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdd3>
+<L111>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xb86>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L140>
-<L146>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xde5>
-               	jmp	 <L139>
-<L147>:
+               	jmp	 <L106>
+<L112>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xb98>
+               	jmp	 <L105>
+<L113>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	%xmm2, %xmm4
                	cvttss2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm2, %xmm5
                	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
-<L148>:
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
+<L114>:
+               	movq	%rax, %rdi
                	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe5b>
+               	callq	 <L115>
+<L115>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xbdc>
                	mulss	-0x30(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe69>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbea>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe93>
-               	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
+               	jne	 <L118>
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xc14>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L154>:
-               	jmp	 <L156>
-<L155>:
-               	movq	%rax, %rcx
-<L156>:
-               	testb	%cl, %cl
-               	jne	 <L169>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L117>:
+               	jmp	 <L119>
+<L118>:
+               	movq	%rcx, %rdx
+<L119>:
+               	testb	%dl, %dl
+               	jne	 <L132>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L158>
-<L157>:
-               	xorps	%xmm2, %xmm2
-               	subss	%xmm0, %xmm2
-<L158>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xf0a>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L159>
-               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf21>
-               	jmp	 <L160>
-<L159>:
+               	jne	 <L120>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L121>
+<L120>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L121>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xc8b>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L122>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	jmp	 <L123>
+<L122>:
                	xorps	%xmm4, %xmm4
-               	subss	, %xmm4 <L160>
-<L160>:
+               	subss	, %xmm4 <L123>
+<L123>:
                	movss	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf3d>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xcbe>
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-<L161>:
+<L124>:
                	ucomiss	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L168>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
                	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-<L162>:
+<L125>:
                	ucomiss	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L128>
                	testb	%cl, %cl
-               	jne	 <L165>
-               	testb	%al, %al
-               	jne	 <L163>
+               	jne	 <L126>
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L164>
-<L163>:
+               	jmp	 <L127>
+<L126>:
                	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
-               	xorps	, %xmm9 <L164>
-<L164>:
-               	jmp	 <L170>
-<L165>:
+               	xorps	, %xmm9 <L127>
+<L127>:
+               	jmp	 <L133>
+<L128>:
                	ucomiss	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L166>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L129>
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L167>
-<L166>:
+               	jmp	 <L130>
+<L129>:
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
-<L167>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfc3>
+<L130>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xd44>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L162>
-<L168>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfd5>
-               	jmp	 <L161>
-<L169>:
+               	jmp	 <L125>
+<L131>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd56>
+               	jmp	 <L124>
+<L132>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfe6>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xd67>
                	cvttss2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1002>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xd83>
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm4, %xmm9
-<L170>:
-               	ucomiss	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rdi
+<L133>:
+               	movq	%rax, %rdi
                	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
-               	callq	 <L171>
-<L171>:
-               	movq	%rax, %r12
-               	jmp	 <L174>
-<L172>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L173>
-<L173>:
-               	movq	%rax, %r12
-<L174>:
+               	callq	 <L134>
+<L134>:
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L177>
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
                	movss	-0x30(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x107f>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xdce>
                	movss	-0x30(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L135>
+               	jmp	 <L136>
+<L135>:
+               	movss	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L136>:
+               	jmp	 <L138>
+<L137>:
+               	movq	%rcx, %rdx
+<L138>:
+               	testb	%dl, %dl
+               	jne	 <L151>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x30(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L139>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L140>
+<L139>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x30(%rbp), %xmm0
+<L140>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L141>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L142>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xe88>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L143>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L144>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	testb	%cl, %cl
+               	jne	 <L145>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L146>
+<L145>:
+               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L146>
+<L146>:
+               	jmp	 <L152>
+<L147>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L148>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L149>
+<L148>:
+               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L149>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xf0a>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L144>
+<L150>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf1c>
+               	jmp	 <L143>
+<L151>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x30(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L152>:
+               	movq	%rax, %rdi
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L153>
+<L153>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L156>
+               	movss	-0x100(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf99>
+               	movss	-0x100(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L154>
+               	jmp	 <L155>
+<L154>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L155>:
+               	jmp	 <L157>
+<L156>:
+               	movq	%rcx, %rdx
+<L157>:
+               	testb	%dl, %dl
+               	jne	 <L170>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L158>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L159>
+<L158>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x100(%rbp), %xmm0
+<L159>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L160>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L161>
+<L160>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L161>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1062>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L162>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L163>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L165>
+<L164>:
+               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L165>
+<L165>:
+               	jmp	 <L171>
+<L166>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L167>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L168>
+<L167>:
+               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L168>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x10e4>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L163>
+<L169>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x10f6>
+               	jmp	 <L162>
+<L170>:
+               	movss	-0x100(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x100(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L171>:
+               	movq	%rax, %rdi
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L172>
+<L172>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x114a>
+               	mulss	-0x30(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L175>
-               	jmp	 <L176>
-<L175>:
-               	movss	-0x30(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L176>:
-               	jmp	 <L178>
-<L177>:
-               	movq	%rax, %rcx
-<L178>:
-               	testb	%cl, %cl
-               	jne	 <L191>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x30(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movsd	-0x30(%rbp), %xmm0
-               	jmp	 <L180>
-<L179>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x30(%rbp), %xmm0
-<L180>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L181>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L182>
-<L181>:
-               	xorps	%xmm2, %xmm2
-               	subss	-0x100(%rbp), %xmm2
-<L182>:
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1139>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L183>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L190>
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L184>:
-               	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	testb	%al, %al
-               	jne	 <L185>
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L186>
-<L185>:
-               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L186>
-<L186>:
-               	jmp	 <L192>
-<L187>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L188>
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L189>
-<L188>:
-               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
-               	subss	%xmm7, %xmm9
-<L189>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11bb>
-               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L184>
-<L190>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11cd>
-               	jmp	 <L183>
-<L191>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	-0x100(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0x100(%rbp), %xmm2
-               	movss	-0x30(%rbp), %xmm8
-               	subss	%xmm2, %xmm8
-<L192>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L194>
-               	movq	%r12, %rdi
-               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L193>
-<L193>:
-               	movq	%rax, %rbx
-               	jmp	 <L196>
-<L194>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L195>
-<L195>:
-               	movq	%rax, %rbx
-<L196>:
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L199>
-               	movss	-0x100(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x127c>
-               	movss	-0x100(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L197>
-               	jmp	 <L198>
-<L197>:
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L198>:
-               	jmp	 <L200>
-<L199>:
-               	movq	%rax, %rcx
-<L200>:
-               	testb	%cl, %cl
-               	jne	 <L213>
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L201>
-               	movsd	-0x100(%rbp), %xmm0
-               	jmp	 <L202>
-<L201>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x100(%rbp), %xmm0
-<L202>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L203>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L204>
-<L203>:
-               	xorps	%xmm2, %xmm2
-               	subss	-0x100(%rbp), %xmm2
-<L204>:
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1345>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L205>:
-               	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L212>
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L206>:
-               	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	testb	%al, %al
-               	jne	 <L207>
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L208>
-<L207>:
-               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L208>
-<L208>:
-               	jmp	 <L214>
-<L209>:
-               	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L210>
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L211>
-<L210>:
-               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
-               	subss	%xmm7, %xmm9
-<L211>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13c7>
-               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L206>
-<L212>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13d9>
-               	jmp	 <L205>
-<L213>:
-               	movss	-0x100(%rbp), %xmm0
-               	divss	-0x100(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0x100(%rbp), %xmm2
-               	movss	-0x100(%rbp), %xmm8
-               	subss	%xmm2, %xmm8
-<L214>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L216>
-               	movq	%rbx, %rdi
-               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %r12
-               	jmp	 <L218>
-<L216>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r12
-<L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x145f>
-               	mulss	-0x30(%rbp), %xmm0
-               	movss	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomiss	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L221>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1497>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1182>
                	ucomiss	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L219>
-               	jmp	 <L220>
-<L219>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L173>
+               	jmp	 <L174>
+<L173>:
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L220>:
-               	jmp	 <L222>
-<L221>:
-               	movq	%rax, %rcx
-<L222>:
-               	testb	%cl, %cl
-               	jne	 <L235>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L174>:
+               	jmp	 <L176>
+<L175>:
+               	movq	%rcx, %rdx
+<L176>:
+               	testb	%dl, %dl
+               	jne	 <L189>
                	xorps	%xmm14, %xmm14
                	ucomiss	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L223>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L224>
-<L223>:
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-<L224>:
-               	xorps	%xmm14, %xmm14
-               	ucomiss	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L225>
+               	jne	 <L177>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L178>
+<L177>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L178>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L179>
                	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	xorps	%xmm2, %xmm2
                	subss	-0x100(%rbp), %xmm2
-<L226>:
+<L180>:
                	movss	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1541>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x122c>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L227>:
+<L181>:
                	ucomiss	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L234>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L188>
                	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L228>:
+<L182>:
                	ucomiss	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L185>
                	testb	%cl, %cl
-               	jne	 <L231>
-               	testb	%al, %al
-               	jne	 <L229>
+               	jne	 <L183>
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L230>
-<L229>:
+               	jmp	 <L184>
+<L183>:
                	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
-               	xorps	, %xmm8 <L230>
-<L230>:
-               	jmp	 <L236>
-<L231>:
+               	xorps	, %xmm8 <L184>
+<L184>:
+               	jmp	 <L190>
+<L185>:
                	ucomiss	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L232>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L186>
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L233>
-<L232>:
+               	jmp	 <L187>
+<L186>:
                	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
-<L233>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15c3>
+<L187>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x12ae>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L228>
-<L234>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15d5>
-               	jmp	 <L227>
-<L235>:
+               	jmp	 <L182>
+<L188>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x12c0>
+               	jmp	 <L181>
+<L189>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	-0x100(%rbp), %xmm1
                	cvttss2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	-0x100(%rbp), %xmm2
                	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
                	subss	%xmm2, %xmm8
-<L236>:
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r12, %rdi
+<L190>:
+               	movq	%rax, %rdi
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
-               	movq	%rbx, %rax
+               	callq	 <L191>
+<L191>:
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/arith_f64.dis
+++ b/test/golden/x86_64-linux/float/arith_f64.dis
@@ -12,27 +12,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -44,137 +83,69 @@ Disassembly of section .text:
                	movq	%rbx, -0x108(%rbp)
                	movq	%r12, -0x110(%rbp)
                	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
                	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
                	addq	%rbx, %rax
                	movq	%rax, -0x30(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4c>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x3d>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x10(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x61>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x52>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x20(%rbp)
                	movsd	-0x10(%rbp), %xmm0
                	addsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %r13
-               	jmp	 <L4>
-<L2>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %r13
-<L4>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movsd	-0x10(%rbp), %xmm0
                	subsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%r13, %rdi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
-<L6>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %r12
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movsd	-0x20(%rbp), %xmm0
                	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r13
-               	jmp	 <L12>
-<L10>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %r13
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L2>
+<L2>:
                	movsd	-0x10(%rbp), %xmm0
                	mulsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%r13, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
-<L14>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %r12
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	movsd	-0x10(%rbp), %xmm0
                	divsd	-0x20(%rbp), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	movsd	-0x20(%rbp), %xmm0
                	divsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
+               	callq	 <L5>
+<L5>:
                	movsd	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b5>
+               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xdd>
                	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
+               	callq	 <L6>
+<L6>:
                	xorps	%xmm14, %xmm14
                	subsd	-0x10(%rbp), %xmm14
                	movsd	%xmm14, -0x40(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x40(%rbp), %xmm0
-               	callq	 <L20>
-<L20>:
+               	callq	 <L7>
+<L7>:
                	movsd	-0x10(%rbp), %xmm0
                	subsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L8>
+<L8>:
                	movsd	-0x40(%rbp), %xmm0
                	addsd	-0x10(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x207>
+               	callq	 <L9>
+<L9>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x12f>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x50(%rbp)
                	movsd	-0x30(%rbp), %xmm14
@@ -182,13 +153,13 @@ Disassembly of section .text:
                	movsd	%xmm14, -0x60(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x60(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
+               	callq	 <L10>
+<L10>:
                	movsd	-0x60(%rbp), %xmm0
                	mulsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
+               	callq	 <L11>
+<L11>:
                	movsd	-0x30(%rbp), %xmm0
                	subsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
@@ -196,24 +167,24 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
                	subsd	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
+               	callq	 <L12>
+<L12>:
                	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x275>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x19d>
                	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
+               	callq	 <L13>
+<L13>:
                	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x28a>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b2>
                	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x29a>
+               	callq	 <L14>
+<L14>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1c2>
                	divsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x2b0>
+               	callq	 <L15>
+<L15>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x1d8>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x70(%rbp)
                	movsd	-0x70(%rbp), %xmm14
@@ -221,161 +192,95 @@ Disassembly of section .text:
                	movsd	%xmm14, -0x80(%rbp)
                	movq	%rax, %rdi
                	movsd	-0x80(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L16>
+<L16>:
                	movsd	-0x80(%rbp), %xmm0
                	addsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
+               	callq	 <L17>
+<L17>:
                	movsd	-0x30(%rbp), %xmm0
                	addsd	-0x30(%rbp), %xmm0
                	movsd	-0x70(%rbp), %xmm5
                	addsd	%xmm0, %xmm5
                	movq	%rax, %rdi
                	movsd	%xmm5, %xmm0            # xmm0 = xmm5[0],xmm0[1]
-               	callq	 <L31>
-<L31>:
+               	callq	 <L18>
+<L18>:
                	movsd	-0x70(%rbp), %xmm0
                	subsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
+               	callq	 <L19>
+<L19>:
                	movsd	-0x80(%rbp), %xmm0
                	subsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
+               	callq	 <L20>
+<L20>:
                	xorps	%xmm0, %xmm0
                	mulsd	-0x30(%rbp), %xmm0
                	movq	%rax, %r12
                	movsd	%xmm0, -0xa0(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x18, %r13
-               	jb	 <L34>
-               	jmp	 <L39>
-<L34>:
+               	jb	 <L21>
+               	jmp	 <L23>
+<L21>:
                	movsd	-0xa0(%rbp), %xmm0
                	addsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x374>
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x29c>
                	movsd	%xmm14, -0x90(%rbp)
-               	movsd	-0x90(%rbp), %xmm14
-               	ucomisd	-0x90(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L36>
                	movq	%r12, %rdi
                	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r14
-               	jmp	 <L38>
-<L36>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
-<L38>:
+               	callq	 <L22>
+<L22>:
                	addq	$0x1, %r13
-               	movq	%r14, %r12
+               	movq	%rax, %r12
                	movq	-0x90(%rbp), %r11
                	movq	%r11, -0xa0(%rbp)
                	cmpq	$0x18, %r13
-               	jb	 <L34>
-<L39>:
+               	jb	 <L21>
+<L23>:
                	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, -0xb0(%rbp)
-               	movsd	-0xb0(%rbp), %xmm14
-               	ucomisd	-0xb0(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L41>
                	movq	%r12, %rdi
                	movsd	-0xb0(%rbp), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %r13
-               	jmp	 <L43>
-<L41>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r13
-<L43>:
+               	callq	 <L24>
+<L24>:
                	movsd	-0xb0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x464>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L45>
-               	movq	%r13, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %r12
-               	jmp	 <L47>
-<L45>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %r12
-<L47>:
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x308>
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	movsd	-0xb0(%rbp), %xmm0
                	addsd	-0xb0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L49>
-               	movq	%r12, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r13
-               	jmp	 <L51>
-<L49>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %r13
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	movsd	-0xb0(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4fe>
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x33a>
                	movsd	%xmm14, -0xc0(%rbp)
-               	movq	%r13, %rdi
+               	movq	%rax, %rdi
                	movsd	-0xc0(%rbp), %xmm0
-               	callq	 <L52>
-<L52>:
+               	callq	 <L27>
+<L27>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
+               	callq	 <L28>
+<L28>:
                	movsd	-0xb0(%rbp), %xmm0
                	mulsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
+               	callq	 <L29>
+<L29>:
                	movsd	-0xb0(%rbp), %xmm0
                	subsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
+               	callq	 <L30>
+<L30>:
                	movabsq	$0x10000000000000, %rcx # imm = 0x10000000000000
                	addq	%rbx, %rcx
                	movq	%rcx, -0xd0(%rbp)
@@ -383,1119 +288,988 @@ Disassembly of section .text:
                	addq	%rbx, %rcx
                	movq	%rcx, -0xe0(%rbp)
                	movsd	-0xd0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x58f>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x3cb>
                	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
+               	callq	 <L31>
+<L31>:
                	movsd	-0xd0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5a7>
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x3e3>
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
+               	callq	 <L32>
+<L32>:
                	movsd	-0xd0(%rbp), %xmm0
                	subsd	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
+               	callq	 <L33>
+<L33>:
                	movsd	-0xd0(%rbp), %xmm0
                	mulsd	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
+               	callq	 <L34>
+<L34>:
                	movsd	-0xe0(%rbp), %xmm0
                	addsd	-0xe0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
+               	callq	 <L35>
+<L35>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x604>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x440>
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
+               	callq	 <L36>
+<L36>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x61c>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x458>
                	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
+               	callq	 <L37>
+<L37>:
                	movsd	-0xe0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x634>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x470>
                	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
+               	callq	 <L38>
+<L38>:
                	movsd	-0xe0(%rbp), %xmm0
                	divsd	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rbx
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x660>
+               	callq	 <L39>
+<L39>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x499>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0xf0(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x678>
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4b1>
                	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x100(%rbp)
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L67>
-               	movsd	-0xf0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x6bf>
-               	movsd	-0xf0(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L65>
-               	jmp	 <L66>
-<L65>:
+               	jne	 <L42>
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x4f8>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L40>
+               	jmp	 <L41>
+<L40>:
                	movsd	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L66>:
-               	jmp	 <L68>
-<L67>:
-               	movq	%rax, %rcx
-<L68>:
-               	testb	%cl, %cl
-               	jne	 <L81>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L41>:
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	testb	%dl, %dl
+               	jne	 <L56>
                	xorps	%xmm14, %xmm14
                	ucomisd	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L69>
-               	movsd	-0xf0(%rbp), %xmm0
-               	jmp	 <L70>
-<L69>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xf0(%rbp), %xmm0
-<L70>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L71>
+               	jne	 <L44>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L45>
+<L44>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+<L45>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L46>
                	movsd	-0x100(%rbp), %xmm4
-               	jmp	 <L72>
-<L71>:
+               	jmp	 <L47>
+<L46>:
                	xorps	%xmm4, %xmm4
                	subsd	-0x100(%rbp), %xmm4
-<L72>:
+<L47>:
                	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x78c>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x5c5>
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-<L73>:
+<L48>:
                	ucomisd	%xmm6, %xmm5
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L80>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L55>
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-<L74>:
+<L49>:
                	ucomisd	%xmm4, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L52>
                	testb	%cl, %cl
-               	jne	 <L77>
-               	testb	%al, %al
-               	jne	 <L75>
+               	jne	 <L50>
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-               	jmp	 <L76>
-<L75>:
+               	jmp	 <L51>
+<L50>:
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-               	xorps	, %xmm9 <L76>
-<L76>:
-               	jmp	 <L82>
-<L77>:
+               	xorps	, %xmm9 <L51>
+<L51>:
+               	jmp	 <L57>
+<L52>:
                	ucomisd	%xmm8, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L78>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L53>
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	jmp	 <L79>
-<L78>:
+               	jmp	 <L54>
+<L53>:
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
                	subsd	%xmm8, %xmm10
-<L79>:
-               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x815>
+<L54>:
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x64e>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
-               	jmp	 <L74>
-<L80>:
-               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x827>
-               	jmp	 <L73>
-<L81>:
+               	jmp	 <L49>
+<L55>:
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x660>
+               	jmp	 <L48>
+<L56>:
                	movsd	-0xf0(%rbp), %xmm0
                	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	mulsd	-0x100(%rbp), %xmm4
                	movsd	-0xf0(%rbp), %xmm9
                	subsd	%xmm4, %xmm9
-<L82>:
-               	ucomisd	%xmm9, %xmm9
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L84>
-               	movq	%rbx, %rdi
+<L57>:
+               	movq	%rax, %rdi
                	movsd	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1]
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r12
-               	jmp	 <L86>
-<L84>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-<L86>:
+               	callq	 <L58>
+<L58>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf0(%rbp), %xmm0
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L89>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e7>
-               	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L87>
-               	jmp	 <L88>
-<L87>:
+               	jne	 <L61>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x6eb>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L59>
+               	jmp	 <L60>
+<L59>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L88>:
-               	jmp	 <L90>
-<L89>:
-               	movq	%rax, %rcx
-<L90>:
-               	testb	%cl, %cl
-               	jne	 <L103>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L60>:
+               	jmp	 <L62>
+<L61>:
+               	movq	%rcx, %rdx
+<L62>:
+               	testb	%dl, %dl
+               	jne	 <L75>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L91>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L92>
-<L91>:
-               	xorps	%xmm4, %xmm4
-               	subsd	%xmm0, %xmm4
-<L92>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L93>
+               	jne	 <L63>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L64>
+<L63>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L64>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L65>
                	movsd	-0x100(%rbp), %xmm5
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L66>
+<L65>:
                	xorps	%xmm5, %xmm5
                	subsd	-0x100(%rbp), %xmm5
-<L94>:
+<L66>:
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x995>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x799>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L95>:
+<L67>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L102>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L74>
                	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L96>:
+<L68>:
                	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L71>
                	testb	%cl, %cl
-               	jne	 <L99>
-               	testb	%al, %al
-               	jne	 <L97>
+               	jne	 <L69>
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L98>
-<L97>:
+               	jmp	 <L70>
+<L69>:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L98>
-<L98>:
-               	jmp	 <L104>
-<L99>:
+               	xorps	, %xmm10 <L70>
+<L70>:
+               	jmp	 <L76>
+<L71>:
                	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L100>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L72>
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L101>
-<L100>:
+               	jmp	 <L73>
+<L72>:
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa1f>
+<L73>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x823>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L96>
-<L102>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa31>
-               	jmp	 <L95>
-<L103>:
+               	jmp	 <L68>
+<L74>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x835>
+               	jmp	 <L67>
+<L75>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	divsd	-0x100(%rbp), %xmm4
                	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	mulsd	-0x100(%rbp), %xmm5
                	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
                	subsd	%xmm5, %xmm10
-<L104>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%r12, %rdi
+<L76>:
+               	movq	%rax, %rdi
                	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-               	jmp	 <L108>
-<L106>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rbx
-<L108>:
+               	callq	 <L77>
+<L77>:
                	xorps	%xmm0, %xmm0
                	subsd	-0x100(%rbp), %xmm0
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L111>
-               	movsd	-0xf0(%rbp), %xmm4
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xae4>
-               	movsd	-0xf0(%rbp), %xmm14
-               	ucomisd	%xmm4, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L109>
-               	jmp	 <L110>
-<L109>:
+               	jne	 <L80>
+               	movsd	-0xf0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8b3>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm4, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L78>
+               	jmp	 <L79>
+<L78>:
                	movsd	-0xf0(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L110>:
-               	jmp	 <L112>
-<L111>:
-               	movq	%rax, %rcx
-<L112>:
-               	testb	%cl, %cl
-               	jne	 <L125>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L79>:
+               	jmp	 <L81>
+<L80>:
+               	movq	%rcx, %rdx
+<L81>:
+               	testb	%dl, %dl
+               	jne	 <L94>
                	xorps	%xmm14, %xmm14
                	ucomisd	-0xf0(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movsd	-0xf0(%rbp), %xmm4
-               	jmp	 <L114>
-<L113>:
-               	xorps	%xmm4, %xmm4
-               	subsd	-0xf0(%rbp), %xmm4
-<L114>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L115>
+               	jne	 <L82>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L83>
+<L82>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0xf0(%rbp), %xmm4
+<L83>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L84>
                	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
-               	jmp	 <L116>
-<L115>:
+               	jmp	 <L85>
+<L84>:
                	xorps	%xmm5, %xmm5
                	subsd	%xmm0, %xmm5
-<L116>:
+<L85>:
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xba5>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x974>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L117>:
+<L86>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L124>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L93>
                	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L118>:
+<L87>:
                	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L90>
                	testb	%cl, %cl
-               	jne	 <L121>
-               	testb	%al, %al
-               	jne	 <L119>
+               	jne	 <L88>
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L120>
-<L119>:
+               	jmp	 <L89>
+<L88>:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L120>
-<L120>:
-               	jmp	 <L126>
-<L121>:
+               	xorps	, %xmm10 <L89>
+<L89>:
+               	jmp	 <L95>
+<L90>:
                	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L122>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L91>
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L123>
-<L122>:
+               	jmp	 <L92>
+<L91>:
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
-<L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc2f>
+<L92>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x9fe>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L118>
-<L124>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc41>
-               	jmp	 <L117>
-<L125>:
+               	jmp	 <L87>
+<L93>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa10>
+               	jmp	 <L86>
+<L94>:
                	movsd	-0xf0(%rbp), %xmm4
                	divsd	%xmm0, %xmm4
                	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm0, %xmm5
                	movsd	-0xf0(%rbp), %xmm10
                	subsd	%xmm5, %xmm10
-<L126>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rbx, %rdi
+<L95>:
+               	movq	%rax, %rdi
                	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r12
-               	jmp	 <L130>
-<L128>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-<L130>:
+               	callq	 <L96>
+<L96>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
                	subsd	-0x100(%rbp), %xmm2
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm2
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcfb>
-               	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L131>
-               	jmp	 <L132>
-<L131>:
+               	jne	 <L99>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xa95>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L97>
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L98>:
+               	jmp	 <L100>
+<L99>:
+               	movq	%rcx, %rdx
+<L100>:
+               	testb	%dl, %dl
+               	jne	 <L113>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L101>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L102>
+<L101>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L102>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L103>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L104>
+<L103>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm2, %xmm5
+<L104>:
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb37>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L105>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L112>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L106>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L109>
+               	testb	%cl, %cl
+               	jne	 <L107>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L108>
+<L107>:
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L108>
+<L108>:
+               	jmp	 <L114>
+<L109>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L110>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L111>
+<L110>:
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L111>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xbc1>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L106>
+<L112>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xbd3>
+               	jmp	 <L105>
+<L113>:
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	%xmm2, %xmm4
+               	cvttsd2si	%xmm4, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm4
+               	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
+               	mulsd	%xmm2, %xmm5
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L114>:
+               	movq	%rax, %rdi
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L115>
+<L115>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xc17>
+               	mulsd	-0x30(%rbp), %xmm0
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xc28>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L116>
+               	jmp	 <L117>
+<L116>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
                	setne	%cl
                	setp	%r11b
                	orb	%r11b, %cl
                	movzbq	%cl, %rcx
-<L132>:
-               	jmp	 <L134>
-<L133>:
-               	movq	%rax, %rcx
-<L134>:
+<L117>:
                	testb	%cl, %cl
-               	jne	 <L147>
+               	jne	 <L128>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L135>
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	jmp	 <L136>
-<L135>:
-               	xorps	%xmm4, %xmm4
-               	subsd	%xmm0, %xmm4
-<L136>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm2, %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L137>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-               	jmp	 <L138>
-<L137>:
-               	xorps	%xmm5, %xmm5
-               	subsd	%xmm2, %xmm5
-<L138>:
-               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd9d>
-               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L139>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L146>
-               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
-               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
-<L140>:
-               	ucomisd	%xmm5, %xmm9
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L143>
-               	testb	%al, %al
-               	jne	 <L141>
-               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	jmp	 <L142>
-<L141>:
-               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
-               	xorps	, %xmm10 <L142>
-<L142>:
-               	jmp	 <L148>
-<L143>:
-               	ucomisd	%xmm9, %xmm8
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L144>
-               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	jmp	 <L145>
-<L144>:
-               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
-               	subsd	%xmm9, %xmm11
-<L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe27>
-               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
-               	jmp	 <L140>
-<L146>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe39>
-               	jmp	 <L139>
-<L147>:
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	%xmm2, %xmm4
-               	cvttsd2si	%xmm4, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm4
-               	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
-               	mulsd	%xmm2, %xmm5
-               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
-               	subsd	%xmm5, %xmm10
-<L148>:
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
-               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xeb2>
-               	mulsd	-0x30(%rbp), %xmm0
+               	jne	 <L118>
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xec3>
-               	ucomisd	%xmm2, %xmm0
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	jmp	 <L154>
-<L153>:
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-<L154>:
-               	testb	%al, %al
-               	jne	 <L165>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L155>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	jmp	 <L156>
-<L155>:
+               	jmp	 <L119>
+<L118>:
                	xorps	%xmm2, %xmm2
                	subsd	%xmm0, %xmm2
-<L156>:
+<L119>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf35>
-               	movsd	, %xmm5 <L157>
-<L157>:
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc9a>
+               	movsd	, %xmm5 <L120>
+<L120>:
                	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L164>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L127>
                	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L158>:
-               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf60>
-               	setae	%cl
-               	movzbq	%cl, %rcx
+<L121>:
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xcc5>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L124>
                	testb	%cl, %cl
-               	jne	 <L161>
-               	testb	%al, %al
-               	jne	 <L159>
+               	jne	 <L122>
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L160>
-<L159>:
+               	jmp	 <L123>
+<L122>:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L160>
-<L160>:
-               	jmp	 <L166>
-<L161>:
+               	xorps	, %xmm8 <L123>
+<L123>:
+               	jmp	 <L129>
+<L124>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L162>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L125>
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L163>
-<L162>:
+               	jmp	 <L126>
+<L125>:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
-<L163>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfc2>
+<L126>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xd27>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L158>
-<L164>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfd4>
-               	jmp	 <L157>
-<L165>:
+               	jmp	 <L121>
+<L127>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xd39>
+               	jmp	 <L120>
+<L128>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfe5>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xd4a>
                	cvttsd2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm2
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1001>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xd66>
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm4, %xmm8
-<L166>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L168>
-               	movq	%rbx, %rdi
+<L129>:
+               	movq	%rax, %rdi
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L167>
-<L167>:
-               	movq	%rax, %r12
-               	jmp	 <L170>
-<L168>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L169>
-<L169>:
-               	movq	%rax, %r12
-<L170>:
+               	callq	 <L130>
+<L130>:
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm14
-               	sete	%al
+               	sete	%cl
                	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L173>
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L133>
                	movsd	-0x30(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1082>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xdb2>
                	movsd	-0x30(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	movsd	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rcx, %rdx
+<L134>:
+               	testb	%dl, %dl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x30(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L135>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x30(%rbp), %xmm0
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L137>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L138>:
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xe70>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L139>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L146>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L140>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L143>
+               	testb	%cl, %cl
+               	jne	 <L141>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L142>
+<L141>:
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L142>
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L144>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L145>
+<L144>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L145>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xef5>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xf07>
+               	jmp	 <L139>
+<L147>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x30(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L148>:
+               	movq	%rax, %rdi
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L149>
+<L149>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L152>
+               	movsd	-0x100(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xf85>
+               	movsd	-0x100(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L150>
+               	jmp	 <L151>
+<L150>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L151>:
+               	jmp	 <L153>
+<L152>:
+               	movq	%rcx, %rdx
+<L153>:
+               	testb	%dl, %dl
+               	jne	 <L166>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L154>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L155>
+<L154>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x100(%rbp), %xmm0
+<L155>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L156>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L157>
+<L156>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L157>:
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1052>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L158>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L165>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L159>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L162>
+               	testb	%cl, %cl
+               	jne	 <L160>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L161>
+<L160>:
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L161>
+<L161>:
+               	jmp	 <L167>
+<L162>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L163>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L164>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x10d7>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L159>
+<L165>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x10e9>
+               	jmp	 <L158>
+<L166>:
+               	movsd	-0x100(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x100(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L167>:
+               	movq	%rax, %rdi
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L168>
+<L168>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x113d>
+               	mulsd	-0x30(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
                	sete	%cl
                	setnp	%r11b
                	andb	%r11b, %cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L171>
-               	jmp	 <L172>
-<L171>:
-               	movsd	-0x30(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L172>:
-               	jmp	 <L174>
-<L173>:
-               	movq	%rax, %rcx
-<L174>:
-               	testb	%cl, %cl
-               	jne	 <L187>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x30(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movsd	-0x30(%rbp), %xmm0
-               	jmp	 <L176>
-<L175>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x30(%rbp), %xmm0
-<L176>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L177>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L178>
-<L177>:
-               	xorps	%xmm2, %xmm2
-               	subsd	-0x100(%rbp), %xmm2
-<L178>:
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1140>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L179>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L186>
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L180>:
-               	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L183>
-               	testb	%al, %al
-               	jne	 <L181>
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L182>
-<L181>:
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L182>
-<L182>:
-               	jmp	 <L188>
-<L183>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L184>
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L185>
-<L184>:
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	subsd	%xmm7, %xmm9
-<L185>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11c5>
-               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L180>
-<L186>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d7>
-               	jmp	 <L179>
-<L187>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	-0x100(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0x100(%rbp), %xmm2
-               	movsd	-0x30(%rbp), %xmm8
-               	subsd	%xmm2, %xmm8
-<L188>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L190>
-               	movq	%r12, %rdi
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L189>
-<L189>:
-               	movq	%rax, %rbx
-               	jmp	 <L192>
-<L190>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L191>
-<L191>:
-               	movq	%rax, %rbx
-<L192>:
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L195>
-               	movsd	-0x100(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x128a>
-               	movsd	-0x100(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L193>
-               	jmp	 <L194>
-<L193>:
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L194>:
-               	jmp	 <L196>
-<L195>:
-               	movq	%rax, %rcx
-<L196>:
-               	testb	%cl, %cl
-               	jne	 <L209>
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L197>
-               	movsd	-0x100(%rbp), %xmm0
-               	jmp	 <L198>
-<L197>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x100(%rbp), %xmm0
-<L198>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L199>
-               	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L200>
-<L199>:
-               	xorps	%xmm2, %xmm2
-               	subsd	-0x100(%rbp), %xmm2
-<L200>:
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1357>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L201>:
-               	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L208>
-               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L202>:
-               	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L205>
-               	testb	%al, %al
-               	jne	 <L203>
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L204>
-<L203>:
-               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L204>
-<L204>:
-               	jmp	 <L210>
-<L205>:
-               	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L206>
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L207>
-<L206>:
-               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	subsd	%xmm7, %xmm9
-<L207>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13dc>
-               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L202>
-<L208>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13ee>
-               	jmp	 <L201>
-<L209>:
-               	movsd	-0x100(%rbp), %xmm0
-               	divsd	-0x100(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0x100(%rbp), %xmm2
-               	movsd	-0x100(%rbp), %xmm8
-               	subsd	%xmm2, %xmm8
-<L210>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L212>
-               	movq	%rbx, %rdi
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r12
-               	jmp	 <L214>
-<L212>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %r12
-<L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1477>
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	-0x100(%rbp), %xmm14
-               	xorps	%xmm15, %xmm15
-               	ucomisd	%xmm15, %xmm14
-               	sete	%al
-               	setnp	%r11b
-               	andb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L217>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x14b0>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1176>
                	ucomisd	%xmm1, %xmm0
-               	sete	%cl
+               	sete	%dl
                	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L215>
-               	jmp	 <L216>
-<L215>:
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L169>
+               	jmp	 <L170>
+<L169>:
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm0
-               	setne	%cl
+               	setne	%dl
                	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-<L216>:
-               	jmp	 <L218>
-<L217>:
-               	movq	%rax, %rcx
-<L218>:
-               	testb	%cl, %cl
-               	jne	 <L231>
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+<L170>:
+               	jmp	 <L172>
+<L171>:
+               	movq	%rcx, %rdx
+<L172>:
+               	testb	%dl, %dl
+               	jne	 <L185>
                	xorps	%xmm14, %xmm14
                	ucomisd	%xmm0, %xmm14
-               	seta	%al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L219>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L220>
-<L219>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-<L220>:
-               	xorps	%xmm14, %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
-               	jne	 <L221>
+               	jne	 <L173>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L174>
+<L173>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L174>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L175>
                	movsd	-0x100(%rbp), %xmm2
-               	jmp	 <L222>
-<L221>:
+               	jmp	 <L176>
+<L175>:
                	xorps	%xmm2, %xmm2
                	subsd	-0x100(%rbp), %xmm2
-<L222>:
+<L176>:
                	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x155e>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1224>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-<L223>:
+<L177>:
                	ucomisd	%xmm5, %xmm4
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L230>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L184>
                	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
-<L224>:
+<L178>:
                	ucomisd	%xmm2, %xmm7
-               	setae	%cl
-               	movzbq	%cl, %rcx
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L181>
                	testb	%cl, %cl
-               	jne	 <L227>
-               	testb	%al, %al
-               	jne	 <L225>
+               	jne	 <L179>
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	jmp	 <L226>
-<L225>:
+               	jmp	 <L180>
+<L179>:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
-               	xorps	, %xmm8 <L226>
-<L226>:
-               	jmp	 <L232>
-<L227>:
+               	xorps	, %xmm8 <L180>
+<L180>:
+               	jmp	 <L186>
+<L181>:
                	ucomisd	%xmm7, %xmm6
-               	setae	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L228>
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L182>
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
-               	jmp	 <L229>
-<L228>:
+               	jmp	 <L183>
+<L182>:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
-<L229>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15e3>
+<L183>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x12a9>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
-               	jmp	 <L224>
-<L230>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15f5>
-               	jmp	 <L223>
-<L231>:
+               	jmp	 <L178>
+<L184>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x12bb>
+               	jmp	 <L177>
+<L185>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	-0x100(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
+               	movq	%r11, %rcx
+               	movq	%rcx, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	-0x100(%rbp), %xmm2
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm2, %xmm8
-<L232>:
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%r12, %rdi
+<L186>:
+               	movq	%rax, %rdi
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %rbx
-               	jmp	 <L236>
-<L234>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %rbx
-<L236>:
-               	movq	%rbx, %rax
+               	callq	 <L187>
+<L187>:
                	movq	-0x108(%rbp), %rbx
                	movq	-0x110(%rbp), %r12
                	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/cmp_f32.dis
+++ b/test/golden/x86_64-linux/float/cmp_f32.dis
@@ -7,27 +7,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,16 +74,13 @@ Disassembly of section .text:
 <corpus.cases.float.cmp_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xb0, %rsp
-               	movq	%rbx, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movl	%edi, %eax
                	leaq	-0x30(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
@@ -53,470 +89,648 @@ Disassembly of section .text:
                	movq	$0x0, 0x20(%rbx)
                	movq	$0x0, 0x28(%rbx)
                	movl	$0xff800000, %edx       # imm = 0xFF800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0xbf800000, %edx       # imm = 0xBF800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x4(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80800000, %edx       # imm = 0x80800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x8(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80000001, %edx       # imm = 0x80000001
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0xc(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x80000000, %edx       # imm = 0x80000000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x10(%rbx), %rdx
                	movss	%xmm0, (%rdx)
-               	movd	%ecx, %xmm0
+               	movd	%eax, %xmm0
                	leaq	0x14(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x1, %edx
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x18(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x3f800000, %edx       # imm = 0x3F800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x1c(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f7fffff, %edx       # imm = 0x7F7FFFFF
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x20(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f800000, %edx       # imm = 0x7F800000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x24(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7fc00000, %edx       # imm = 0x7FC00000
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
                	leaq	0x28(%rbx), %rdx
                	movss	%xmm0, (%rdx)
                	movl	$0x7f800001, %edx       # imm = 0x7F800001
-               	addl	%ecx, %edx
+               	addl	%eax, %edx
                	movd	%edx, %xmm0
-               	leaq	0x2c(%rbx), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	%rax, %r12
-               	movl	$0x0, %r13d
-               	cmpl	$0xc, %r13d
+               	leaq	0x2c(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x40(%rbp)
+               	movl	$0x0, %eax
+               	cmpl	$0xc, %eax
+               	jb	 <L0>
+               	jmp	 <L47>
+<L0>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdx
+               	movl	$0x0, %r12d
+               	cmpl	$0xc, %r12d
                	jb	 <L1>
-               	jmp	 <L36>
+               	jmp	 <L46>
 <L1>:
-               	movl	%r13d, %eax
-               	leaq	(%rbx,%rax,4), %r14
-               	movq	%r12, %r15
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	cmpl	$0xc, %r8d
-               	jb	 <L2>
-               	jmp	 <L35>
-<L2>:
-               	movl	(%r14), %r11d
-               	movl	%r11d, -0x48(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x58(%rbp)
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%sil
+               	movq	-0x38(%rbp), %r8
+               	movss	(%r8), %xmm0
+               	movl	%r12d, %r13d
+               	leaq	(%rbx,%r13,4), %r14
+               	movss	(%r14), %xmm1
+               	ucomiss	%xmm1, %xmm0
+               	sete	%r13b
                	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%r15, %rdi
-               	callq	 <L3>
+               	andb	%r11b, %r13b
+               	movzbq	%r13b, %r13
+               	movzbq	%r13b, %r14
+               	movq	%rdx, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm1, %xmm0
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L4>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L5>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm1
                	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L7>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm1
                	setae	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L8>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x68(%rbp), %r8
-               	testb	%r8b, %r8b
-               	jne	 <L9>
-               	movq	$0x0, %rcx
-               	jmp	 <L10>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	$0x1, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L11>
-               	movq	%rcx, %rdx
-               	jmp	 <L12>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	addl	$0x2, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L13>
-               	movq	%rdx, %rcx
-               	jmp	 <L14>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	addl	$0x4, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L14>
+               	movq	$0x0, %rsi
+               	jmp	 <L15>
 <L14>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setae	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L15>
-               	movq	%rcx, %rdx
-               	jmp	 <L16>
+               	movq	$0x1, %rsi
 <L15>:
-               	addl	$0x8, %ecx
-               	movq	%rcx, %rdx
+               	ucomiss	%xmm0, %xmm1
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L16>
+               	movq	%rsi, %rdi
+               	jmp	 <L17>
 <L16>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L17>
-               	movq	%rdx, %rcx
-               	jmp	 <L18>
+               	addl	$0x2, %esi
+               	movq	%rsi, %rdi
 <L17>:
-               	addl	$0x10, %edx
-               	movq	%rdx, %rcx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L18>
+               	movq	%rdi, %rsi
+               	jmp	 <L19>
 <L18>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L19>
-               	movq	%rcx, %rsi
-               	jmp	 <L20>
+               	addl	$0x4, %edi
+               	movq	%rdi, %rsi
 <L19>:
-               	addl	$0x20, %ecx
-               	movq	%rcx, %rsi
+               	ucomiss	%xmm1, %xmm0
+               	setae	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L20>
+               	movq	%rsi, %rdi
+               	jmp	 <L21>
 <L20>:
-               	callq	 <L21>
+               	addl	$0x8, %esi
+               	movq	%rsi, %rdi
 <L21>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm1, %xmm0
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
                	jne	 <L22>
+               	movq	%rdi, %rsi
                	jmp	 <L23>
 <L22>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
+               	addl	$0x10, %edi
+               	movq	%rdi, %rsi
 <L23>:
-               	movq	%rcx, %rsi
-               	callq	 <L24>
+               	ucomiss	%xmm1, %xmm0
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L24>
+               	movq	%rsi, %rdi
+               	jmp	 <L25>
 <L24>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L25>
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	jmp	 <L26>
+               	addl	$0x20, %esi
+               	movq	%rsi, %rdi
 <L25>:
-               	movq	%rcx, %rdx
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rdx, %rsi
-               	callq	 <L27>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rdi
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	cmpb	$0x1, %cl
-               	setne	%sil
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L28>
+               	testb	%sil, %sil
+               	jne	 <L28>
+               	jmp	 <L29>
 <L28>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L29>
-               	jmp	 <L30>
+               	ucomiss	%xmm1, %xmm0
+               	seta	%sil
+               	movzbq	%sil, %rsi
 <L29>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%cl
-               	setnp	%r11b
-               	andb	%r11b, %cl
-               	movzbq	%cl, %rcx
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
 <L30>:
-               	movq	%rcx, %rsi
-               	callq	 <L31>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
 <L31>:
-               	movq	%rax, %rdi
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setne	%cl
-               	setp	%r11b
-               	orb	%r11b, %cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
                	jne	 <L32>
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	ucomiss	%xmm1, %xmm0
+               	seta	%dil
+               	movzbq	%dil, %rdi
                	jmp	 <L33>
 <L32>:
-               	movq	%rcx, %rdx
+               	movq	%rsi, %rdi
 <L33>:
-               	movq	%rdx, %rsi
-               	callq	 <L34>
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+               	jmp	 <L35>
 <L34>:
-               	movq	%rax, %r15
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %eax
-               	addl	$0x1, %eax
-               	movq	%rax, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	cmpl	$0xc, %r8d
-               	jb	 <L2>
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
 <L35>:
-               	addl	$0x1, %r13d
-               	movq	%r15, %r12
-               	cmpl	$0xc, %r13d
-               	jb	 <L1>
+               	ucomiss	%xmm0, %xmm1
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	cmpb	$0x1, %sil
+               	setne	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
+               	jmp	 <L37>
 <L36>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L36>
+<L37>:
+               	ucomiss	%xmm0, %xmm0
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	ucomiss	%xmm1, %xmm1
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+<L39>:
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+<L41>:
+               	ucomiss	%xmm0, %xmm0
+               	setne	%sil
+               	setp	%r11b
+               	orb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L42>
+               	ucomiss	%xmm1, %xmm1
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L43>
+<L42>:
+               	movq	%rsi, %rdi
+<L43>:
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+               	jmp	 <L45>
+<L44>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L44>
+<L45>:
+               	addl	$0x1, %r12d
+               	movq	%r13, %rdx
+               	cmpl	$0xc, %r12d
+               	jb	 <L1>
+<L46>:
+               	addl	$0x1, %eax
+               	movq	%rdx, %r8
+               	movq	%r8, -0x40(%rbp)
+               	cmpl	$0xc, %eax
+               	jb	 <L0>
+<L47>:
                	leaq	(%rbx), %rax
                	movss	(%rax), %xmm0
                	movss	(%rax), %xmm1
-               	movsd	%xmm1, -0x78(%rbp)
+               	movsd	%xmm1, -0x60(%rbp)
                	movl	$0x1, %eax
                	cmpl	$0xc, %eax
-               	jb	 <L37>
-               	jmp	 <L42>
-<L37>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
+               	jb	 <L48>
+               	jmp	 <L53>
+<L48>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
                	ucomiss	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L38>
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L49>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L39>
-<L38>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm1
-<L39>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm3
-               	ucomiss	-0x78(%rbp), %xmm3
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L40>
-               	movsd	-0x78(%rbp), %xmm3
-               	jmp	 <L41>
-<L40>:
-               	movl	%eax, %ecx
-               	leaq	(%rbx,%rcx,4), %rdx
-               	movss	(%rdx), %xmm3
-<L41>:
+               	jmp	 <L50>
+<L49>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm1
+<L50>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm3
+               	ucomiss	-0x60(%rbp), %xmm3
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L51>
+               	movsd	-0x60(%rbp), %xmm3
+               	jmp	 <L52>
+<L51>:
+               	movl	%eax, %edx
+               	leaq	(%rbx,%rdx,4), %rsi
+               	movss	(%rsi), %xmm3
+<L52>:
                	addl	$0x1, %eax
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	movsd	%xmm3, -0x78(%rbp)
+               	movsd	%xmm3, -0x60(%rbp)
                	cmpl	$0xc, %eax
-               	jb	 <L37>
-<L42>:
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L44>
-               	movq	%r12, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-               	jmp	 <L46>
-<L44>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r13
-<L46>:
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L48>
-               	movq	%r13, %rdi
-               	movss	-0x78(%rbp), %xmm0
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-               	jmp	 <L50>
-<L48>:
-               	movq	%r13, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r12
-<L50>:
+               	jb	 <L48>
+<L53>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L54>
+<L54>:
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	callq	 <L55>
+<L55>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x48(%rbp), %r8
                	movl	$0x0, %r8d
-               	movq	%r8, -0x38(%rbp)
-               	movl	$0x0, %ecx
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-               	jmp	 <L54>
-<L51>:
-               	movl	%ecx, %edx
-               	leaq	(%rbx,%rdx,4), %rsi
-               	movq	-0x38(%rbp), %r8
-               	movq	%r8, %rdx
-               	movl	$0x0, %edi
-               	cmpl	$0xc, %edi
-               	jb	 <L52>
-               	jmp	 <L53>
-<L52>:
-               	movss	(%rsi), %xmm0
-               	movl	%edi, %r13d
-               	leaq	(%rbx,%r13,4), %r14
-               	movss	(%r14), %xmm1
+               	movq	%r8, -0x50(%rbp)
+               	movl	$0x0, %esi
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+               	jmp	 <L59>
+<L56>:
+               	movl	%esi, %edi
+               	leaq	(%rbx,%rdi,4), %r12
+               	movq	-0x50(%rbp), %r8
+               	movq	%r8, %rdi
+               	movl	$0x0, %r13d
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movss	(%r12), %xmm0
+               	movl	%r13d, %r14d
+               	leaq	(%rbx,%r14,4), %r15
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	seta	%r13b
-               	movzbq	%r13b, %r13
-               	movzbl	%r13b, %r15d
-               	movl	%edx, %r13d
-               	addl	%r15d, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	seta	%r14b
+               	movzbq	%r14b, %r14
+               	movzbl	%r14b, %eax
+               	movl	%edi, %r14d
+               	addl	%eax, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm0, %xmm1
-               	setae	%r15b
-               	movzbq	%r15b, %r15
-               	movzbl	%r15b, %eax
-               	addl	%eax, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r13d
-               	movss	(%rsi), %xmm0
-               	movss	(%r14), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	movss	(%r12), %xmm0
+               	movss	(%r15), %xmm1
                	ucomiss	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r14d
-               	addl	%r14d, %r13d
-               	addl	$0x1, %edi
-               	movq	%r13, %rdx
-               	cmpl	$0xc, %edi
-               	jb	 <L52>
-<L53>:
-               	addl	$0x1, %ecx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x38(%rbp)
-               	cmpl	$0xc, %ecx
-               	jb	 <L51>
-<L54>:
-               	movq	%r12, %rdi
-               	movq	-0x38(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L55>
-<L55>:
-               	movq	-0x88(%rbp), %rbx
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	movzbl	%al, %edx
+               	addl	%edx, %r14d
+               	addl	$0x1, %r13d
+               	movq	%r14, %rdi
+               	cmpl	$0xc, %r13d
+               	jb	 <L57>
+<L58>:
+               	addl	$0x1, %esi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x50(%rbp)
+               	cmpl	$0xc, %esi
+               	jb	 <L56>
+<L59>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L60>
+               	jmp	 <L61>
+<L60>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L60>
+<L61>:
+               	movq	%rdx, %rax
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/cmp_f64.dis
+++ b/test/golden/x86_64-linux/float/cmp_f64.dis
@@ -7,27 +7,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,614 +74,1053 @@ Disassembly of section .text:
 <corpus.cases.float.cmp_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
-               	movq	%rbx, -0x108(%rbp)
-               	movq	%r12, -0x110(%rbp)
-               	movq	%r13, -0x118(%rbp)
-               	movq	%r14, -0x120(%rbp)
-               	movq	%r15, -0x128(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	leaq	-0x60(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
+               	subq	$0x290, %rsp            # imm = 0x290
+               	movq	%rbx, -0x268(%rbp)
+               	movq	%r12, -0x270(%rbp)
+               	movq	%r13, -0x278(%rbp)
+               	movq	%r14, -0x280(%rbp)
+               	movq	%r15, -0x288(%rbp)
+               	movl	%edi, %ebx
+               	leaq	-0x80(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+<L0>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
-               	jne	 <L1>
-               	movabsq	$-0x10000000000000, %rcx # imm = 0xFFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x4010000000000000, %rcx # imm = 0xBFF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7ff0000000000000, %rcx # imm = 0x8010000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x7fffffffffffffff, %rcx # imm = 0x8000000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x18(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$-0x8000000000000000, %rcx # imm = 0x8000000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x20(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rbx, %xmm0
-               	leaq	0x28(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	$0x1, %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x30(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x3ff0000000000000, %rcx # imm = 0x3FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x38(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7fefffffffffffff, %rcx # imm = 0x7FEFFFFFFFFFFFFF
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x40(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000000, %rcx # imm = 0x7FF0000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x48(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff8000000000000, %rcx # imm = 0x7FF8000000000000
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x50(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movabsq	$0x7ff0000000000001, %rcx # imm = 0x7FF0000000000001
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
-               	leaq	0x58(%r13), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movq	%rax, %rbx
+               	jne	 <L0>
+               	movabsq	$-0x10000000000000, %rax # imm = 0xFFF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x4010000000000000, %rax # imm = 0xBFF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x8(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x7ff0000000000000, %rax # imm = 0x8010000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x10(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x7fffffffffffffff, %rax # imm = 0x8000000000000001
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x18(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x8000000000000000, %rax # imm = 0x8000000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x20(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movq	%rdi, %xmm0
+               	leaq	0x28(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movq	$0x1, %rax
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x30(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x38(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x40(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff0000000000000, %rax # imm = 0x7FF0000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x48(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff8000000000000, %rax # imm = 0x7FF8000000000000
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x50(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$0x7ff0000000000001, %rax # imm = 0x7FF0000000000001
+               	addq	%rdi, %rax
+               	movq	%rax, %xmm0
+               	leaq	0x58(%r12), %rax
+               	movsd	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
                	movq	$0x0, %r14
                	cmpq	$0xc, %r14
-               	jb	 <L2>
-               	jmp	 <L37>
-<L2>:
-               	leaq	(%r13,%r14,8), %r15
-               	movq	%rbx, %r8
-               	movq	%r8, -0xb0(%rbp)
+               	jb	 <L1>
+               	jmp	 <L46>
+<L1>:
+               	leaq	(%r12,%r14,8), %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x210(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
                	cmpq	$0xc, %r8
-               	jb	 <L3>
-               	jmp	 <L36>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L45>
+<L2>:
                	movq	(%r15), %r11
-               	movq	%r11, -0x98(%rbp)
-               	movq	-0xb8(%rbp), %r8
-               	leaq	(%r13,%r8,8), %rdx
-               	movq	(%rdx), %r11
-               	movq	%r11, -0xa8(%rbp)
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movq	%r11, -0x1f8(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	leaq	(%r12,%r8,8), %rsi
+               	movq	(%rsi), %r11
+               	movq	%r11, -0x208(%rbp)
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	-0xb0(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x88(%rbp)
+               	movq	-0x210(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L4>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L5>
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0x90(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0xc0(%rbp)
-               	movq	-0xc0(%rbp), %r8
+               	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L6>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xb0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xb8(%rbp)
+               	movq	-0xa8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	-0xc0(%rbp), %r8
-               	testb	%r8b, %r8b
-               	jne	 <L10>
-               	movq	$0x0, %rdx
-               	jmp	 <L11>
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xc8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L7>
+<L8>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0xe0(%rbp)
+               	movq	-0xe0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L9>
 <L10>:
-               	movq	$0x1, %rdx
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L11>
 <L11>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
-               	testb	%sil, %sil
-               	jne	 <L12>
-               	movq	%rdx, %rsi
-               	jmp	 <L13>
+               	callq	 <L12>
 <L12>:
-               	addl	$0x2, %edx
-               	movq	%rdx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L13>
+               	movq	$0x0, %rdi
+               	jmp	 <L14>
 <L13>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L14>
-               	movq	%rsi, %rdx
-               	jmp	 <L15>
+               	movq	$0x1, %rdi
 <L14>:
-               	addl	$0x4, %esi
-               	movq	%rsi, %rdx
-<L15>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	testb	%sil, %sil
-               	jne	 <L16>
-               	movq	%rdx, %rsi
-               	jmp	 <L17>
+               	jne	 <L15>
+               	movq	%rdi, %rsi
+               	jmp	 <L16>
+<L15>:
+               	addl	$0x2, %edi
+               	movq	%rdi, %rsi
 <L16>:
-               	addl	$0x8, %edx
-               	movq	%rdx, %rsi
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L17>
+               	movq	%rsi, %rdi
+               	jmp	 <L18>
 <L17>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L18>
-               	movq	%rsi, %rdx
-               	jmp	 <L19>
+               	addl	$0x4, %esi
+               	movq	%rsi, %rdi
 <L18>:
-               	addl	$0x10, %esi
-               	movq	%rsi, %rdx
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L19>
+               	movq	%rdi, %rsi
+               	jmp	 <L20>
 <L19>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	addl	$0x8, %edi
+               	movq	%rdi, %rsi
+<L20>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	sete	%dil
+               	setnp	%r11b
+               	andb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	testb	%dil, %dil
+               	jne	 <L21>
+               	movq	%rsi, %rdi
+               	jmp	 <L22>
+<L21>:
+               	addl	$0x10, %esi
+               	movq	%rsi, %rdi
+<L22>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	testb	%sil, %sil
-               	jne	 <L20>
-               	movq	%rdx, %rsi
-               	jmp	 <L21>
-<L20>:
-               	addl	$0x20, %edx
-               	movq	%rdx, %rsi
-<L21>:
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
                	jne	 <L23>
+               	movq	%rdi, %rsi
                	jmp	 <L24>
 <L23>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
+               	addl	$0x20, %edi
+               	movq	%rdi, %rsi
 <L24>:
-               	movq	%rdx, %rsi
-               	callq	 <L25>
+               	movzbq	%sil, %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L26>
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x108(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L25>
+<L26>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	jmp	 <L27>
-<L26>:
-               	movq	%rdx, %rsi
+               	testb	%sil, %sil
+               	jne	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	seta	%dl
-               	movzbq	%dl, %rdx
-               	cmpb	$0x1, %dl
-               	setne	%sil
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%sil
                	movzbq	%sil, %rsi
-               	callq	 <L29>
+<L28>:
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x100(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
+               	jmp	 <L30>
 <L29>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L30>
-               	jmp	 <L31>
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x120(%rbp)
+               	movq	-0x120(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L29>
 <L30>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	sete	%dl
-               	setnp	%r11b
-               	andb	%r11b, %dl
-               	movzbq	%dl, %rdx
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L31>
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	seta	%dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L32>
 <L31>:
-               	movq	%rdx, %rsi
-               	callq	 <L32>
+               	movq	%rsi, %rdi
 <L32>:
-               	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setne	%dl
-               	setp	%r11b
-               	orb	%r11b, %dl
-               	movzbq	%dl, %rdx
-               	testb	%dl, %dl
-               	jne	 <L33>
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x118(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x128(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L33>
+<L34>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	cmpb	$0x1, %sil
+               	setne	%dil
+               	movzbq	%dil, %rdi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x140(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x148(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	-0x150(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L35>
+<L36>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+               	testb	%sil, %sil
+               	jne	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	sete	%sil
+               	setnp	%r11b
+               	andb	%r11b, %sil
+               	movzbq	%sil, %rsi
+<L38>:
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x148(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L39>
+<L40>:
+               	movsd	-0x1f8(%rbp), %xmm14
+               	ucomisd	-0x1f8(%rbp), %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	jmp	 <L34>
-<L33>:
-               	movq	%rdx, %rsi
-<L34>:
-               	callq	 <L35>
-<L35>:
-               	movq	-0xb8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rax, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
+               	testb	%sil, %sil
+               	jne	 <L41>
+               	movsd	-0x208(%rbp), %xmm14
+               	ucomisd	-0x208(%rbp), %xmm14
+               	setne	%dil
+               	setp	%r11b
+               	orb	%r11b, %dil
+               	movzbq	%dil, %rdi
+               	jmp	 <L42>
+<L41>:
+               	movq	%rsi, %rdi
+<L42>:
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x160(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+               	jmp	 <L44>
+<L43>:
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x180(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L43>
+<L44>:
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	-0x178(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
                	cmpq	$0xc, %r8
-               	jb	 <L3>
-<L36>:
-               	addq	$0x1, %r14
-               	movq	-0xb0(%rbp), %r8
-               	movq	%r8, %rbx
-               	cmpq	$0xc, %r14
                	jb	 <L2>
-<L37>:
-               	leaq	-0x80(%rbp), %r14
+<L45>:
+               	addq	$0x1, %r14
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %r13
+               	cmpq	$0xc, %r14
+               	jb	 <L1>
+<L46>:
+               	leaq	-0x20(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
                	movq	$0x0, 0x10(%r14)
                	movq	$0x0, 0x18(%r14)
                	movl	$0xff800000, %eax       # imm = 0xFF800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0xbf800000, %eax       # imm = 0xBF800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x4(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x80000000, %eax       # imm = 0x80000000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x8(%r14), %rax
                	movss	%xmm0, (%rax)
-               	movd	%r12d, %xmm0
+               	movd	%ebx, %xmm0
                	leaq	0xc(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x1, %eax
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x10(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x14(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7f800000, %eax       # imm = 0x7F800000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x18(%r14), %rax
                	movss	%xmm0, (%rax)
                	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
-               	addl	%r12d, %eax
+               	addl	%ebx, %eax
                	movd	%eax, %xmm0
                	leaq	0x1c(%r14), %rax
                	movss	%xmm0, (%rax)
-               	movq	$0x0, %r12
-               	cmpq	$0xc, %r12
-               	jb	 <L38>
-               	jmp	 <L47>
-<L38>:
-               	leaq	(%r13,%r12,8), %r15
-               	movq	%rbx, %r8
-               	movq	%r8, -0xe8(%rbp)
+               	movq	$0x0, %rbx
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
+               	jmp	 <L59>
+<L47>:
+               	leaq	(%r12,%rbx,8), %r15
+               	movq	%r13, %r8
+               	movq	%r8, -0x240(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L39>
-               	jmp	 <L46>
-<L39>:
+               	jb	 <L48>
+               	jmp	 <L58>
+<L48>:
                	movq	(%r15), %r11
-               	movq	%r11, -0xd0(%rbp)
-               	movq	-0xf0(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdx
-               	movss	(%rdx), %xmm1
-               	cvtss2sd	%xmm1, %xmm14
-               	movsd	%xmm14, -0xe0(%rbp)
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
+               	movq	%r11, -0x228(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	leaq	(%r14,%r8,4), %rsi
+               	movl	(%rsi), %r11d
+               	movl	%r11d, -0x238(%rbp)
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	-0xe8(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x240(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x190(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x198(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L49>
+<L50>:
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
                	setne	%sil
                	setp	%r11b
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm14
-               	ucomisd	-0xd0(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movsd	-0xe0(%rbp), %xmm14
-               	ucomisd	-0xd0(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	movsd	-0xd0(%rbp), %xmm14
-               	ucomisd	-0xe0(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L45>
-<L45>:
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rax, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	-0xf0(%rbp), %r8
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x190(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
                	cmpq	$0x8, %r8
-               	jb	 <L39>
-<L46>:
-               	addq	$0x1, %r12
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rbx
-               	cmpq	$0xc, %r12
-               	jb	 <L38>
-<L47>:
-               	leaq	(%r13), %rax
-               	movsd	(%rax), %xmm0
-               	movsd	(%rax), %xmm1
-               	movsd	%xmm1, -0x100(%rbp)
-               	movq	$0x1, %rax
-               	cmpq	$0xc, %rax
-               	jb	 <L48>
-               	jmp	 <L53>
-<L48>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
-               	ucomisd	%xmm1, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L49>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	jmp	 <L50>
-<L49>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm1
-<L50>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm3
-               	ucomisd	-0x100(%rbp), %xmm3
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L51>
-               	movsd	-0x100(%rbp), %xmm3
+               	jb	 <L51>
                	jmp	 <L52>
 <L51>:
-               	leaq	(%r13,%rax,8), %rcx
-               	movsd	(%rcx), %xmm3
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L51>
 <L52>:
-               	addq	$0x1, %rax
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	movsd	%xmm3, -0x100(%rbp)
-               	cmpq	$0xc, %rax
-               	jb	 <L48>
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	ucomisd	-0x228(%rbp), %xmm2
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	movq	-0x1a8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
+               	jmp	 <L54>
 <L53>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L55>
-               	movq	%rbx, %rdi
-               	callq	 <L54>
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x1b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L53>
 <L54>:
-               	movq	%rax, %r12
-               	jmp	 <L57>
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	ucomisd	-0x228(%rbp), %xmm2
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	-0x1d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L55>
 <L55>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
+               	movq	%rax, %rdi
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%sil
+               	movzbq	%sil, %rsi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L56>
 <L56>:
-               	movq	%rax, %r12
+               	movq	%rax, %rdi
+               	movss	-0x238(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm2
+               	movsd	-0x228(%rbp), %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	setae	%sil
+               	movzbq	%sil, %rsi
+               	callq	 <L57>
 <L57>:
-               	movsd	-0x100(%rbp), %xmm14
-               	ucomisd	-0x100(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L59>
-               	movq	%r12, %rdi
-               	movsd	-0x100(%rbp), %xmm0
-               	callq	 <L58>
+               	movq	-0x248(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L48>
 <L58>:
-               	movq	%rax, %rbx
-               	jmp	 <L61>
+               	addq	$0x1, %rbx
+               	movq	-0x240(%rbp), %r8
+               	movq	%r8, %r13
+               	cmpq	$0xc, %rbx
+               	jb	 <L47>
 <L59>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rbx
-<L61>:
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x88(%rbp)
-               	movq	$0x0, %rcx
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
+               	leaq	(%r12), %rax
+               	movsd	(%rax), %xmm0
+               	movsd	(%rax), %xmm1
+               	movsd	%xmm1, -0x258(%rbp)
+               	movq	$0x1, %rax
+               	cmpq	$0xc, %rax
+               	jb	 <L60>
                	jmp	 <L65>
+<L60>:
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
+               	ucomisd	%xmm1, %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L61>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L62>
+<L61>:
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm1
 <L62>:
-               	leaq	(%r13,%rcx,8), %rdx
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	movq	$0x0, %rdi
-               	cmpq	$0xc, %rdi
-               	jb	 <L63>
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm3
+               	ucomisd	-0x258(%rbp), %xmm3
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L63>
+               	movsd	-0x258(%rbp), %xmm3
                	jmp	 <L64>
 <L63>:
-               	movsd	(%rdx), %xmm0
-               	leaq	(%r13,%rdi,8), %r12
-               	movsd	(%r12), %xmm1
+               	leaq	(%r12,%rax,8), %rdx
+               	movsd	(%rdx), %xmm3
+<L64>:
+               	addq	$0x1, %rax
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	movsd	%xmm3, -0x258(%rbp)
+               	cmpq	$0xc, %rax
+               	jb	 <L60>
+<L65>:
+               	movq	%r13, %rdi
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movsd	-0x258(%rbp), %xmm0
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	movl	$0x0, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0xc, %rsi
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	leaq	(%r12,%rsi,8), %rdi
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movsd	(%rdi), %xmm0
+               	leaq	(%r12,%r13,8), %r14
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm0, %xmm1
-               	seta	%r14b
-               	movzbq	%r14b, %r14
-               	movzbl	%r14b, %r15d
-               	movl	%esi, %r14d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
-               	ucomisd	%xmm0, %xmm1
-               	setae	%r15b
+               	seta	%r15b
                	movzbq	%r15b, %r15
                	movzbl	%r15b, %eax
-               	addl	%eax, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
+               	movl	%ebx, %r15d
+               	addl	%eax, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
+               	ucomisd	%xmm0, %xmm1
+               	setae	%al
+               	movzbq	%al, %rax
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
                	andb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r15d
-               	addl	%r15d, %r14d
-               	movsd	(%rdx), %xmm0
-               	movsd	(%r12), %xmm1
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	movsd	(%rdi), %xmm0
+               	movsd	(%r14), %xmm1
                	ucomisd	%xmm1, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
-               	movzbl	%al, %r12d
-               	addl	%r12d, %r14d
-               	addq	$0x1, %rdi
-               	movq	%r14, %rsi
-               	cmpq	$0xc, %rdi
-               	jb	 <L63>
-<L64>:
-               	addq	$0x1, %rcx
-               	movq	%rsi, %r8
-               	movq	%r8, -0x88(%rbp)
-               	cmpq	$0xc, %rcx
-               	jb	 <L62>
-<L65>:
-               	movq	%rbx, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x108(%rbp), %rbx
-               	movq	-0x110(%rbp), %r12
-               	movq	-0x118(%rbp), %r13
-               	movq	-0x120(%rbp), %r14
-               	movq	-0x128(%rbp), %r15
+               	movzbl	%al, %edx
+               	addl	%edx, %r15d
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0xc, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	cmpq	$0xc, %rsi
+               	jb	 <L68>
+<L71>:
+               	movq	-0x1e8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L72>
+<L73>:
+               	movq	%rdx, %rax
+               	movq	-0x268(%rbp), %rbx
+               	movq	-0x270(%rbp), %r12
+               	movq	-0x278(%rbp), %r13
+               	movq	-0x280(%rbp), %r14
+               	movq	-0x288(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/special_f32.dis
+++ b/test/golden/x86_64-linux/float/special_f32.dis
@@ -12,27 +12,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	%rdi, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rax, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movabsq	$0xffffffff, %rdx       # imm = 0xFFFFFFFF
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,941 +79,916 @@ Disassembly of section .text:
 <corpus.cases.float.special_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x190, %rsp            # imm = 0x190
-               	movq	%rbx, -0x168(%rbp)
-               	movq	%r12, -0x170(%rbp)
-               	movq	%r13, -0x178(%rbp)
-               	movq	%r14, -0x180(%rbp)
-               	movq	%r15, -0x188(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x130, %rsp            # imm = 0x130
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%r15, -0x128(%rbp)
+               	movl	%edi, %ebx
+               	movl	$0x3f800000, %eax       # imm = 0x3F800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x30(%rbp)
+               	movl	$0xbf800000, %eax       # imm = 0xBF800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x40(%rbp)
+               	movl	%ebx, -0x50(%rbp)
+               	movl	$0x80000000, %eax       # imm = 0x80000000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x60(%rbp)
+               	movl	$0x7f800000, %eax       # imm = 0x7F800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x70(%rbp)
+               	movl	$0xff800000, %eax       # imm = 0xFF800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x80(%rbp)
+               	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
+               	addl	%ebx, %eax
+               	movl	%eax, -0x90(%rbp)
+               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
+               	addl	%ebx, %eax
+               	movl	%eax, -0xa0(%rbp)
+               	movl	$0x800000, %eax         # imm = 0x800000
+               	addl	%ebx, %eax
+               	movl	%eax, -0xb0(%rbp)
+               	movl	$0x7fffff, %eax         # imm = 0x7FFFFF
+               	addl	%ebx, %eax
+               	movl	%eax, -0xc0(%rbp)
+               	movl	$0x1, %eax
+               	addl	%ebx, %eax
+               	movl	%eax, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movss	-0x50(%rbp), %xmm0
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %r12
-               	movl	%ebx, %r13d
-               	movl	$0x3f800000, %eax       # imm = 0x3F800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x38(%rbp)
-               	movl	$0xbf800000, %eax       # imm = 0xBF800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x48(%rbp)
-               	movl	%r13d, -0x58(%rbp)
-               	movl	$0x80000000, %eax       # imm = 0x80000000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x68(%rbp)
-               	movl	$0x7f800000, %eax       # imm = 0x7F800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x78(%rbp)
-               	movl	$0xff800000, %eax       # imm = 0xFF800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x88(%rbp)
-               	movl	$0x7fc00000, %eax       # imm = 0x7FC00000
-               	addl	%r13d, %eax
-               	movl	%eax, -0x98(%rbp)
-               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0xa8(%rbp)
-               	movl	$0x800000, %eax         # imm = 0x800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0xb8(%rbp)
-               	movl	$0x7fffff, %eax         # imm = 0x7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0xc8(%rbp)
-               	movl	$0x1, %eax
-               	addl	%r13d, %eax
-               	movl	%eax, -0xd8(%rbp)
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	movss	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rbx
-               	jmp	 <L4>
+               	movss	-0x50(%rbp), %xmm0
+               	addss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L2>
 <L2>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	addss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
 <L4>:
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%rbx, %rdi
-               	movss	-0x68(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
+               	movss	-0x50(%rbp), %xmm0
+               	subss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
 <L6>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %r12
+               	movss	-0x60(%rbp), %xmm0
+               	subss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
 <L8>:
-               	movss	-0x58(%rbp), %xmm0
-               	addss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rbx
-               	jmp	 <L12>
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
 <L10>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L12>
 <L12>:
-               	movss	-0x58(%rbp), %xmm0
-               	addss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%rbx, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
 <L14>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %r12
+               	movss	-0x50(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1cf>
+               	movq	%rax, %rdi
+               	callq	 <L16>
 <L16>:
-               	movss	-0x68(%rbp), %xmm0
-               	addss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%r12, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1e3>
+               	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
 <L18>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rbx
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
 <L20>:
-               	movss	-0x68(%rbp), %xmm0
-               	addss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rdi
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x40(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movss	-0x50(%rbp), %xmm14
+               	ucomiss	-0x60(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L23>
-<L23>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
                	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movss	-0x60(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movss	-0x58(%rbp), %xmm0
-               	subss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
 <L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
+               	movss	-0x50(%rbp), %xmm14
+               	ucomiss	-0x60(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L27>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
 <L27>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rdi
+               	movss	-0x70(%rbp), %xmm0
+               	callq	 <L28>
 <L28>:
-               	movss	-0x58(%rbp), %xmm0
-               	subss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	movss	-0x80(%rbp), %xmm0
                	callq	 <L29>
 <L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
+               	movss	-0x70(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x398>
+               	movq	%rax, %rdi
+               	callq	 <L30>
 <L30>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movq	%rax, %r12
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
-               	movss	-0x68(%rbp), %xmm0
-               	subss	-0x58(%rbp), %xmm0
-               	movq	%r12, %rdi
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movss	-0x68(%rbp), %xmm0
-               	subss	-0x68(%rbp), %xmm0
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L34>
 <L34>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	addss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	subss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L38>
 <L38>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x40(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movss	-0x58(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x37a>
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	movss	-0x68(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x38e>
+               	movss	-0x40(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L42>
 <L42>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm0
+               	divss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0xa0(%rbp), %xmm0
+               	addss	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm14
+               	ucomiss	-0xa0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	xorps	%xmm0, %xmm0
+               	subss	-0xa0(%rbp), %xmm0
+               	ucomiss	-0x80(%rbp), %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L47>
 <L47>:
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0x70(%rbp), %xmm0
+               	subss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x68(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0x80(%rbp), %xmm0
+               	addss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L49>
 <L49>:
+               	movss	-0x70(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	-0x78(%rbp), %xmm0
                	callq	 <L50>
 <L50>:
+               	movss	-0x80(%rbp), %xmm0
+               	mulss	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movss	-0x88(%rbp), %xmm0
                	callq	 <L51>
 <L51>:
-               	movss	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x45f>
+               	movss	-0x70(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0x50(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x68(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm0
+               	divss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movl	-0x90(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x68(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movss	-0x78(%rbp), %xmm0
-               	addss	-0x38(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	movss	-0x78(%rbp), %xmm0
-               	addss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	movss	-0x78(%rbp), %xmm0
-               	subss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm14
+               	ucomiss	-0x90(%rbp), %xmm14
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x632>
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x650>
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x65b>
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L61>
 <L61>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L62>
 <L62>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0x30(%rbp), %xmm0
+               	addss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L63>
 <L63>:
-               	movss	-0x48(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movss	-0x38(%rbp), %xmm0
-               	divss	-0x88(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	subss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L65>
 <L65>:
-               	movss	-0x78(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	divss	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L66>
 <L66>:
-               	movss	-0xa8(%rbp), %xmm0
-               	addss	-0xa8(%rbp), %xmm0
+               	movss	-0x90(%rbp), %xmm0
+               	divss	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L67>
 <L67>:
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0xa8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movss	-0xd0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xa8(%rbp), %xmm0
-               	ucomiss	-0x88(%rbp), %xmm0
-               	seta	%sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movss	-0xc0(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
-               	movss	-0x78(%rbp), %xmm0
-               	subss	-0x78(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movss	-0xb0(%rbp), %xmm0
                	callq	 <L70>
 <L70>:
-               	movss	-0x88(%rbp), %xmm0
-               	addss	-0x78(%rbp), %xmm0
+               	movss	-0xc0(%rbp), %xmm0
+               	addss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L71>
 <L71>:
-               	movss	-0x78(%rbp), %xmm0
-               	mulss	-0x58(%rbp), %xmm0
+               	movss	-0xb0(%rbp), %xmm0
+               	subss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movss	-0x88(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	addss	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L73>
 <L73>:
-               	movss	-0x78(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x776>
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x78e>
                	movq	%rax, %rdi
                	callq	 <L75>
 <L75>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x58(%rbp), %xmm0
+               	movss	-0xd0(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x7a5>
                	movq	%rax, %rdi
                	callq	 <L76>
 <L76>:
-               	movl	-0x98(%rbp), %ecx
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x7bd>
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L77>
 <L77>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	setne	%sil
-               	setp	%r11b
-               	orb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movss	-0xc0(%rbp), %xmm0
+               	divss	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L78>
 <L78>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movss	-0xd0(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L79>
 <L79>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movss	-0xd0(%rbp), %xmm14
+               	ucomiss	-0x50(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movss	-0x98(%rbp), %xmm14
-               	ucomiss	-0x98(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
+               	xorps	%xmm0, %xmm0
+               	subss	-0xd0(%rbp), %xmm0
+               	movss	-0x60(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	movss	-0x98(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0x6fb>
-               	movss	%xmm14, -0xe8(%rbp)
-               	movl	-0xe8(%rbp), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L82>
+               	movq	%rax, %r12
+               	movq	-0xb0(%rbp), %r11
+               	movq	%r11, -0xf0(%rbp)
+               	movl	$0x0, %r13d
+               	cmpl	$0x1e, %r13d
+               	jb	 <L82>
+               	jmp	 <L84>
 <L82>:
-               	movss	-0xe8(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x723>
-               	movd	%xmm2, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
+               	movss	-0xf0(%rbp), %xmm14
+               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x886>
+               	movss	%xmm14, -0xe0(%rbp)
+               	movq	%r12, %rdi
+               	movss	-0xe0(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	movss	-0x98(%rbp), %xmm0
-               	addss	-0x38(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
+               	addl	$0x1, %r13d
+               	movq	%rax, %r12
+               	movq	-0xe0(%rbp), %r11
+               	movq	%r11, -0xf0(%rbp)
+               	cmpl	$0x1e, %r13d
+               	jb	 <L82>
 <L84>:
-               	movss	-0x38(%rbp), %xmm0
-               	addss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
+               	leaq	-0x20(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	leaq	(%rax), %rdx
+               	movl	$0x0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movl	$0x80000000, (%rdx)     # imm = 0x80000000
+               	leaq	0x8(%rax), %rdx
+               	movl	$0x1, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movl	$0x7f800000, (%rdx)     # imm = 0x7F800000
+               	leaq	0x10(%rax), %rdx
+               	movl	$0xff800000, (%rdx)     # imm = 0xFF800000
+               	leaq	0x14(%rax), %rdx
+               	movl	$0x7fc00000, (%rdx)     # imm = 0x7FC00000
+               	leaq	0x18(%rax), %rdx
+               	movl	$0xffc0dead, (%rdx)     # imm = 0xFFC0DEAD
+               	leaq	0x1c(%rax), %rdx
+               	movl	$0x7f800001, (%rdx)     # imm = 0x7F800001
+               	movl	$0x0, %edx
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
+               	jmp	 <L88>
 <L85>:
-               	movss	-0x98(%rbp), %xmm0
-               	mulss	-0x58(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
+               	movl	%edx, %esi
+               	leaq	(%rax,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	addl	%ebx, %esi
+               	movd	%esi, %xmm0
+               	movd	%xmm0, %esi
+               	movl	%esi, %edi
+               	movq	%r12, %rsi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
+               	jmp	 <L87>
 <L86>:
-               	movss	-0x98(%rbp), %xmm0
-               	subss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L86>
 <L87>:
-               	movss	-0x98(%rbp), %xmm0
-               	divss	-0x98(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	addl	$0x1, %edx
+               	movq	%rsi, %r12
+               	cmpl	$0x8, %edx
+               	jb	 <L85>
 <L88>:
-               	movss	-0x98(%rbp), %xmm0
-               	divss	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
+               	movl	$0x1000000, %eax        # imm = 0x1000000
+               	addl	%ebx, %eax
+               	movl	$0x1000001, %r13d       # imm = 0x1000001
+               	addl	%ebx, %r13d
+               	movl	$0x1000003, %r14d       # imm = 0x1000003
+               	addl	%ebx, %r14d
+               	movl	$0xffffffff, %r15d      # imm = 0xFFFFFFFF
+               	addl	%ebx, %r15d
+               	movl	$0xfeffffff, %r8d       # imm = 0xFEFFFFFF
+               	addl	%ebx, %r8d
+               	movq	%r8, -0xf8(%rbp)
+               	movl	$0x80000000, %r8d       # imm = 0x80000000
+               	addl	%ebx, %r8d
+               	movq	%r8, -0x100(%rbp)
+               	movl	%eax, %r11d
+               	cvtsi2ss	%r11, %xmm0
+               	movq	%r12, %rdi
                	callq	 <L89>
 <L89>:
+               	movl	%r13d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xd8(%rbp), %xmm0
                	callq	 <L90>
 <L90>:
+               	movl	%r14d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xc8(%rbp), %xmm0
                	callq	 <L91>
 <L91>:
+               	movl	%r15d, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
-               	movss	-0xb8(%rbp), %xmm0
                	callq	 <L92>
 <L92>:
-               	movss	-0xc8(%rbp), %xmm0
-               	addss	-0xd8(%rbp), %xmm0
+               	movl	%ebx, %r11d
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	movss	-0xb8(%rbp), %xmm0
-               	subss	-0xd8(%rbp), %xmm0
+               	movq	-0xf8(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	movss	-0xd8(%rbp), %xmm0
-               	addss	-0xd8(%rbp), %xmm0
+               	movq	-0x100(%rbp), %r8
+               	movslq	%r8d, %r11
+               	cvtsi2ss	%r11, %xmm0
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x83e>
-               	movq	%rax, %rdi
-               	callq	 <L96>
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xa85>
+               	mulss	-0x30(%rbp), %xmm0
+               	movss	, %xmm2 <corpus.cases.float.special_f32.checksum+0xa92>
+               	mulss	-0x30(%rbp), %xmm2
+               	movss	, %xmm4 <corpus.cases.float.special_f32.checksum+0xa9f>
+               	mulss	-0x30(%rbp), %xmm4
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm0, %xmm5
+               	movss	, %xmm6 <corpus.cases.float.special_f32.checksum+0xab3>
+               	mulss	-0x30(%rbp), %xmm6
+               	cvttss2si	%xmm0, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
+               	jmp	 <L97>
 <L96>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x856>
-               	movq	%rax, %rdi
-               	callq	 <L97>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L96>
 <L97>:
-               	movss	-0xd8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x86d>
-               	movq	%rax, %rdi
-               	callq	 <L98>
+               	cvttss2si	%xmm2, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
+               	jmp	 <L99>
 <L98>:
-               	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x885>
-               	movq	%rax, %rdi
-               	callq	 <L99>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L98>
 <L99>:
-               	movss	-0xc8(%rbp), %xmm0
-               	divss	-0xb8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L100>
+               	cvttss2si	%xmm4, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
+               	jmp	 <L101>
 <L100>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L101>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L100>
 <L101>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L102>
+               	cvttss2si	%xmm6, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
+               	jmp	 <L103>
 <L102>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0xd8(%rbp), %xmm0
-               	movss	-0x68(%rbp), %xmm14
-               	ucomiss	%xmm0, %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L103>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L102>
 <L103>:
-               	movq	%rax, %rbx
-               	movq	-0xb8(%rbp), %r11
-               	movq	%r11, -0x108(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x1e, %r12d
+               	movss	-0x50(%rbp), %xmm14
+               	cvttss2si	%xmm14, %r11
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L104>
-               	jmp	 <L109>
+               	jmp	 <L105>
 <L104>:
-               	movss	-0x108(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x945>
-               	movss	%xmm14, -0xf8(%rbp)
-               	movss	-0xf8(%rbp), %xmm14
-               	ucomiss	-0xf8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L106>
-               	movq	%rbx, %rdi
-               	movss	-0xf8(%rbp), %xmm0
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %r14
-               	jmp	 <L108>
-<L106>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r14
-<L108>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
-               	movq	-0xf8(%rbp), %r11
-               	movq	%r11, -0x108(%rbp)
-               	cmpl	$0x1e, %r12d
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
                	jb	 <L104>
+<L105>:
+               	cvttss2si	%xmm5, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+               	jmp	 <L107>
+<L106>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L106>
+<L107>:
+               	cvttss2si	%xmm4, %r11d
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
+               	jmp	 <L109>
+<L108>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L108>
 <L109>:
-               	leaq	-0x20(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0x0, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movl	$0x80000000, (%rax)     # imm = 0x80000000
-               	leaq	0x8(%r12), %rax
-               	movl	$0x1, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movl	$0x7f800000, (%rax)     # imm = 0x7F800000
-               	leaq	0x10(%r12), %rax
-               	movl	$0xff800000, (%rax)     # imm = 0xFF800000
-               	leaq	0x14(%r12), %rax
-               	movl	$0x7fc00000, (%rax)     # imm = 0x7FC00000
-               	leaq	0x18(%r12), %rax
-               	movl	$0xffc0dead, (%rax)     # imm = 0xFFC0DEAD
-               	leaq	0x1c(%r12), %rax
-               	movl	$0x7f800001, (%rax)     # imm = 0x7F800001
-               	movl	$0x0, %r14d
-               	cmpl	$0x8, %r14d
-               	jb	 <L110>
-               	jmp	 <L112>
-<L110>:
-               	movl	%r14d, %eax
-               	leaq	(%r12,%rax,4), %rcx
-               	movl	(%rcx), %eax
-               	addl	%r13d, %eax
-               	movd	%eax, %xmm0
-               	movd	%xmm0, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L111>
-<L111>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r14d
-               	jb	 <L110>
-<L112>:
-               	movl	$0x1000000, %eax        # imm = 0x1000000
-               	addl	%r13d, %eax
-               	movl	$0x1000001, %r12d       # imm = 0x1000001
-               	addl	%r13d, %r12d
-               	movl	$0x1000003, %r14d       # imm = 0x1000003
-               	addl	%r13d, %r14d
-               	movl	$0xffffffff, %r15d      # imm = 0xFFFFFFFF
-               	addl	%r13d, %r15d
-               	movl	$0xfeffffff, %r8d       # imm = 0xFEFFFFFF
-               	addl	%r13d, %r8d
-               	movq	%r8, -0x110(%rbp)
-               	movl	$0x80000000, %r8d       # imm = 0x80000000
-               	addl	%r13d, %r8d
-               	movq	%r8, -0x118(%rbp)
-               	movl	%eax, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L114>
-               	movq	%rbx, %rdi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-               	jmp	 <L116>
-<L114>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x28(%rbp)
-<L116>:
-               	movl	%r12d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L118>
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rbx
-               	jmp	 <L120>
-<L118>:
-               	movq	-0x28(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-<L120>:
-               	movl	%r14d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L122>
-               	movq	%rbx, %rdi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %r12
-               	jmp	 <L124>
-<L122>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %r12
-<L124>:
-               	movl	%r15d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
-               	movq	%r12, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %rbx
-               	jmp	 <L128>
-<L126>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-<L128>:
-               	movl	%r13d, %r11d
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L130>
-               	movq	%rbx, %rdi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %r12
-               	jmp	 <L132>
-<L130>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-<L132>:
-               	movq	-0x110(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L134>
-               	movq	%r12, %rdi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rbx
-               	jmp	 <L136>
-<L134>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-<L136>:
-               	movq	-0x118(%rbp), %r8
-               	movslq	%r8d, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%rbx, %rdi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %r12
-               	jmp	 <L140>
-<L138>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r12
-<L140>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xcb0>
-               	mulss	-0x38(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcbe>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x128(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcd6>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x138(%rbp)
-               	xorps	%xmm14, %xmm14
-               	subss	%xmm0, %xmm14
-               	movss	%xmm14, -0x148(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xd00>
-               	mulss	-0x38(%rbp), %xmm14
-               	movss	%xmm14, -0x158(%rbp)
-               	cvttss2si	%xmm0, %r11
-               	movl	%r11d, %eax
-               	movq	%r12, %rdi
-               	movl	%eax, %esi
-               	callq	 <L141>
-<L141>:
-               	movss	-0x128(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L142>
-<L142>:
-               	movss	-0x138(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L143>
-<L143>:
-               	movss	-0x158(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L144>
-<L144>:
-               	movss	-0x58(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L145>
-<L145>:
-               	movss	-0x148(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L146>
-<L146>:
-               	movss	-0x138(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L147>
-<L147>:
                	xorps	%xmm0, %xmm0
-               	subss	-0x158(%rbp), %xmm0
+               	subss	%xmm6, %xmm0
                	cvttss2si	%xmm0, %r11d
-               	movl	%r11d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L148>
-<L148>:
-               	movss	-0x148(%rbp), %xmm14
-               	cvttss2si	%xmm14, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+               	jmp	 <L111>
+<L110>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L110>
+<L111>:
+               	cvttss2si	%xmm5, %r11
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L112>
+               	jmp	 <L113>
+<L112>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L112>
+<L113>:
                	xorps	%xmm0, %xmm0
-               	subss	-0x128(%rbp), %xmm0
+               	subss	%xmm2, %xmm0
                	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	movq	-0x168(%rbp), %rbx
-               	movq	-0x170(%rbp), %r12
-               	movq	-0x178(%rbp), %r13
-               	movq	-0x180(%rbp), %r14
-               	movq	-0x188(%rbp), %r15
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L114>
+               	jmp	 <L115>
+<L114>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L114>
+<L115>:
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
+               	movq	-0x128(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/special_f64.dis
+++ b/test/golden/x86_64-linux/float/special_f64.dis
@@ -12,27 +12,66 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x10, %rsp
                	movq	%rbx, -0x8(%rbp)
-               	movq	%rdi, %rbx
+               	movq	%r12, -0x10(%rbp)
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L1>
-               	movq	%rbx, %rdi
-               	callq	 <L0>
+               	jne	 <L2>
+               	movq	%xmm0, %rax
+               	movq	%rdi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+<L1>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L1>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L2>
 <L2>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	$-0x1, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L3>
+<L4>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,1114 +79,1097 @@ Disassembly of section .text:
 <corpus.cases.float.special_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x220, %rsp            # imm = 0x220
-               	movq	%rbx, -0x1f8(%rbp)
-               	movq	%r12, -0x200(%rbp)
-               	movq	%r13, -0x208(%rbp)
-               	movq	%r14, -0x210(%rbp)
-               	movq	%r15, -0x218(%rbp)
+               	subq	$0x1c0, %rsp            # imm = 0x1C0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%r15, -0x1b8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
                	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x58(%rbp)
+               	movq	%rax, -0x50(%rbp)
                	movabsq	$-0x4010000000000000, %rax # imm = 0xBFF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x68(%rbp)
-               	movq	%rbx, -0x78(%rbp)
+               	movq	%rax, -0x60(%rbp)
+               	movq	%rbx, -0x70(%rbp)
                	movabsq	$-0x8000000000000000, %rax # imm = 0x8000000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x88(%rbp)
+               	movq	%rax, -0x80(%rbp)
                	movabsq	$0x7ff0000000000000, %rax # imm = 0x7FF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0x98(%rbp)
+               	movq	%rax, -0x90(%rbp)
                	movabsq	$-0x10000000000000, %rax # imm = 0xFFF0000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xa8(%rbp)
+               	movq	%rax, -0xa0(%rbp)
                	movabsq	$0x7ff8000000000000, %rax # imm = 0x7FF8000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xb8(%rbp)
+               	movq	%rax, -0xb0(%rbp)
                	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
-               	movq	%rax, -0xc8(%rbp)
+               	movq	%rax, -0xc0(%rbp)
                	movabsq	$0x10000000000000, %rax # imm = 0x10000000000000
                	addq	%rbx, %rax
-               	movq	%rax, -0xd8(%rbp)
+               	movq	%rax, -0xd0(%rbp)
                	movabsq	$0xfffffffffffff, %rax  # imm = 0xFFFFFFFFFFFFF
                	addq	%rbx, %rax
-               	movq	%rax, -0xe8(%rbp)
+               	movq	%rax, -0xe0(%rbp)
                	movq	$0x1, %rax
                	addq	%rbx, %rax
-               	movq	%rax, -0xf8(%rbp)
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L2>
-               	movq	%r12, %rdi
-               	movsd	-0x78(%rbp), %xmm0
+               	movq	%rax, -0xf0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movsd	-0x70(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	movsd	-0x80(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %r13
-               	jmp	 <L4>
+               	movsd	-0x70(%rbp), %xmm0
+               	addsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L2>
 <L2>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	addsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
 <L4>:
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L6>
-               	movq	%r13, %rdi
-               	movsd	-0x88(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %r12
-               	jmp	 <L8>
+               	movsd	-0x70(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
 <L6>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	subsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %r12
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
 <L8>:
-               	movsd	-0x78(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L10>
-               	movq	%r12, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %r13
-               	jmp	 <L12>
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
 <L10>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L12>
 <L12>:
-               	movsd	-0x78(%rbp), %xmm0
-               	addsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L14>
-               	movq	%r13, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %r12
-               	jmp	 <L16>
+               	movsd	-0x80(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
 <L14>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %r12
+               	movsd	-0x70(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x21a>
+               	movq	%rax, %rdi
+               	callq	 <L16>
 <L16>:
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
-               	movq	%r12, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x22e>
+               	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %r13
-               	jmp	 <L20>
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
 <L18>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %r13
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
 <L20>:
-               	movsd	-0x88(%rbp), %xmm0
-               	addsd	-0x88(%rbp), %xmm0
-               	movq	%r13, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	-0x80(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
 <L23>:
-               	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
+               	movsd	-0x80(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
 <L24>:
-               	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
 <L25>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	-0x80(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0x90(%rbp), %xmm0
                	callq	 <L27>
 <L27>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0xa0(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x3a5>
                	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L30>
 <L30>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movsd	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x362>
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movsd	-0x88(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x379>
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	addsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L34>
 <L34>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	addsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L38>
 <L38>:
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x60(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x88(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
+               	movsd	-0x60(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movsd	-0x98(%rbp), %xmm0
                	callq	 <L41>
 <L41>:
+               	movsd	-0x50(%rbp), %xmm0
+               	divsd	-0xa0(%rbp), %xmm0
                	movq	%rax, %rdi
-               	movsd	-0xa8(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	movsd	-0x98(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x462>
+               	movsd	-0x90(%rbp), %xmm0
+               	divsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	movsd	-0xc0(%rbp), %xmm0
+               	addsd	-0xc0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x88(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm14
+               	ucomisd	-0xc0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xc0(%rbp), %xmm0
+               	ucomisd	-0xa0(%rbp), %xmm0
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x88(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	subsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L47>
 <L47>:
-               	movsd	-0x98(%rbp), %xmm0
-               	addsd	-0x58(%rbp), %xmm0
+               	movsd	-0xa0(%rbp), %xmm0
+               	addsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movsd	-0x98(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	mulsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L49>
 <L49>:
-               	movsd	-0x98(%rbp), %xmm0
-               	subsd	-0xa8(%rbp), %xmm0
+               	movsd	-0xa0(%rbp), %xmm0
+               	mulsd	-0x80(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L50>
 <L50>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x98(%rbp), %xmm0
+               	movsd	-0x90(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L51>
 <L51>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0xa8(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm0
+               	divsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movq	-0xb0(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	movsd	-0x68(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setne	%dl
+               	setp	%r11b
+               	orb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	movsd	-0x58(%rbp), %xmm0
-               	divsd	-0xa8(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movsd	-0x98(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	movsd	-0xc8(%rbp), %xmm0
-               	addsd	-0xc8(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setae	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0xc8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xb0(%rbp), %xmm14
+               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x68e>
+               	movsd	%xmm14, -0x100(%rbp)
+               	movq	-0x100(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xc8(%rbp), %xmm0
-               	ucomisd	-0xa8(%rbp), %xmm0
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0x100(%rbp), %xmm2
+               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x6b5>
+               	movq	%xmm2, %rsi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
-               	movsd	-0x98(%rbp), %xmm0
-               	subsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	addsd	-0x50(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L61>
 <L61>:
-               	movsd	-0xa8(%rbp), %xmm0
-               	addsd	-0x98(%rbp), %xmm0
+               	movsd	-0x50(%rbp), %xmm0
+               	addsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L62>
 <L62>:
-               	movsd	-0x98(%rbp), %xmm0
-               	mulsd	-0x78(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	mulsd	-0x70(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L63>
 <L63>:
-               	movsd	-0xa8(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movsd	-0x98(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	-0xb0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L65>
 <L65>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	-0x90(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L66>
 <L66>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x78(%rbp), %xmm0
                	movq	%rax, %rdi
+               	movsd	-0xf0(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
-               	movq	-0xb8(%rbp), %rsi
                	movq	%rax, %rdi
+               	movsd	-0xe0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	setne	%sil
-               	setp	%r11b
-               	orb	%r11b, %sil
-               	movzbq	%sil, %rsi
                	movq	%rax, %rdi
+               	movsd	-0xd0(%rbp), %xmm0
                	callq	 <L69>
 <L69>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xe0(%rbp), %xmm0
+               	addsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L70>
 <L70>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xd0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L71>
 <L71>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	ucomisd	-0xb8(%rbp), %xmm14
-               	setae	%sil
-               	movzbq	%sil, %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	addsd	-0xf0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movsd	-0xb8(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x745>
-               	movsd	%xmm14, -0x108(%rbp)
-               	movq	-0x108(%rbp), %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x7d1>
                	movq	%rax, %rdi
                	callq	 <L73>
 <L73>:
-               	movsd	-0x108(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x76c>
-               	movq	%xmm2, %rsi
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x7e9>
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	addsd	-0x58(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x800>
                	movq	%rax, %rdi
                	callq	 <L75>
 <L75>:
-               	movsd	-0x58(%rbp), %xmm0
-               	addsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x818>
                	movq	%rax, %rdi
                	callq	 <L76>
 <L76>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	mulsd	-0x78(%rbp), %xmm0
+               	movsd	-0xe0(%rbp), %xmm0
+               	divsd	-0xd0(%rbp), %xmm0
                	movq	%rax, %rdi
                	callq	 <L77>
 <L77>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	subsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L78>
 <L78>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	divsd	-0xb8(%rbp), %xmm0
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	-0x70(%rbp), %xmm14
+               	sete	%dl
+               	setnp	%r11b
+               	andb	%r11b, %dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L79>
 <L79>:
-               	movsd	-0xb8(%rbp), %xmm0
-               	divsd	-0x98(%rbp), %xmm0
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+               	movsd	-0x80(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movq	%rax, %rdi
-               	movsd	-0xf8(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	movsd	-0xe8(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movq	%rax, %rdi
-               	movsd	-0xd8(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movsd	-0xe8(%rbp), %xmm0
-               	addsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movsd	-0xd8(%rbp), %xmm0
-               	subsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	addsd	-0xf8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x888>
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8a0>
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8b7>
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8cf>
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	movsd	-0xe8(%rbp), %xmm0
-               	divsd	-0xd8(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	sete	%sil
-               	setnp	%r11b
-               	andb	%r11b, %sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0xf8(%rbp), %xmm0
-               	movsd	-0x88(%rbp), %xmm14
-               	ucomisd	%xmm0, %xmm14
-               	seta	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
                	movq	%rax, %r12
-               	movq	-0xd8(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
+               	movq	-0xd0(%rbp), %r11
+               	movq	%r11, -0x120(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3c, %r13
-               	jb	 <L95>
-               	jmp	 <L100>
-<L95>:
-               	movsd	-0x128(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x996>
-               	movsd	%xmm14, -0x118(%rbp)
-               	movsd	-0x118(%rbp), %xmm14
-               	ucomisd	-0x118(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
+               	jb	 <L81>
+               	jmp	 <L83>
+<L81>:
+               	movsd	-0x120(%rbp), %xmm14
+               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x8e5>
+               	movsd	%xmm14, -0x110(%rbp)
                	movq	%r12, %rdi
-               	movsd	-0x118(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %r14
-               	jmp	 <L99>
-<L97>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r14
-<L99>:
+               	movsd	-0x110(%rbp), %xmm0
+               	callq	 <L82>
+<L82>:
                	addq	$0x1, %r13
-               	movq	%r14, %r12
-               	movq	-0x118(%rbp), %r11
-               	movq	%r11, -0x128(%rbp)
+               	movq	%rax, %r12
+               	movq	-0x110(%rbp), %r11
+               	movq	%r11, -0x120(%rbp)
                	cmpq	$0x3c, %r13
-               	jb	 <L95>
-<L100>:
-               	leaq	-0x40(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, 0x18(%r13)
-               	movq	$0x0, 0x20(%r13)
-               	movq	$0x0, 0x28(%r13)
-               	movq	$0x0, 0x30(%r13)
-               	movq	$0x0, 0x38(%r13)
-               	leaq	(%r13), %rax
+               	jb	 <L81>
+<L83>:
+               	leaq	-0x40(%rbp), %rax
                	movq	$0x0, (%rax)
-               	leaq	0x8(%r13), %rax
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	movq	$0x0, 0x30(%rax)
+               	movq	$0x0, 0x38(%rax)
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x10(%r13), %rax
-               	movq	$0x1, (%rax)
-               	leaq	0x18(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movq	$0x1, (%rdx)
+               	leaq	0x18(%rax), %rdx
                	movabsq	$0x7ff0000000000000, %r11 # imm = 0x7FF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x20(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x20(%rax), %rdx
                	movabsq	$-0x10000000000000, %r11 # imm = 0xFFF0000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x28(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x28(%rax), %rdx
                	movabsq	$0x7ff8000000000000, %r11 # imm = 0x7FF8000000000000
-               	movq	%r11, (%rax)
-               	leaq	0x30(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x30(%rax), %rdx
                	movabsq	$-0x7ffffff3f2153, %r11 # imm = 0xFFF8000000C0DEAD
-               	movq	%r11, (%rax)
-               	leaq	0x38(%r13), %rax
+               	movq	%r11, (%rdx)
+               	leaq	0x38(%rax), %rdx
                	movabsq	$0x7ff0000000000001, %r11 # imm = 0x7FF0000000000001
-               	movq	%r11, (%rax)
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
-               	jb	 <L101>
-               	jmp	 <L103>
-<L101>:
-               	leaq	(%r13,%r14,8), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	movq	%rcx, %xmm0
+               	movq	%r11, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+               	jmp	 <L87>
+<L84>:
+               	leaq	(%rax,%rdx,8), %rsi
+               	movq	(%rsi), %rdi
+               	addq	%rbx, %rdi
+               	movq	%rdi, %xmm0
                	movq	%xmm0, %rsi
                	movq	%r12, %rdi
-               	callq	 <L102>
-<L102>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r14
-               	jb	 <L101>
-<L103>:
-               	movsd	-0xc8(%rbp), %xmm15
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+               	jmp	 <L86>
+<L85>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L85>
+<L86>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L84>
+<L87>:
+               	movsd	-0xc0(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm0
-               	movsd	-0xf8(%rbp), %xmm15
-               	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x138(%rbp)
+               	movsd	-0xf0(%rbp), %xmm15
+               	cvtsd2ss	%xmm15, %xmm2
                	movabsq	$0x36a0000000000000, %rax # imm = 0x36A0000000000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x148(%rbp)
+               	cvtsd2ss	%xmm5, %xmm7
                	movabsq	$0x3ff0000010000000, %rax # imm = 0x3FF0000010000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x158(%rbp)
+               	cvtsd2ss	%xmm5, %xmm8
                	movabsq	$0x3ff0000030000000, %rax # imm = 0x3FF0000030000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm5
-               	cvtsd2ss	%xmm5, %xmm14
-               	movss	%xmm14, -0x168(%rbp)
-               	movsd	-0x88(%rbp), %xmm15
+               	cvtsd2ss	%xmm5, %xmm9
+               	movsd	-0x80(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x178(%rbp)
-               	movsd	-0xa8(%rbp), %xmm15
+               	movss	%xmm14, -0x130(%rbp)
+               	movsd	-0xa0(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm14
-               	movss	%xmm14, -0x188(%rbp)
+               	movss	%xmm14, -0x140(%rbp)
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+               	jmp	 <L89>
+<L88>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L88>
+<L89>:
+               	movd	%xmm2, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+               	jmp	 <L91>
+<L90>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L90>
+<L91>:
+               	movd	%xmm7, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+               	jmp	 <L93>
+<L92>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L92>
+<L93>:
+               	movd	%xmm8, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+               	jmp	 <L95>
+<L94>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L94>
+<L95>:
+               	movd	%xmm9, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+               	jmp	 <L97>
+<L96>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L96>
+<L97>:
+               	movl	-0x130(%rbp), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+               	jmp	 <L99>
+<L98>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L98>
+<L99>:
+               	movl	-0x140(%rbp), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
+               	jmp	 <L101>
+<L100>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r12, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rax
+               	jb	 <L100>
+<L101>:
+               	cvtss2sd	%xmm7, %xmm0
+               	movq	%r12, %rdi
+               	callq	 <L102>
+<L102>:
+               	movss	-0x130(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L103>
+<L103>:
+               	movss	-0x140(%rbp), %xmm15
+               	cvtss2sd	%xmm15, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
-               	movq	%rax, %rdi
-               	movss	-0x138(%rbp), %xmm0
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rdi
-               	movss	-0x148(%rbp), %xmm0
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rdi
-               	movss	-0x158(%rbp), %xmm0
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rdi
-               	movss	-0x168(%rbp), %xmm0
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %rdi
-               	movss	-0x178(%rbp), %xmm0
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %rdi
-               	movss	-0x188(%rbp), %xmm0
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r12
-               	movss	-0x148(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %r13
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r13
-<L114>:
-               	movss	-0x178(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%r13, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movss	-0x188(%rbp), %xmm15
-               	cvtss2sd	%xmm15, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L120>
-               	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %r13
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %r13
-<L122>:
-               	movabsq	$0x20000000000000, %rax # imm = 0x20000000000000
-               	addq	%rbx, %rax
+               	movabsq	$0x20000000000000, %rdx # imm = 0x20000000000000
+               	addq	%rbx, %rdx
                	movabsq	$0x20000000000001, %r12 # imm = 0x20000000000001
                	addq	%rbx, %r12
-               	movabsq	$0x20000000000003, %r14 # imm = 0x20000000000003
+               	movabsq	$0x20000000000003, %r13 # imm = 0x20000000000003
+               	addq	%rbx, %r13
+               	movq	$-0x1, %r14
                	addq	%rbx, %r14
-               	movq	$-0x1, %r15
+               	movabsq	$-0x20000000000001, %r15 # imm = 0xFFDFFFFFFFFFFFFF
                	addq	%rbx, %r15
-               	movabsq	$-0x20000000000001, %r8 # imm = 0xFFDFFFFFFFFFFFFF
-               	addq	%rbx, %r8
-               	movq	%r8, -0x190(%rbp)
                	movabsq	$-0x8000000000000000, %r8 # imm = 0x8000000000000000
                	addq	%rbx, %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	%rax, %r11
+               	movq	%r8, -0x148(%rbp)
+               	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L123>
+               	jl	 <L105>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L124>
-<L123>:
+               	jmp	 <L106>
+<L105>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L124>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L126>
-               	movq	%r13, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-               	jmp	 <L128>
-<L126>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x48(%rbp)
-<L128>:
+<L106>:
+               	movq	%rax, %rdi
+               	callq	 <L107>
+<L107>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L129>
+               	jl	 <L108>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L130>
-<L129>:
+               	jmp	 <L109>
+<L108>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L130>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	-0x48(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L109>:
+               	movq	%rax, %rdi
+               	callq	 <L110>
+<L110>:
+               	movq	%r13, %r11
+               	testq	%r11, %r11
+               	jl	 <L111>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L112>
+<L111>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L112>:
+               	movq	%rax, %rdi
+               	callq	 <L113>
+<L113>:
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L135>
+               	jl	 <L114>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L136>
-<L135>:
+               	jmp	 <L115>
+<L114>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L136>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L138>
-               	movq	%r12, %rdi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %r13
-               	jmp	 <L140>
-<L138>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r13
-<L140>:
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L141>
-               	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L142>
-<L141>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	addsd	%xmm0, %xmm0
-<L142>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r13, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %r12
-               	jmp	 <L146>
-<L144>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %r12
-<L146>:
+<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L116>
+<L116>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L147>
+               	jl	 <L117>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L148>
-<L147>:
+               	jmp	 <L118>
+<L117>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L148>:
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L150>
-               	movq	%r12, %rdi
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rbx
-               	jmp	 <L152>
-<L150>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-<L152>:
-               	movq	-0x190(%rbp), %r8
+<L118>:
+               	movq	%rax, %rdi
+               	callq	 <L119>
+<L119>:
+               	movq	%r15, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L120>
+<L120>:
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L154>
-               	movq	%rbx, %rdi
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %r12
-               	jmp	 <L156>
-<L154>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L155>
-<L155>:
-               	movq	%rax, %r12
-<L156>:
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L158>
-               	movq	%r12, %rdi
-               	callq	 <L157>
-<L157>:
-               	movq	%rax, %rbx
-               	jmp	 <L160>
-<L158>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L159>
-<L159>:
-               	movq	%rax, %rbx
-<L160>:
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1020>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1a8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1b8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1050>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1c8(%rbp)
+               	movq	%rax, %rdi
+               	callq	 <L121>
+<L121>:
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf25>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x158(%rbp)
+               	movsd	, %xmm2 <corpus.cases.float.special_f64.checksum+0xf3c>
+               	mulsd	-0x50(%rbp), %xmm2
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf4a>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x168(%rbp)
                	xorps	%xmm14, %xmm14
-               	subsd	-0x1a8(%rbp), %xmm14
-               	movsd	%xmm14, -0x1d8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x107e>
-               	mulsd	-0x58(%rbp), %xmm14
-               	movsd	%xmm14, -0x1e8(%rbp)
-               	movsd	-0x1a8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x109f>
-               	jb	 <L161>
+               	subsd	-0x158(%rbp), %xmm14
+               	movsd	%xmm14, -0x178(%rbp)
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf78>
+               	mulsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x188(%rbp)
+               	movsd	-0x158(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf99>
+               	jb	 <L122>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10b2>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xfac>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L162>
-<L161>:
+               	jmp	 <L123>
+<L122>:
                	cvttsd2si	%xmm14, %r11
-<L162>:
-               	movq	%r11, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
-               	movsd	-0x1b8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10eb>
-               	jb	 <L164>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10fe>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L165>
-<L164>:
-               	cvttsd2si	%xmm14, %r11
-<L165>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	movsd	-0x1c8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1137>
-               	jb	 <L167>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x114a>
-               	cvttsd2si	%xmm14, %r11
-               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
-               	addq	%r10, %r11
-               	jmp	 <L168>
-<L167>:
-               	cvttsd2si	%xmm14, %r11
-<L168>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
-               	movsd	-0x1e8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1183>
-               	jb	 <L170>
-               	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1196>
+<L123>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L124>
+               	jmp	 <L125>
+<L124>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L124>
+<L125>:
+               	ucomisd	, %xmm2 <corpus.cases.float.special_f64.checksum+0x1025>
+               	jb	 <L126>
+               	movaps	%xmm2, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L171>
-<L170>:
-               	cvttsd2si	%xmm14, %r11
-<L171>:
-               	movq	%r11, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L172>
-<L172>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11cc>
-               	jb	 <L173>
+               	jmp	 <L127>
+<L126>:
+               	cvttsd2si	%xmm2, %r11
+<L127>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L128>
+               	jmp	 <L129>
+<L128>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L128>
+<L129>:
+               	movsd	-0x168(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10bb>
+               	jb	 <L130>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11df>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10ce>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L174>
-<L173>:
+               	jmp	 <L131>
+<L130>:
                	cvttsd2si	%xmm14, %r11
-<L174>:
+<L131>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L132>
+               	jmp	 <L133>
+<L132>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L132>
+<L133>:
+               	movsd	-0x188(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1151>
+               	jb	 <L134>
+               	movaps	%xmm14, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1164>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L135>
+<L134>:
+               	cvttsd2si	%xmm14, %r11
+<L135>:
+               	movq	%r11, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L136>
+               	jmp	 <L137>
+<L136>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L136>
+<L137>:
+               	movsd	-0x70(%rbp), %xmm14
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11e4>
+               	jb	 <L138>
+               	movaps	%xmm14, %xmm14
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11f7>
+               	cvttsd2si	%xmm14, %r11
+               	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
+               	addq	%r10, %r11
+               	jmp	 <L139>
+<L138>:
+               	cvttsd2si	%xmm14, %r11
+<L139>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
-               	movsd	-0x1d8(%rbp), %xmm14
+               	callq	 <L140>
+<L140>:
+               	movsd	-0x178(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
-               	movsd	-0x1c8(%rbp), %xmm14
+               	callq	 <L141>
+<L141>:
+               	movsd	-0x168(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L142>
+<L142>:
                	xorps	%xmm1, %xmm1
-               	subsd	-0x1e8(%rbp), %xmm1
+               	subsd	-0x188(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
-               	movsd	-0x1d8(%rbp), %xmm14
+               	callq	 <L143>
+<L143>:
+               	movsd	-0x178(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movslq	%edx, %rsi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L179>
-<L179>:
-               	movsd	-0x1a8(%rbp), %xmm14
+               	callq	 <L144>
+<L144>:
+               	movsd	-0x158(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L180>
-<L180>:
-               	movq	-0x1f8(%rbp), %rbx
-               	movq	-0x200(%rbp), %r12
-               	movq	-0x208(%rbp), %r13
-               	movq	-0x210(%rbp), %r14
-               	movq	-0x218(%rbp), %r15
+               	callq	 <L145>
+<L145>:
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
+               	movq	-0x1b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/frame/frame_align.dis
+++ b/test/golden/x86_64-linux/frame/frame_align.dis
@@ -7,28 +7,108 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,18 +118,58 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -59,32 +179,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -161,73 +353,70 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	andq	$-0x40, %rsp
-               	subq	$0x3c0, %rsp            # imm = 0x3C0
-               	movq	%rbx, 0x28(%rsp)
-               	movq	%r12, 0x20(%rsp)
-               	movq	%r13, 0x18(%rsp)
-               	movq	%r14, 0x10(%rsp)
-               	movq	%r15, 0x8(%rsp)
+               	subq	$0x380, %rsp            # imm = 0x380
+               	movq	%rbx, 0x58(%rsp)
+               	movq	%r12, 0x50(%rsp)
+               	movq	%r13, 0x48(%rsp)
+               	movq	%r14, 0x40(%rsp)
+               	movq	%r15, 0x38(%rsp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, 0xe8(%rsp)
-               	movq	0xe8(%rsp), %r8
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L4>:
-               	leaq	0x3b0(%rsp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xb4>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xbb>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     # imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xd5>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xdc>
-               	leaq	0xc(%rcx), %rsi
-               	movss	%xmm2, (%rsi)
-               	movups	(%rcx), %xmm2
-               	leaq	0x3a0(%rsp), %r8
-               	movq	%r8, 0xe0(%rsp)
-               	movq	0xe0(%rsp), %r8
+<L3>:
+               	leaq	0x370(%rsp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x9c>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xa3>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     # imm = 0x40700000
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xbd>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0xc4>
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	0x360(%rsp), %r8
+               	movq	%r8, 0x148(%rsp)
+               	movq	0x148(%rsp), %r8
                	movups	%xmm2, (%r8)
-               	leaq	0x390(%rsp), %rsi
-               	leaq	(%rsi), %r12
+               	leaq	0x350(%rsp), %rdi
+               	leaq	(%rdi), %r12
                	movabsq	$0x3ff4000000000000, %r11 # imm = 0x3FF4000000000000
                	movq	%r11, (%r12)
-               	leaq	0x8(%rsi), %r12
+               	leaq	0x8(%rdi), %r12
                	movabsq	$-0x3ff4000000000000, %r11 # imm = 0xC00C000000000000
                	movq	%r11, (%r12)
-               	movups	(%rsi), %xmm3
-               	leaq	0x380(%rsp), %rsi
-               	movups	%xmm3, (%rsi)
-               	leaq	0x370(%rsp), %r12
+               	movups	(%rdi), %xmm3
+               	leaq	0x340(%rsp), %r8
+               	movq	%r8, 0x110(%rsp)
+               	movq	0x110(%rsp), %r8
+               	movups	%xmm3, (%r8)
+               	leaq	0x330(%rsp), %r12
                	leaq	(%r12), %r13
                	movl	$0xffffffff, (%r13)     # imm = 0xFFFFFFFF
                	leaq	0x4(%r12), %r13
@@ -237,9 +426,9 @@ Disassembly of section .text:
                	leaq	0xc(%r12), %r13
                	movl	$0x12345678, (%r13)     # imm = 0x12345678
                	movups	(%r12), %xmm4
-               	leaq	0x360(%rsp), %r12
+               	leaq	0x320(%rsp), %r12
                	movups	%xmm4, (%r12)
-               	leaq	0x350(%rsp), %r13
+               	leaq	0x310(%rsp), %r13
                	leaq	(%r13), %r14
                	movabsq	$0x3fe0000000000000, %r11 # imm = 0x3FE0000000000000
                	movq	%r11, (%r14)
@@ -247,663 +436,478 @@ Disassembly of section .text:
                	movabsq	$0x4019000000000000, %r11 # imm = 0x4019000000000000
                	movq	%r11, (%r14)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, 0x80(%rsp)
-               	leaq	0x340(%rsp), %r13
-               	movups	0x80(%rsp), %xmm14
+               	movups	%xmm14, 0xc0(%rsp)
+               	leaq	0x300(%rsp), %r13
+               	leaq	(%r13), %r14
+               	movl	$0xc2b2ae3d, (%r14)     # imm = 0xC2B2AE3D
+               	leaq	0x4(%r13), %r14
+               	movl	$0x85ebca77, (%r14)     # imm = 0x85EBCA77
+               	leaq	0x8(%r13), %r14
+               	movl	$0x7, (%r14)
+               	leaq	0xc(%r13), %r14
+               	movl	$0xfffffffb, (%r14)     # imm = 0xFFFFFFFB
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, 0xb0(%rsp)
+               	leaq	0x2f0(%rsp), %r13
+               	movups	0xb0(%rsp), %xmm14
                	movups	%xmm14, (%r13)
-               	leaq	0x330(%rsp), %r14
+               	leaq	0x200(%rsp), %r14
                	leaq	(%r14), %r15
-               	movl	$0xc2b2ae3d, (%r15)     # imm = 0xC2B2AE3D
-               	leaq	0x4(%r14), %r15
-               	movl	$0x85ebca77, (%r15)     # imm = 0x85EBCA77
-               	leaq	0x8(%r14), %r15
-               	movl	$0x7, (%r15)
-               	leaq	0xc(%r14), %r15
-               	movl	$0xfffffffb, (%r15)     # imm = 0xFFFFFFFB
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, 0x70(%rsp)
-               	leaq	0x320(%rsp), %r14
-               	movups	0x70(%rsp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	0x240(%rsp), %r15
-               	leaq	(%r15), %rdi
-               	addq	$0x0, %rdi
-               	movq	$0xc0, %rcx
-<L5>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L5>
-               	leaq	0x200(%rsp), %r8
-               	movq	%r8, 0x68(%rsp)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, (%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x30(%r8)
-               	movq	0x68(%rsp), %r8
-               	movq	$0x0, 0x38(%r8)
-               	movq	%rbx, %rdi
-               	addq	$0x1, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xd8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x3, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xd0(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x5, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xc8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0x7, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xc0(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0xfff1, %rdi           # imm = 0xFFF1
-               	movw	%di, %r8w
-               	movq	%r8, 0xb8(%rsp)
-               	movq	%rbx, %rdi
-               	addq	$0xfb, %rdi
-               	movb	%dil, %r8b
-               	movq	%r8, 0xb0(%rsp)
-               	movq	0xe0(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm7
+               	addq	$0x0, %r15
+               	movq	$0xc0, %rsi
+<L4>:
+               	movq	$0x0, (%r15)
+               	addq	$0x8, %r15
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L4>
+               	leaq	0x1c0(%rsp), %r15
+               	movq	$0x0, (%r15)
+               	movq	$0x0, 0x8(%r15)
+               	movq	$0x0, 0x10(%r15)
+               	movq	$0x0, 0x18(%r15)
+               	movq	$0x0, 0x20(%r15)
+               	movq	$0x0, 0x28(%r15)
+               	movq	$0x0, 0x30(%r15)
+               	movq	$0x0, 0x38(%r15)
+               	movq	%rbx, %rsi
+               	addq	$0x1, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x140(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x3, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x138(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x5, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x130(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0x7, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x128(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0xfff1, %rsi           # imm = 0xFFF1
+               	movw	%si, %r8w
+               	movq	%r8, 0x120(%rsp)
+               	movq	%rbx, %rsi
+               	addq	$0xfb, %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, 0x118(%rsp)
+               	movq	0x148(%rsp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm7
                	movss	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1,2,3]
                	addss	%xmm0, %xmm8
-               	leaq	0x1f0(%rsp), %r8
-               	movq	%r8, 0xa8(%rsp)
-               	movq	0xa8(%rsp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	0xa8(%rsp), %r8
-               	leaq	(%r8), %rdi
+               	leaq	0x1b0(%rsp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	(%rsi), %rdi
                	movss	%xmm8, (%rdi)
-               	movq	0xa8(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x50(%rsp)
-               	leaq	0x8(%rsi), %rdi
-               	movsd	(%rdi), %xmm0
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, 0xa0(%rsp)
+               	movq	0x110(%rsp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movsd	(%rsi), %xmm0
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	addsd	%xmm1, %xmm7
-               	leaq	0x1e0(%rsp), %r8
-               	movq	%r8, 0x60(%rsp)
-               	movq	0x60(%rsp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	0x60(%rsp), %r8
-               	leaq	0x8(%r8), %rdi
+               	leaq	0x1a0(%rsp), %rsi
+               	movups	%xmm3, (%rsi)
+               	leaq	0x8(%rsi), %rdi
                	movsd	%xmm7, (%rdi)
-               	movq	0x60(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x40(%rsp)
-               	leaq	0x8(%r12), %rdi
-               	movl	(%rdi), %r12d
-               	movl	%ebx, %edi
-               	addl	%edi, %r12d
-               	leaq	0x1d0(%rsp), %r8
-               	movq	%r8, 0xa0(%rsp)
-               	movq	0xa0(%rsp), %r8
-               	movups	%xmm4, (%r8)
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movl	%r12d, (%rdi)
-               	movq	0xa0(%rsp), %r8
-               	movups	(%r8), %xmm14
-               	movups	%xmm14, 0x30(%rsp)
-               	movq	0xa8(%rsp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	0xe8(%rsp), %r8
-               	movq	%r8, %rdi
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, 0x90(%rsp)
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %edi
+               	movl	%ebx, %esi
+               	addl	%esi, %edi
+               	leaq	0x190(%rsp), %r12
+               	movups	%xmm4, (%r12)
+               	leaq	0x8(%r12), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, 0x80(%rsp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	0xa0(%rsp), %xmm0
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %rdi
+               	movups	0x90(%rsp), %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0x4(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movups	0x80(%rsp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0x8(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movaps	0xa0(%rsp), %xmm14
+               	addps	0xa0(%rsp), %xmm14
+               	movaps	%xmm14, 0x70(%rsp)
+               	movups	0x70(%rsp), %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	0xa8(%rsp), %r8
-               	leaq	0xc(%r8), %r12
-               	movss	(%r12), %xmm0
+               	movaps	0xa0(%rsp), %xmm14
+               	mulps	0xa0(%rsp), %xmm14
+               	movaps	%xmm14, 0x60(%rsp)
+               	movups	0x60(%rsp), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	movq	0x60(%rsp), %r8
-               	leaq	(%r8), %r12
-               	movsd	(%r12), %xmm0
+               	movups	0xc0(%rsp), %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	0x60(%rsp), %r8
-               	leaq	0x8(%r8), %r12
-               	movsd	(%r12), %xmm0
+               	movaps	0x90(%rsp), %xmm14
+               	mulpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movaps	0x90(%rsp), %xmm14
+               	subpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movaps	0x90(%rsp), %xmm14
+               	divpd	0xc0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movups	0xb0(%rsp), %xmm0
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
+               	movq	%rax, %r8
+               	movq	%r8, 0x108(%rsp)
+               	movq	0x108(%rsp), %r8
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %r8d
+               	movq	%r8, 0x100(%rsp)
+               	leaq	(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movq	0x100(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, 0xf8(%rsp)
+               	leaq	0x4(%r12), %rdi
+               	movl	(%rdi), %r8d
+               	movq	%r8, 0xf0(%rsp)
+               	leaq	0x4(%r13), %rdi
+               	movl	(%rdi), %esi
+               	movq	0xf0(%rsp), %r9
+               	movl	%r9d, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, 0xe8(%rsp)
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %r8d
+               	movq	%r8, 0xe0(%rsp)
+               	leaq	0x8(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movq	0xe0(%rsp), %r8
+               	movl	%r8d, %esi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rdi
+               	movl	(%rdi), %r12d
+               	leaq	0xc(%r13), %rdi
+               	movl	(%rdi), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0x180(%rsp), %rdi
+               	movups	0x80(%rsp), %xmm14
+               	movups	%xmm14, (%rdi)
+               	leaq	(%rdi), %r13
+               	movq	0xf8(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x170(%rsp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rdi), %r13
+               	movq	0xe8(%rsp), %r8
+               	movl	%r8d, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x160(%rsp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x8(%rdi), %r13
+               	movl	%esi, (%r13)
+               	movups	(%rdi), %xmm0
+               	leaq	0x150(%rsp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	%r12d, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movq	0x108(%rsp), %r8
+               	movq	%r8, %rdi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movaps	0x50(%rsp), %xmm14
-               	addps	0x50(%rsp), %xmm14
+               	movaps	0x80(%rsp), %xmm14
+               	paddd	0xb0(%rsp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1b0(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movss	(%rsi), %xmm0
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movaps	0x80(%rsp), %xmm14
+               	pxor	0xb0(%rsp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm3, %xmm0
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	movups	0xa0(%rsp), %xmm0
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%r12, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rdi
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x1a0(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	movups	0x60(%rsp), %xmm0
                	callq	 <L20>
 <L20>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%r12, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movss	(%rsi), %xmm0
+               	movq	%rax, %r12
+               	leaq	(%r15), %rsi
+               	movups	0xa0(%rsp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movups	0x70(%rsp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movups	0xa0(%rsp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	mulpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x190(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	subpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x180(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	0x40(%rsp), %xmm14
-               	divpd	0x80(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x170(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movsd	(%rsi), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r8
-               	movq	%r8, 0x98(%rsp)
-               	movq	0x98(%rsp), %r8
-               	movq	0xa0(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	leaq	(%r14), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, 0x90(%rsp)
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r13d
-               	leaq	0x4(%r14), %rsi
-               	movl	(%rsi), %edi
-               	imull	%edi, %r13d
-               	movq	0xa0(%rsp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %edi
-               	leaq	0x8(%r14), %rsi
-               	movl	(%rsi), %r12d
-               	imull	%r12d, %edi
-               	movq	0xa0(%rsp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	(%rsi), %r12d
-               	leaq	0xc(%r14), %rsi
-               	movl	(%rsi), %r14d
-               	imull	%r14d, %r12d
-               	leaq	0x160(%rsp), %rsi
-               	movups	0x30(%rsp), %xmm14
+               	leaq	0x20(%r15), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x30(%r15), %rsi
+               	movups	0x60(%rsp), %xmm14
                	movups	%xmm14, (%rsi)
-               	leaq	(%rsi), %r14
-               	movq	0x90(%rsp), %r8
-               	movl	%r8d, (%r14)
-               	movups	(%rsi), %xmm0
-               	leaq	0x150(%rsp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x4(%rsi), %r14
-               	movl	%r13d, (%r14)
-               	movups	(%rsi), %xmm0
-               	leaq	0x140(%rsp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	0x8(%rsi), %r13
-               	movl	%edi, (%r13)
-               	movups	(%rsi), %xmm0
-               	leaq	0x130(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rsi
-               	movl	%r12d, (%rsi)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movq	0x98(%rsp), %r8
-               	movq	%r8, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	movaps	0x30(%rsp), %xmm14
-               	paddd	0x70(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0x120(%rsp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	movaps	0x30(%rsp), %xmm14
-               	pxor	0x70(%rsp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x110(%rsp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rsi
-               	movl	(%rsi), %r13d
-               	movl	%r13d, %esi
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rsi
-               	movl	(%rsi), %r12d
-               	movl	%r12d, %esi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-               	movups	0x50(%rsp), %xmm0
-               	callq	 <L48>
-<L48>:
-               	leaq	0x100(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %r12
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L53>
-<L53>:
-               	leaq	0xf0(%rsp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r12, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r12
-               	movq	0x68(%rsp), %r8
-               	leaq	(%r8), %rsi
-               	movups	0x50(%rsp), %xmm14
-               	movups	%xmm14, (%rsi)
-               	movaps	0x50(%rsp), %xmm14
-               	addps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	0x68(%rsp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movups	%xmm0, (%rsi)
-               	movups	0x50(%rsp), %xmm0
-               	callq	 <L58>
-<L58>:
-               	movq	0x68(%rsp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movups	%xmm0, (%rsi)
-               	movaps	0x50(%rsp), %xmm14
-               	mulps	0x50(%rsp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	movq	0x68(%rsp), %r8
-               	leaq	0x30(%r8), %rsi
-               	movups	%xmm2, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L59>
-               	jmp	 <L64>
-<L59>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rsi
                	imulq	$0x10, %rsi, %rsi
-               	movq	0x68(%rsp), %r8
-               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%r15,%rsi), %rdi
                	movups	(%rdi), %xmm0
-               	leaq	0x1c0(%rsp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %r12
+               	addq	$0x1, %r13
+               	cmpq	$0x4, %r13
+               	jb	 <L23>
+<L25>:
+               	movabsq	$0x1111111111111111, %r8 # imm = 0x1111111111111111
+               	addq	%rbx, %r8
+               	movq	%r8, 0xd8(%rsp)
+               	movabsq	$0x7777777777777777, %rdi # imm = 0x7777777777777777
+               	xorq	%rbx, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	0xd8(%rsp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r12, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %r13
                	movq	%rsi, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L59>
-<L64>:
-               	movabsq	$0x1111111111111111, %r13 # imm = 0x1111111111111111
-               	addq	%rbx, %r13
-               	movabsq	$0x7777777777777777, %r14 # imm = 0x7777777777777777
-               	xorq	%rbx, %r14
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L66>
-<L66>:
-               	movq	%rax, %rcx
+               	cmpq	$0x8, %r13
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r12, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r12
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
                	movq	$0x0, %rsi
                	cmpq	$0x3, %rsi
-               	jb	 <L67>
-               	jmp	 <L68>
-<L67>:
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
                	movq	%rsi, %rdi
                	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
                	imulq	%r11, %rdi
                	addq	%rbx, %rdi
-               	movq	%rsi, %r12
-               	imulq	$0x40, %r12, %r12
-               	leaq	(%r15,%r12), %r14
-               	leaq	(%r14), %r12
-               	movq	%rdi, (%r12)
+               	movq	%rsi, %r13
+               	imulq	$0x40, %r13, %r13
+               	leaq	(%r14,%r13), %r15
+               	leaq	(%r15), %r13
+               	movq	%rdi, (%r13)
                	movq	%rsi, %rdi
                	shlq	$0x28, %rdi
-               	xorq	%r13, %rdi
-               	leaq	0x8(%r14), %r12
-               	movq	%rdi, (%r12)
+               	movq	0xd8(%rsp), %r8
+               	xorq	%r8, %rdi
+               	leaq	0x8(%r15), %r13
+               	movq	%rdi, (%r13)
                	addq	$0x1, %rsi
                	cmpq	$0x3, %rsi
-               	jb	 <L67>
-<L68>:
-               	movq	%rcx, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x3, %r12
-               	jb	 <L69>
-               	jmp	 <L72>
-<L69>:
-               	movq	%r12, %rcx
-               	imulq	$0x40, %rcx, %rcx
-               	leaq	(%r15,%rcx), %r13
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	cmpq	$0x3, %r12
-               	jb	 <L69>
-<L72>:
-               	movq	%rbx, %rdi
-               	movq	0xd8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
+               	jb	 <L30>
+<L31>:
+               	movq	%r12, %r8
+               	movq	%r8, 0xd0(%rsp)
                	movq	$0x0, %rsi
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rdi
+               	cmpq	$0x3, %rsi
+               	jb	 <L32>
+               	jmp	 <L37>
+<L32>:
+               	movq	%rsi, %rdi
+               	imulq	$0x40, %rdi, %rdi
+               	leaq	(%r14,%rdi), %rbx
+               	leaq	(%rbx), %rdi
+               	movq	(%rdi), %rbx
                	movq	0xd0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L75>
-<L75>:
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %r12
+               	xorq	%r15, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %r13
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L33>
+<L34>:
+               	movq	%rsi, %rbx
+               	imulq	$0x40, %rbx, %rbx
+               	leaq	(%r14,%rbx), %r12
+               	leaq	0x8(%r12), %rbx
+               	movq	(%rbx), %r12
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L35>
+<L36>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, 0xd0(%rsp)
+               	cmpq	$0x3, %rsi
+               	jb	 <L32>
+<L37>:
+               	movq	0x140(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	movq	0xd0(%rsp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+               	jmp	 <L39>
+<L38>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L38>
+<L39>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+               	jmp	 <L41>
+<L40>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x0, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L40>
+<L41>:
+               	movq	0x138(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L42>
+<L42>:
                	movq	%rax, %rdi
-               	movq	0xc8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L76>
-<L76>:
+               	movq	0x130(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L43>
+<L43>:
                	movq	%rax, %rdi
-               	movq	0xc0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L77>
-<L77>:
+               	movq	0x128(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %rdi
-               	movq	0xb8(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L78>
-<L78>:
+               	movq	0x120(%rsp), %r8
+               	movzwq	%r8w, %rsi
+               	callq	 <L45>
+<L45>:
                	movq	%rax, %rdi
-               	movq	0xb0(%rsp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	0x28(%rsp), %rbx
-               	movq	0x20(%rsp), %r12
-               	movq	0x18(%rsp), %r13
-               	movq	0x10(%rsp), %r14
-               	movq	0x8(%rsp), %r15
+               	movq	0x118(%rsp), %r8
+               	movzbq	%r8b, %rsi
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	0x58(%rsp), %rbx
+               	movq	0x50(%rsp), %r12
+               	movq	0x48(%rsp), %r13
+               	movq	0x40(%rsp), %r14
+               	movq	0x38(%rsp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/frame/frame_large.dis
+++ b/test/golden/x86_64-linux/frame/frame_large.dis
@@ -5,282 +5,547 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2070, %rsp           # imm = 0x2070
-               	movq	%rbx, -0x2048(%rbp)
-               	movq	%r12, -0x2050(%rbp)
-               	movq	%r13, -0x2058(%rbp)
-               	movq	%r14, -0x2060(%rbp)
-               	movq	%r15, -0x2068(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x1400(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x1400, %rsi           # imm = 0x1400
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	leaq	-0x1c00(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x800, %rsi            # imm = 0x800
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L2>
-               	leaq	-0x2000(%rbp), %r8
+               	subq	$0x2050, %rsp           # imm = 0x2050
+               	movq	%rbx, -0x2028(%rbp)
+               	movq	%r12, -0x2030(%rbp)
+               	movq	%r13, -0x2038(%rbp)
+               	movq	%r14, -0x2040(%rbp)
+               	movq	%r15, -0x2048(%rbp)
+               	movq	%rdi, %r8
                	movq	%r8, -0x2020(%rbp)
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x400, %rsi            # imm = 0x400
-<L3>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L3>
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	leaq	0x13f8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7fc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	0x3ff(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x280, %rsi            # imm = 0x280
-               	jb	 <L10>
-               	jmp	 <L11>
-<L10>:
-               	movq	%rsi, %rdi
-               	addq	%rbx, %rdi
-               	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
-               	imulq	%r11, %rdi
-               	movq	%rsi, %r15
-               	shlq	$0x11, %r15
-               	xorq	%r15, %rdi
-               	leaq	(%r12,%rsi,8), %r15
-               	movq	%rdi, (%r15)
-               	addq	$0x1, %rsi
-               	cmpq	$0x280, %rsi            # imm = 0x280
-               	jb	 <L10>
-<L11>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
-               	jb	 <L12>
-               	jmp	 <L13>
-<L12>:
-               	movq	%rsi, %rdi
-               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rdi
-               	addq	%rbx, %rdi
-               	movq	%rsi, %r15
-               	shrq	$0x3, %r15
-               	xorq	%r15, %rdi
-               	movl	%edi, %r15d
-               	leaq	(%r13,%rsi,4), %rdi
-               	movl	%r15d, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
-               	jb	 <L12>
-<L13>:
-               	movq	$0x0, %rsi
-               	cmpq	$0x400, %rsi            # imm = 0x400
-               	jb	 <L14>
-               	jmp	 <L15>
-<L14>:
-               	movq	%rsi, %rdi
-               	imulq	$0x83, %rdi, %rdi
-               	addq	%rbx, %rdi
-               	movq	%rsi, %r15
-               	shrq	$0x2, %r15
-               	xorq	%r15, %rdi
-               	movb	%dil, %r15b
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8,%rsi), %rdi
-               	movb	%r15b, (%rdi)
-               	addq	$0x1, %rsi
-               	cmpq	$0x400, %rsi            # imm = 0x400
-               	jb	 <L14>
-<L15>:
-               	movq	%rcx, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x2038(%rbp)
-               	movq	-0x2038(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L16>
-               	jmp	 <L20>
-<L16>:
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0x9, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %rax
-               	movq	$0x280, %rsi            # imm = 0x280
-               	xorl	%edx, %edx
-               	divq	%rsi
-               	movq	%rdx, %rsi
-               	leaq	(%r12,%rsi,8), %rdi
-               	movq	(%rdi), %rsi
-               	movq	%r15, %rdi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %r8
+               	leaq	-0x1400(%rbp), %r8
+               	movq	%r8, -0x2018(%rbp)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x1400, %r12           # imm = 0x1400
+<L0>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L0>
+               	leaq	-0x1c00(%rbp), %r8
+               	movq	%r8, -0x2010(%rbp)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0x800, %r13            # imm = 0x800
+<L1>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L1>
+               	leaq	-0x2000(%rbp), %r8
                	movq	%r8, -0x2008(%rbp)
                	movq	-0x2008(%rbp), %r8
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	(%r8), %r13
+               	addq	$0x0, %r13
+               	movq	$0x400, %r14            # imm = 0x400
+<L2>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L2>
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	(%r13), %r14
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r15, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %rbx
+               	xorq	%r12, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L3>
+<L4>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rbx
+               	movq	(%rbx), %r12
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+<L6>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movl	(%rbx), %r12d
+               	movl	%r12d, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L7>
+<L8>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rbx
+               	movl	(%rbx), %r12d
+               	movl	%r12d, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L9>
+<L10>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movzbl	(%rbx), %r12d
+               	movzbq	%r12b, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rbx
+               	movzbl	(%rbx), %r12d
+               	movzbq	%r12b, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%r12, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r13
+               	cmpq	$0x8, %r12
+               	jb	 <L13>
+<L14>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x280, %rbx            # imm = 0x280
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	-0x2020(%rbp), %r8
+               	movq	%rbx, %r12
+               	addq	%r8, %r12
+               	movabsq	$0x5851f42d4c957f2d, %r11 # imm = 0x5851F42D4C957F2D
+               	imulq	%r11, %r12
+               	movq	%rbx, %r14
+               	shlq	$0x11, %r14
+               	xorq	%r14, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %r14
+               	movq	%r12, (%r14)
+               	addq	$0x1, %rbx
+               	cmpq	$0x280, %rbx            # imm = 0x280
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rbx            # imm = 0x200
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rbx, %r12
+               	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
+               	imulq	%r11, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rbx, %r14
+               	shrq	$0x3, %r14
+               	xorq	%r14, %r12
+               	movl	%r12d, %r14d
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	%r14d, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x200, %rbx            # imm = 0x200
+               	jb	 <L17>
+<L18>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x400, %rbx            # imm = 0x400
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%rbx, %r12
+               	imulq	$0x83, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%rbx, %r14
+               	shrq	$0x2, %r14
+               	xorq	%r14, %r12
+               	movb	%r12b, %r14b
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rbx), %r12
+               	movb	%r14b, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x400, %rbx            # imm = 0x400
+               	jb	 <L19>
+<L20>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x40, %rbx
+               	jb	 <L21>
+               	jmp	 <L28>
+<L21>:
+               	movq	%rbx, %r12
+               	imulq	$0x9, %r12, %r12
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	%r12, %rax
+               	movq	$0x280, %r12            # imm = 0x280
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%r12,8), %r14
+               	movq	(%r14), %r12
+               	movq	%r13, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L22>
+<L23>:
+               	movq	%rbx, %rsi
                	imulq	$0xd, %rsi, %rsi
-               	addq	%rbx, %rsi
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rsi
                	movq	%rsi, %rax
                	movq	$0x200, %rsi            # imm = 0x200
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	leaq	(%r13,%rsi,4), %rdi
-               	movl	(%rdi), %esi
-               	movq	-0x2008(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x2010(%rbp)
                	movq	-0x2010(%rbp), %r8
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rsi
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rsi
                	imulq	$0x1d, %rsi, %rsi
-               	addq	%rbx, %rsi
+               	movq	-0x2020(%rbp), %r8
+               	addq	%r8, %rsi
                	movq	%rsi, %rax
                	movq	$0x400, %rsi            # imm = 0x400
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	movq	-0x2020(%rbp), %r8
+               	movq	-0x2008(%rbp), %r8
                	leaq	(%r8,%rsi), %rdi
                	movzbl	(%rdi), %esi
-               	movq	-0x2010(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r15
-               	movq	-0x2038(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x2038(%rbp)
-               	movq	-0x2038(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L16>
-<L20>:
-               	leaq	0x13f8(%r12), %r8
-               	movq	%r8, -0x2040(%rbp)
-               	movq	-0x2040(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, %r8
-               	addq	$0x1, %r8
-               	movq	%r8, -0x2018(%rbp)
-               	movq	%rbx, %rdi
-               	andq	$0x1, %rdi
-               	movq	$0x27f, %rsi            # imm = 0x27F
-               	subq	%rdi, %rsi
-               	leaq	(%r12,%rsi,8), %rdi
-               	movq	-0x2018(%rbp), %r8
-               	movq	%r8, (%rdi)
-               	leaq	0x7fc(%r13), %r14
-               	movl	(%r14), %esi
-               	movl	%esi, %r8d
-               	addl	$0x7, %r8d
-               	movq	%r8, -0x2028(%rbp)
-               	movq	%rbx, %rdi
-               	andq	$0x3, %rdi
-               	movq	$0x1ff, %rsi            # imm = 0x1FF
-               	subq	%rdi, %rsi
-               	leaq	(%r13,%rsi,4), %rdi
-               	movq	-0x2028(%rbp), %r8
-               	movl	%r8d, (%rdi)
-               	movq	-0x2020(%rbp), %r9
-               	leaq	0x3ff(%r9), %r8
-               	movq	%r8, -0x2030(%rbp)
-               	movq	-0x2030(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	addl	$0xb, %esi
-               	andq	$0x7, %rbx
-               	movq	$0x3ff, %rdi            # imm = 0x3FF
-               	subq	%rbx, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	(%r8,%rdi), %rbx
-               	movb	%sil, (%rbx)
-               	leaq	0x13f0(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	movq	%r15, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	movq	-0x2040(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	leaq	0x7f0(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	movl	(%r14), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	movq	-0x2020(%rbp), %r8
-               	leaq	0x3f8(%r8), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	movq	-0x2030(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	callq	 <L26>
+               	movzbq	%sil, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
 <L26>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x2048(%rbp), %rbx
-               	movq	-0x2050(%rbp), %r12
-               	movq	-0x2058(%rbp), %r13
-               	movq	-0x2060(%rbp), %r14
-               	movq	-0x2068(%rbp), %r15
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x40, %rbx
+               	jb	 <L21>
+<L28>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	addq	$0x1, %rdi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x1, %rsi
+               	movq	$0x27f, %rbx            # imm = 0x27F
+               	subq	%rsi, %rbx
+               	movq	-0x2018(%rbp), %r8
+               	leaq	(%r8,%rbx,8), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rsi
+               	movl	(%rsi), %edi
+               	addl	$0x7, %edi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x3, %rsi
+               	movq	$0x1ff, %rbx            # imm = 0x1FF
+               	subq	%rsi, %rbx
+               	movq	-0x2010(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	addl	$0xb, %edi
+               	movq	-0x2020(%rbp), %r8
+               	movq	%r8, %rsi
+               	andq	$0x7, %rsi
+               	movq	$0x3ff, %rbx            # imm = 0x3FF
+               	subq	%rsi, %rbx
+               	movq	-0x2008(%rbp), %r8
+               	leaq	(%r8,%rbx), %rsi
+               	movb	%dil, (%rsi)
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f0(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x2018(%rbp), %r8
+               	leaq	0x13f8(%r8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L31>
+<L32>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7f0(%r8), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L33>
+<L34>:
+               	movq	-0x2010(%rbp), %r8
+               	leaq	0x7fc(%r8), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L35>
+<L36>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3f8(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L37>
+<L38>:
+               	movq	-0x2008(%rbp), %r8
+               	leaq	0x3ff(%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r13, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L39>
+<L40>:
+               	movq	%r13, %rax
+               	movq	-0x2028(%rbp), %rbx
+               	movq	-0x2030(%rbp), %r12
+               	movq	-0x2038(%rbp), %r13
+               	movq	-0x2040(%rbp), %r14
+               	movq	-0x2048(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/frame/frame_spill.dis
+++ b/test/golden/x86_64-linux/frame/frame_spill.dis
@@ -22,144 +22,139 @@ Disassembly of section .text:
                	movq	%r13, -0x2b8(%rbp)
                	movq	%r14, -0x2c0(%rbp)
                	movq	%r15, -0x2c8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	movabsq	$0x5851f42d4c957f2d, %r8 # imm = 0x5851F42D4C957F2D
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x48(%rbp)
                	movabsq	$0x14057b7ef767814f, %rdx # imm = 0x14057B7EF767814F
-               	xorq	%rbx, %rdx
+               	xorq	%rdi, %rdx
                	movabsq	$-0x61c8864680b583eb, %rsi # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rsi
-               	movabsq	$-0x3d4d51c2d82b14b1, %rdi # imm = 0xC2B2AE3D27D4EB4F
-               	xorq	%rbx, %rdi
+               	addq	%rdi, %rsi
+               	movabsq	$-0x3d4d51c2d82b14b1, %rbx # imm = 0xC2B2AE3D27D4EB4F
+               	xorq	%rdi, %rbx
                	movabsq	$0x165667b19e3779f9, %r12 # imm = 0x165667B19E3779F9
-               	addq	%rbx, %r12
+               	addq	%rdi, %r12
                	movabsq	$-0x7a1435883d4d519d, %r13 # imm = 0x85EBCA77C2B2AE63
-               	xorq	%rbx, %r13
+               	xorq	%rdi, %r13
                	movabsq	$0x27d4eb2f165667c5, %r14 # imm = 0x27D4EB2F165667C5
-               	addq	%rbx, %r14
+               	addq	%rdi, %r14
                	movabsq	$0x72a63cd72e2d1e61, %r15 # imm = 0x72A63CD72E2D1E61
-               	xorq	%rbx, %r15
+               	xorq	%rdi, %r15
                	movabsq	$0x42f1ea7f85a51475, %r8 # imm = 0x42F1EA7F85A51475
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x8(%rbp)
                	movabsq	$0x30befe08be84df1f, %r8 # imm = 0x30BEFE08BE84DF1F
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x10(%rbp)
                	movabsq	$0x61c8864680b583eb, %r8 # imm = 0x61C8864680B583EB
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x18(%rbp)
                	movabsq	$0x4cf43f349dbb99b1, %r8 # imm = 0x4CF43F349DBB99B1
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x20(%rbp)
                	movabsq	$-0x5555555555555555, %r8 # imm = 0xAAAAAAAAAAAAAAAB
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x28(%rbp)
                	movabsq	$-0x25c1c6346b46a425, %r8 # imm = 0xDA3E39CB94B95BDB
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x30(%rbp)
                	movabsq	$0x1f2e512d5ac22ad1, %r8 # imm = 0x1F2E512D5AC22AD1
-               	addq	%rbx, %r8
+               	addq	%rdi, %r8
                	movq	%r8, -0x38(%rbp)
                	movabsq	$0x2d54e746111a977f, %r8 # imm = 0x2D54E746111A977F
-               	xorq	%rbx, %r8
+               	xorq	%rdi, %r8
                	movq	%r8, -0x40(%rbp)
-               	movabsq	$0x9e3779b1, %rcx       # imm = 0x9E3779B1
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x9e3779b1, %rax       # imm = 0x9E3779B1
+               	addq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x50(%rbp)
-               	movq	$0x9e37, %rcx           # imm = 0x9E37
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movq	$0x9e37, %rax           # imm = 0x9E37
+               	xorq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x58(%rbp)
-               	movabsq	$0x85ebca77, %rcx       # imm = 0x85EBCA77
-               	addq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0x85ebca77, %rax       # imm = 0x85EBCA77
+               	addq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x60(%rbp)
-               	movabsq	$0xc2b2ae3d, %rcx       # imm = 0xC2B2AE3D
-               	xorq	%rbx, %rcx
-               	movl	%ecx, %r8d
+               	movabsq	$0xc2b2ae3d, %rax       # imm = 0xC2B2AE3D
+               	xorq	%rdi, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x68(%rbp)
-               	movq	%rbx, %r11
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x1ab>
+<L1>:
+               	movsd	, %xmm1 <corpus.cases.frame.frame_spill.checksum+0x1a3>
                	addsd	%xmm0, %xmm1
-               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x1b7>
+               	movsd	, %xmm2 <corpus.cases.frame.frame_spill.checksum+0x1af>
                	addsd	%xmm0, %xmm2
-               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x1c3>
+               	movsd	, %xmm3 <corpus.cases.frame.frame_spill.checksum+0x1bb>
                	addsd	%xmm0, %xmm3
-               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x1cf>
+               	movsd	, %xmm4 <corpus.cases.frame.frame_spill.checksum+0x1c7>
                	addsd	%xmm0, %xmm4
-               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x1db>
+               	movsd	, %xmm5 <corpus.cases.frame.frame_spill.checksum+0x1d3>
                	addsd	%xmm0, %xmm5
-               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x1e7>
+               	movsd	, %xmm6 <corpus.cases.frame.frame_spill.checksum+0x1df>
                	addsd	%xmm0, %xmm6
-               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x1f3>
+               	movsd	, %xmm7 <corpus.cases.frame.frame_spill.checksum+0x1eb>
                	addsd	%xmm0, %xmm7
-               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x200>
+               	movsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x1f8>
                	addsd	%xmm0, %xmm8
-               	movq	%rax, %r8
-               	movq	%r8, -0xd8(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x168(%rbp)
                	movq	-0x48(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x208(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	movq	%rdx, %r8
-               	movq	%r8, -0x210(%rbp)
+               	movq	%r8, -0x78(%rbp)
                	movq	%rsi, %r8
                	movq	%r8, -0x218(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x70(%rbp)
-               	movq	%r14, %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0x8(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x78(%rbp)
+               	movq	%r8, -0x80(%rbp)
                	movq	-0x10(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x80(%rbp)
+               	movq	%r8, -0x88(%rbp)
                	movq	-0x18(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x88(%rbp)
+               	movq	%r8, -0x90(%rbp)
                	movq	-0x20(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x90(%rbp)
+               	movq	%r8, -0x98(%rbp)
                	movq	-0x28(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x98(%rbp)
+               	movq	%r8, -0xa0(%rbp)
                	movq	-0x30(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xa0(%rbp)
+               	movq	%r8, -0xa8(%rbp)
                	movq	-0x38(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xa8(%rbp)
+               	movq	%r8, -0xb0(%rbp)
                	movq	-0x40(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xb0(%rbp)
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0x50(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xb8(%rbp)
+               	movq	%r8, -0xc0(%rbp)
                	movq	-0x58(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xc0(%rbp)
+               	movq	%r8, -0xc8(%rbp)
                	movq	-0x60(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xc8(%rbp)
+               	movq	%r8, -0xd0(%rbp)
                	movq	-0x68(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movq	%r8, -0xd8(%rbp)
                	movsd	%xmm1, -0x228(%rbp)
                	movsd	%xmm2, -0x238(%rbp)
                	movsd	%xmm3, -0x248(%rbp)
@@ -168,44 +163,44 @@ Disassembly of section .text:
                	movsd	%xmm6, -0x278(%rbp)
                	movsd	%xmm7, -0x288(%rbp)
                	movsd	%xmm8, -0x298(%rbp)
-               	movq	$0x0, %rbx
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
-               	jmp	 <L7>
-<L3>:
-               	movq	-0xb0(%rbp), %r8
+               	movq	$0x0, %r15
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+               	jmp	 <L6>
+<L2>:
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x1d, %rsi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xb8(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x23, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x208(%rbp), %r9
+               	movq	-0x70(%rbp), %r9
                	movq	%r9, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0x208(%rbp), %r8
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0x7, %rsi
-               	movq	-0x208(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x39, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x210(%rbp), %r9
+               	movq	-0x78(%rbp), %r9
                	movq	%r9, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0x210(%rbp), %r8
+               	movq	%r8, -0xf0(%rbp)
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0xb, %rsi
-               	movq	-0x210(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movq	%r8, %rdi
                	shrq	$0x35, %rdi
                	orq	%rdi, %rsi
                	movq	-0x218(%rbp), %r9
                	movq	%r9, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%r8, -0xf8(%rbp)
                	movq	-0x218(%rbp), %r8
                	movq	%r8, %rsi
                	shlq	$0xd, %rsi
@@ -213,20 +208,17 @@ Disassembly of section .text:
                	movq	%r8, %rdi
                	shrq	$0x33, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x70(%rbp), %r9
-               	movq	%r9, %r8
+               	movq	%rbx, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, -0x100(%rbp)
+               	movq	%rbx, %rsi
                	shlq	$0x11, %rsi
-               	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%rbx, %rdi
                	shrq	$0x2f, %rdi
                	orq	%rdi, %rsi
                	movq	%r12, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	%r8, -0x108(%rbp)
                	movq	%r12, %rsi
                	shlq	$0x13, %rsi
                	movq	%r12, %rdi
@@ -234,225 +226,223 @@ Disassembly of section .text:
                	orq	%rdi, %rsi
                	movq	%r13, %r8
                	addq	%rsi, %r8
-               	movq	%r8, -0x108(%rbp)
+               	movq	%r8, -0x110(%rbp)
                	movq	%r13, %rsi
                	shlq	$0x17, %rsi
                	movq	%r13, %rdi
                	shrq	$0x29, %rdi
                	orq	%rdi, %rsi
-               	movq	-0x160(%rbp), %r9
-               	movq	%r9, %r8
+               	movq	%r14, %r8
                	xorq	%rsi, %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%r8, -0x118(%rbp)
+               	movq	%r14, %rsi
                	shlq	$0x1f, %rsi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rdi
+               	movq	%r14, %rdi
                	shrq	$0x21, %rdi
                	orq	%rdi, %rsi
-               	movq	%r15, %r8
-               	addq	%rsi, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	%r15, %rsi
-               	shlq	$0x25, %rsi
-               	movq	%r15, %rdi
-               	shrq	$0x1b, %rdi
-               	orq	%rdi, %rsi
-               	movq	-0x78(%rbp), %r9
+               	movq	-0xe0(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x120(%rbp)
-               	movq	-0x78(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x29, %rsi
-               	movq	-0x78(%rbp), %r8
+               	shlq	$0x25, %rsi
+               	movq	-0xe0(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x17, %rdi
+               	shrq	$0x1b, %rdi
                	orq	%rdi, %rsi
                	movq	-0x80(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x128(%rbp)
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x2b, %rsi
+               	shlq	$0x29, %rsi
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x15, %rdi
+               	shrq	$0x17, %rdi
                	orq	%rdi, %rsi
                	movq	-0x88(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x130(%rbp)
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x2f, %rsi
+               	shlq	$0x2b, %rsi
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x11, %rdi
+               	shrq	$0x15, %rdi
                	orq	%rdi, %rsi
                	movq	-0x90(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x138(%rbp)
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x35, %rsi
+               	shlq	$0x2f, %rsi
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0xb, %rdi
+               	shrq	$0x11, %rdi
                	orq	%rdi, %rsi
                	movq	-0x98(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x140(%rbp)
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3b, %rsi
+               	shlq	$0x35, %rsi
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x5, %rdi
+               	shrq	$0xb, %rdi
                	orq	%rdi, %rsi
                	movq	-0xa0(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x148(%rbp)
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3d, %rsi
+               	shlq	$0x3b, %rsi
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x3, %rdi
+               	shrq	$0x5, %rdi
                	orq	%rdi, %rsi
                	movq	-0xa8(%rbp), %r9
                	movq	%r9, %r8
-               	xorq	%rsi, %r8
+               	addq	%rsi, %r8
                	movq	%r8, -0x150(%rbp)
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	$0x3, %rsi
+               	shlq	$0x3d, %rsi
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rdi
-               	shrq	$0x3d, %rdi
+               	shrq	$0x3, %rdi
                	orq	%rdi, %rsi
                	movq	-0xb0(%rbp), %r9
                	movq	%r9, %r8
-               	addq	%rsi, %r8
+               	xorq	%rsi, %r8
                	movq	%r8, -0x158(%rbp)
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %r14
-               	addq	%rbx, %r14
-               	movq	-0x148(%rbp), %r8
-               	movl	%r8d, %esi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shlq	$0x3, %rsi
+               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	$0x3d, %rdi
+               	orq	%rdi, %rsi
                	movq	-0xb8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	xorl	%esi, %r8d
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r9, %r8
+               	addq	%rsi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	%r15, %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	-0x150(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xc0(%rbp), %r9
                	movl	%r9d, %r8d
-               	addl	%esi, %r8d
+               	xorl	%esi, %r8d
                	movq	%r8, -0x170(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0xf0(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xc8(%rbp), %r9
                	movl	%r9d, %r8d
-               	xorl	%esi, %r8d
+               	addl	%esi, %r8d
                	movq	%r8, -0x178(%rbp)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
                	movl	%r8d, %esi
                	movq	-0xd0(%rbp), %r9
                	movl	%r9d, %r8d
-               	addl	%esi, %r8d
+               	xorl	%esi, %r8d
                	movq	%r8, -0x180(%rbp)
-               	movsd	-0x228(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6a6>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	movq	-0x130(%rbp), %r8
+               	movl	%r8d, %esi
+               	movq	-0xd8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	addl	%esi, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	movsd	-0x228(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x68f>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
                	addsd	-0x238(%rbp), %xmm14
-               	movsd	%xmm14, -0x190(%rbp)
-               	movsd	-0x238(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6cd>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x248(%rbp), %xmm14
-               	movsd	%xmm14, -0x1a0(%rbp)
-               	movsd	-0x248(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x6f4>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x258(%rbp), %xmm14
-               	movsd	%xmm14, -0x1b0(%rbp)
-               	movsd	-0x258(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x71b>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x268(%rbp), %xmm14
-               	movsd	%xmm14, -0x1c0(%rbp)
-               	movsd	-0x268(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x742>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x278(%rbp), %xmm14
                	movsd	%xmm14, -0x1d0(%rbp)
-               	movsd	-0x278(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x769>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x288(%rbp), %xmm14
+               	movsd	-0x238(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x6b8>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x248(%rbp), %xmm14
                	movsd	%xmm14, -0x1e0(%rbp)
-               	movsd	-0x288(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x790>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x298(%rbp), %xmm14
+               	movsd	-0x248(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x6e1>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x258(%rbp), %xmm14
                	movsd	%xmm14, -0x1f0(%rbp)
-               	movsd	-0x298(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.frame.frame_spill.checksum+0x7b7>
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	addsd	-0x228(%rbp), %xmm14
+               	movsd	-0x258(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x70a>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x268(%rbp), %xmm14
                	movsd	%xmm14, -0x200(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movq	-0x128(%rbp), %r9
+               	movsd	-0x268(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x733>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x278(%rbp), %xmm14
+               	movsd	%xmm14, -0x210(%rbp)
+               	movsd	-0x278(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x75c>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x288(%rbp), %xmm14
+               	movsd	%xmm14, -0x198(%rbp)
+               	movsd	-0x288(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x785>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x298(%rbp), %xmm14
+               	movsd	%xmm14, -0x1a8(%rbp)
+               	movsd	-0x298(%rbp), %xmm8
+               	mulsd	, %xmm8 <corpus.cases.frame.frame_spill.checksum+0x7ae>
+               	movsd	%xmm8, %xmm14           # xmm14 = xmm8[0],xmm14[1]
+               	addsd	-0x228(%rbp), %xmm14
+               	movsd	%xmm14, -0x1b8(%rbp)
+               	movq	-0xf0(%rbp), %r8
+               	movq	-0x130(%rbp), %r9
                	movq	%r8, %rsi
                	xorq	%r9, %rsi
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L3>
+<L3>:
+               	movq	%rax, %rdi
+               	movq	-0x178(%rbp), %r8
+               	movl	%r8d, %esi
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	movq	-0x170(%rbp), %r8
-               	movl	%r8d, %esi
+               	movsd	-0x1d0(%rbp), %xmm8
+               	addsd	-0x210(%rbp), %xmm8
+               	movq	%xmm8, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
-               	movsd	-0x190(%rbp), %xmm0
-               	addsd	-0x1d0(%rbp), %xmm0
-               	callq	 <L6>
-<L6>:
                	movq	%rax, %rsi
-               	addq	$0x1, %rbx
+               	addq	$0x1, %r15
                	movq	%rsi, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xe8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x208(%rbp)
+               	movq	%r8, -0x168(%rbp)
                	movq	-0xf0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x210(%rbp)
+               	movq	%r8, -0x70(%rbp)
                	movq	-0xf8(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x218(%rbp)
+               	movq	%r8, -0x78(%rbp)
                	movq	-0x100(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x70(%rbp)
+               	movq	%r8, -0x218(%rbp)
                	movq	-0x108(%rbp), %r8
-               	movq	%r8, %r12
+               	movq	%r8, %rbx
                	movq	-0x110(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %r13
-               	movq	-0x118(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x160(%rbp)
                	movq	-0x120(%rbp), %r8
-               	movq	%r8, %r15
+               	movq	%r8, %r14
                	movq	-0x128(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x78(%rbp)
+               	movq	%r8, -0xe0(%rbp)
                	movq	-0x130(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0x80(%rbp)
@@ -471,9 +461,10 @@ Disassembly of section .text:
                	movq	-0x158(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xa8(%rbp)
-               	movq	%r14, %r8
+               	movq	-0x160(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0xb0(%rbp)
-               	movq	-0x170(%rbp), %r9
+               	movq	-0x1c0(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xb8(%rbp)
                	movq	-0x178(%rbp), %r9
@@ -482,158 +473,417 @@ Disassembly of section .text:
                	movq	-0x180(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xc8(%rbp)
-               	movq	-0x168(%rbp), %r9
+               	movq	-0x188(%rbp), %r9
                	movq	%r9, %r8
                	movq	%r8, -0xd0(%rbp)
-               	movq	-0x190(%rbp), %r11
-               	movq	%r11, -0x228(%rbp)
-               	movq	-0x1a0(%rbp), %r11
-               	movq	%r11, -0x238(%rbp)
-               	movq	-0x1b0(%rbp), %r11
-               	movq	%r11, -0x248(%rbp)
-               	movq	-0x1c0(%rbp), %r11
-               	movq	%r11, -0x258(%rbp)
+               	movq	-0x170(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd8(%rbp)
                	movq	-0x1d0(%rbp), %r11
-               	movq	%r11, -0x268(%rbp)
+               	movq	%r11, -0x228(%rbp)
                	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, -0x278(%rbp)
+               	movq	%r11, -0x238(%rbp)
                	movq	-0x1f0(%rbp), %r11
-               	movq	%r11, -0x288(%rbp)
+               	movq	%r11, -0x248(%rbp)
                	movq	-0x200(%rbp), %r11
+               	movq	%r11, -0x258(%rbp)
+               	movq	-0x210(%rbp), %r11
+               	movq	%r11, -0x268(%rbp)
+               	movq	-0x198(%rbp), %r11
+               	movq	%r11, -0x278(%rbp)
+               	movq	-0x1a8(%rbp), %r11
+               	movq	%r11, -0x288(%rbp)
+               	movq	-0x1b8(%rbp), %r11
                	movq	%r11, -0x298(%rbp)
-               	cmpq	$0x18, %rbx
-               	jb	 <L3>
+               	cmpq	$0x18, %r15
+               	jb	 <L2>
+<L6>:
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	-0xd8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x208(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	-0x210(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x218(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x70(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x160(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L7>
+<L8>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L16>
-<L16>:
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+<L12>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L13>
+<L14>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r12, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+<L16>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L17>
+<L18>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L19>
+<L20>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0xe0(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L21>
+<L22>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+               	jmp	 <L24>
+<L23>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x80(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L17>
-<L17>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+<L24>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x88(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L18>
-<L18>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+<L26>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x90(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L19>
-<L19>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+<L28>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0x98(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L20>
-<L20>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L29>
+<L30>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xa0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L21>
-<L21>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L31>
+<L32>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+               	jmp	 <L34>
+<L33>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xa8(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L22>
-<L22>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L33>
+<L34>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xb0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L23>
-<L23>:
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L35>
+<L36>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+               	jmp	 <L38>
+<L37>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xb8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L24>
-<L24>:
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L37>
+<L38>:
                	movq	-0xc0(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L25>
-<L25>:
                	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
                	movq	-0xc8(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L26>
-<L26>:
                	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
                	movq	-0xd0(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L27>
-<L27>:
                	movq	%rax, %rdi
-               	movsd	-0x228(%rbp), %xmm0
-               	callq	 <L28>
-<L28>:
+               	callq	 <L41>
+<L41>:
+               	movq	-0xd8(%rbp), %r8
+               	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	movsd	-0x238(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
+               	callq	 <L42>
+<L42>:
+               	movq	-0x228(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x248(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
+               	callq	 <L43>
+<L43>:
+               	movq	-0x238(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x258(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
+               	callq	 <L44>
+<L44>:
+               	movq	-0x248(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x268(%rbp), %xmm0
-               	callq	 <L32>
-<L32>:
+               	callq	 <L45>
+<L45>:
+               	movq	-0x258(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x278(%rbp), %xmm0
-               	callq	 <L33>
-<L33>:
+               	callq	 <L46>
+<L46>:
+               	movq	-0x268(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x288(%rbp), %xmm0
-               	callq	 <L34>
-<L34>:
+               	callq	 <L47>
+<L47>:
+               	movq	-0x278(%rbp), %rsi
                	movq	%rax, %rdi
-               	movsd	-0x298(%rbp), %xmm0
-               	callq	 <L35>
-<L35>:
+               	callq	 <L48>
+<L48>:
+               	movq	-0x288(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	-0x298(%rbp), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	movq	-0x2a8(%rbp), %rbx
                	movq	-0x2b0(%rbp), %r12
                	movq	-0x2b8(%rbp), %r13

--- a/test/golden/x86_64-linux/imm/imm_add.dis
+++ b/test/golden/x86_64-linux/imm/imm_add.dis
@@ -9,141 +9,404 @@ Disassembly of section .text:
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movl	%ebx, %eax
+               	addl	$0x7ff, %eax            # imm = 0x7FF
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	movl	%ecx, %r12d
-               	addl	$0x7ff, %r12d           # imm = 0x7FF
-               	movl	%r12d, %esi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r13d
-               	addl	$0x800, %r13d           # imm = 0x800
-               	movl	%r13d, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	addl	$0xfff, %r13d           # imm = 0xFFF
-               	movl	%r13d, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	addl	$0x1000, %r13d          # imm = 0x1000
-               	movl	%r13d, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	addl	$0x7fffffff, %r13d      # imm = 0x7FFFFFFF
-               	movl	%r13d, %esi
-               	callq	 <L5>
-<L5>:
-               	movq	%rax, %rdi
-               	addl	$0x80000000, %r13d      # imm = 0x80000000
-               	movl	%r13d, %esi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	addl	$0xffffffff, %r13d      # imm = 0xFFFFFFFF
-               	movl	%r13d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	addq	$0x7ff, %rbx            # imm = 0x7FF
-               	movq	%rbx, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r13
-               	subq	$0x800, %r13            # imm = 0x800
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
                	movq	%r13, %rsi
-               	callq	 <L9>
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+<L1>:
+               	addl	$0x800, %eax            # imm = 0x800
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L2>
+<L3>:
+               	addl	$0xfff, %eax            # imm = 0xFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+<L5>:
+               	addl	$0x1000, %eax           # imm = 0x1000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+<L7>:
+               	addl	$0x7fffffff, %eax       # imm = 0x7FFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r13, %r14
-               	addq	$0xfff000, %r14         # imm = 0xFFF000
-               	movq	%r14, %rsi
-               	callq	 <L10>
+               	addl	$0x80000000, %eax       # imm = 0x80000000
+               	movl	%eax, %edx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	addq	$0xffffff, %r14         # imm = 0xFFFFFF
-               	movq	%r14, %rsi
-               	callq	 <L11>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	addq	$0x7fffffff, %r14       # imm = 0x7FFFFFFF
-               	movq	%r14, %rsi
-               	callq	 <L12>
+               	addl	$0xffffffff, %eax       # imm = 0xFFFFFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movabsq	$0x80000000, %r11       # imm = 0x80000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L14>
+               	movq	%rbx, %rax
+               	addq	$0x7ff, %rax            # imm = 0x7FF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movabsq	$0x100000000, %r11      # imm = 0x100000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L15>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	addq	%r11, %r14
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	subq	$0x800, %rax            # imm = 0x800
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	subl	$0x800, %r12d           # imm = 0x800
-               	movl	%r12d, %esi
-               	callq	 <L18>
+               	addq	$0xfff000, %rax         # imm = 0xFFF000
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	addl	$0x7fffffff, %r12d      # imm = 0x7FFFFFFF
-               	movl	%r12d, %esi
-               	callq	 <L19>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rdi
-               	subl	$0x80000000, %r12d      # imm = 0x80000000
-               	movl	%r12d, %esi
-               	callq	 <L20>
+               	addq	$0xffffff, %rax         # imm = 0xFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	addq	$0x7fffffff, %rax       # imm = 0x7FFFFFFF
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x80000000, %r11       # imm = 0x80000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	movabsq	$0x100000000, %r11      # imm = 0x100000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	addq	%r11, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L30>
+<L31>:
+               	movl	%ebx, %eax
+               	movl	%eax, %r12d
+               	addl	$0x7ff, %r12d           # imm = 0x7FF
+               	movslq	%r12d, %rax
+               	movq	%rsi, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L32>
+<L32>:
+               	subl	$0x800, %r12d           # imm = 0x800
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	addl	$0x7fffffff, %r12d      # imm = 0x7FFFFFFF
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	subl	$0x80000000, %r12d      # imm = 0x80000000
+               	movslq	%r12d, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	addq	$0x7ff, %rbx            # imm = 0x7FF
                	movq	%rax, %rdi
                	movq	%rbx, %rsi
-               	callq	 <L21>
-<L21>:
+               	callq	 <L36>
+<L36>:
+               	subq	$0x800, %rbx            # imm = 0x800
                	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L22>
-<L22>:
+               	movq	%rbx, %rsi
+               	callq	 <L37>
+<L37>:
+               	addq	$0x7fffffff, %rbx       # imm = 0x7FFFFFFF
                	movq	%rax, %rdi
-               	addq	$0x7fffffff, %r13       # imm = 0x7FFFFFFF
-               	movq	%r13, %rsi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L38>
+<L38>:
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	subq	%r11, %r13
-               	movq	%r13, %rsi
-               	callq	 <L24>
-<L24>:
+               	subq	%r11, %rbx
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	callq	 <L39>
+<L39>:
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/imm/imm_addr.dis
+++ b/test/golden/x86_64-linux/imm/imm_addr.dis
@@ -5,271 +5,596 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_addr.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x9390, %rsp           # imm = 0x9390
-               	movq	%rbx, -0x9368(%rbp)
-               	movq	%r12, -0x9370(%rbp)
-               	movq	%r13, -0x9378(%rbp)
-               	movq	%r14, -0x9380(%rbp)
-               	movq	%r15, -0x9388(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x9360, %rsp           # imm = 0x9360
+               	movq	%rbx, -0x9338(%rbp)
+               	movq	%r12, -0x9340(%rbp)
+               	movq	%r13, -0x9348(%rbp)
+               	movq	%r14, -0x9350(%rbp)
+               	movq	%r15, -0x9358(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9318(%rbp)
+               	leaq	-0x8400(%rbp), %rbx
+               	leaq	(%rbx), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x8400, %r12           # imm = 0x8400
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x8400(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x8400, %rsi           # imm = 0x8400
-<L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	leaq	-0x9300(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0xf00, %rsi            # imm = 0xF00
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L2>
-               	movq	%rbx, %rcx
-               	addq	$0x1, %rcx
-               	leaq	(%r12), %rsi
-               	movq	%rcx, (%rsi)
-               	movq	%rbx, %rcx
-               	addq	$0x2, %rcx
-               	leaq	0x7f8(%r12), %r14
-               	movq	%rcx, (%r14)
-               	movq	%rbx, %rcx
-               	addq	$0x3, %rcx
-               	leaq	0x800(%r12), %r15
-               	movq	%rcx, (%r15)
-               	movq	%rbx, %rcx
-               	addq	$0x4, %rcx
-               	leaq	0x7ff8(%r12), %r8
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L0>
+               	leaq	-0x9300(%rbp), %r8
                	movq	%r8, -0x9308(%rbp)
                	movq	-0x9308(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	%rbx, %rcx
-               	addq	$0x5, %rcx
-               	leaq	0x8000(%r12), %r8
-               	movq	%r8, -0x9310(%rbp)
-               	movq	-0x9310(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	%rbx, %rcx
-               	addq	$0x6, %rcx
-               	leaq	0x83f8(%r12), %r8
-               	movq	%r8, -0x9318(%rbp)
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0xf00, %r13            # imm = 0xF00
+<L1>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L1>
                	movq	-0x9318(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L3>
+               	movq	%r8, %r12
+               	addq	$0x1, %r12
+               	leaq	(%rbx), %r13
+               	movq	%r12, (%r13)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x2, %r12
+               	leaq	0x7f8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x3, %r12
+               	leaq	0x800(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x4, %r12
+               	leaq	0x7ff8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x5, %r12
+               	leaq	0x8000(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0x6, %r12
+               	leaq	0x83f8(%rbx), %r14
+               	movq	%r12, (%r14)
+               	movq	(%r13), %r12
+               	movabsq	$-0x340d631b7bdddcdb, %r13 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	(%r14), %rsi
-               	callq	 <L4>
+               	leaq	0x7f8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	(%r15), %rsi
-               	callq	 <L5>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L6>
+               	leaq	0x800(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x9310(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L7>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x9318(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L8>
+               	leaq	0x7ff8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rax
-               	movq	$0x1080, %rcx           # imm = 0x1080
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	%rbx, %rsi
-               	addq	$0xfff, %rsi            # imm = 0xFFF
-               	movq	%rsi, %rax
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0x8000(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0x83f8(%rbx), %rsi
+               	movq	(%rsi), %r12
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
                	movq	$0x1080, %rsi           # imm = 0x1080
                	xorl	%edx, %edx
                	divq	%rsi
                	movq	%rdx, %rsi
-               	movq	%rbx, %r14
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r12
+               	addq	$0xfff, %r12            # imm = 0xFFF
+               	movq	%r12, %rax
+               	movq	$0x1080, %r12           # imm = 0x1080
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r14
                	addq	$0x800, %r14            # imm = 0x800
                	movq	%r14, %rax
                	movq	$0x1080, %r14           # imm = 0x1080
                	xorl	%edx, %edx
                	divq	%r14
-               	movq	%rdx, %r14
-               	leaq	(%r12,%rcx,8), %r15
-               	movq	(%r15), %rcx
-               	addq	$0x7, %rcx
-               	movq	%rcx, (%r15)
-               	leaq	(%r12,%rsi,8), %r8
-               	movq	%r8, -0x9358(%rbp)
-               	movq	-0x9358(%rbp), %r8
-               	movq	(%r8), %rsi
-               	addq	$0x8, %rsi
-               	movq	-0x9358(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	leaq	(%r12,%r14,8), %r8
-               	movq	%r8, -0x9320(%rbp)
-               	movq	-0x9320(%rbp), %r8
-               	movq	(%r8), %rsi
-               	addq	$0x9, %rsi
-               	movq	-0x9320(%rbp), %r8
-               	movq	%rsi, (%r8)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9310(%rbp)
+               	leaq	(%rbx,%rsi,8), %r15
                	movq	(%r15), %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x9358(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x9320(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rax
-               	movq	$0x60, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	%rbx, %rsi
-               	addq	$0x3f, %rsi
-               	movq	%rsi, %rax
+               	addq	$0x7, %rsi
+               	movq	%rsi, (%r15)
+               	leaq	(%rbx,%r12,8), %rsi
+               	movq	(%rsi), %r14
+               	addq	$0x8, %r14
+               	movq	%r14, (%rsi)
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rbx,%r8,8), %rsi
+               	movq	(%rsi), %r14
+               	addq	$0x9, %r14
+               	movq	%r14, (%rsi)
+               	movq	(%r15), %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rsi, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L14>
+<L15>:
+               	leaq	(%rbx,%r12,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	movq	-0x9310(%rbp), %r8
+               	leaq	(%rbx,%r8,8), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rax
                	movq	$0x60, %rsi
                	xorl	%edx, %edx
                	divq	%rsi
-               	movq	%rdx, %rsi
-               	imulq	$0x28, %rcx, %rcx
-               	leaq	(%r13,%rcx), %r12
-               	leaq	(%r12), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	movq	%rbx, %r14
-               	addq	$0xa, %r14
-               	leaq	0x8(%r12), %r15
-               	leaq	(%r15), %r8
+               	movq	%rdx, %r8
                	movq	%r8, -0x9328(%rbp)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x3f, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x60, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x9320(%rbp)
                	movq	-0x9328(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xb, %r14
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9330(%rbp)
-               	movq	-0x9330(%rbp), %r8
-               	movq	%r14, (%r8)
-               	movq	%rbx, %r14
-               	addq	$0xc, %r14
-               	leaq	0x10(%r15), %r8
-               	movq	%r8, -0x9338(%rbp)
-               	movq	-0x9338(%rbp), %r8
-               	movq	%r14, (%r8)
-               	leaq	0x20(%r12), %r14
-               	movl	$0x12345678, (%r14)     # imm = 0x12345678
+               	movq	%r8, %r12
+               	imulq	$0x28, %r12, %r12
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%r12), %r14
+               	leaq	(%r14), %r12
+               	movl	$0xffffffff, (%r12)     # imm = 0xFFFFFFFF
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0xa, %r15
+               	leaq	0x8(%r14), %rdi
+               	leaq	(%rdi), %rsi
+               	movq	%r15, (%rsi)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xb, %rsi
+               	leaq	0x8(%rdi), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xc, %rsi
+               	leaq	0x10(%rdi), %r15
+               	movq	%rsi, (%r15)
+               	leaq	0x20(%r14), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
                	imulq	$0x28, %rsi, %rsi
-               	leaq	(%r13,%rsi), %r12
-               	leaq	(%r12), %r13
-               	movl	$0xabcdef01, (%r13)     # imm = 0xABCDEF01
-               	movq	%rbx, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	$0xabcdef01, (%rsi)     # imm = 0xABCDEF01
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
                	addq	$0xd, %rsi
-               	leaq	0x8(%r12), %r15
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x9340(%rbp)
-               	movq	-0x9340(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	%rbx, %rsi
+               	leaq	0x8(%rdi), %r14
+               	leaq	(%r14), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
                	addq	$0xe, %rsi
-               	leaq	0x8(%r15), %r8
-               	movq	%r8, -0x9348(%rbp)
-               	movq	-0x9348(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	addq	$0xf, %rbx
-               	leaq	0x10(%r15), %r8
-               	movq	%r8, -0x9350(%rbp)
-               	movq	-0x9350(%rbp), %r8
-               	movq	%rbx, (%r8)
-               	leaq	0x20(%r12), %rbx
-               	movl	$0x1234567, (%rbx)      # imm = 0x1234567
-               	movl	(%rcx), %esi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x9328(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x9330(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x9338(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movl	(%r14), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movl	(%r13), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x9340(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x9348(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x9350(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L20>
+               	leaq	0x8(%r14), %r15
+               	movq	%rsi, (%r15)
+               	movq	-0x9318(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0xf, %rsi
+               	leaq	0x10(%r14), %r15
+               	movq	%rsi, (%r15)
+               	leaq	0x20(%rdi), %rsi
+               	movl	$0x1234567, (%rsi)      # imm = 0x1234567
+               	movl	(%r12), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	movq	%rax, %rdi
-               	movl	(%rbx), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L21>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
 <L21>:
-               	movq	%rax, %rdi
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
                	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rcx
-               	addq	$0x10, %rcx
-               	movq	-0x9308(%rbp), %r8
-               	movq	%rcx, (%r8)
-               	movq	-0x9308(%rbp), %r8
-               	movq	(%r8), %rsi
-               	callq	 <L22>
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x9368(%rbp), %rbx
-               	movq	-0x9370(%rbp), %r12
-               	movq	-0x9378(%rbp), %r13
-               	movq	-0x9380(%rbp), %r14
-               	movq	-0x9388(%rbp), %r15
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L22>
+<L23>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	0x8(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	0x10(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	-0x9328(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x20(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+<L29>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L32>
+               	jmp	 <L33>
+<L32>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rdi
+               	jb	 <L32>
+<L33>:
+               	movq	-0x9320(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x28, %rsi, %rsi
+               	movq	-0x9308(%rbp), %r8
+               	leaq	(%r8,%rsi), %r12
+               	leaq	0x8(%r12), %r14
+               	leaq	0x8(%r14), %rsi
+               	movq	(%rsi), %r15
+               	movq	%r13, %rdi
+               	movq	%r15, %rsi
+               	callq	 <L34>
+<L34>:
+               	movq	%rax, %rdi
+               	leaq	0x10(%r14), %rsi
+               	movq	(%rsi), %r13
+               	movq	%r13, %rsi
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %rdi
+               	leaq	0x20(%r12), %rsi
+               	movl	(%rsi), %r12d
+               	movl	%r12d, %esi
+               	callq	 <L36>
+<L36>:
+               	movq	%rax, %rdi
+               	leaq	0x7ff8(%rbx), %rsi
+               	movq	(%rsi), %rbx
+               	addq	$0x10, %rbx
+               	movq	%rbx, (%rsi)
+               	movq	(%rsi), %rbx
+               	movq	%rbx, %rsi
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	-0x9338(%rbp), %rbx
+               	movq	-0x9340(%rbp), %r12
+               	movq	-0x9348(%rbp), %r13
+               	movq	-0x9350(%rbp), %r14
+               	movq	-0x9358(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/imm/imm_logic.dis
+++ b/test/golden/x86_64-linux/imm/imm_logic.dis
@@ -5,152 +5,416 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_logic.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x8(%rbp)
+               	movq	%r12, -0x10(%rbp)
+               	movq	%r13, -0x18(%rbp)
+               	movq	%r14, -0x20(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movl	%ebx, %eax
+               	movl	%eax, %edx
+               	orl	$0x55555555, %edx       # imm = 0x55555555
+               	movl	%edx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %r12d
-               	movl	%r12d, %r13d
-               	orl	$0x55555555, %r13d      # imm = 0x55555555
-               	movl	%r13d, %esi
-               	callq	 <L1>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	xorl	$0x55555555, %ecx       # imm = 0x55555555
-               	andl	$0xf0f0f0f, %ecx        # imm = 0xF0F0F0F
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movl	%eax, %esi
+               	xorl	$0x55555555, %esi       # imm = 0x55555555
+               	andl	$0xf0f0f0f, %esi        # imm = 0xF0F0F0F
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	orl	$0xffff0000, %ecx       # imm = 0xFFFF0000
-               	movl	%ecx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	andl	$0xffff, %ecx           # imm = 0xFFFF
-               	movl	%ecx, %esi
-               	callq	 <L4>
+               	movl	%eax, %esi
+               	orl	$0xffff0000, %esi       # imm = 0xFFFF0000
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %r14d
-               	xorl	$-0x1, %r14d
-               	movl	%r14d, %esi
-               	callq	 <L5>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %ecx
-               	orl	$0x55555555, %ecx       # imm = 0x55555555
-               	xorl	$-0x1, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %esi
+               	andl	$0xffff, %esi           # imm = 0xFFFF
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %ecx
-               	andl	$0xf0f0f0f, %ecx        # imm = 0xF0F0F0F
-               	xorl	$0xffff0000, %ecx       # imm = 0xFFFF0000
-               	movl	%ecx, %esi
-               	callq	 <L7>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r15
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	orq	%r11, %r15
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rcx
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	xorq	%r11, %rcx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
-               	orq	%r11, %rsi
-               	callq	 <L10>
+               	orl	$0x55555555, %esi       # imm = 0x55555555
+               	xorl	$-0x1, %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	movabsq	$0xff00ff00ff00ff, %r11 # imm = 0xFF00FF00FF00FF
-               	andq	%r11, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	xorq	$-0x1, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
+               	andl	$0xf0f0f0f, %eax        # imm = 0xF0F0F0F
+               	xorl	$0xffff0000, %eax       # imm = 0xFFFF0000
+               	movl	%eax, %esi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdx
-               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
-               	orq	%r11, %rdx
-               	xorq	$-0x1, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L13>
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rdx
-               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
-               	andq	%r11, %rdx
-               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
-               	xorq	%r11, %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L14>
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L15>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movq	%rbx, %rax
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	xorq	%r11, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	xorl	%r14d, %r12d
-               	andl	$0xf0f0f0f, %r12d       # imm = 0xF0F0F0F
-               	movl	%r12d, %esi
-               	callq	 <L17>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L18>
+               	movq	%rbx, %rax
+               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
+               	orq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L19>
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
 <L19>:
+               	movq	%rbx, %rax
+               	movabsq	$0xff00ff00ff00ff, %r11 # imm = 0xFF00FF00FF00FF
+               	andq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	xorq	%r8, %rbx
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movq	%rbx, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rax
+               	xorq	$-0x1, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	movq	%rbx, %rax
+               	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
+               	andq	%r11, %rax
+               	movabsq	$-0xffff00010000, %r11  # imm = 0xFFFF0000FFFF0000
+               	xorq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movl	%ebx, %eax
+               	movl	%eax, %esi
+               	orl	$0x55555555, %esi       # imm = 0x55555555
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	movl	%eax, %esi
+               	xorl	$-0x1, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L30>
+<L31>:
+               	xorl	%esi, %eax
+               	andl	$0xf0f0f0f, %eax        # imm = 0xF0F0F0F
+               	movslq	%eax, %rsi
+               	movq	%rdx, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rbx, %rsi
+               	movabsq	$0x5555555555555555, %r11 # imm = 0x5555555555555555
+               	orq	%r11, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movq	%rbx, %r12
+               	xorq	$-0x1, %r12
+               	movq	%rax, %rdi
+               	movq	%r12, %rsi
+               	callq	 <L34>
+<L34>:
+               	xorq	%r12, %rbx
                	movabsq	$0xf0f0f0f0f0f0f0f, %r11 # imm = 0xF0F0F0F0F0F0F0F
                	andq	%r11, %rbx
+               	movq	%rax, %rdi
                	movq	%rbx, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	callq	 <L35>
+<L35>:
+               	movq	-0x8(%rbp), %rbx
+               	movq	-0x10(%rbp), %r12
+               	movq	-0x18(%rbp), %r13
+               	movq	-0x20(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/imm/imm_mov.dis
+++ b/test/golden/x86_64-linux/imm/imm_mov.dis
@@ -5,126 +5,318 @@ Disassembly of section .text:
 <corpus.cases.imm.imm_mov.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x50, %rsp
                	movq	%rbx, -0x28(%rbp)
                	movq	%r12, -0x30(%rbp)
                	movq	%r13, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x0, %r8
+               	je	 <L0>
+               	movl	$0x80000000, %esi       # imm = 0x80000000
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	cmpq	$0x0, %rbx
-               	je	 <L1>
-               	movl	$0x80000000, %ecx       # imm = 0x80000000
-               	jmp	 <L2>
+               	movl	$0x7ff, %esi            # imm = 0x7FF
 <L1>:
-               	movl	$0x7ff, %ecx            # imm = 0x7FF
+               	movl	%esi, %ebx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movl	%ecx, %esi
-               	callq	 <L3>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	cmpq	$0x1, %rbx
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x1, %r8
                	je	 <L4>
-               	movabsq	$0x7fffffffffffffff, %rsi # imm = 0x7FFFFFFFFFFFFFFF
+               	movabsq	$0x7fffffffffffffff, %rbx # imm = 0x7FFFFFFFFFFFFFFF
                	jmp	 <L5>
 <L4>:
-               	movabsq	$0xffffffff, %rsi       # imm = 0xFFFFFFFF
+               	movabsq	$0xffffffff, %rbx       # imm = 0xFFFFFFFF
 <L5>:
-               	callq	 <L6>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	cmpq	$0x2, %rbx
-               	je	 <L7>
-               	movl	$0xf0f0f0f, %ecx        # imm = 0xF0F0F0F
-               	jmp	 <L8>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movl	$0x55555555, %ecx       # imm = 0x55555555
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x2, %r8
+               	je	 <L8>
+               	movl	$0xf0f0f0f, %ebx        # imm = 0xF0F0F0F
+               	jmp	 <L9>
 <L8>:
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movl	$0x55555555, %ebx       # imm = 0x55555555
 <L9>:
-               	movq	%rax, %rdi
-               	cmpq	$0x3, %rbx
-               	je	 <L10>
-               	movabsq	$-0xffff00010000, %rsi  # imm = 0xFFFF0000FFFF0000
+               	movl	%ebx, %r12d
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
                	jmp	 <L11>
 <L10>:
-               	movabsq	$0x5555555555555555, %rsi # imm = 0x5555555555555555
-<L11>:
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	leaq	-0x18(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	leaq	(%r12), %rcx
-               	movabsq	$0x100000000, %r11      # imm = 0x100000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movabsq	$0xffff0000, %r11       # imm = 0xFFFF0000
-               	movq	%r11, (%rcx)
-               	movq	%rbx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %r13
-               	leaq	(%r12,%r13,8), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
                	movq	%r13, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L14>
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x20(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	je	 <L12>
+               	movabsq	$-0xffff00010000, %rbx  # imm = 0xFFFF0000FFFF0000
+               	jmp	 <L13>
+<L12>:
+               	movabsq	$0x5555555555555555, %rbx # imm = 0x5555555555555555
+<L13>:
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	addq	$0x2, %r13
-               	movq	%r13, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r12,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L15>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
 <L15>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %ecx
-               	movl	$0x7ff, %esi            # imm = 0x7FF
-               	addl	%ecx, %esi
-               	callq	 <L16>
+               	leaq	-0x18(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	leaq	(%rbx), %r12
+               	movabsq	$0x100000000, %r11      # imm = 0x100000000
+               	movq	%r11, (%r12)
+               	leaq	0x8(%rbx), %r12
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%r12)
+               	leaq	0x10(%rbx), %r12
+               	movabsq	$0xffff0000, %r11       # imm = 0xFFFF0000
+               	movq	%r11, (%r12)
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3, %r12
+               	xorl	%edx, %edx
+               	divq	%r12
+               	movq	%rdx, %r12
+               	leaq	(%rbx,%r12,8), %r13
+               	movq	(%r13), %r14
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rdi
-               	movl	$0x80000000, %esi       # imm = 0x80000000
-               	callq	 <L17>
+               	movq	%r13, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r14, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r13
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L16>
 <L17>:
-               	movq	%rax, %rdi
-               	movabsq	$-0x8000000000000000, %rsi # imm = 0x8000000000000000
-               	callq	 <L18>
+               	movq	%r12, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rbx,%rdi,8), %r13
+               	movq	(%r13), %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
+               	jmp	 <L19>
 <L18>:
-               	movq	%rax, %rdi
-               	movl	$0x55555555, %esi       # imm = 0x55555555
-               	callq	 <L19>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rdi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r13
+               	jb	 <L18>
 <L19>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	addq	$0x2, %r12
+               	movq	%r12, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rbx,%rdi,8), %r12
+               	movq	(%r12), %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %edi
+               	movl	$0x7ff, %ebx            # imm = 0x7FF
+               	addl	%edi, %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$0x80000000, %rbx       # imm = 0x80000000
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L24>
+<L25>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movabsq	$-0x8000000000000000, %rbx # imm = 0x8000000000000000
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x55555555, %rbx       # imm = 0x55555555
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L28>
+<L29>:
+               	movq	%rsi, %rax
                	movq	-0x28(%rbp), %rbx
                	movq	-0x30(%rbp), %r12
                	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/addr_modes.dis
+++ b/test/golden/x86_64-linux/mem/addr_modes.dis
@@ -5,19 +5,14 @@ Disassembly of section .text:
 <corpus.cases.mem.addr_modes.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x34f0, %rsp           # imm = 0x34F0
-               	movq	%rbx, -0x34c8(%rbp)
-               	movq	%r12, -0x34d0(%rbp)
-               	movq	%r13, -0x34d8(%rbp)
-               	movq	%r14, -0x34e0(%rbp)
-               	movq	%r15, -0x34e8(%rbp)
+               	subq	$0x3540, %rsp           # imm = 0x3540
+               	movq	%rbx, -0x3518(%rbp)
+               	movq	%r12, -0x3520(%rbp)
+               	movq	%r13, -0x3528(%rbp)
+               	movq	%r14, -0x3530(%rbp)
+               	movq	%r15, -0x3538(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x33e8(%rbp)
-               	movq	-0x33e8(%rbp), %r8
-               	leaq	-0x40(%rbp), %r12
+               	leaq	-0x140(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -26,101 +21,102 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	-0xc0(%rbp), %r8
-               	movq	%r8, -0x3408(%rbp)
-               	movq	-0x3408(%rbp), %r8
+               	leaq	-0x1c0(%rbp), %r8
+               	movq	%r8, -0x33e0(%rbp)
+               	movq	-0x33e0(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
                	movq	$0x80, %rdi
+<L0>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L0>
+               	leaq	-0x2c0(%rbp), %r8
+               	movq	%r8, -0x3418(%rbp)
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x100, %rdi            # imm = 0x100
 <L1>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L1>
-               	leaq	-0x1c0(%rbp), %r14
-               	leaq	(%r14), %rsi
+               	leaq	-0x4c0(%rbp), %r8
+               	movq	%r8, -0x3410(%rbp)
+               	movq	-0x3410(%rbp), %r8
+               	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x100, %rdi            # imm = 0x100
+               	movq	$0x200, %rdi            # imm = 0x200
 <L2>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L2>
-               	leaq	-0x3c0(%rbp), %r8
-               	movq	%r8, -0x3478(%rbp)
-               	movq	-0x3478(%rbp), %r8
+               	leaq	-0x8c0(%rbp), %r8
+               	movq	%r8, -0x33d8(%rbp)
+               	movq	-0x33d8(%rbp), %r8
                	leaq	(%r8), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x200, %rdi            # imm = 0x200
+               	movq	$0x400, %rdi            # imm = 0x400
 <L3>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L3>
-               	leaq	-0x7c0(%rbp), %r8
-               	movq	%r8, -0x33d8(%rbp)
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8), %rsi
+               	leaq	-0xbc0(%rbp), %r13
+               	leaq	(%r13), %rsi
                	addq	$0x0, %rsi
-               	movq	$0x400, %rdi            # imm = 0x400
+               	movq	$0x300, %rdi            # imm = 0x300
 <L4>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
                	jne	 <L4>
-               	leaq	-0xac0(%rbp), %r8
-               	movq	%r8, -0x33e0(%rbp)
-               	movq	-0x33e0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x300, %rdi            # imm = 0x300
-<L5>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L5>
                	movq	$0x0, %r8
-               	movq	%r8, -0x33f8(%rbp)
-               	movq	-0x33f8(%rbp), %r8
+               	movq	%r8, -0x33e8(%rbp)
+               	movq	-0x33e8(%rbp), %r8
                	cmpq	$0x40, %r8
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	-0x33f8(%rbp), %r8
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rdi
                	imulq	$0x3, %rdi, %rdi
                	addq	$0x1, %rdi
                	addq	%rbx, %rdi
-               	movb	%dil, %cl
-               	movq	-0x33f8(%rbp), %r8
+               	movb	%dil, %sil
+               	movq	-0x33e8(%rbp), %r8
                	leaq	(%r12,%r8), %rdi
-               	movb	%cl, (%rdi)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x44f, %rcx, %rcx      # imm = 0x44F
-               	addq	$0x7, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %di
-               	movq	-0x3408(%rbp), %r8
-               	movq	-0x33f8(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rcx
-               	movw	%di, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
+               	movb	%sil, (%rdi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x44f, %rsi, %rsi      # imm = 0x44F
+               	addq	$0x7, %rsi
+               	addq	%rbx, %rsi
+               	movw	%si, %di
+               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movw	%di, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
                	movabsq	$0x9e3779b1, %r11       # imm = 0x9E3779B1
-               	imulq	%r11, %rcx
-               	addq	$0xb, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %edi
-               	movq	-0x33f8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	%edi, (%rcx)
-               	movq	-0x33f8(%rbp), %r9
+               	imulq	%r11, %rsi
+               	addq	$0xb, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3418(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x33e8(%rbp), %r9
                	movq	%r9, %r8
                	addq	$0x1, %r8
                	movq	%r8, -0x33f0(%rbp)
@@ -128,547 +124,927 @@ Disassembly of section .text:
                	movabsq	$-0x61c8864680b583eb, %rdi # imm = 0x9E3779B97F4A7C15
                	imulq	%r8, %rdi
                	addq	%rbx, %rdi
-               	movq	-0x3478(%rbp), %r8
-               	movq	-0x33f8(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rcx
-               	movq	%rdi, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x5, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	addq	%rbx, %rcx
-               	movw	%cx, %di
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movw	%di, (%rcx)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x80, %rcx
-               	movb	%cl, %dil
-               	leaq	0x2(%rsi), %rcx
-               	movb	%dil, (%rcx)
-               	movq	-0x33f0(%rbp), %r8
-               	movabsq	$0x100000001b3, %rcx    # imm = 0x100000001B3
-               	imulq	%r8, %rcx
-               	addq	%rbx, %rcx
-               	leaq	0x8(%rsi), %rdi
-               	movq	%rcx, (%rdi)
-               	movq	-0x33f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x11, %rcx, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x1, %rsi
-               	addq	%rbx, %rsi
-               	movl	%esi, %edi
-               	movq	-0x33f8(%rbp), %r8
+               	movq	-0x3410(%rbp), %r8
+               	movq	-0x33e8(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	%rdi, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0xc, %rsi, %rsi
-               	movq	-0x33e0(%rbp), %r9
-               	leaq	(%r9,%rsi), %r8
-               	movq	%r8, -0x3400(%rbp)
-               	movq	-0x3400(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	%edi, (%rsi)
-               	movq	%rcx, %rsi
+               	imulq	$0x5, %rsi, %rsi
                	addq	$0x2, %rsi
                	addq	%rbx, %rsi
-               	movl	%esi, %edi
-               	movq	-0x3400(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	%edi, (%rsi)
-               	addq	$0x3, %rcx
-               	addq	%rbx, %rcx
-               	movl	%ecx, %esi
-               	movq	-0x3400(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	%esi, (%rcx)
-               	movq	-0x33f0(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x33f8(%rbp)
-               	movq	-0x33f8(%rbp), %r8
-               	cmpq	$0x40, %r8
-               	jb	 <L6>
-<L7>:
-               	movq	-0x33e8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x34b0(%rbp)
-               	movq	$0x0, %r13
-               	cmpq	$0x40, %r13
-               	jb	 <L8>
-               	jmp	 <L19>
-<L8>:
-               	movq	%r13, %rsi
-               	imulq	$0xd, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	movq	%rsi, %r8
-               	andq	$0x3f, %r8
-               	movq	%r8, -0x3410(%rbp)
-               	movq	-0x3410(%rbp), %r8
-               	leaq	(%r12,%r8), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x3418(%rbp)
-               	movq	-0x34b0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x3418(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	movq	-0x3408(%rbp), %r8
-               	movq	-0x3410(%rbp), %r9
-               	leaq	(%r8,%r9,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x3420(%rbp)
-               	movq	-0x3420(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x3428(%rbp)
-               	movq	-0x3428(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	-0x3478(%rbp), %r8
-               	movq	-0x3410(%rbp), %r9
-               	leaq	(%r8,%r9,8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x3430(%rbp)
-               	movq	-0x3430(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
+               	movw	%si, %di
+               	movq	-0x33e8(%rbp), %r8
                	movq	%r8, %rsi
                	imulq	$0x10, %rsi, %rsi
                	movq	-0x33d8(%rbp), %r9
                	leaq	(%r9,%rsi), %r8
+               	movq	%r8, -0x33f8(%rbp)
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movw	%di, (%rsi)
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x80, %rsi
+               	movb	%sil, %dil
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	0x2(%r8), %rsi
+               	movb	%dil, (%rsi)
+               	movq	-0x33f0(%rbp), %r8
+               	movabsq	$0x100000001b3, %rsi    # imm = 0x100000001B3
+               	imulq	%r8, %rsi
+               	addq	%rbx, %rsi
+               	movq	-0x33f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movq	%rsi, (%rdi)
+               	movq	-0x33e8(%rbp), %r9
+               	movq	%r9, %r8
+               	imulq	$0x11, %r8, %r8
+               	movq	%r8, -0x3400(%rbp)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %esi
+               	movq	-0x33e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x3408(%rbp)
+               	movq	-0x3408(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	%esi, (%rdi)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x2, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3408(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x3400(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x3, %rsi
+               	addq	%rbx, %rsi
+               	movl	%esi, %edi
+               	movq	-0x3408(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movl	%edi, (%rsi)
+               	movq	-0x33f0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x33e8(%rbp)
+               	movq	-0x33e8(%rbp), %r8
+               	cmpq	$0x40, %r8
+               	jb	 <L5>
+<L6>:
+               	movabsq	$-0x340d631b7bdddcdb, %r15 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x40, %r14
+               	jb	 <L7>
+               	jmp	 <L22>
+<L7>:
+               	movq	%r14, %rsi
+               	imulq	$0xd, %rsi, %rsi
+               	addq	%rbx, %rsi
+               	movq	%rsi, %r8
+               	andq	$0x3f, %r8
+               	movq	%r8, -0x3420(%rbp)
+               	movq	-0x3420(%rbp), %r8
+               	leaq	(%r12,%r8), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x3428(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x3430(%rbp)
+               	movq	$0x0, %r8
                	movq	%r8, -0x3438(%rbp)
                	movq	-0x3438(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	-0x3438(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3428(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3430(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3438(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3430(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3438(%rbp)
+               	movq	-0x3438(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L8>
+<L9>:
+               	movq	-0x33e0(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movzwl	(%rsi), %edi
+               	movzwq	%di, %r8
                	movq	%r8, -0x3440(%rbp)
-               	movq	-0x3440(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	-0x3438(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
-               	movzbl	(%rsi), %r8d
+               	movq	-0x3430(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x3448(%rbp)
-               	movq	-0x3448(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	-0x3438(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %r8
+               	movq	$0x0, %r8
                	movq	%r8, -0x3450(%rbp)
                	movq	-0x3450(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	-0x3450(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3440(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3448(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	movq	-0x3410(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0xc, %rsi, %rsi
-               	movq	-0x33e0(%rbp), %r9
-               	leaq	(%r9,%rsi), %r8
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3450(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3448(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3450(%rbp)
+               	movq	-0x3450(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L10>
+<L11>:
+               	movq	-0x3418(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
                	movq	%r8, -0x3458(%rbp)
-               	movq	-0x3458(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	-0x3448(%rbp), %r9
+               	movq	%r9, %r8
                	movq	%r8, -0x3460(%rbp)
-               	movq	-0x3460(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	movq	-0x3458(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	$0x0, %r8
                	movq	%r8, -0x3468(%rbp)
                	movq	-0x3468(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	-0x3468(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
                	movq	-0x3458(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3460(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x3468(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3460(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3468(%rbp)
+               	movq	-0x3468(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L12>
+<L13>:
+               	movq	-0x3410(%rbp), %r8
+               	movq	-0x3420(%rbp), %r9
+               	leaq	(%r8,%r9,8), %rsi
+               	movq	(%rsi), %r8
                	movq	%r8, -0x3470(%rbp)
-               	movq	-0x3470(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r13
-               	movq	%rcx, %r8
-               	movq	%r8, -0x34b0(%rbp)
-               	cmpq	$0x40, %r13
-               	jb	 <L8>
-<L19>:
-               	movq	-0x34b0(%rbp), %r8
-               	movq	%r8, %r13
+               	movq	-0x3460(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3478(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x34b8(%rbp)
-               	movq	-0x34b8(%rbp), %r8
-               	cmpq	$0x20, %r8
-               	jb	 <L20>
-               	jmp	 <L26>
-<L20>:
-               	movq	-0x34b8(%rbp), %r8
-               	movq	%r8, %r15
-               	imulq	$0x2, %r15, %r15
-               	leaq	(%r14,%r15,4), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x3480(%rbp)
-               	movq	%r13, %rdi
                	movq	-0x3480(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L21>
-<L21>:
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	-0x3480(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x3470(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x3478(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x3480(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3478(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3480(%rbp)
+               	movq	-0x3480(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+<L15>:
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movzwl	(%rsi), %edi
+               	movzwq	%di, %rsi
+               	movq	-0x3478(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r8
                	movq	%r8, -0x3488(%rbp)
                	movq	-0x3488(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	shlq	%rsi
-               	leaq	(%r14,%rsi,4), %rdi
-               	movl	(%rdi), %esi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x2(%rdi), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
                	movq	-0x3488(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L22>
-<L22>:
+               	callq	 <L17>
+<L17>:
                	movq	%rax, %r8
-               	movq	%r8, -0x3498(%rbp)
-               	movq	-0x3498(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	$0x1, %r8
                	movq	%r8, -0x3490(%rbp)
                	movq	-0x3490(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x2, %rsi, %rsi
-               	subq	$0x2, %rsi
-               	movq	-0x3478(%rbp), %r8
-               	leaq	(%r8,%rsi,8), %rdi
-               	movq	(%rdi), %rsi
-               	movq	-0x3498(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x3498(%rbp)
+               	movq	-0x3490(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L23>
-<L23>:
+               	movq	-0x3498(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L18>
+<L18>:
                	movq	%rax, %r8
                	movq	%r8, -0x34a0(%rbp)
                	movq	-0x34a0(%rbp), %r8
-               	movq	-0x34b8(%rbp), %r8
-               	movq	$0x3f, %rsi
-               	subq	%r8, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	movzbl	(%rdi), %esi
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
                	movq	-0x34a0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	addq	%rbx, %r15
-               	andq	$0x3f, %r15
-               	imulq	$0x10, %r15, %r15
-               	movq	-0x33d8(%rbp), %r8
-               	leaq	(%r8,%r15), %rsi
-               	leaq	0x8(%rsi), %r15
-               	movq	(%r15), %rsi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r13
-               	movq	-0x3490(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x34b8(%rbp)
-               	movq	-0x34b8(%rbp), %r8
-               	cmpq	$0x20, %r8
-               	jb	 <L20>
-<L26>:
-               	leaq	-0xbc0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x100, %rsi            # imm = 0x100
-<L27>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L27>
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L28>
-               	jmp	 <L31>
-<L28>:
-               	movq	%rcx, %r8
-               	imulq	$0x47, %r8, %r8
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %r8
                	movq	%r8, -0x34a8(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0x20, %rdi, %rdi
-               	leaq	(%r12,%rdi), %r14
-               	movq	$0x0, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L29>
-               	jmp	 <L30>
-<L29>:
-               	movq	%rdi, %r15
-               	imulq	$0xd, %r15, %r15
                	movq	-0x34a8(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
                	movq	%r8, %rsi
-               	addq	%r15, %rsi
-               	addq	%rbx, %rsi
-               	movl	%esi, %r15d
-               	leaq	(%r14,%rdi,4), %rsi
-               	movl	%r15d, (%rsi)
-               	addq	$0x1, %rdi
-               	cmpq	$0x8, %rdi
-               	jb	 <L29>
-<L30>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L28>
-<L31>:
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	0x4(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	-0x34a8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x34b0(%rbp)
+               	movq	-0x34b0(%rbp), %r8
+               	movq	-0x3420(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	0x8(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	-0x34b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L21>
+<L21>:
+               	movq	%rax, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r15
+               	cmpq	$0x40, %r14
+               	jb	 <L7>
+<L22>:
+               	movq	$0x0, %r13
+               	cmpq	$0x20, %r13
+               	jb	 <L23>
+               	jmp	 <L32>
+<L23>:
+               	movq	%r13, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x34b8(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x34c0(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L32>
-               	jmp	 <L36>
-<L32>:
-               	movq	%r14, %rcx
-               	imulq	$0x20, %rcx, %rcx
-               	leaq	(%r12,%rcx), %r15
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r13, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0x60(%r12), %rcx
-               	leaq	(%rcx,%r14,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rcx
-               	addq	%rbx, %rcx
-               	andq	$0x7, %rcx
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r13
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x34b8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x34c0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x34c0(%rbp)
                	cmpq	$0x8, %r14
-               	jb	 <L32>
-<L36>:
-               	leaq	0xe0(%r12), %rcx
-               	leaq	0x1c(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%r13, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L37>
-<L37>:
+               	jb	 <L24>
+<L25>:
+               	movq	%r13, %rsi
+               	shlq	%rsi
+               	movq	-0x3418(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x34c8(%rbp)
+               	movq	-0x34c0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34d0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x34c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x34d0(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x34d0(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rsi
+               	addq	$0x1, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	subq	$0x2, %rsi
+               	movq	-0x3410(%rbp), %r8
+               	leaq	(%r8,%rsi,8), %rdi
+               	movq	(%rdi), %r8
+               	movq	%r8, -0x34d8(%rbp)
+               	movq	-0x34d0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x34e0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x34d8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x34e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r8
+               	movq	%r8, -0x34e0(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L28>
+<L29>:
+               	movq	$0x3f, %rsi
+               	subq	%r13, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movzbl	(%rdi), %esi
+               	movzbq	%sil, %r14
+               	movq	-0x34e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	-0x33d0(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x2810, %rsi           # imm = 0x2810
-<L39>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L39>
-               	movq	$0x12345678, %rcx       # imm = 0x12345678
-               	addq	%rbx, %rcx
+               	movq	%r13, %rsi
+               	imulq	$0x2, %rsi, %rsi
+               	addq	%rbx, %rsi
+               	andq	$0x3f, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	movq	-0x33d8(%rbp), %r8
+               	leaq	(%r8,%rsi), %r14
+               	leaq	0x8(%r14), %rsi
+               	movq	(%rsi), %r14
+               	movq	%r14, %rsi
+               	callq	 <L31>
+<L31>:
+               	movq	%rax, %r15
+               	addq	$0x1, %r13
+               	cmpq	$0x20, %r13
+               	jb	 <L23>
+<L32>:
+               	leaq	-0x100(%rbp), %r12
                	leaq	(%r12), %rsi
-               	movq	%rcx, (%rsi)
-               	movl	%ebx, %ecx
-               	movl	$0x9abcdef0, %esi       # imm = 0x9ABCDEF0
-               	addl	%ecx, %esi
-               	leaq	0x2008(%r12), %rcx
-               	movl	%esi, (%rcx)
-               	movw	%bx, %cx
-               	movl	$0x1234, %esi           # imm = 0x1234
-               	addl	%ecx, %esi
-               	leaq	0x280c(%r12), %rcx
-               	movw	%si, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	$0x400, %rcx            # imm = 0x400
-               	jb	 <L40>
-               	jmp	 <L41>
+               	addq	$0x0, %rsi
+               	movq	$0x100, %rdi            # imm = 0x100
+<L33>:
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L33>
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+               	jmp	 <L37>
+<L34>:
+               	movq	%rsi, %r8
+               	imulq	$0x47, %r8, %r8
+               	movq	%r8, -0x34e8(%rbp)
+               	movq	%rsi, %r13
+               	imulq	$0x20, %r13, %r13
+               	leaq	(%r12,%r13), %r8
+               	movq	%r8, -0x34f0(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L35>
+               	jmp	 <L36>
+<L35>:
+               	movq	%r13, %rdi
+               	imulq	$0xd, %rdi, %rdi
+               	movq	-0x34e8(%rbp), %r8
+               	movq	%r8, %r14
+               	addq	%rdi, %r14
+               	addq	%rbx, %r14
+               	movl	%r14d, %edi
+               	movq	-0x34f0(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	%edi, (%r14)
+               	addq	$0x1, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L35>
+<L36>:
+               	addq	$0x1, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L34>
+<L37>:
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L38>
+               	jmp	 <L44>
+<L38>:
+               	movq	%r13, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	leaq	0xc(%rdi), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x34f8(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x3500(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L39>
+               	jmp	 <L40>
+<L39>:
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x34f8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x3500(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r8
+               	movq	%r8, -0x3500(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L39>
 <L40>:
-               	movq	%rcx, %rsi
-               	imulq	$0x1f, %rsi, %rsi
-               	addq	%rbx, %rsi
-               	leaq	0x8(%r12), %r13
-               	leaq	(%r13,%rcx,8), %r14
-               	movq	%rsi, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	$0x400, %rcx            # imm = 0x400
-               	jb	 <L40>
+               	leaq	0x60(%r12), %rsi
+               	leaq	(%rsi,%r13,4), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x3508(%rbp)
+               	movq	-0x3500(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x3510(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	movq	$0x0, %rcx
-               	cmpq	$0x200, %rcx            # imm = 0x200
-               	jb	 <L42>
-               	jmp	 <L43>
+               	movq	%r14, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x3508(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x3510(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r8
+               	movq	%r8, -0x3510(%rbp)
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
 <L42>:
-               	movq	%rcx, %rsi
-               	imulq	$0x25, %rsi, %rsi
+               	movq	%r13, %rsi
+               	imulq	$0x20, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movq	%r13, %rsi
                	addq	%rbx, %rsi
-               	movl	%esi, %r13d
-               	leaq	0x200c(%r12), %rsi
-               	leaq	(%rsi,%rcx,4), %r14
-               	movl	%r13d, (%r14)
-               	addq	$0x1, %rcx
-               	cmpq	$0x200, %rcx            # imm = 0x200
-               	jb	 <L42>
+               	andq	$0x7, %rsi
+               	leaq	(%rdi,%rsi,4), %r14
+               	movl	(%r14), %esi
+               	movl	%esi, %r14d
+               	movq	-0x3510(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L43>
 <L43>:
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L44>
+               	movq	%rax, %rsi
+               	addq	$0x1, %r13
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %r13
+               	jb	 <L38>
 <L44>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L45>
+               	leaq	0xe0(%r12), %rsi
+               	leaq	0x1c(%rsi), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L45>
+               	jmp	 <L46>
 <L45>:
-               	movq	%rax, %rdi
-               	leaq	0x1ff8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L46>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L45>
 <L46>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rcx
-               	addq	$0x2bc, %rcx            # imm = 0x2BC
-               	movq	%rcx, %rax
-               	movq	$0x400, %rcx            # imm = 0x400
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,8), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L47>
+               	leaq	(%r12), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	(%rdi), %esi
+               	movl	%esi, %edi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L47>
+               	jmp	 <L48>
 <L47>:
-               	movq	%rax, %rdi
-               	leaq	0x2008(%r12), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L48>
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L47>
 <L48>:
-               	movq	%rax, %rdi
-               	leaq	0x200c(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L49>
+               	leaq	-0x33d0(%rbp), %r12
+               	leaq	(%r12), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x2810, %rdi           # imm = 0x2810
 <L49>:
-               	movq	%rax, %rdi
-               	leaq	0x7fc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L50>
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L49>
+               	movq	$0x12345678, %rsi       # imm = 0x12345678
+               	addq	%rbx, %rsi
+               	leaq	(%r12), %rdi
+               	movq	%rsi, (%rdi)
+               	movl	%ebx, %esi
+               	movl	$0x9abcdef0, %edi       # imm = 0x9ABCDEF0
+               	addl	%esi, %edi
+               	leaq	0x2008(%r12), %rsi
+               	movl	%edi, (%rsi)
+               	movw	%bx, %si
+               	movl	$0x1234, %edi           # imm = 0x1234
+               	addl	%esi, %edi
+               	leaq	0x280c(%r12), %rsi
+               	movw	%di, (%rsi)
+               	movq	$0x0, %rsi
+               	cmpq	$0x400, %rsi            # imm = 0x400
+               	jb	 <L50>
+               	jmp	 <L51>
 <L50>:
-               	movq	%rax, %rdi
-               	addq	$0x12c, %rbx            # imm = 0x12C
-               	movq	%rbx, %rax
-               	movq	$0x200, %rcx            # imm = 0x200
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%r13,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L51>
+               	movq	%rsi, %rdi
+               	imulq	$0x1f, %rdi, %rdi
+               	addq	%rbx, %rdi
+               	leaq	0x8(%r12), %r13
+               	leaq	(%r13,%rsi,8), %r14
+               	movq	%rdi, (%r14)
+               	addq	$0x1, %rsi
+               	cmpq	$0x400, %rsi            # imm = 0x400
+               	jb	 <L50>
 <L51>:
-               	movq	%rax, %rdi
-               	leaq	0x280c(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L52>
+               	movq	$0x0, %rsi
+               	cmpq	$0x200, %rsi            # imm = 0x200
+               	jb	 <L52>
+               	jmp	 <L53>
 <L52>:
-               	movq	%rax, %rdi
-               	movq	$0x2008, %rsi           # imm = 0x2008
-               	callq	 <L53>
+               	movq	%rsi, %rdi
+               	imulq	$0x25, %rdi, %rdi
+               	addq	%rbx, %rdi
+               	movl	%edi, %r13d
+               	leaq	0x200c(%r12), %rdi
+               	leaq	(%rdi,%rsi,4), %r14
+               	movl	%r13d, (%r14)
+               	addq	$0x1, %rsi
+               	cmpq	$0x200, %rsi            # imm = 0x200
+               	jb	 <L52>
 <L53>:
-               	movq	%rax, %rdi
-               	movq	$0x200c, %rsi           # imm = 0x200C
-               	callq	 <L54>
+               	leaq	(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
+               	jmp	 <L55>
 <L54>:
-               	movq	%rax, %rdi
-               	movq	$0x280c, %rsi           # imm = 0x280C
-               	callq	 <L55>
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L54>
 <L55>:
-               	movq	%rax, %rdi
-               	movq	$0x2810, %rsi           # imm = 0x2810
-               	callq	 <L56>
+               	leaq	0x8(%r12), %rsi
+               	leaq	(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L56>
+               	jmp	 <L57>
 <L56>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x400, %rcx            # imm = 0x400
-               	jb	 <L57>
-               	jmp	 <L58>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L56>
 <L57>:
-               	leaq	0x8(%r12), %rbx
-               	leaq	(%rbx,%rcx,8), %r13
-               	movq	(%r13), %rbx
-               	addq	$0x1, %rcx
-               	imulq	%rcx, %rbx
-               	xorq	%rbx, %rsi
-               	cmpq	$0x400, %rcx            # imm = 0x400
-               	jb	 <L57>
+               	leaq	0x8(%r12), %rsi
+               	leaq	0x1ff8(%rsi), %rdi
+               	movq	(%rdi), %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L58>
+               	jmp	 <L59>
 <L58>:
-               	callq	 <L59>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L58>
 <L59>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rcx            # imm = 0x200
-               	jb	 <L60>
-               	jmp	 <L61>
+               	leaq	0x8(%r12), %rsi
+               	movq	%rbx, %rdi
+               	addq	$0x2bc, %rdi            # imm = 0x2BC
+               	movq	%rdi, %rax
+               	movq	$0x400, %rdi            # imm = 0x400
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rsi,%rdi,8), %r13
+               	movq	(%r13), %rsi
+               	movq	%r15, %rdi
+               	callq	 <L60>
 <L60>:
-               	leaq	0x200c(%r12), %rbx
-               	leaq	(%rbx,%rcx,4), %r13
-               	movl	(%r13), %ebx
-               	movl	%ebx, %r13d
-               	movq	%rcx, %rbx
-               	addq	$0x3, %rbx
-               	imulq	%rbx, %r13
-               	addq	%r13, %rsi
-               	addq	$0x1, %rcx
-               	cmpq	$0x200, %rcx            # imm = 0x200
-               	jb	 <L60>
+               	movq	%rax, %rdi
+               	leaq	0x2008(%r12), %rsi
+               	movl	(%rsi), %r13d
+               	movl	%r13d, %esi
+               	callq	 <L61>
 <L61>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	leaq	(%rsi), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %r13d
+               	movq	%r13, %rsi
                	callq	 <L62>
 <L62>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x34c8(%rbp), %rbx
-               	movq	-0x34d0(%rbp), %r12
-               	movq	-0x34d8(%rbp), %r13
-               	movq	-0x34e0(%rbp), %r14
-               	movq	-0x34e8(%rbp), %r15
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	leaq	0x7fc(%rsi), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %r13d
+               	movq	%r13, %rsi
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rdi
+               	leaq	0x200c(%r12), %rsi
+               	addq	$0x12c, %rbx            # imm = 0x12C
+               	movq	%rbx, %rax
+               	movq	$0x200, %rbx            # imm = 0x200
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rsi,%rbx,4), %r13
+               	movl	(%r13), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rdi
+               	leaq	0x280c(%r12), %rsi
+               	movzwl	(%rsi), %ebx
+               	movzwq	%bx, %rsi
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rdi
+               	movq	$0x2008, %rsi           # imm = 0x2008
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movq	$0x200c, %rsi           # imm = 0x200C
+               	callq	 <L67>
+<L67>:
+               	movq	%rax, %rdi
+               	movq	$0x280c, %rsi           # imm = 0x280C
+               	callq	 <L68>
+<L68>:
+               	movq	%rax, %rdi
+               	movq	$0x2810, %rsi           # imm = 0x2810
+               	callq	 <L69>
+<L69>:
+               	movq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L70>
+               	jmp	 <L71>
+<L70>:
+               	leaq	0x8(%r12), %r13
+               	leaq	(%r13,%rdi,8), %r14
+               	movq	(%r14), %r13
+               	addq	$0x1, %rdi
+               	imulq	%rdi, %r13
+               	xorq	%r13, %rbx
+               	cmpq	$0x400, %rdi            # imm = 0x400
+               	jb	 <L70>
+<L71>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L72>
+<L73>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	leaq	0x200c(%r12), %r13
+               	leaq	(%r13,%rdi,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r14d
+               	movq	%rdi, %r13
+               	addq	$0x3, %r13
+               	imulq	%r13, %r14
+               	addq	%r14, %rbx
+               	addq	$0x1, %rdi
+               	cmpq	$0x200, %rdi            # imm = 0x200
+               	jb	 <L74>
+<L75>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L76>
+<L77>:
+               	movq	%rsi, %rax
+               	movq	-0x3518(%rbp), %rbx
+               	movq	-0x3520(%rbp), %r12
+               	movq	-0x3528(%rbp), %r13
+               	movq	-0x3530(%rbp), %r14
+               	movq	-0x3538(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/array_index.dis
+++ b/test/golden/x86_64-linux/mem/array_index.dis
@@ -5,29 +5,84 @@ Disassembly of section .text:
 <corpus.cases.mem.array_index.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,676 +90,1002 @@ Disassembly of section .text:
 <corpus.cases.mem.array_index.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x200, %rsp            # imm = 0x200
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%r12, -0x1e0(%rbp)
-               	movq	%r13, -0x1e8(%rbp)
-               	movq	%r14, -0x1f0(%rbp)
-               	movq	%r15, -0x1f8(%rbp)
-               	movq	%rdi, %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0x158(%rbp)
-               	callq	 <L0>
+               	subq	$0x2f0, %rsp            # imm = 0x2F0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
+               	movq	%r15, -0x2e8(%rbp)
+               	movq	%rdi, %rbx
+               	leaq	-0x1c(%rbp), %r12
+               	leaq	-0x108(%rbp), %r13
+               	leaq	(%r13), %rsi
+               	addq	$0x0, %rsi
+               	movq	$0x80, %rdi
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x9c(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x80, %rsi
+               	movq	$0x0, (%rsi)
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	cmpq	$0x0, %rdi
+               	jne	 <L0>
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L1>
-               	movq	$0x0, %rcx
-               	cmpq	$0x20, %rcx
-               	jb	 <L2>
-               	jmp	 <L3>
-<L2>:
-               	movq	%rcx, %rsi
-               	addq	$0x1, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x1, %rdi
                	movabsq	$0x9e3779b1, %r14       # imm = 0x9E3779B1
-               	imulq	%rsi, %r14
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %r14
+               	imulq	%rdi, %r14
+               	addq	%rbx, %r14
                	movl	%r14d, %r15d
-               	leaq	(%r13,%rcx,4), %r14
+               	leaq	(%r13,%rsi,4), %r14
                	movl	%r15d, (%r14)
-               	movq	%rsi, %rcx
-               	cmpq	$0x20, %rcx
-               	jb	 <L2>
+               	movq	%rdi, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L1>
+<L2>:
+               	leaq	(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x160(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L4>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rdi, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %r14
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x4(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x3c(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x3c(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	0x7c(%r13), %rcx
-               	movl	(%rcx), %esi
+               	leaq	0x7c(%r13), %rsi
+               	movl	(%rsi), %r14d
+               	movl	%r14d, %esi
                	callq	 <L7>
 <L7>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x20, %r15
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x20, %r8
                	jb	 <L8>
-               	jmp	 <L10>
+               	jmp	 <L11>
 <L8>:
-               	movq	%r15, %rcx
-               	imulq	$0x7, %rcx, %rcx
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rcx
-               	andq	$0x1f, %rcx
-               	leaq	(%r13,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%r14, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0x7, %r14, %r14
+               	addq	%rbx, %r14
+               	andq	$0x1f, %r14
+               	leaq	(%r13,%r14,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x168(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	movq	%rax, %r14
-               	addq	$0x1, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L8>
+               	movq	%rsi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x170(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r14, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
 <L10>:
-               	movq	$0x20, %r15
-               	movq	$0x0, %r11
-               	cmpq	%r15, %r11
-               	jb	 <L11>
-               	jmp	 <L13>
+               	movq	-0x178(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x178(%rbp)
+               	movq	-0x178(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L8>
 <L11>:
-               	subq	$0x1, %r15
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r14, %rdi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %r14
+               	movq	-0x168(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	$0x20, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
                	movq	$0x0, %r11
-               	cmpq	%r15, %r11
-               	jb	 <L11>
-<L13>:
+               	cmpq	%r8, %r11
+               	jb	 <L12>
+               	jmp	 <L15>
+<L12>:
+               	movq	-0x198(%rbp), %r9
+               	movq	%r9, %r8
+               	subq	$0x1, %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r15
+               	movl	(%r15), %r14d
+               	movl	%r14d, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x190(%rbp), %r8
+               	movq	%r8, %r14
                	movq	$0x0, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L14>
-               	jmp	 <L16>
-<L14>:
-               	leaq	(%r13,%r15,4), %rcx
-               	movl	(%rcx), %esi
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r14, %rdi
-               	callq	 <L15>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L13>
+<L14>:
+               	movq	%r14, %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	-0x180(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
+               	movq	$0x0, %r11
+               	cmpq	%r8, %r11
+               	jb	 <L12>
 <L15>:
-               	movq	%rax, %r14
-               	addq	$0x5, %r15
-               	cmpq	$0x20, %r15
-               	jb	 <L14>
+               	movq	-0x190(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+               	jmp	 <L19>
 <L16>:
-               	leaq	-0xcc(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r8d
+               	movq	%r8, -0x1a8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	-0x1a8(%rbp), %r8
+               	movq	%r8, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r15, %rdi
+               	xorq	%r14, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
+               	movq	-0x1b0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x5, %rsi
+               	movq	%r15, %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1b0(%rbp)
+               	movq	-0x1b0(%rbp), %r8
+               	cmpq	$0x20, %r8
+               	jb	 <L16>
+<L19>:
+               	leaq	-0x4c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	movq	$0x0, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
-               	jmp	 <L20>
-<L17>:
-               	movq	%rcx, %r8
-               	imulq	$0x64, %r8, %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0xc, %rdi, %rdi
-               	leaq	(%r13,%rdi), %r8
-               	movq	%r8, -0x148(%rbp)
-               	movq	$0x0, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
-               	movq	%rdi, %rsi
-               	imulq	$0x7, %rsi, %rsi
-               	movq	-0x140(%rbp), %r8
-               	movq	%r8, %r15
-               	addq	%rsi, %r15
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %r15
-               	movw	%r15w, %si
-               	movq	-0x148(%rbp), %r8
-               	leaq	(%r8,%rdi,2), %r15
-               	movw	%si, (%r15)
-               	addq	$0x1, %rdi
-               	cmpq	$0x6, %rdi
-               	jb	 <L18>
-<L19>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x4, %rcx
-               	jb	 <L17>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L20>
+               	jmp	 <L23>
 <L20>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rsi
-               	movzwl	(%rsi), %ecx
-               	movq	%r14, %rdi
-               	movq	%rcx, %rsi
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x24(%r13), %rcx
-               	leaq	0xa(%rcx), %rsi
-               	movzwl	(%rsi), %ecx
-               	movq	%rcx, %rsi
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	andq	$0x3, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rsi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x4, %rcx
-               	andq	$0x3, %rcx
-               	leaq	(%rsi,%rcx,2), %r14
-               	movzwl	(%r14), %esi
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%r15, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%r13,%rcx), %r8
-               	movq	%r8, -0x150(%rbp)
-               	movq	%r14, %r8
+               	movq	%rsi, %r8
+               	imulq	$0x64, %r8, %r8
                	movq	%r8, -0x1b8(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L27>
-<L25>:
-               	movq	-0x150(%rbp), %r8
-               	leaq	(%r8,%r12,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x160(%rbp)
+               	movq	%rsi, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r13,%r14), %r8
+               	movq	%r8, -0x1c0(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x6, %r14
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%r14, %rdi
+               	imulq	$0x7, %rdi, %rdi
                	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	%rdi, %r15
+               	addq	%rbx, %r15
+               	movw	%r15w, %di
+               	movq	-0x1c0(%rbp), %r8
+               	leaq	(%r8,%r14,2), %r15
+               	movw	%di, (%r15)
+               	addq	$0x1, %r14
+               	cmpq	$0x6, %r14
+               	jb	 <L21>
+<L22>:
+               	addq	$0x1, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L20>
+<L23>:
+               	leaq	(%r13), %rsi
+               	leaq	(%rsi), %rdi
+               	movzwl	(%rdi), %esi
+               	movzwq	%si, %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rsi
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L24>
+<L25>:
+               	leaq	0x24(%r13), %rdi
+               	leaq	0xa(%rdi), %r14
+               	movzwl	(%r14), %edi
+               	movzwq	%di, %r14
+               	movq	%rsi, %rdi
+               	movq	%r14, %rsi
                	callq	 <L26>
 <L26>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r12
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1b8(%rbp)
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L27>:
-               	addq	$0x1, %r15
-               	movq	-0x1b8(%rbp), %r8
-               	movq	%r8, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L24>
-<L28>:
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L29>
-               	jmp	 <L33>
-<L29>:
-               	movq	%r14, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L30>
-               	jmp	 <L32>
-<L30>:
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	%rax, %rdi
+               	movq	%rbx, %rsi
+               	addq	$0x2, %rsi
+               	andq	$0x3, %rsi
                	imulq	$0xc, %rsi, %rsi
-               	leaq	(%r13,%rsi), %rdi
-               	leaq	(%rdi,%r12,2), %rsi
-               	movzwl	(%rsi), %r8d
-               	movq	%r8, -0x168(%rbp)
-               	movq	%r15, %rdi
-               	movq	-0x168(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r15
-               	movq	-0x1c0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1c0(%rbp)
-               	movq	-0x1c0(%rbp), %r8
+               	leaq	(%r13,%rsi), %r14
+               	movq	%rbx, %rsi
+               	addq	$0x4, %rsi
+               	andq	$0x3, %rsi
+               	leaq	(%r14,%rsi,2), %r15
+               	movzwl	(%r15), %esi
+               	movzwq	%si, %r14
+               	movq	%r14, %rsi
+               	callq	 <L27>
+<L27>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L30>
-<L32>:
-               	addq	$0x1, %r12
-               	movq	%r15, %r14
-               	cmpq	$0x6, %r12
+               	jb	 <L28>
+               	jmp	 <L33>
+<L28>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %r14
+               	imulq	$0xc, %r14, %r14
+               	leaq	(%r13,%r14), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x1d0(%rbp), %r8
+               	movq	-0x1f8(%rbp), %r9
+               	leaq	(%r8,%r9,2), %rsi
+               	movzwl	(%rsi), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x1f8(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L29>
+<L32>:
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x1e0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L28>
 <L33>:
-               	leaq	-0xe7(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movw	$0x0, 0x18(%r12)
-               	movb	$0x0, 0x1a(%r12)
-               	movq	$0x0, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x1d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
                	jmp	 <L39>
 <L34>:
-               	movq	%rcx, %r8
-               	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	%rcx, %rdi
-               	imulq	$0x9, %rdi, %rdi
-               	leaq	(%r12,%rdi), %r8
-               	movq	%r8, -0x178(%rbp)
-               	movq	$0x0, %rdi
-               	cmpq	$0x3, %rdi
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
                	jmp	 <L38>
 <L35>:
-               	movq	%rdi, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x170(%rbp), %r9
-               	movq	%r9, %r8
-               	addq	%r15, %r8
-               	movq	%r8, -0x180(%rbp)
-               	movq	%rdi, %r15
-               	imulq	$0x3, %r15, %r15
-               	movq	-0x178(%rbp), %r9
-               	leaq	(%r9,%r15), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	$0x0, %r15
-               	cmpq	$0x3, %r15
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	movq	-0x218(%rbp), %r8
+               	leaq	(%r14,%r8,2), %rsi
+               	movzwl	(%rsi), %r14d
+               	movzwq	%r14w, %r8
+               	movq	%r8, -0x210(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L36>
                	jmp	 <L37>
 <L36>:
-               	movq	-0x180(%rbp), %r8
-               	movq	%r8, %rsi
-               	addq	%r15, %rsi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rsi
-               	movb	%sil, %r13b
-               	movq	-0x188(%rbp), %r8
-               	leaq	(%r8,%r15), %rsi
-               	movb	%r13b, (%rsi)
-               	addq	$0x1, %r15
-               	cmpq	$0x3, %r15
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x210(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r14, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rsi
                	jb	 <L36>
 <L37>:
-               	addq	$0x1, %rdi
-               	cmpq	$0x3, %rdi
+               	movq	-0x220(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	%r14, %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r8
+               	cmpq	$0x4, %r8
                	jb	 <L35>
 <L38>:
-               	addq	$0x1, %rcx
-               	cmpq	$0x3, %rcx
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x208(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x200(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	cmpq	$0x6, %r8
                	jb	 <L34>
 <L39>:
-               	movq	%r14, %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	$0x0, %r13
-               	cmpq	$0x3, %r13
+               	leaq	-0x67(%rbp), %r8
+               	movq	%r8, -0x230(%rbp)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movw	$0x0, 0x18(%r8)
+               	movq	-0x230(%rbp), %r8
+               	movb	$0x0, 0x1a(%r8)
+               	movq	$0x0, %rdi
+               	cmpq	$0x3, %rdi
                	jb	 <L40>
-               	jmp	 <L46>
-<L40>:
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %r15
-               	movq	$0x0, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c8(%rbp), %r8
-               	cmpq	$0x3, %r8
-               	jb	 <L41>
                	jmp	 <L45>
-<L41>:
-               	movq	%r15, %rbx
+<L40>:
+               	movq	%rdi, %r8
+               	imulq	$0x9, %r8, %r8
+               	movq	%r8, -0x228(%rbp)
+               	movq	%rdi, %r14
+               	imulq	$0x9, %r14, %r14
+               	movq	-0x230(%rbp), %r9
+               	leaq	(%r9,%r14), %r8
+               	movq	%r8, -0x238(%rbp)
                	movq	$0x0, %r14
                	cmpq	$0x3, %r14
-               	jb	 <L42>
+               	jb	 <L41>
                	jmp	 <L44>
+<L41>:
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x228(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	%r13, %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%r14, %r13
+               	imulq	$0x3, %r13, %r13
+               	movq	-0x238(%rbp), %r9
+               	leaq	(%r9,%r13), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L42>
+               	jmp	 <L43>
 <L42>:
-               	movq	%r14, %rsi
-               	imulq	$0x9, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	movq	-0x1c8(%rbp), %r8
+               	movq	-0x240(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x3, %rsi, %rsi
-               	leaq	(%rdi,%rsi), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	movq	-0x1a0(%rbp), %r8
+               	addq	%r13, %rsi
+               	addq	%rbx, %rsi
+               	movb	%sil, %r15b
+               	movq	-0x248(%rbp), %r8
                	leaq	(%r8,%r13), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	movq	%rbx, %rdi
-               	movq	-0x1a8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L43>
+               	movb	%r15b, (%rsi)
+               	addq	$0x1, %r13
+               	cmpq	$0x3, %r13
+               	jb	 <L42>
 <L43>:
-               	movq	%rax, %rbx
                	addq	$0x1, %r14
                	cmpq	$0x3, %r14
-               	jb	 <L42>
-<L44>:
-               	movq	-0x1c8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rbx, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c8(%rbp), %r8
-               	cmpq	$0x3, %r8
                	jb	 <L41>
-<L45>:
-               	addq	$0x1, %r13
-               	movq	%r15, %r8
-               	movq	%r8, -0x198(%rbp)
-               	cmpq	$0x3, %r13
-               	jb	 <L40>
-<L46>:
-               	leaq	0x12(%r12), %rcx
-               	leaq	(%rcx), %rsi
-               	leaq	0x1(%rsi), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x9, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x2, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	leaq	(%rsi,%rcx), %rbx
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rax
-               	movq	$0x3, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	movzbl	(%rsi), %ecx
-               	movq	%rcx, %rsi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rcx
-               	leaq	-0x138(%rbp), %rbx
-               	leaq	(%rbx), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x50, %rdi
-<L49>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L49>
-               	movq	$0x0, %rsi
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	movq	%rsi, %rdi
-               	imulq	$0x3, %rdi, %rdi
+<L44>:
                	addq	$0x1, %rdi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rdi
-               	movw	%di, %r12w
-               	movq	%rsi, %rdi
-               	imulq	$0x10, %rdi, %rdi
-               	leaq	(%rbx,%rdi), %r13
-               	leaq	(%r13), %rdi
-               	movw	%r12w, (%rdi)
-               	movq	%rsi, %rdi
-               	addq	$0xc8, %rdi
-               	movb	%dil, %r12b
-               	leaq	0x2(%r13), %rdi
-               	movb	%r12b, (%rdi)
-               	addq	$0x1, %rsi
-               	movabsq	$0x100000001b3, %rdi    # imm = 0x100000001B3
-               	imulq	%rsi, %rdi
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rdi
-               	leaq	0x8(%r13), %r12
-               	movq	%rdi, (%r12)
-               	cmpq	$0x5, %rsi
-               	jb	 <L50>
-<L51>:
-               	movq	%rcx, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x5, %r13
-               	jb	 <L52>
-               	jmp	 <L56>
-<L52>:
+               	cmpq	$0x3, %rdi
+               	jb	 <L40>
+<L45>:
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+               	jmp	 <L53>
+<L46>:
+               	movq	-0x250(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+               	jmp	 <L52>
+<L47>:
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x260(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x3, %rsi
+               	jb	 <L48>
+               	jmp	 <L51>
+<L48>:
+               	movq	%rsi, %r13
+               	imulq	$0x9, %r13, %r13
+               	movq	-0x230(%rbp), %r8
+               	leaq	(%r8,%r13), %r15
+               	movq	-0x278(%rbp), %r8
+               	movq	%r8, %r13
+               	imulq	$0x3, %r13, %r13
+               	leaq	(%r15,%r13), %rdi
+               	movq	-0x268(%rbp), %r8
+               	leaq	(%rdi,%r8), %r13
+               	movzbl	(%r13), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x270(%rbp)
+               	movq	-0x260(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%r15, %r13
+               	imulq	$0x8, %r13, %r13
                	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %r14d
-               	leaq	0x2(%rsi), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	movq	-0x1b0(%rbp), %r8
+               	movq	-0x270(%rbp), %r8
+               	movq	%r8, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r15
+               	jb	 <L49>
+<L50>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x260(%rbp)
+               	cmpq	$0x3, %rsi
+               	jb	 <L48>
+<L51>:
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rcx
+               	addq	$0x1, %rsi
+               	movq	-0x260(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x278(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L47>
+<L52>:
+               	movq	-0x268(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x250(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x268(%rbp)
+               	movq	-0x268(%rbp), %r8
+               	cmpq	$0x3, %r8
+               	jb	 <L46>
+<L53>:
+               	movq	-0x230(%rbp), %r8
+               	leaq	0x12(%r8), %rsi
+               	leaq	(%rsi), %rdi
+               	leaq	0x1(%rdi), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	-0x250(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
                	addq	$0x1, %r13
-               	movq	%rcx, %r12
-               	cmpq	$0x5, %r13
-               	jb	 <L52>
-<L56>:
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x5, %rcx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %r13
+               	jb	 <L54>
+<L55>:
+               	movq	%rbx, %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x3, %rsi
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %r13d
-               	leaq	0x2(%rsi), %rcx
-               	movzbl	(%rcx), %r14d
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	movq	%r12, %rdi
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x9, %rsi, %rsi
+               	movq	-0x230(%rbp), %r8
+               	leaq	(%r8,%rsi), %r13
+               	movq	%rbx, %rsi
+               	addq	$0x2, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x3, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x3, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	movq	%rbx, %rax
+               	movq	$0x3, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	(%r14,%rsi), %r13
+               	movzbl	(%r13), %esi
+               	movzbq	%sil, %r13
                	movq	%r13, %rsi
-               	callq	 <L57>
+               	callq	 <L56>
+<L56>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x280(%rbp)
+               	movq	-0x280(%rbp), %r8
+               	leaq	-0x158(%rbp), %r13
+               	leaq	(%r13), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x50, %r14
 <L57>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L58>
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L57>
+               	movq	$0x0, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L58>
+               	jmp	 <L59>
 <L58>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L59>
+               	movq	%rdi, %r14
+               	imulq	$0x3, %r14, %r14
+               	addq	$0x1, %r14
+               	addq	%rbx, %r14
+               	movw	%r14w, %r15w
+               	movq	%rdi, %r14
+               	imulq	$0x10, %r14, %r14
+               	leaq	(%r13,%r14), %rsi
+               	leaq	(%rsi), %r14
+               	movw	%r15w, (%r14)
+               	movq	%rdi, %r14
+               	addq	$0xc8, %r14
+               	movb	%r14b, %r15b
+               	leaq	0x2(%rsi), %r14
+               	movb	%r15b, (%r14)
+               	addq	$0x1, %rdi
+               	movabsq	$0x100000001b3, %r14    # imm = 0x100000001B3
+               	imulq	%rdi, %r14
+               	addq	%rbx, %r14
+               	leaq	0x8(%rsi), %r15
+               	movq	%r14, (%r15)
+               	cmpq	$0x5, %rdi
+               	jb	 <L58>
 <L59>:
-               	movq	%rax, %rdi
-               	leaq	0x40(%rbx), %rcx
-               	leaq	0x8(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L60>
+               	movq	-0x280(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L60>
+               	jmp	 <L62>
 <L60>:
-               	movq	%rax, %rdi
-               	movq	-0x190(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x5, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	leaq	(%rsi), %rcx
-               	movzwl	(%rcx), %esi
+               	movq	%r15, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	-0x78(%rbp), %r8
+               	movq	%r8, -0x288(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	0x8(%rdi), %r8
+               	movq	%r8, -0x290(%rbp)
+               	movq	-0x288(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movq	-0x288(%rbp), %r8
+               	movq	-0x290(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x288(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x288(%rbp), %r9
+               	movq	0x8(%r9), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	%r14, %rdi
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
                	callq	 <L61>
 <L61>:
+               	movq	%rax, %r14
+               	addq	$0x1, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L60>
+<L62>:
+               	movq	%rbx, %rsi
+               	addq	$0x3, %rsi
+               	movq	%rsi, %rax
+               	movq	$0x5, %rsi
+               	xorl	%edx, %edx
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %rdi
+               	leaq	-0x88(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	(%rdi), %r15
+               	movq	0x8(%rdi), %rsi
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%r15, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	%rsi, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x2a0(%rbp), %r8
+               	movq	0x8(%r8), %r15
+               	movq	%r14, %rdi
+               	movq	%r15, %rdx
+               	callq	 <L63>
+<L63>:
+               	movq	%rax, %rsi
+               	leaq	0x40(%r13), %rdi
+               	leaq	0x8(%rdi), %r14
+               	movq	(%r14), %r8
+               	movq	%r8, -0x2a8(%rbp)
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2a8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rsi, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %r14
+               	jb	 <L64>
+<L65>:
+               	movq	%rbx, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rdi, %rax
+               	movq	$0x5, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r14
+               	leaq	(%r14), %rdi
+               	movzwl	(%rdi), %r13d
+               	movzwq	%r13w, %r14
+               	movq	%rsi, %rdi
+               	movq	%r14, %rsi
+               	callq	 <L66>
+<L66>:
                	movq	%rax, %rdi
                	movq	$0x10, %rsi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x158(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x158(%rbp), %r8
-               	movl	$0x0, 0x18(%r8)
-               	movq	-0x190(%rbp), %r8
-               	movl	%r8d, %ecx
-               	movq	$0x0, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-               	jmp	 <L64>
-<L63>:
-               	movl	%esi, %ebx
-               	imull	$0x12345678, %ebx, %ebx # imm = 0x12345678
-               	addl	%ecx, %ebx
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rsi,4), %r12
-               	movl	%ebx, (%r12)
-               	addq	$0x1, %rsi
-               	cmpq	$0x7, %rsi
-               	jb	 <L63>
-<L64>:
-               	movq	$0x11, %rsi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rbx
-               	movq	$0x0, %r12
-               	cmpq	$0x7, %r12
-               	jb	 <L66>
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	movq	-0x190(%rbp), %r8
-               	addq	%r8, %rcx
-               	movq	%rcx, %rax
-               	movq	$0x7, %rcx
-               	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8,%rcx,4), %rsi
-               	movl	(%rsi), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
                	callq	 <L67>
 <L67>:
-               	movq	%rax, %rbx
-               	addq	$0x1, %r12
-               	cmpq	$0x7, %r12
-               	jb	 <L66>
+               	movq	%rax, %rsi
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	movq	$0x0, 0x10(%r12)
+               	movl	$0x0, 0x18(%r12)
+               	movl	%ebx, %edi
+               	movq	$0x0, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
+               	jmp	 <L69>
 <L68>:
-               	movq	%rbx, %rdi
-               	movq	$0x1234, %rsi           # imm = 0x1234
-               	callq	 <L69>
+               	movl	%r13d, %r14d
+               	imull	$0x12345678, %r14d, %r14d # imm = 0x12345678
+               	addl	%edi, %r14d
+               	leaq	(%r12,%r13,4), %r15
+               	movl	%r14d, (%r15)
+               	addq	$0x1, %r13
+               	cmpq	$0x7, %r13
+               	jb	 <L68>
 <L69>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L70>
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L70>
+               	jmp	 <L71>
 <L70>:
-               	movq	%rax, %rdi
-               	movq	-0x158(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x10(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x14(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movq	-0x158(%rbp), %r8
-               	leaq	0x18(%r8), %rbx
-               	movl	(%rbx), %r12d
-               	movl	%esi, %ebx
-               	xorl	$0xf0f0f0f0, %ebx       # imm = 0xF0F0F0F0
-               	movl	(%rcx), %esi
-               	callq	 <L71>
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	$0x11, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L70>
 <L71>:
+               	movq	%rsi, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x7, %rdi
+               	jb	 <L72>
+               	jmp	 <L75>
+<L72>:
+               	movq	%rdi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	%rbx, %r13
+               	movq	%r13, %rax
+               	movq	$0x7, %r13
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r13
+               	leaq	(%r12,%r13,4), %r14
+               	movl	(%r14), %r13d
+               	movl	%r13d, %r8d
+               	movq	%r8, -0x2b8(%rbp)
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+               	jmp	 <L74>
+<L73>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r15
+               	movq	%r14, %r13
+               	cmpq	$0x8, %r15
+               	jb	 <L73>
+<L74>:
+               	addq	$0x1, %rdi
+               	movq	%r13, %r8
+               	movq	%r8, -0x2b0(%rbp)
+               	cmpq	$0x7, %rdi
+               	jb	 <L72>
+<L75>:
+               	movq	-0x2b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+               	jmp	 <L77>
+<L76>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	$0x1234, %rbx           # imm = 0x1234
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L76>
+<L77>:
+               	movq	$0x4, %rsi
+               	callq	 <L78>
+<L78>:
+               	movq	%rax, %rdi
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x4(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0xc(%r12), %rsi
+               	movl	(%rsi), %ebx
+               	leaq	0x10(%r12), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x14(%r12), %r13
+               	movl	(%r13), %r14d
+               	leaq	0x18(%r12), %r13
+               	movl	(%r13), %r12d
+               	xorl	$0xf0f0f0f0, %ebx       # imm = 0xF0F0F0F0
+               	movl	(%rsi), %r12d
+               	movl	%r12d, %esi
+               	callq	 <L79>
+<L79>:
                	movq	%rax, %rdi
                	movl	%ebx, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L80>
+<L80>:
                	movq	%rax, %rdi
                	movq	$0x11, %rsi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L81>
+<L81>:
                	movq	%rax, %rdi
                	movq	$0x1234, %rsi           # imm = 0x1234
-               	callq	 <L74>
-<L74>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %r12
-               	movq	-0x1e8(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r14
-               	movq	-0x1f8(%rbp), %r15
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
+               	movq	-0x2e8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/global_data.dis
+++ b/test/golden/x86_64-linux/mem/global_data.dis
@@ -5,29 +5,84 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,131 +90,355 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.fold_globals>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movzbl	, %esi <corpus.cases.mem.global_data.fold_globals+0x1b>
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movzbl	, %eax <corpus.cases.mem.global_data.fold_globals+0x1f>
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_data.fold_globals+0x2a>
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_data.fold_globals+0x38>
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movzwl	, %eax <corpus.cases.mem.global_data.fold_globals+0x7c>
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x49>
-               	callq	 <L3>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movzbl	, %esi <corpus.cases.mem.global_data.fold_globals+0x58>
-               	callq	 <L4>
+               	movl	, %eax <corpus.cases.mem.global_data.fold_globals+0xd8>
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_data.fold_globals+0x67>
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_data.fold_globals+0x75>
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movq	, %rax <corpus.cases.mem.global_data.fold_globals+0x133>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x86>
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x95>
-               	movss	(%rcx), %xmm0
-               	callq	 <L8>
+               	movzbl	, %eax <corpus.cases.mem.global_data.fold_globals+0x18c>
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0xa8>
-               	movsd	(%rcx), %xmm0
-               	callq	 <L9>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0xb8>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x6, %r13
+               	movzwl	, %eax <corpus.cases.mem.global_data.fold_globals+0x1e9>
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
                	jb	 <L10>
-               	jmp	 <L12>
+               	jmp	 <L11>
 <L10>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
-<L11>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x6, %r13
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
                	jb	 <L10>
+<L11>:
+               	movl	, %eax <corpus.cases.mem.global_data.fold_globals+0x245>
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0xf9>
-               	movzwl	(%rax), %esi
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x103>
-               	movzbl	(%rax), %ebx
-               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x10d>
-               	movq	(%rax), %r13
-               	movq	%r12, %rdi
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L14>
+               	movq	, %rax <corpus.cases.mem.global_data.fold_globals+0x2a1>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L15>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
 <L15>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x135>
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %esi
-               	leaq	0x2(%rcx), %rdx
-               	movzbl	(%rdx), %ebx
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %r12
-               	movq	%rax, %rdi
+               	leaq	, %rax <corpus.cases.mem.global_data.fold_globals+0x2fa>
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L16>
 <L16>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x311>
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rsi
                	movq	%rax, %rdi
-               	movq	%rbx, %rsi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L18>
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x329>
+               	movq	$0x0, %rsi
+               	cmpq	$0x6, %rsi
+               	jb	 <L18>
+               	jmp	 <L21>
 <L18>:
-               	leaq	, %rbx <corpus.cases.mem.global_data.fold_globals+0x16e>
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
+               	leaq	(%rdx,%rsi,4), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	%rax, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
 <L20>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x6, %rsi
+               	jb	 <L18>
 <L21>:
-               	leaq	, %rcx <corpus.cases.mem.global_data.fold_globals+0x1a1>
-               	movl	(%rcx), %edx
+               	leaq	-0x10(%rbp), %rdx
+               	movq	, %rsi <corpus.cases.mem.global_data.fold_globals+0x3b8>
+               	movq	, %rdi <corpus.cases.mem.global_data.fold_globals+0x3bf>
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rbx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rbx, %rdx
                	callq	 <L22>
 <L22>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x3df>
+               	leaq	-0x20(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %rbx
+               	movq	%rdi, (%rsi)
+               	movq	%rbx, 0x8(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rbx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	movq	%rbx, %rdx
+               	callq	 <L23>
+<L23>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x40d>
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x470>
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x4d4>
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L28>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_data.fold_globals+0x538>
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -291,263 +570,261 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x140, %rsp            # imm = 0x140
-               	movq	%rbx, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movq	%r13, -0x128(%rbp)
-               	movq	%r14, -0x130(%rbp)
-               	movq	%r15, -0x138(%rbp)
+               	subq	$0x150, %rsp            # imm = 0x150
+               	movq	%rbx, -0x128(%rbp)
+               	movq	%r12, -0x130(%rbp)
+               	movq	%r13, -0x138(%rbp)
+               	movq	%r14, -0x140(%rbp)
+               	movq	%r15, -0x148(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
+               	movabsq	$-0x61c8864680b583eb, %rsi # imm = 0x9E3779B97F4A7C15
+               	addq	%rbx, %rsi
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdi
-               	movabsq	$-0x61c8864680b583eb, %rsi # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rsi
+               	movq	$-0x12d687, %rsi        # imm = 0xFFED2979
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rdi
-               	movl	$0xffed2979, %esi       # imm = 0xFFED2979
+               	movabsq	$0x3fc4000000000000, %rsi # imm = 0x3FC4000000000000
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x6b>
-               	callq	 <L4>
-<L4>:
                	movq	%rax, %rcx
-               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0x7a>
-               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0x81>
-               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x88>
-               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x8f>
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x96>
-               	movq	%r8, -0x110(%rbp)
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xa4>
-               	movq	%r8, -0x48(%rbp)
-               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xaf>
-               	movq	%r8, -0x50(%rbp)
-               	movq	%rcx, %r8
+               	leaq	, %r12 <corpus.cases.mem.global_data.checksum+0x80>
+               	leaq	, %r13 <corpus.cases.mem.global_data.checksum+0x87>
+               	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x8e>
+               	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x95>
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x9c>
+               	movq	%r8, -0x120(%rbp)
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xaa>
                	movq	%r8, -0x58(%rbp)
+               	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xb5>
+               	movq	%r8, -0x60(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x68(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
                	cmpq	$0x5, %r8
-               	jb	 <L5>
-               	jmp	 <L9>
-<L5>:
-               	movq	-0x108(%rbp), %r8
+               	jb	 <L4>
+               	jmp	 <L8>
+<L4>:
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x60(%rbp)
-               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0xfd>
-               	movq	-0x60(%rbp), %r9
-               	movb	%r9b, %r8b
-               	movq	%r8, -0x68(%rbp)
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %edi
-               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x116>
-               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x11d>
-               	movq	-0x60(%rbp), %r9
-               	movw	%r9w, %r8w
                	movq	%r8, -0x70(%rbp)
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %edi
-               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x137>
-               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x13d>
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
+               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x103>
+               	movq	-0x70(%rbp), %r9
+               	movb	%r9b, %r8b
                	movq	%r8, -0x78(%rbp)
                	movq	-0x78(%rbp), %r8
                	addl	%r8d, %edi
-               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x155>
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x15c>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rdi
-               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x16a>
-               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x171>
-               	movq	-0x68(%rbp), %r8
-               	addl	%r8d, %edi
-               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x17f>
-               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x186>
-               	movq	-0x70(%rbp), %r8
-               	addl	%r8d, %edi
-               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x194>
-               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x19a>
-               	movq	-0x78(%rbp), %r8
-               	addl	%r8d, %edi
-               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x1a7>
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x1ae>
-               	movq	-0x60(%rbp), %r8
-               	addq	%r8, %rdi
-               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x1bc>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1c3>
-               	movss	(%rdi), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1d3>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1da>
-               	movss	%xmm1, (%rdi)
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1e5>
-               	movsd	(%rdi), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1f5>
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x201>
-               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x208>
-               	movsd	%xmm0, (%rdi)
-               	movq	-0x60(%rbp), %r9
-               	movl	%r9d, %r8d
+               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x11c>
+               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x123>
+               	movq	-0x70(%rbp), %r9
+               	movw	%r9w, %r8w
                	movq	%r8, -0x80(%rbp)
-               	movq	$0x0, %r8
+               	movq	-0x80(%rbp), %r8
+               	addl	%r8d, %edi
+               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x13d>
+               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x143>
+               	movq	-0x70(%rbp), %r9
+               	movl	%r9d, %r8d
                	movq	%r8, -0x88(%rbp)
                	movq	-0x88(%rbp), %r8
-               	cmpq	$0x6, %r8
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	-0x88(%rbp), %r9
-               	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x90(%rbp)
-               	movq	-0x90(%rbp), %r9
-               	movl	(%r9), %r8d
-               	movq	%r8, -0x98(%rbp)
+               	addl	%r8d, %edi
+               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x161>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x168>
+               	movq	-0x70(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x176>
+               	movzbl	, %edi <corpus.cases.mem.global_data.checksum+0x17d>
+               	movq	-0x78(%rbp), %r8
+               	addl	%r8d, %edi
+               	movb	%dil,  <corpus.cases.mem.global_data.checksum+0x18b>
+               	movzwl	, %edi <corpus.cases.mem.global_data.checksum+0x192>
+               	movq	-0x80(%rbp), %r8
+               	addl	%r8d, %edi
+               	movw	%di,  <corpus.cases.mem.global_data.checksum+0x1a0>
+               	movl	, %edi <corpus.cases.mem.global_data.checksum+0x1a6>
                	movq	-0x88(%rbp), %r8
+               	addl	%r8d, %edi
+               	movl	%edi,  <corpus.cases.mem.global_data.checksum+0x1b6>
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x1bd>
+               	movq	-0x70(%rbp), %r8
+               	addq	%r8, %rdi
+               	movq	%rdi,  <corpus.cases.mem.global_data.checksum+0x1cb>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1d2>
+               	movss	(%rdi), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.global_data.checksum+0x1e2>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1e9>
+               	movss	%xmm1, (%rdi)
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x1f4>
+               	movsd	(%rdi), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.global_data.checksum+0x204>
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.global_data.checksum+0x210>
+               	leaq	, %rdi <corpus.cases.mem.global_data.checksum+0x217>
+               	movsd	%xmm0, (%rdi)
+               	movq	-0x70(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x90(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	-0x98(%rbp), %r9
+               	leaq	(%r12,%r9,4), %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	-0xa0(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0x98(%rbp), %r8
                	movl	%r8d, %edi
                	addl	$0x1, %edi
-               	movq	-0x80(%rbp), %r9
+               	movq	-0x90(%rbp), %r9
                	movl	%r9d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0xa0(%rbp)
-               	movq	-0x98(%rbp), %r8
-               	movq	-0xa0(%rbp), %r9
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0xa8(%rbp), %r8
+               	movq	-0xb0(%rbp), %r9
                	movl	%r8d, %edi
                	xorl	%r9d, %edi
-               	movq	-0x90(%rbp), %r8
+               	movq	-0xa0(%rbp), %r8
                	movl	%edi, (%r8)
-               	movq	-0x88(%rbp), %r8
+               	movq	-0x98(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
-               	movq	%r8, -0x88(%rbp)
-               	movq	-0x88(%rbp), %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	-0x98(%rbp), %r8
                	cmpq	$0x6, %r8
-               	jb	 <L6>
-<L7>:
+               	jb	 <L5>
+<L6>:
                	movzwl	(%r13), %r8d
-               	movq	%r8, -0xa8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movw	%r8w, %di
-               	movq	-0xa8(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%edi, %r8d
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
-               	movw	%r8w, (%r13)
-               	movzbl	(%r14), %r8d
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movb	%r8b, %dil
+               	movq	-0x70(%rbp), %r8
+               	movw	%r8w, %di
                	movq	-0xb8(%rbp), %r9
                	movl	%r9d, %r8d
-               	xorl	%edi, %r8d
+               	addl	%edi, %r8d
                	movq	%r8, -0xc0(%rbp)
                	movq	-0xc0(%rbp), %r8
+               	movw	%r8w, (%r13)
+               	movzbl	(%r14), %r8d
+               	movq	%r8, -0xc8(%rbp)
+               	movq	-0x70(%rbp), %r8
+               	movb	%r8b, %dil
+               	movq	-0xc8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	xorl	%edi, %r8d
+               	movq	%r8, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %r8
                	movb	%r8b, (%r14)
                	movq	(%r15), %rdi
                	imulq	$0x3, %rdi, %rdi
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x70(%rbp), %r8
                	addq	%r8, %rdi
                	movq	%rdi, (%r15)
-               	leaq	-0x40(%rbp), %r8
-               	movq	%r8, -0xc8(%rbp)
-               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x34b>
-               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x352>
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xc8(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0xc8(%rbp), %r8
-               	movq	-0xd0(%rbp), %r9
-               	movq	%r9, 0x8(%r8)
-               	movq	-0xc8(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	-0xc8(%rbp), %r9
-               	movq	0x8(%r9), %r8
+               	leaq	-0x50(%rbp), %r8
                	movq	%r8, -0xd8(%rbp)
-               	movq	-0x110(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movq	-0x110(%rbp), %r8
-               	movq	-0xd8(%rbp), %r9
-               	movq	%r9, 0x8(%r8)
-               	movq	-0x60(%rbp), %r8
-               	movq	%r8, %rax
-               	movq	$0x3, %rdi
-               	xorl	%edx, %edx
-               	divq	%rdi
-               	movq	%rdx, %rdi
-               	movq	-0x48(%rbp), %r9
-               	leaq	(%r9,%rdi,2), %r8
+               	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x360>
+               	movq	, %r8 <corpus.cases.mem.global_data.checksum+0x367>
                	movq	%r8, -0xe0(%rbp)
-               	movq	-0xe0(%rbp), %r8
-               	movzwl	(%r8), %edi
-               	movl	%edi, %r8d
-               	addl	$0x64, %r8d
+               	movq	-0xd8(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe0(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0xd8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	-0xd8(%rbp), %r9
+               	movq	0x8(%r9), %r8
                	movq	%r8, -0xe8(%rbp)
-               	movq	-0x60(%rbp), %r8
+               	movq	-0x120(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x120(%rbp), %r8
+               	movq	-0xe8(%rbp), %r9
+               	movq	%r9, 0x8(%r8)
+               	movq	-0x70(%rbp), %r8
                	movq	%r8, %rax
                	movq	$0x3, %rdi
                	xorl	%edx, %edx
                	divq	%rdi
                	movq	%rdx, %rdi
-               	movq	-0x48(%rbp), %r9
+               	movq	-0x58(%rbp), %r9
                	leaq	(%r9,%rdi,2), %r8
                	movq	%r8, -0xf0(%rbp)
                	movq	-0xf0(%rbp), %r8
-               	movq	-0xe8(%rbp), %r9
-               	movw	%r9w, (%r8)
-               	movq	-0x50(%rbp), %r9
-               	movl	(%r9), %r8d
+               	movzwl	(%r8), %edi
+               	movl	%edi, %r8d
+               	addl	$0x64, %r8d
                	movq	%r8, -0xf8(%rbp)
-               	movq	-0x60(%rbp), %r8
-               	movl	%r8d, %edi
+               	movq	-0x70(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	movq	-0x58(%rbp), %r9
+               	leaq	(%r9,%rdi,2), %r8
+               	movq	%r8, -0x100(%rbp)
+               	movq	-0x100(%rbp), %r8
                	movq	-0xf8(%rbp), %r9
+               	movw	%r9w, (%r8)
+               	movq	-0x60(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x70(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	-0x108(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%edi, %r8d
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x50(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x60(%rbp), %r8
+               	movq	-0x110(%rbp), %r9
                	movl	%r9d, (%r8)
-               	movq	-0x58(%rbp), %r8
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %rdi
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x118(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdi, %r8
-               	movq	%r8, -0x58(%rbp)
+               	movq	%r8, -0x68(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x118(%rbp), %r8
                	cmpq	$0x5, %r8
-               	jb	 <L5>
-<L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x49f>
+               	jb	 <L4>
+<L8>:
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x4b4>
                	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x4b3>
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x4ba>
-               	movq	-0x58(%rbp), %r8
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x4c8>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x4cf>
+               	movq	-0x68(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L10>
-<L10>:
+               	callq	 <L9>
+<L9>:
                	movq	%rax, %rdi
                	leaq	-0x10(%rbp), %rcx
                	leaq	-0x20(%rbp), %rsi
-               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x4d8>
-               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4df>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x4ed>
+               	movq	, %r12 <corpus.cases.mem.global_data.checksum+0x4f4>
                	movq	%rbx, (%rsi)
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rbx
@@ -565,34 +842,28 @@ Disassembly of section .text:
                	movq	%r12, 0x8(%rsi)
                	movq	(%rsi), %rcx
                	movq	0x8(%rsi), %rbx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x522>
-               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x529>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x530>
-               	movzwl	(%rcx), %esi
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x53a>
-               	movzbl	(%rcx), %ebx
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x544>
-               	movq	(%rcx), %r12
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x537>
+               	movq	%rbx,  <corpus.cases.mem.global_data.checksum+0x53e>
+               	leaq	-0x40(%rbp), %rcx
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x549>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x550>
+               	movq	%rsi, (%rcx)
+               	movq	%rbx, 0x8(%rcx)
+               	movq	(%rcx), %rsi
+               	movq	0x8(%rcx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0x118(%rbp), %rbx
-               	movq	-0x120(%rbp), %r12
-               	movq	-0x128(%rbp), %r13
-               	movq	-0x130(%rbp), %r14
-               	movq	-0x138(%rbp), %r15
+               	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %r12
+               	movq	-0x138(%rbp), %r13
+               	movq	-0x140(%rbp), %r14
+               	movq	-0x148(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/global_zero.dis
+++ b/test/golden/x86_64-linux/mem/global_zero.dis
@@ -5,29 +5,84 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,145 +90,342 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.fold_zeros>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movzbl	, %esi <corpus.cases.mem.global_zero.fold_zeros+0x23>
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movzbl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x1f>
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movzwl	, %esi <corpus.cases.mem.global_zero.fold_zeros+0x32>
-               	callq	 <L1>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_zero.fold_zeros+0x40>
-               	movl	%ecx, %esi
-               	callq	 <L2>
+               	movzwl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x7c>
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0x51>
-               	callq	 <L3>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movl	, %ecx <corpus.cases.mem.global_zero.fold_zeros+0x5f>
-               	movl	%ecx, %esi
-               	callq	 <L4>
+               	movl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0xd8>
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0x70>
-               	callq	 <L5>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.fold_zeros+0x7f>
-               	movss	(%rcx), %xmm0
-               	callq	 <L6>
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x133>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.fold_zeros+0x92>
-               	movsd	(%rcx), %xmm0
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	, %rsi <corpus.cases.mem.global_zero.fold_zeros+0xa5>
-               	callq	 <L8>
+               	movl	, %eax <corpus.cases.mem.global_zero.fold_zeros+0x18b>
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xb1>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x200, %r13            # imm = 0x200
-               	jb	 <L9>
-               	jmp	 <L11>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
 <L9>:
-               	leaq	(%rbx,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x1e7>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x200, %r13            # imm = 0x200
-               	jb	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0xf8>
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x240>
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x2a4>
+               	movsd	(%rax), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x306>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L16>
+<L17>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x35f>
+               	movq	$0x0, %rdx
+               	cmpq	$0x200, %rdx            # imm = 0x200
+               	jb	 <L18>
+               	jmp	 <L21>
+<L18>:
+               	leaq	(%rax,%rdx,4), %rsi
+               	movl	(%rsi), %ebx
+               	movl	%ebx, %esi
+               	movq	%rdi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+               	jmp	 <L20>
+<L19>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %r12
+               	jb	 <L19>
+<L20>:
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x200, %rdx            # imm = 0x200
+               	jb	 <L18>
+<L21>:
+               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x3f0>
+               	movq	%rdi, %r12
                	movq	$0x0, %r13
                	cmpq	$0x8, %r13
-               	jb	 <L12>
-               	jmp	 <L16>
-<L12>:
+               	jb	 <L22>
+               	jmp	 <L24>
+<L22>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %esi
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r14d
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r15
-               	movq	%r12, %rdi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L15>
-<L15>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L12>
-<L16>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x164>
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	0x2(%rax), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %r13
-               	movq	%r12, %rdi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L19>
-<L19>:
-               	leaq	, %rbx <corpus.cases.mem.global_zero.fold_zeros+0x19d>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%r13,8), %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	-0x10(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
                	movq	(%rax), %rsi
-               	movq	%r12, %rdi
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L20>
-<L22>:
-               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x1dd>
-               	movzbl	(%rax), %esi
+               	movq	0x8(%rax), %rdx
                	movq	%r12, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	addq	$0x1, %r13
+               	movq	%rax, %r12
+               	cmpq	$0x8, %r13
+               	jb	 <L22>
+<L24>:
+               	leaq	, %rax <corpus.cases.mem.global_zero.fold_zeros+0x44d>
+               	leaq	-0x20(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdi
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rax
+               	movq	%r12, %rdi
+               	movq	%rax, %rdx
+               	callq	 <L25>
+<L25>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x478>
+               	movq	$0x0, %rsi
+               	cmpq	$0x4, %rsi
+               	jb	 <L26>
+               	jmp	 <L29>
+<L26>:
+               	leaq	(%rdx,%rsi,8), %rdi
+               	movq	(%rdi), %rbx
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+               	jmp	 <L28>
+<L27>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %r12
+               	jb	 <L27>
+<L28>:
+               	addq	$0x1, %rsi
+               	movq	%rdi, %rax
+               	cmpq	$0x4, %rsi
+               	jb	 <L26>
+<L29>:
+               	leaq	, %rdx <corpus.cases.mem.global_zero.fold_zeros+0x502>
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L30>
+<L31>:
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -181,232 +433,254 @@ Disassembly of section .text:
 <corpus.cases.mem.global_zero.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x38(%rbp)
                	movq	%r12, -0x40(%rbp)
                	movq	%r13, -0x48(%rbp)
                	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
                	movq	%rdi, %rbx
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	movl	$0xc8, %esi
-               	addl	%ecx, %esi
-               	movb	%sil,  <corpus.cases.mem.global_zero.checksum+0x3b>
-               	movw	%bx, %cx
-               	movl	$0x9c40, %esi           # imm = 0x9C40
-               	addl	%ecx, %esi
-               	movw	%si,  <corpus.cases.mem.global_zero.checksum+0x4c>
-               	movl	%ebx, %ecx
-               	movl	$0xb2d05e00, %esi       # imm = 0xB2D05E00
-               	addl	%ecx, %esi
-               	movl	%esi,  <corpus.cases.mem.global_zero.checksum+0x5b>
-               	movabsq	$-0x123456789abcdf0, %rsi # imm = 0xFEDCBA9876543210
+               	movb	%bl, %sil
+               	movl	$0xc8, %r12d
+               	addl	%esi, %r12d
+               	movb	%r12b,  <corpus.cases.mem.global_zero.checksum+0x44>
+               	movw	%bx, %si
+               	movl	$0x9c40, %r12d          # imm = 0x9C40
+               	addl	%esi, %r12d
+               	movw	%r12w,  <corpus.cases.mem.global_zero.checksum+0x58>
+               	movl	%ebx, %esi
+               	movl	$0xb2d05e00, %r12d      # imm = 0xB2D05E00
+               	addl	%esi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x6a>
+               	movabsq	$-0x123456789abcdf0, %r12 # imm = 0xFEDCBA9876543210
+               	addq	%rbx, %r12
+               	movq	%r12,  <corpus.cases.mem.global_zero.checksum+0x7e>
+               	movl	$0x77359400, %r12d      # imm = 0x77359400
+               	addl	%esi, %r12d
+               	movl	%r12d,  <corpus.cases.mem.global_zero.checksum+0x8e>
+               	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
                	addq	%rbx, %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0x6f>
-               	movl	$0x77359400, %esi       # imm = 0x77359400
-               	addl	%ecx, %esi
-               	movl	%esi,  <corpus.cases.mem.global_zero.checksum+0x7c>
-               	movabsq	$0x7ce66c50e2840000, %rcx # imm = 0x7CE66C50E2840000
-               	addq	%rbx, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_zero.checksum+0x90>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x97>
-               	movl	$0x3fe00000, (%rcx)     # imm = 0x3FE00000
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0xa4>
+               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0xa2>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xa9>
+               	movl	$0x3fe00000, (%rsi)     # imm = 0x3FE00000
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xb6>
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movabsq	$0x100000001b3, %rcx    # imm = 0x100000001B3
-               	addq	%rbx, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_zero.checksum+0xc5>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0xcc>
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
-               	jb	 <L2>
-               	jmp	 <L3>
+               	movq	%r11, (%rsi)
+               	movabsq	$0x100000001b3, %rsi    # imm = 0x100000001B3
+               	addq	%rbx, %rsi
+               	movq	%rsi,  <corpus.cases.mem.global_zero.checksum+0xd7>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0xde>
+               	movq	$0x0, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movabsq	$0x9e3779b1, %r14       # imm = 0x9E3779B1
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	movl	%r14d, %r15d
+               	leaq	(%rsi,%r12,4), %r14
+               	movl	%r15d, (%r14)
+               	movq	%r13, %r12
+               	cmpq	$0x200, %r12            # imm = 0x200
+               	jb	 <L1>
 <L2>:
-               	movq	%rsi, %r12
-               	addq	$0x1, %r12
-               	movabsq	$0x9e3779b1, %r13       # imm = 0x9E3779B1
-               	imulq	%r12, %r13
-               	addq	%rbx, %r13
-               	movl	%r13d, %r14d
-               	leaq	(%rcx,%rsi,4), %r13
-               	movl	%r14d, (%r13)
-               	movq	%r12, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
-               	jb	 <L2>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x130>
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x11f>
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
-               	jb	 <L4>
-               	jmp	 <L5>
-<L4>:
-               	movq	%rsi, %r12
-               	imulq	$0xb, %r12, %r12
-               	addq	$0x3, %r12
-               	addq	%rbx, %r12
-               	movw	%r12w, %r13w
-               	movq	%rsi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rcx,%r12), %r14
-               	leaq	(%r14), %r12
-               	movw	%r13w, (%r12)
-               	movq	%rsi, %r12
-               	addq	$0xfa, %r12
-               	movb	%r12b, %r13b
-               	leaq	0x2(%r14), %r12
-               	movb	%r13b, (%r12)
-               	addq	$0x1, %rsi
-               	movabsq	$-0x61c8864680b583eb, %r12 # imm = 0x9E3779B97F4A7C15
-               	imulq	%rsi, %r12
-               	addq	%rbx, %r12
-               	leaq	0x8(%r14), %r13
-               	movq	%r12, (%r13)
-               	cmpq	$0x8, %rsi
-               	jb	 <L4>
-<L5>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x19d>
-               	leaq	-0x10(%rbp), %rsi
-               	movq	(%rcx), %r12
-               	movq	0x8(%rcx), %r13
-               	movq	%r12, (%rsi)
-               	movq	%r13, 0x8(%rsi)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x1b6>
-               	movq	(%rsi), %r12
-               	movq	0x8(%rsi), %r13
-               	movq	%r12, (%rcx)
-               	movq	%r13, 0x8(%rcx)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x1cb>
-               	movq	$0x0, %rsi
-               	cmpq	$0x4, %rsi
-               	jb	 <L6>
-               	jmp	 <L7>
-<L6>:
-               	movq	%rsi, %r12
+               	movq	%r12, %r13
+               	imulq	$0xb, %r13, %r13
+               	addq	$0x3, %r13
+               	addq	%rbx, %r13
+               	movw	%r13w, %r14w
+               	movq	%r12, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r15
+               	leaq	(%r15), %r13
+               	movw	%r14w, (%r13)
+               	movq	%r12, %r13
+               	addq	$0xfa, %r13
+               	movb	%r13b, %r14b
+               	leaq	0x2(%r15), %r13
+               	movb	%r14b, (%r13)
                	addq	$0x1, %r12
-               	movq	$0x12345678, %r13       # imm = 0x12345678
+               	movabsq	$-0x61c8864680b583eb, %r13 # imm = 0x9E3779B97F4A7C15
                	imulq	%r12, %r13
                	addq	%rbx, %r13
-               	leaq	(%rcx,%rsi,8), %r14
+               	leaq	0x8(%r15), %r14
                	movq	%r13, (%r14)
-               	movq	%r12, %rsi
-               	cmpq	$0x4, %rsi
-               	jb	 <L6>
+               	cmpq	$0x8, %r12
+               	jb	 <L3>
+<L4>:
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1ad>
+               	leaq	-0x10(%rbp), %r12
+               	movq	(%rsi), %r13
+               	movq	0x8(%rsi), %r14
+               	movq	%r13, (%r12)
+               	movq	%r14, 0x8(%r12)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1c8>
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r14
+               	movq	%r13, (%rsi)
+               	movq	%r14, 0x8(%rsi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x1df>
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%r12, %r13
+               	addq	$0x1, %r13
+               	movq	$0x12345678, %r14       # imm = 0x12345678
+               	imulq	%r13, %r14
+               	addq	%rbx, %r14
+               	leaq	(%rsi,%r12,8), %r15
+               	movq	%r14, (%r15)
+               	movq	%r13, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L5>
+<L6>:
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x225>
+               	movb	$0x4d, (%rsi)
+               	callq	 <L7>
 <L7>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x211>
-               	movb	$0x4d, (%rcx)
-               	callq	 <L8>
+               	movq	%rax, %rsi
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x237>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %edi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x223>
-               	movl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x234>
-               	movl	(%rcx), %esi
+               	leaq	, %rdi <corpus.cases.mem.global_zero.checksum+0x296>
+               	movl	(%rdi), %r12d
+               	movl	%r12d, %r13d
+               	movq	%rsi, %rdi
+               	movq	%r13, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
                	addq	$0x1f4, %rbx            # imm = 0x1F4
                	movq	%rbx, %rax
-               	movq	$0x200, %rcx            # imm = 0x200
+               	movq	$0x200, %rsi            # imm = 0x200
                	xorl	%edx, %edx
-               	divq	%rcx
-               	movq	%rdx, %rcx
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x25e>
-               	leaq	(%rsi,%rcx,4), %rbx
-               	movl	(%rbx), %ecx
-               	movl	%ecx, %esi
+               	divq	%rsi
+               	movq	%rdx, %rsi
+               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x2ca>
+               	leaq	(%rbx,%rsi,4), %r12
+               	movl	(%r12), %esi
+               	movl	%esi, %ebx
+               	movq	%rbx, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x275>
-               	movq	$0x0, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x2e6>
+               	movq	$0x0, %rbx
+               	cmpq	$0x200, %rbx            # imm = 0x200
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%rcx,%rsi,4), %rbx
-               	movl	$0x0, (%rbx)
-               	addq	$0x1, %rsi
-               	cmpq	$0x200, %rsi            # imm = 0x200
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	$0x0, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x200, %rbx            # imm = 0x200
                	jb	 <L12>
 <L13>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x2b0>
-               	movq	$0x0, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x323>
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L14>
                	jmp	 <L15>
 <L14>:
-               	leaq	-0x20(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movw	$0x0, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x0, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movq	$0x0, (%r12)
-               	movq	%rsi, %r12
-               	imulq	$0x10, %r12, %r12
-               	leaq	(%rcx,%r12), %r13
-               	movq	(%rbx), %r12
-               	movq	0x8(%rbx), %r14
-               	movq	%r12, (%r13)
-               	movq	%r14, 0x8(%r13)
-               	addq	$0x1, %rsi
-               	cmpq	$0x8, %rsi
+               	leaq	-0x20(%rbp), %r12
+               	leaq	(%r12), %r13
+               	movw	$0x0, (%r13)
+               	leaq	0x2(%r12), %r13
+               	movb	$0x0, (%r13)
+               	leaq	0x8(%r12), %r13
+               	movq	$0x0, (%r13)
+               	movq	%rbx, %r13
+               	imulq	$0x10, %r13, %r13
+               	leaq	(%rsi,%r13), %r14
+               	movq	(%r12), %r13
+               	movq	0x8(%r12), %r15
+               	movq	%r13, (%r14)
+               	movq	%r15, 0x8(%r14)
+               	addq	$0x1, %rbx
+               	cmpq	$0x8, %rbx
                	jb	 <L14>
 <L15>:
-               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x318>
-               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x321>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x32b>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x336>
-               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x340>
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x34b>
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x352>
-               	movl	$0x0, (%rcx)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x35f>
-               	movq	$0x0, (%rcx)
-               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x371>
-               	leaq	-0x30(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movw	$0x0, (%rsi)
-               	leaq	0x2(%rcx), %rsi
-               	movb	$0x0, (%rsi)
-               	leaq	0x8(%rcx), %rsi
+               	movb	$0x0,  <corpus.cases.mem.global_zero.checksum+0x38f>
+               	movw	$0x0,  <corpus.cases.mem.global_zero.checksum+0x398>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3a2>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3ad>
+               	movl	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3b7>
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3c2>
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3c9>
+               	movl	$0x0, (%rsi)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x3d6>
                	movq	$0x0, (%rsi)
-               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x396>
-               	movq	(%rcx), %rbx
-               	movq	0x8(%rcx), %r12
-               	movq	%rbx, (%rsi)
-               	movq	%r12, 0x8(%rsi)
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x3ab>
-               	movq	$0x0, %rsi
-               	cmpq	$0x4, %rsi
+               	movq	$0x0,  <corpus.cases.mem.global_zero.checksum+0x3e8>
+               	leaq	-0x30(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movw	$0x0, (%rbx)
+               	leaq	0x2(%rsi), %rbx
+               	movb	$0x0, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x0, (%rbx)
+               	leaq	, %rbx <corpus.cases.mem.global_zero.checksum+0x40d>
+               	movq	(%rsi), %r12
+               	movq	0x8(%rsi), %r13
+               	movq	%r12, (%rbx)
+               	movq	%r13, 0x8(%rbx)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x422>
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
                	jb	 <L16>
                	jmp	 <L17>
 <L16>:
-               	leaq	(%rcx,%rsi,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rsi
-               	cmpq	$0x4, %rsi
+               	leaq	(%rsi,%rbx,8), %r12
+               	movq	$0x0, (%r12)
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
                	jb	 <L16>
 <L17>:
-               	leaq	, %rcx <corpus.cases.mem.global_zero.checksum+0x3e1>
-               	movb	$0x0, (%rcx)
+               	leaq	, %rsi <corpus.cases.mem.global_zero.checksum+0x459>
+               	movb	$0x0, (%rsi)
                	callq	 <L18>
 <L18>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
+               	movq	%rax, %rsi
+               	movq	%rsi, %rax
                	movq	-0x38(%rbp), %rbx
                	movq	-0x40(%rbp), %r12
                	movq	-0x48(%rbp), %r13
                	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/loadstore.dis
+++ b/test/golden/x86_64-linux/mem/loadstore.dis
@@ -5,68 +5,208 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.fold_packed>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x50, %rsp
+               	movq	%rbx, -0x28(%rbp)
+               	movq	%r12, -0x30(%rbp)
+               	movq	%r13, -0x38(%rbp)
+               	movq	%r14, -0x40(%rbp)
+               	movq	%r15, -0x48(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movzbl	(%rdx), %esi
-               	leaq	0x1(%rcx), %rdx
+               	leaq	0x1(%rax), %rdx
                	movzbl	(%rdx), %ebx
-               	leaq	0x2(%rcx), %rdx
+               	leaq	0x2(%rax), %rdx
                	movzbl	(%rdx), %r12d
-               	leaq	0x3(%rcx), %rdx
+               	leaq	0x3(%rax), %rdx
                	movzbl	(%rdx), %r13d
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movzwl	(%rdx), %r14d
-               	leaq	0x6(%rcx), %rdx
-               	movzwl	(%rdx), %r15d
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %r8d
+               	movq	%r8, -0x18(%rbp)
+               	leaq	0x8(%rax), %rdx
                	movl	(%rdx), %r8d
                	movq	%r8, -0x8(%rbp)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movq	(%rdx), %r8
                	movq	%r8, -0x10(%rbp)
-               	callq	 <L0>
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
+               	movq	%rax, %rcx
+               	movq	%rdx, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %r15
+               	xorq	%rax, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L4>
+               	movzbq	%r12b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	-0x8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L6>
+               	movzbq	%r13b, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movzwq	%r14w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	-0x18(%rbp), %r8
+               	movzwq	%r8w, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
+               	movq	-0x38(%rbp), %r13
+               	movq	-0x40(%rbp), %r14
+               	movq	-0x48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -74,36 +214,33 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xe0, %rsp
-               	movq	%rbx, -0x98(%rbp)
-               	movq	%r12, -0xa0(%rbp)
-               	movq	%r13, -0xa8(%rbp)
-               	movq	%r14, -0xb0(%rbp)
-               	movq	%r15, -0xb8(%rbp)
+               	subq	$0x100, %rsp            # imm = 0x100
+               	movq	%rbx, -0xb8(%rbp)
+               	movq	%r12, -0xc0(%rbp)
+               	movq	%r13, -0xc8(%rbp)
+               	movq	%r14, -0xd0(%rbp)
+               	movq	%r15, -0xd8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	leaq	-0x18(%rbp), %r12
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
-               	leaq	-0x30(%rbp), %rdx
-               	movq	(%r12), %rsi
-               	movq	0x8(%r12), %r13
-               	movq	0x10(%r12), %r14
-               	movq	%rsi, (%rdx)
-               	movq	%r13, 0x8(%rdx)
-               	movq	%r14, 0x10(%rdx)
-               	movq	(%rdx), %rsi
-               	movq	0x8(%rdx), %r13
-               	movq	0x10(%rdx), %r14
-               	movq	%rsi, (%rsp)
-               	movq	%r13, 0x8(%rsp)
-               	movq	%r14, 0x10(%rsp)
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
+               	leaq	-0x58(%rbp), %rax
+               	movq	(%r12), %rdx
+               	movq	0x8(%r12), %rsi
+               	movq	0x10(%r12), %rdi
+               	movq	%rdx, (%rax)
+               	movq	%rsi, 0x8(%rax)
+               	movq	%rdi, 0x10(%rax)
+               	movq	(%rax), %rdx
+               	movq	0x8(%rax), %rsi
+               	movq	0x10(%rax), %rdi
+               	movq	%rdx, (%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movq	%rdi, 0x10(%rsp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	callq	 <L0>
+<L0>:
                	movabsq	$-0x123456789abcdf0, %r13 # imm = 0xFEDCBA9876543210
                	addq	%rbx, %r13
                	movb	%r13b, %dl
@@ -137,27 +274,28 @@ Disassembly of section .text:
                	movl	%edx, (%rsi)
                	leaq	0x10(%r12), %rdx
                	movq	%r13, (%rdx)
-               	leaq	-0x48(%rbp), %rdx
+               	leaq	-0x70(%rbp), %rdx
                	movq	(%r12), %rsi
-               	movq	0x8(%r12), %r14
-               	movq	0x10(%r12), %r15
+               	movq	0x8(%r12), %rdi
+               	movq	0x10(%r12), %r14
                	movq	%rsi, (%rdx)
-               	movq	%r14, 0x8(%rdx)
-               	movq	%r15, 0x10(%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movq	%r14, 0x10(%rdx)
                	movq	(%rdx), %rsi
-               	movq	0x8(%rdx), %r14
-               	movq	0x10(%rdx), %r15
+               	movq	0x8(%rdx), %rdi
+               	movq	0x10(%rdx), %r14
                	movq	%rsi, (%rsp)
-               	movq	%r14, 0x8(%rsp)
-               	movq	%r15, 0x10(%rsp)
-               	callq	 <L2>
-<L2>:
+               	movq	%rdi, 0x8(%rsp)
+               	movq	%r14, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L1>
+<L1>:
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x8, %r15
-               	jb	 <L3>
-               	jmp	 <L5>
-<L3>:
+               	jb	 <L2>
+               	jmp	 <L4>
+<L2>:
                	addq	$0x1, %r15
                	movq	%r13, %rax
                	imulq	%r15, %rax
@@ -174,7 +312,7 @@ Disassembly of section .text:
                	movl	%eax, %edx
                	leaq	0x8(%r12), %rax
                	movl	%edx, (%rax)
-               	leaq	-0x60(%rbp), %rax
+               	leaq	-0x18(%rbp), %rax
                	movq	(%r12), %rdx
                	movq	0x8(%r12), %rsi
                	movq	0x10(%r12), %rdi
@@ -188,139 +326,288 @@ Disassembly of section .text:
                	movq	%rsi, 0x8(%rsp)
                	movq	%rdi, 0x10(%rsp)
                	movq	%r14, %rdi
-               	callq	 <L4>
-<L4>:
+               	callq	 <L3>
+<L3>:
                	movq	%rax, %r14
                	cmpq	$0x8, %r15
-               	jb	 <L3>
-<L5>:
+               	jb	 <L2>
+<L4>:
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L6>
-               	jmp	 <L17>
-<L6>:
-               	addq	$0x1, %r12
-               	movabsq	$-0x61c8864680b583eb, %rax # imm = 0x9E3779B97F4A7C15
-               	imulq	%r12, %rax
-               	movq	%rax, %r15
-               	addq	%rbx, %r15
-               	movb	%r15b, %r8b
+               	jb	 <L5>
+               	jmp	 <L21>
+<L5>:
+               	movq	%r12, %rax
+               	addq	$0x1, %rax
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r8
+               	addq	%rbx, %r8
                	movq	%r8, -0x88(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x8, %rdx
-               	movw	%dx, %r8w
+               	movq	-0x88(%rbp), %r8
+               	movb	%r8b, %r15b
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x8, %rax
+               	movw	%ax, %r8w
                	movq	%r8, -0x78(%rbp)
-               	movq	%r15, %rdx
-               	shrq	$0x10, %rdx
-               	movl	%edx, %r8d
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	$0x10, %rax
+               	movl	%eax, %r8d
                	movq	%r8, -0x80(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L7>
+               	movsbq	%r15b, %r8
+               	movq	%r8, -0x90(%rbp)
+               	movq	%r14, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x90(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rsi, %rax
+               	xorq	%rdx, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdi
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
+               	movq	-0x78(%rbp), %r9
+               	movswq	%r9w, %r8
+               	movq	%r8, -0x98(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	-0x80(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L9>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x98(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L10>
+               	movq	-0x80(%rbp), %r9
+               	movslq	%r9d, %r8
+               	movq	%r8, -0xa0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movsbq	%r8b, %rsi
-               	callq	 <L11>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa0(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	movq	-0x78(%rbp), %r8
-               	movswq	%r8w, %rsi
-               	callq	 <L12>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0x88(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rsi, %rdi
+               	xorq	%rdx, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	movsbq	%r15b, %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0xa8(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rax
+               	xorq	%rdi, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %rdx
+               	movq	%rax, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L14>
+<L15>:
+               	movq	-0x78(%rbp), %r8
+               	movswq	%r8w, %rax
+               	movq	%rsi, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L16>
+<L16>:
                	movq	-0x80(%rbp), %r8
                	movslq	%r8d, %rsi
-               	callq	 <L13>
-<L13>:
                	movq	%rax, %rdi
-               	movq	-0x88(%rbp), %r8
-               	movzbq	%r8b, %rsi
-               	callq	 <L14>
-<L14>:
+               	callq	 <L17>
+<L17>:
+               	movzbq	%r15b, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
                	movq	-0x78(%rbp), %r8
                	movzwq	%r8w, %rsi
                	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
+               	callq	 <L19>
+<L19>:
                	movq	-0x80(%rbp), %r8
                	movl	%r8d, %esi
                	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
+               	callq	 <L20>
+<L20>:
+               	addq	$0x1, %r12
                	movq	%rax, %r14
                	cmpq	$0x6, %r12
-               	jb	 <L6>
-<L17>:
-               	leaq	-0x70(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
+               	jb	 <L5>
+<L21>:
+               	leaq	-0x28(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rdx, %rsi
+               	andq	$0x7, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	movb	%sil, %dil
+               	movb	%dl, %sil
+               	addl	%esi, %edi
+               	leaq	(%rax,%rdx), %rsi
+               	movb	%dil, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+               	jmp	 <L27>
+<L24>:
+               	leaq	(%rax,%rdx), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	%r14, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r15
+               	xorq	%r12, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L25>
+<L26>:
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r14
+               	cmpq	$0x10, %rdx
+               	jb	 <L24>
+<L27>:
+               	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
+               	xorq	%r11, %r13
                	movq	$0x0, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-               	jmp	 <L19>
-<L18>:
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
                	movq	%rax, %rdx
-               	andq	$0x7, %rdx
                	imulq	$0x8, %rdx, %rdx
                	movq	%rdx, %rcx
                	movq	%r13, %rdx
                	shrq	%cl, %rdx
-               	movb	%dl, %sil
-               	movb	%al, %dl
-               	addl	%edx, %esi
-               	leaq	(%rbx,%rax), %rdx
-               	movb	%sil, (%rdx)
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
                	addq	$0x1, %rax
-               	cmpq	$0x10, %rax
-               	jb	 <L18>
-<L19>:
-               	movq	$0x0, %r12
-               	cmpq	$0x10, %r12
-               	jb	 <L20>
-               	jmp	 <L22>
-<L20>:
-               	leaq	(%rbx,%r12), %rax
-               	movzbl	(%rax), %esi
-               	movq	%r14, %rdi
-               	callq	 <L21>
-<L21>:
-               	addq	$0x1, %r12
-               	movq	%rax, %r14
-               	cmpq	$0x10, %r12
-               	jb	 <L20>
-<L22>:
-               	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
-               	xorq	%r11, %r13
-               	movq	%r14, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L23>
-<L23>:
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L28>
+<L29>:
                	addq	$0x1, %r13
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x98(%rbp), %rbx
-               	movq	-0xa0(%rbp), %r12
-               	movq	-0xa8(%rbp), %r13
-               	movq	-0xb0(%rbp), %r14
-               	movq	-0xb8(%rbp), %r15
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%r13, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%r14, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%r14, %rax
+               	movq	-0xb8(%rbp), %rbx
+               	movq	-0xc0(%rbp), %r12
+               	movq	-0xc8(%rbp), %r13
+               	movq	-0xd0(%rbp), %r14
+               	movq	-0xd8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/ptr_arith.dis
+++ b/test/golden/x86_64-linux/mem/ptr_arith.dis
@@ -5,29 +5,84 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.fold_cell>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	-0xe(%rbp), %rcx
-               	movzbl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movq	(%rcx), %r12
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzwl	(%rax), %edx
+               	leaq	-0xe(%rbp), %rax
+               	movzbl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movq	(%rax), %rbx
+               	movzwq	%dx, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movzbq	%sil, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	%rbx, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
+               	movq	%rdi, %rsi
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rax
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -60,17 +115,15 @@ Disassembly of section .text:
 <corpus.cases.mem.ptr_arith.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x160, %rsp            # imm = 0x160
-               	movq	%rbx, -0x138(%rbp)
-               	movq	%r12, -0x140(%rbp)
-               	movq	%r13, -0x148(%rbp)
-               	movq	%r14, -0x150(%rbp)
-               	movq	%r15, -0x158(%rbp)
+               	subq	$0x1c0, %rsp            # imm = 0x1C0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%r15, -0x1b8(%rbp)
                	movq	%rdi, %rbx
                	leaq	-0x20(%rbp), %r12
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x60(%rbp), %r13
+               	leaq	-0x80(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -79,443 +132,683 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r13)
                	movq	$0x0, 0x30(%r13)
                	movq	$0x0, 0x38(%r13)
-               	movq	$0x0, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-               	jmp	 <L2>
-<L1>:
-               	movq	%rcx, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rax, %rdx
                	addq	$0x1, %rdx
                	movabsq	$0x9e3779b1, %rsi       # imm = 0x9E3779B1
                	imulq	%rdx, %rsi
                	addq	%rbx, %rsi
                	movl	%esi, %edi
-               	leaq	(%r13,%rcx,4), %rsi
+               	leaq	(%r13,%rax,4), %rsi
                	movl	%edi, (%rsi)
-               	movq	%rdx, %rcx
-               	cmpq	$0x10, %rcx
-               	jb	 <L1>
-<L2>:
+               	movq	%rdx, %rax
+               	cmpq	$0x10, %rax
+               	jb	 <L0>
+<L1>:
                	leaq	(%r13), %r14
                	leaq	0x20(%r13), %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0xf0(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L3>
+               	jb	 <L2>
                	jmp	 <L5>
-<L3>:
-               	movq	-0xd8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0xd0(%rbp), %r8
+<L2>:
+               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r14,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0xe8(%rbp)
+               	movq	-0xf0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L4>
-<L4>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rax
+               	imulq	$0x8, %rax, %rax
                	movq	%rax, %rcx
-               	movq	-0xd8(%rbp), %r8
+               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, %rax
+               	shrq	%cl, %rax
+               	andq	$0xff, %rax
+               	movq	%rdi, %rdx
+               	xorq	%rax, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0xf8(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r8
-               	movq	%r8, -0xd0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0xf0(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xd8(%rbp)
-               	movq	-0xd8(%rbp), %r8
+               	movq	%r8, -0xf8(%rbp)
+               	movq	-0xf8(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L3>
+               	jb	 <L2>
 <L5>:
-               	movq	-0xd0(%rbp), %r9
+               	movq	-0xf0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0xe0(%rbp)
+               	movq	%r8, -0x100(%rbp)
                	movq	$-0x8, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
                	cmpq	$0x8, %r8
                	jl	 <L6>
-               	jmp	 <L8>
+               	jmp	 <L9>
 <L6>:
-               	movq	-0xe8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0xe0(%rbp), %r8
+               	movq	-0x110(%rbp), %r8
+               	leaq	(%r15,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x108(%rbp)
+               	movq	-0x100(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	-0xe8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x108(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L7>
+<L8>:
+               	movq	-0x110(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x100(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0xe8(%rbp)
-               	movq	-0xe8(%rbp), %r8
+               	movq	%r8, -0x110(%rbp)
+               	movq	-0x110(%rbp), %r8
                	cmpq	$0x8, %r8
                	jl	 <L6>
-<L8>:
-               	movl	(%r15), %ecx
-               	movq	-0xe0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
 <L9>:
-               	leaq	-0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
+               	movl	(%r15), %eax
+               	movl	%eax, %r8d
+               	movq	%r8, -0x118(%rbp)
+               	movq	-0x100(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	leaq	0x1c(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x118(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
+               	leaq	-0x4(%r15), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x120(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L12>
                	jmp	 <L13>
 <L12>:
-               	leaq	(%r15,%rcx,4), %rdx
-               	movl	(%rdx), %esi
-               	movl	%ecx, %edi
-               	addl	%edi, %esi
-               	addl	$0x1, %esi
-               	movl	%esi, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x120(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
                	jb	 <L12>
 <L13>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
-               	cmpq	$0x10, %r8
-               	jb	 <L14>
-               	jmp	 <L16>
-<L14>:
-               	movq	-0xf8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdx
+               	leaq	0x1c(%r15), %rdx
                	movl	(%rdx), %esi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L15>
+               	movl	%esi, %edx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x128(%rbp)
+               	movq	-0x128(%rbp), %r8
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rcx
-               	movq	-0xf8(%rbp), %r8
+               	leaq	(%r15,%rdx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edx, %eax
+               	addl	%eax, %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L15>
+<L16>:
+               	movq	-0x128(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x130(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
+               	cmpq	$0x10, %r8
+               	jb	 <L17>
+               	jmp	 <L20>
+<L17>:
+               	movq	-0x140(%rbp), %r8
+               	leaq	(%r13,%r8,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x130(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x138(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rax
+               	movq	%rdx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movq	-0x140(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
-               	movq	%rcx, %r8
-               	movq	%r8, -0xf0(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x130(%rbp)
                	movq	%rax, %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
                	cmpq	$0x10, %r8
-               	jb	 <L14>
-<L16>:
+               	jb	 <L17>
+<L20>:
                	leaq	0x14(%r13), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x100(%rbp), %r8
+               	movq	%r8, -0x180(%rbp)
+               	movq	-0x180(%rbp), %r8
                	movl	(%r8), %edx
                	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movl	%edx, (%r8)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movl	(%r8), %edx
-               	movq	-0xf0(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	addl	$0x3, %ecx
-               	movq	-0x100(%rbp), %r8
-               	movl	%ecx, (%r8)
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movl	%ecx, %esi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	movq	-0x100(%rbp), %r9
-               	cmpq	%r9, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	cmpq	%r14, %r8
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	callq	 <L21>
+               	movl	%edx, %r8d
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x130(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x150(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	cmpq	$0x0, %r14
-               	sete	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x148(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x150(%rbp), %r8
+               	movq	%r8, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rdi
+               	movq	%rdx, %r8
+               	movq	%r8, -0x150(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
 <L22>:
-               	cmpq	%r14, %r15
-               	setne	%sil
-               	movzbq	%sil, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	-0x180(%rbp), %r8
+               	movl	(%r8), %edx
+               	addl	$0x3, %edx
+               	movq	-0x180(%rbp), %r8
+               	movl	%edx, (%r8)
+               	movq	-0x180(%rbp), %r8
+               	movl	(%r8), %edx
+               	movl	%edx, %r8d
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x150(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	leaq	-0xc0(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L24>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L24>
-               	movq	$0x0, %rcx
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
-               	jmp	 <L26>
-<L25>:
-               	movq	%rcx, %rdx
-               	imulq	$0x5, %rdx, %rdx
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x158(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rdx
-               	addq	%rbx, %rdx
-               	movw	%dx, %si
-               	movq	%rcx, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r13,%rdx), %rdi
-               	leaq	(%rdi), %rdx
-               	movw	%si, (%rdx)
-               	movq	%rcx, %rdx
-               	addq	$0x64, %rdx
-               	movb	%dl, %sil
-               	leaq	0x2(%rdi), %rdx
-               	movb	%sil, (%rdx)
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    # imm = 0x100000001B3
-               	imulq	%rcx, %rdx
-               	addq	%rbx, %rdx
-               	leaq	0x8(%rdi), %rsi
-               	movq	%rdx, (%rsi)
-               	cmpq	$0x6, %rcx
-               	jb	 <L25>
+               	movq	%rdi, %r8
+               	movq	%r8, -0x160(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L23>
+<L24>:
+               	leaq	0x14(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x160(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L25>
+<L25>:
+               	movq	%rax, %rdi
+               	movq	-0x180(%rbp), %r8
+               	movq	-0x180(%rbp), %r9
+               	cmpq	%r9, %r8
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	callq	 <L26>
 <L26>:
+               	movq	%rax, %rdi
+               	movq	-0x180(%rbp), %r8
+               	cmpq	%r14, %r8
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	callq	 <L27>
+<L27>:
+               	cmpq	$0x0, %r14
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	cmpq	%r14, %r15
+               	setne	%dl
+               	movzbq	%dl, %rdx
+               	movzbq	%dl, %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	leaq	-0xe0(%rbp), %r13
+               	leaq	(%r13), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x60, %rsi
+<L30>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L30>
+               	movq	$0x0, %rdx
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+               	jmp	 <L32>
+<L31>:
+               	movq	%rdx, %rsi
+               	imulq	$0x5, %rsi, %rsi
+               	addq	$0x1, %rsi
+               	addq	%rbx, %rsi
+               	movw	%si, %di
+               	movq	%rdx, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r13,%rsi), %r14
+               	leaq	(%r14), %rsi
+               	movw	%di, (%rsi)
+               	movq	%rdx, %rsi
+               	addq	$0x64, %rsi
+               	movb	%sil, %dil
+               	leaq	0x2(%r14), %rsi
+               	movb	%dil, (%rsi)
+               	addq	$0x1, %rdx
+               	movabsq	$0x100000001b3, %rsi    # imm = 0x100000001B3
+               	imulq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	leaq	0x8(%r14), %rdi
+               	movq	%rsi, (%rdi)
+               	cmpq	$0x6, %rdx
+               	jb	 <L31>
+<L32>:
                	leaq	0x20(%r13), %r14
                	movq	%rax, %r15
                	movq	$-0x2, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x188(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jl	 <L27>
-               	jmp	 <L31>
-<L27>:
-               	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r14,%rcx), %rdx
-               	leaq	(%rdx), %rcx
-               	movzwl	(%rcx), %esi
-               	leaq	0x2(%rdx), %rcx
-               	movzbl	(%rcx), %r8d
-               	movq	%r8, -0xc8(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	movq	-0xc8(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	-0x110(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rcx
-               	movq	-0x108(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rcx, %r15
-               	movq	%rax, %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jl	 <L27>
-<L31>:
-               	leaq	0x10(%r14), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
-               	addq	$0x11, %rax
-               	movq	%rax, (%rcx)
-               	leaq	-0x10(%r14), %rax
-               	leaq	(%rax), %rcx
-               	movzwl	(%rcx), %eax
-               	addl	$0x9, %eax
-               	movw	%ax, (%rcx)
-               	movq	$0x0, %r14
-               	cmpq	$0x6, %r14
-               	jb	 <L32>
-               	jmp	 <L36>
-<L32>:
-               	movq	%r14, %rax
-               	imulq	$0x10, %rax, %rax
-               	leaq	(%r13,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movzwl	(%rax), %esi
-               	leaq	0x2(%rcx), %rax
-               	movzbl	(%rax), %r8d
-               	movq	%r8, -0x118(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x120(%rbp)
-               	movq	%r15, %rdi
-               	callq	 <L33>
+               	jl	 <L33>
+               	jmp	 <L35>
 <L33>:
-               	movq	%rax, %rdi
-               	movq	-0x118(%rbp), %r8
-               	movq	%r8, %rsi
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r14,%rdx), %rsi
+               	leaq	-0x30(%rbp), %r8
+               	movq	%r8, -0x168(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	0x8(%rsi), %rdx
+               	movq	-0x168(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movq	-0x168(%rbp), %r8
+               	movq	%rdx, 0x8(%r8)
+               	movq	-0x168(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x168(%rbp), %r8
+               	movq	0x8(%r8), %rdx
+               	movq	%r15, %rdi
                	callq	 <L34>
 <L34>:
-               	movq	%rax, %rdi
-               	movq	-0x120(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L35>
-<L35>:
-               	addq	$0x1, %r14
                	movq	%rax, %r15
+               	movq	-0x188(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x188(%rbp)
+               	movq	-0x188(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jl	 <L33>
+<L35>:
+               	leaq	0x10(%r14), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	$0x11, %rax
+               	movq	%rax, (%rdx)
+               	leaq	-0x10(%r14), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	addl	$0x9, %eax
+               	movw	%ax, (%rdx)
+               	movq	$0x0, %r14
                	cmpq	$0x6, %r14
-               	jb	 <L32>
+               	jb	 <L36>
+               	jmp	 <L38>
 <L36>:
-               	leaq	0x40(%r13), %rax
-               	leaq	0x8(%rax), %rcx
-               	movq	(%rcx), %rax
-               	imulq	$0x3, %rax, %rax
-               	movq	%rax, (%rcx)
-               	movq	(%rcx), %rsi
+               	movq	%r14, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r13,%rax), %rdx
+               	leaq	-0x40(%rbp), %rax
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movq	%rsi, (%rax)
+               	movq	%rdi, 0x8(%rax)
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %rdx
                	movq	%r15, %rdi
                	callq	 <L37>
 <L37>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movzwl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movw	%cx, (%rdx)
-               	movzwl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
+               	addq	$0x1, %r14
+               	movq	%rax, %r15
+               	cmpq	$0x6, %r14
+               	jb	 <L36>
 <L38>:
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movl	%ebx, %ecx
-               	movl	$0x12345678, %r13d      # imm = 0x12345678
-               	addl	%ecx, %r13d
-               	movl	$0x9abcdef0, %r14d      # imm = 0x9ABCDEF0
-               	addl	%ecx, %r14d
-               	movl	%ebx, %ecx
+               	leaq	0x40(%r13), %rax
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	imulq	$0x3, %rax, %rax
+               	movq	%rax, (%rdx)
+               	movq	(%rdx), %rax
                	movq	$0x0, %rdx
                	cmpq	$0x8, %rdx
                	jb	 <L39>
                	jmp	 <L40>
 <L39>:
-               	movl	%edx, %esi
-               	imull	$0x7, %esi, %esi
-               	addl	$0x3, %esi
-               	addl	%ecx, %esi
-               	leaq	(%r12,%rdx,4), %rdi
-               	movl	%esi, (%rdi)
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rdx
+               	movq	%rdi, %r15
                	cmpq	$0x8, %rdx
                	jb	 <L39>
 <L40>:
-               	leaq	0xc(%r12), %rbx
-               	movq	%rax, %r15
-               	movq	$-0x3, %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	cmpq	$0x5, %r8
-               	jl	 <L41>
-               	jmp	 <L43>
+               	leaq	(%r13), %rax
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	addl	$0x1, %eax
+               	movw	%ax, (%rdx)
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
+               	jmp	 <L42>
 <L41>:
-               	movq	-0x128(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %edx
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r15, %rdi
-               	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %r15
-               	movq	-0x128(%rbp), %r8
-               	movq	%r8, %rax
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
                	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r8
-               	cmpq	$0x5, %r8
-               	jl	 <L41>
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L41>
+<L42>:
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	movq	$0x0, 0x10(%r12)
+               	movq	$0x0, 0x18(%r12)
+               	movl	%ebx, %eax
+               	movl	$0x12345678, %r8d       # imm = 0x12345678
+               	addl	%eax, %r8d
+               	movq	%r8, -0x178(%rbp)
+               	movl	$0x9abcdef0, %r8d       # imm = 0x9ABCDEF0
+               	addl	%eax, %r8d
+               	movq	%r8, -0x170(%rbp)
+               	movl	%ebx, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
+               	jmp	 <L44>
 <L43>:
-               	leaq	(%r12), %rax
-               	movq	$0x0, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
-               	jmp	 <L45>
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x3, %ebx
+               	addl	%eax, %ebx
+               	leaq	(%r12,%rdi,4), %r13
+               	movl	%ebx, (%r13)
+               	addq	$0x1, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L43>
 <L44>:
-               	leaq	(%rax,%rcx,4), %rdx
-               	movl	(%rdx), %esi
-               	movl	%ecx, %edi
-               	addl	%edi, %esi
-               	addl	$0x1, %esi
-               	movl	%esi, (%rdx)
-               	addq	$0x1, %rcx
-               	cmpq	$0x8, %rcx
-               	jb	 <L44>
+               	leaq	0xc(%r12), %rax
+               	movq	$-0x3, %rdi
+               	cmpq	$0x5, %rdi
+               	jl	 <L45>
+               	jmp	 <L48>
 <L45>:
-               	movq	%r15, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L46>
+               	leaq	(%rax,%rdi,4), %rbx
+               	movl	(%rbx), %r13d
+               	movl	%r13d, %ebx
+               	movq	%r15, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L46>
+               	jmp	 <L47>
 <L46>:
-               	movq	%rax, %rbx
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L47>
-               	jmp	 <L49>
+               	movq	%r14, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rbx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdx
+               	xorq	%rsi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %r14
+               	movq	%rdx, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L46>
 <L47>:
-               	leaq	(%r12,%r13,4), %rax
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L48>
+               	addq	$0x1, %rdi
+               	movq	%r13, %r15
+               	cmpq	$0x5, %rdi
+               	jl	 <L45>
 <L48>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	cmpq	$0x8, %r13
-               	jb	 <L47>
+               	leaq	(%r12), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
 <L49>:
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L50>
+               	leaq	(%rax,%rdx,4), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edx, %ebx
+               	addl	%ebx, %edi
+               	addl	$0x1, %edi
+               	movl	%edi, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
 <L50>:
-               	movq	-0x138(%rbp), %rbx
-               	movq	-0x140(%rbp), %r12
-               	movq	-0x148(%rbp), %r13
-               	movq	-0x150(%rbp), %r14
-               	movq	-0x158(%rbp), %r15
+               	movq	-0x178(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+               	jmp	 <L52>
+<L51>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L51>
+<L52>:
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+               	jmp	 <L56>
+<L53>:
+               	leaq	(%r12,%rax,4), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	%r15, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L54>
+               	jmp	 <L55>
+<L54>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r13
+               	xorq	%rbx, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L54>
+<L55>:
+               	addq	$0x1, %rax
+               	movq	%rsi, %r15
+               	cmpq	$0x8, %rax
+               	jb	 <L53>
+<L56>:
+               	movq	-0x170(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+               	jmp	 <L58>
+<L57>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r15, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r15
+               	cmpq	$0x8, %rdx
+               	jb	 <L57>
+<L58>:
+               	movq	%r15, %rax
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
+               	movq	-0x1b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/rec_layout.dis
+++ b/test/golden/x86_64-linux/mem/rec_layout.dis
@@ -5,29 +5,85 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_tiny>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
                	movq	%rsi, -0x10(%rbp)
                	movq	%rdx, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	-0xc(%rbp), %rcx
-               	movl	(%rcx), %ebx
-               	leaq	-0x8(%rbp), %rcx
-               	movzbl	(%rcx), %r12d
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movzbl	(%rax), %edx
+               	leaq	-0xc(%rbp), %rax
+               	movl	(%rax), %esi
+               	leaq	-0x8(%rbp), %rax
+               	movzbl	(%rax), %ebx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L1>
+               	movq	%rdx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rax, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L2>
+               	movl	%esi, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movzbq	%bl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,45 +91,135 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_mid>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	leaq	0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	movq	%r15, -0x28(%rbp)
+               	leaq	0x10(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movzwl	(%rdx), %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	leaq	(%rdx), %rbx
                	movzbl	(%rbx), %r12d
                	leaq	0x4(%rdx), %rbx
                	movl	(%rbx), %r13d
                	leaq	0x8(%rdx), %rbx
-               	movzbl	(%rbx), %r14d
-               	leaq	0x10(%rcx), %rdx
-               	movzbl	(%rdx), %ebx
-               	callq	 <L0>
+               	movzbl	(%rbx), %edx
+               	leaq	0x10(%rax), %rbx
+               	movzbl	(%rbx), %eax
+               	movzwq	%si, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L1>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
+               	movzbq	%r12b, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L3>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L4>
+               	movl	%r13d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L4>
+<L5>:
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -81,69 +227,162 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_wide>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x80, %rsp
+               	subq	$0x90, %rsp
                	movq	%rbx, -0x48(%rbp)
                	movq	%r12, -0x50(%rbp)
                	movq	%r13, -0x58(%rbp)
                	movq	%r14, -0x60(%rbp)
-               	leaq	0x10(%rbp), %rcx
+               	movq	%r15, -0x68(%rbp)
+               	leaq	0x10(%rbp), %rdx
                	leaq	-0x28(%rbp), %rbx
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movq	0x10(%rcx), %r12
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movq	%r12, 0x10(%rbx)
-               	movq	%r13, 0x18(%rbx)
-               	movq	%r14, 0x20(%rbx)
-               	leaq	(%rbx), %rcx
-               	leaq	-0x3c(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %r12
-               	movl	0x10(%rcx), %r13d
-               	movq	%rsi, (%rdx)
-               	movq	%r12, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %r12d
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%r12d, 0x10(%rsp)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %r12
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
+               	movq	%rsi, (%rbx)
+               	movq	%r12, 0x8(%rbx)
+               	movq	%r13, 0x10(%rbx)
+               	movq	%r14, 0x18(%rbx)
+               	movq	%r15, 0x20(%rbx)
+               	leaq	(%rbx), %rdx
+               	leaq	-0x3c(%rbp), %rsi
+               	movq	(%rdx), %r12
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%r12, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movl	%r14d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %r12
+               	movl	0x10(%rsi), %r13d
+               	movq	%rdx, (%rsp)
+               	movq	%r12, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x18(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	leaq	0x18(%rbx), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	leaq	0x20(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L3>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x26(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	leaq	0x20(%rbx), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+<L6>:
+               	leaq	0x20(%rbx), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+<L8>:
+               	leaq	0x26(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
                	movq	-0x48(%rbp), %rbx
                	movq	-0x50(%rbp), %r12
                	movq	-0x58(%rbp), %r13
                	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -151,154 +390,264 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.fold_nest>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
+               	subq	$0x140, %rsp            # imm = 0x140
                	movq	%rbx, -0xf8(%rbp)
                	movq	%r12, -0x100(%rbp)
                	movq	%r13, -0x108(%rbp)
                	movq	%r14, -0x110(%rbp)
+               	movq	%r15, -0x118(%rbp)
                	leaq	0x10(%rbp), %rax
                	leaq	-0x58(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	leaq	(%rax), %rdx
-               	cmpq	%rdx, %rcx
+               	leaq	(%rbx), %rdx
+               	leaq	(%rax), %rsi
+               	cmpq	%rsi, %rdx
                	jb	 <L1>
-               	movq	%rcx, %rax
+               	movq	%rdx, %rax
                	addq	$0x58, %rax
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %r12
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
 <L0>:
                	subq	$0x8, %rax
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r13
-               	movq	%r13, (%rax)
                	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rax)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
                	jne	 <L0>
                	jmp	 <L3>
 <L1>:
-               	addq	$0x0, %rcx
                	addq	$0x0, %rdx
+               	addq	$0x0, %rsi
                	movq	$0x58, %rax
 <L2>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rcx)
-               	addq	$0x8, %rcx
+               	movq	(%rsi), %r12
+               	movq	%r12, (%rdx)
                	addq	$0x8, %rdx
+               	addq	$0x8, %rsi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
                	jne	 <L2>
 <L3>:
                	leaq	(%rbx), %rax
-               	leaq	-0x80(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movq	0x10(%rax), %r12
-               	movq	0x18(%rax), %r13
-               	movq	0x20(%rax), %r14
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movq	%r12, 0x10(%rcx)
-               	movq	%r13, 0x18(%rcx)
-               	movq	%r14, 0x20(%rcx)
+               	leaq	-0x80(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %r12
+               	movq	0x10(%rax), %r13
+               	movq	0x18(%rax), %r14
+               	movq	0x20(%rax), %r15
+               	movq	%rsi, (%rdx)
+               	movq	%r12, 0x8(%rdx)
+               	movq	%r13, 0x10(%rdx)
+               	movq	%r14, 0x18(%rdx)
+               	movq	%r15, 0x20(%rdx)
                	leaq	-0xa8(%rbp), %r12
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movq	0x10(%rcx), %rsi
-               	movq	0x18(%rcx), %r13
-               	movq	0x20(%rcx), %r14
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movq	0x10(%rdx), %r13
+               	movq	0x18(%rdx), %r14
+               	movq	0x20(%rdx), %r15
                	movq	%rax, (%r12)
-               	movq	%rdx, 0x8(%r12)
-               	movq	%rsi, 0x10(%r12)
-               	movq	%r13, 0x18(%r12)
-               	movq	%r14, 0x20(%r12)
+               	movq	%rsi, 0x8(%r12)
+               	movq	%r13, 0x10(%r12)
+               	movq	%r14, 0x18(%r12)
+               	movq	%r15, 0x20(%r12)
                	leaq	(%r12), %rax
-               	leaq	-0xbc(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	0x8(%rax), %rsi
-               	movl	0x10(%rax), %r13d
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%r13d, 0x10(%rcx)
-               	movq	(%rcx), %rax
-               	movq	0x8(%rcx), %rdx
-               	movl	0x10(%rcx), %esi
+               	leaq	-0xbc(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	0x8(%rax), %r13
+               	movl	0x10(%rax), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%r13, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rax
+               	movq	0x8(%rdx), %rsi
+               	movl	0x10(%rdx), %r13d
                	movq	%rax, (%rsp)
-               	movq	%rdx, 0x8(%rsp)
-               	movl	%esi, 0x10(%rsp)
+               	movq	%rsi, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
                	callq	 <L4>
 <L4>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
+               	jmp	 <L6>
 <L5>:
-               	leaq	0x20(%r12), %r13
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L5>
 <L6>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L7>
+               	leaq	0x20(%r12), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L7>
 <L8>:
-               	leaq	0x26(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	leaq	0x20(%r12), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
+               	jmp	 <L10>
 <L9>:
-               	leaq	0x28(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	leaq	-0xd0(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movl	0x10(%rcx), %r13d
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movl	%r13d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %edi
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L9>
 <L10>:
-               	leaq	0x14(%r12), %rcx
-               	leaq	-0xe4(%rbp), %rdx
-               	movq	(%rcx), %rsi
-               	movq	0x8(%rcx), %rdi
-               	movl	0x10(%rcx), %r12d
-               	movq	%rsi, (%rdx)
-               	movq	%rdi, 0x8(%rdx)
-               	movl	%r12d, 0x10(%rdx)
-               	movq	(%rdx), %rcx
-               	movq	0x8(%rdx), %rsi
-               	movl	0x10(%rdx), %edi
-               	movq	%rcx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	leaq	0x20(%r12), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
 <L11>:
-               	leaq	0x50(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
 <L12>:
+               	leaq	0x26(%r12), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L13>
+<L14>:
+               	leaq	0x28(%rbx), %r12
+               	leaq	(%r12), %rdx
+               	leaq	-0xd0(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r13
+               	movl	0x10(%rdx), %r14d
+               	movq	%rdi, (%rsi)
+               	movq	%r13, 0x8(%rsi)
+               	movl	%r14d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movl	0x10(%rsi), %r13d
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r13d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	leaq	0x14(%r12), %rdx
+               	leaq	-0xe4(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	0x8(%rdx), %r12
+               	movl	0x10(%rdx), %r13d
+               	movq	%rdi, (%rsi)
+               	movq	%r12, 0x8(%rsi)
+               	movl	%r13d, 0x10(%rsi)
+               	movq	(%rsi), %rdx
+               	movq	0x8(%rsi), %rdi
+               	movl	0x10(%rsi), %r12d
+               	movq	%rdx, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r12d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
+               	leaq	0x50(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
                	movq	-0xf8(%rbp), %rbx
                	movq	-0x100(%rbp), %r12
                	movq	-0x108(%rbp), %r13
                	movq	-0x110(%rbp), %r14
+               	movq	-0x118(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -331,774 +680,880 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3e0, %rsp            # imm = 0x3E0
-               	movq	%rbx, -0x358(%rbp)
-               	movq	%r12, -0x360(%rbp)
-               	movq	%r13, -0x368(%rbp)
-               	movq	%r14, -0x370(%rbp)
-               	movq	%r15, -0x378(%rbp)
+               	subq	$0x420, %rsp            # imm = 0x420
+               	movq	%rbx, -0x398(%rbp)
+               	movq	%r12, -0x3a0(%rbp)
+               	movq	%r13, -0x3a8(%rbp)
+               	movq	%r14, -0x3b0(%rbp)
+               	movq	%r15, -0x3b8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movl	%ebx, %r12d
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
+<L0>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0xc, %rsi
-               	callq	 <L1>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	movq	$0x14, %rsi
-               	callq	 <L2>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x14, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
-               	callq	 <L3>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	$0x58, %rsi
-               	callq	 <L4>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x28, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L5>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	movq	$0x4, %rsi
-               	callq	 <L6>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	$0x58, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L7>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	movq	$0x8, %rsi
-               	callq	 <L8>
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	$0x4, %rsi
-               	callq	 <L9>
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rax, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
                	movq	%rax, %rdi
-               	movq	$0x8, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movq	$0x4, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	movq	$0x10, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rdi
-               	movq	$0x18, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	$0x20, %rsi
+               	movq	$0x8, %rsi
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movq	$0x26, %rsi
+               	movq	$0x4, %rsi
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	movq	$0x28, %rsi
+               	movq	$0x10, %rsi
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rdi
-               	movq	$0x50, %rsi
+               	movq	$0x18, %rsi
                	callq	 <L17>
 <L17>:
+               	movq	%rax, %rdi
+               	movq	$0x20, %rsi
+               	callq	 <L18>
+<L18>:
+               	movq	%rax, %rdi
+               	movq	$0x26, %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rdi
+               	movq	$0x28, %rsi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %rdi
+               	movq	$0x50, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	%rax, %r8
                	movq	%r8, -0x330(%rbp)
                	movq	-0x330(%rbp), %r8
                	leaq	-0x58(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x58, %rdx
-<L18>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L18>
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L20>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
+               	leaq	(%r13), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x58, %rsi
+<L22>:
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L22>
+               	leaq	-0xb0(%rbp), %r8
+               	movq	%r8, -0x338(%rbp)
+               	movq	-0x338(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L24>
                	movq	%rsi, %r14
                	addq	$0x58, %r14
-               	movq	$0x58, %r15
-<L19>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r14
-               	movq	(%r14), %rax
-               	movq	%rax, (%rdi)
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L19>
-               	jmp	 <L22>
-<L20>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
                	movq	$0x58, %rax
-<L21>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
+<L23>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L21>
-<L22>:
-               	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L24>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L23>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
                	jne	 <L23>
                	jmp	 <L26>
 <L24>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
-<L25>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L25>
-<L26>:
-               	movq	-0x330(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xa, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %r14
-               	movb	%dil, (%r14)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %r14
-               	movl	%edi, (%r14)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %r14b
-               	leaq	0x8(%rsi), %rdi
-               	movb	%r14b, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	movabsq	$-0x123456789abcdf0, %rcx # imm = 0xFEDCBA9876543210
-               	addq	%rbx, %rcx
-               	leaq	(%r13), %rdx
-               	leaq	0x18(%rdx), %rsi
-               	movq	%rcx, (%rsi)
-               	movl	$0x14, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	0x20(%rdx), %rcx
-               	leaq	(%rcx), %rdi
-               	movw	%si, (%rdi)
-               	movl	$0x15, %esi
-               	addl	%r12d, %esi
-               	movw	%si, %di
-               	leaq	0x2(%rcx), %rsi
-               	movw	%di, (%rsi)
-               	movl	$0x16, %esi
-               	addl	%r12d, %esi
-               	movw	%si, %di
-               	leaq	0x4(%rcx), %rsi
-               	movw	%di, (%rsi)
-               	movl	$0x17, %ecx
-               	addl	%r12d, %ecx
-               	movb	%cl, %sil
-               	leaq	0x26(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	leaq	0x28(%r13), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x1e, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	%dil, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %rbx
-               	movl	%edi, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %bl
-               	leaq	0x8(%rsi), %rdi
-               	movb	%bl, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	leaq	0x28(%r13), %rcx
-               	leaq	0x14(%rcx), %rdx
-               	movl	$0x28, %ecx
-               	addl	%r12d, %ecx
-               	movw	%cx, %si
-               	leaq	(%rdx), %rdi
-               	movw	%si, (%rdi)
-               	movl	%ecx, %esi
-               	addl	$0x1, %esi
-               	movb	%sil, %dil
-               	leaq	0x4(%rdx), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	%dil, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x2, %edi
-               	leaq	0x4(%rsi), %rbx
-               	movl	%edi, (%rbx)
-               	movl	%ecx, %edi
-               	addl	$0x3, %edi
-               	movb	%dil, %bl
-               	leaq	0x8(%rsi), %rdi
-               	movb	%bl, (%rdi)
-               	addl	$0x4, %ecx
-               	movb	%cl, %sil
-               	leaq	0x10(%rdx), %rcx
-               	movb	%sil, (%rcx)
-               	movl	$0x32, %ecx
-               	addl	%r12d, %ecx
-               	leaq	0x50(%r13), %rbx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x108(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L29>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r12
-               	addq	$0x58, %r12
-               	movq	$0x58, %r14
-<L28>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r12
-               	movq	(%r12), %r15
-               	movq	%r15, (%rdi)
-               	subq	$0x8, %r14
-               	cmpq	$0x0, %r14
-               	jne	 <L28>
-               	jmp	 <L31>
-<L29>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L30>:
-               	movq	(%rsi), %r12
-               	movq	%r12, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L30>
-<L31>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L33>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rsi, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %r12
-<L32>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r14
-               	movq	%r14, (%rcx)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L32>
-               	jmp	 <L35>
-<L33>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
-<L34>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L34>
-<L35>:
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x338(%rbp)
-               	movq	-0x338(%rbp), %r8
-               	leaq	(%r13), %r12
-               	leaq	(%r12), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
-               	movl	%edx, (%rcx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L38>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r14
-               	addq	$0x58, %r14
-               	movq	$0x58, %r15
-<L37>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %r14
-               	movq	(%r14), %rax
-               	movq	%rax, (%rdi)
-               	subq	$0x8, %r15
-               	cmpq	$0x0, %r15
-               	jne	 <L37>
-               	jmp	 <L40>
-<L38>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
                	movq	$0x58, %rax
-<L39>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+<L25>:
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
                	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L39>
-<L40>:
+               	jne	 <L25>
+<L26>:
                	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
+               	movq	-0x338(%rbp), %r8
+               	leaq	(%r8), %rdx
                	cmpq	%rdx, %rax
-               	jb	 <L42>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
+               	jb	 <L28>
+               	movq	%rax, %rsi
                	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L41>:
-               	subq	$0x8, %rcx
+               	movq	%rdx, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r14
+<L27>:
                	subq	$0x8, %rsi
-               	movq	(%rsi), %r14
-               	movq	%r14, (%rcx)
                	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L41>
-               	jmp	 <L44>
-<L42>:
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L27>
+               	jmp	 <L30>
+<L28>:
                	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
-<L43>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
+               	movq	$0x58, %rsi
+<L29>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
                	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L43>
-<L44>:
-               	movq	-0x338(%rbp), %r8
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L29>
+<L30>:
+               	movq	-0x330(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L45>
-<L45>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %r8
                	movq	%r8, -0x340(%rbp)
                	movq	-0x340(%rbp), %r8
-               	leaq	0x28(%r13), %r14
-               	leaq	0x14(%r14), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	leaq	0x8(%rdx), %rcx
-               	movzbl	(%rcx), %edx
-               	addl	$0x7, %edx
-               	movb	%dl, (%rcx)
-               	leaq	-0x1b8(%rbp), %r8
-               	movq	%r8, -0x348(%rbp)
-               	movq	-0x348(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0xa, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %r14
+               	movw	%di, (%r14)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %r14b
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r15
+               	movb	%r14b, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x2, %r14d
+               	leaq	0x4(%rdi), %r15
+               	movl	%r14d, (%r15)
+               	movl	%edx, %r14d
+               	addl	$0x3, %r14d
+               	movb	%r14b, %r15b
+               	leaq	0x8(%rdi), %r14
+               	movb	%r15b, (%r14)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	movabsq	$-0x123456789abcdf0, %rdx # imm = 0xFEDCBA9876543210
+               	addq	%rbx, %rdx
                	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L47>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %r15
-               	addq	$0x58, %r15
-               	movq	$0x58, %rax
-<L46>:
-               	subq	$0x8, %rdi
+               	leaq	0x18(%rsi), %rdi
+               	movq	%rdx, (%rdi)
+               	movl	$0x14, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	0x20(%rsi), %rdx
+               	leaq	(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movl	$0x15, %edi
+               	addl	%r12d, %edi
+               	movw	%di, %bx
+               	leaq	0x2(%rdx), %rdi
+               	movw	%bx, (%rdi)
+               	movl	$0x16, %edi
+               	addl	%r12d, %edi
+               	movw	%di, %bx
+               	leaq	0x4(%rdx), %rdi
+               	movw	%bx, (%rdi)
+               	movl	$0x17, %edx
+               	addl	%r12d, %edx
+               	movb	%dl, %dil
+               	leaq	0x26(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	leaq	0x28(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x1e, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %rbx
+               	movw	%di, (%rbx)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %bl
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r14
+               	movb	%bl, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x2, %ebx
+               	leaq	0x4(%rdi), %r14
+               	movl	%ebx, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x3, %ebx
+               	movb	%bl, %r14b
+               	leaq	0x8(%rdi), %rbx
+               	movb	%r14b, (%rbx)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	leaq	0x28(%r13), %rdx
+               	leaq	0x14(%rdx), %rsi
+               	movl	$0x28, %edx
+               	addl	%r12d, %edx
+               	movw	%dx, %di
+               	leaq	(%rsi), %rbx
+               	movw	%di, (%rbx)
+               	movl	%edx, %edi
+               	addl	$0x1, %edi
+               	movb	%dil, %bl
+               	leaq	0x4(%rsi), %rdi
+               	leaq	(%rdi), %r14
+               	movb	%bl, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x2, %ebx
+               	leaq	0x4(%rdi), %r14
+               	movl	%ebx, (%r14)
+               	movl	%edx, %ebx
+               	addl	$0x3, %ebx
+               	movb	%bl, %r14b
+               	leaq	0x8(%rdi), %rbx
+               	movb	%r14b, (%rbx)
+               	addl	$0x4, %edx
+               	movb	%dl, %dil
+               	leaq	0x10(%rsi), %rdx
+               	movb	%dil, (%rdx)
+               	movl	$0x32, %edx
+               	addl	%r12d, %edx
+               	leaq	0x50(%r13), %rbx
+               	movl	%edx, (%rbx)
+               	leaq	-0x108(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L33>
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	%rdi, %r14
+               	addq	$0x58, %r14
+               	movq	$0x58, %r15
+<L32>:
+               	subq	$0x8, %r12
+               	subq	$0x8, %r14
+               	movq	(%r14), %rax
+               	movq	%rax, (%r12)
                	subq	$0x8, %r15
-               	movq	(%r15), %rcx
-               	movq	%rcx, (%rdi)
-               	subq	$0x8, %rax
-               	cmpq	$0x0, %rax
-               	jne	 <L46>
-               	jmp	 <L49>
-<L47>:
-               	addq	$0x0, %rdx
+               	cmpq	$0x0, %r15
+               	jne	 <L32>
+               	jmp	 <L35>
+<L33>:
                	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
                	movq	$0x58, %rax
-<L48>:
-               	movq	(%rsi), %rcx
-               	movq	%rcx, (%rdx)
-               	addq	$0x8, %rdx
+<L34>:
+               	movq	(%rdi), %r12
+               	movq	%r12, (%rsi)
                	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L48>
-<L49>:
+               	jne	 <L34>
+<L35>:
                	leaq	(%rsp), %rax
-               	movq	-0x348(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	cmpq	%rcx, %rax
-               	jb	 <L51>
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rax
+               	jb	 <L37>
                	movq	%rax, %rdx
                	addq	$0x58, %rdx
-               	movq	%rcx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L50>:
+               	movq	%rsi, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r12
+<L36>:
                	subq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r15
-               	movq	%r15, (%rdx)
                	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
+               	movq	(%rdi), %r14
+               	movq	%r14, (%rdx)
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L36>
+               	jmp	 <L39>
+<L37>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L38>:
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L38>
+<L39>:
+               	movq	-0x340(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
+               	leaq	(%r13), %r12
+               	leaq	(%r12), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	leaq	0x4(%rsi), %rdx
+               	movl	(%rdx), %esi
+               	xorl	$0xf0f0f0f0, %esi       # imm = 0xF0F0F0F0
+               	movl	%esi, (%rdx)
+               	leaq	-0x160(%rbp), %r8
+               	movq	%r8, -0x350(%rbp)
+               	movq	-0x350(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L42>
+               	movq	%rsi, %r14
+               	addq	$0x58, %r14
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
+               	movq	$0x58, %rax
+<L41>:
+               	subq	$0x8, %r14
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r14)
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
+               	jne	 <L41>
+               	jmp	 <L44>
+<L42>:
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
+<L43>:
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
+               	jne	 <L43>
+<L44>:
+               	leaq	(%rsp), %rax
+               	movq	-0x350(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L46>
+               	movq	%rax, %rsi
+               	addq	$0x58, %rsi
+               	movq	%rdx, %rdi
+               	addq	$0x58, %rdi
+               	movq	$0x58, %r14
+<L45>:
+               	subq	$0x8, %rsi
+               	subq	$0x8, %rdi
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
+               	subq	$0x8, %r14
+               	cmpq	$0x0, %r14
+               	jne	 <L45>
+               	jmp	 <L48>
+<L46>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rdx
+               	movq	$0x58, %rsi
+<L47>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L47>
+<L48>:
+               	movq	-0x348(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	-0x358(%rbp), %r8
+               	leaq	0x28(%r13), %r14
+               	leaq	0x14(%r14), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	leaq	0x8(%rsi), %rdx
+               	movzbl	(%rdx), %esi
+               	addl	$0x7, %esi
+               	movb	%sil, (%rdx)
+               	leaq	-0x1b8(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x360(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x368(%rbp)
+               	leaq	(%r13), %rdi
+               	movq	-0x368(%rbp), %r8
+               	cmpq	%rdi, %r8
+               	jb	 <L51>
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %r15
+               	addq	$0x58, %r15
+               	movq	%rdi, %rax
+               	addq	$0x58, %rax
+               	movq	$0x58, %rdx
+<L50>:
+               	subq	$0x8, %r15
+               	subq	$0x8, %rax
+               	movq	(%rax), %rsi
+               	movq	%rsi, (%r15)
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
                	jne	 <L50>
                	jmp	 <L53>
 <L51>:
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
                	addq	$0x0, %rax
-               	addq	$0x0, %rcx
+               	addq	$0x0, %rdi
                	movq	$0x58, %rdx
 <L52>:
-               	movq	(%rcx), %rsi
+               	movq	(%rdi), %rsi
                	movq	%rsi, (%rax)
                	addq	$0x8, %rax
-               	addq	$0x8, %rcx
+               	addq	$0x8, %rdi
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L52>
 <L53>:
-               	movq	-0x340(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x350(%rbp)
-               	movq	-0x350(%rbp), %r8
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	shrq	$0x3, %rdx
-               	movq	%rdx, (%rcx)
-               	leaq	-0x210(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L56>
+               	leaq	(%rsp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x360(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	-0x370(%rbp), %r8
+               	cmpq	%rdx, %r8
+               	jb	 <L55>
+               	movq	-0x370(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x58, %rsi
                	movq	%rdx, %rdi
                	addq	$0x58, %rdi
-               	movq	%rsi, %r12
-               	addq	$0x58, %r12
                	movq	$0x58, %r15
-<L55>:
+<L54>:
+               	subq	$0x8, %rsi
                	subq	$0x8, %rdi
-               	subq	$0x8, %r12
-               	movq	(%r12), %rax
-               	movq	%rax, (%rdi)
+               	movq	(%rdi), %rax
+               	movq	%rax, (%rsi)
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L55>
-               	jmp	 <L58>
-<L56>:
+               	jne	 <L54>
+               	jmp	 <L57>
+<L55>:
+               	movq	-0x370(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rax
-<L57>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
+               	movq	$0x58, %rsi
+<L56>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L56>
+<L57>:
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L58>
+<L58>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x378(%rbp)
+               	movq	-0x378(%rbp), %r8
+               	leaq	0x18(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	shrq	$0x3, %rsi
+               	movq	%rsi, (%rdx)
+               	leaq	-0x210(%rbp), %r8
+               	movq	%r8, -0x380(%rbp)
+               	movq	-0x380(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L60>
+               	movq	%rsi, %r12
+               	addq	$0x58, %r12
+               	movq	%rdi, %r15
+               	addq	$0x58, %r15
+               	movq	$0x58, %rax
+<L59>:
+               	subq	$0x8, %r12
+               	subq	$0x8, %r15
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%r12)
                	subq	$0x8, %rax
                	cmpq	$0x0, %rax
-               	jne	 <L57>
-<L58>:
-               	leaq	(%rsp), %rax
-               	leaq	(%rcx), %rdx
-               	cmpq	%rdx, %rax
-               	jb	 <L60>
-               	movq	%rax, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rdx, %rsi
-               	addq	$0x58, %rsi
-               	movq	$0x58, %rdi
-<L59>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	movq	(%rsi), %r12
-               	movq	%r12, (%rcx)
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
                	jne	 <L59>
                	jmp	 <L62>
 <L60>:
-               	addq	$0x0, %rax
-               	addq	$0x0, %rdx
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
 <L61>:
-               	movq	(%rdx), %rsi
-               	movq	%rsi, (%rax)
-               	addq	$0x8, %rax
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	movq	(%rdi), %rdx
+               	movq	%rdx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L61>
 <L62>:
-               	movq	-0x350(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L63>
-<L63>:
-               	movl	(%rbx), %ecx
-               	imull	$0x3, %ecx, %ecx
-               	movl	%ecx, (%rbx)
-               	leaq	-0x268(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L65>
+               	leaq	(%rsp), %rax
+               	movq	-0x380(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	cmpq	%rdx, %rax
+               	jb	 <L64>
+               	movq	%rax, %rsi
+               	addq	$0x58, %rsi
                	movq	%rdx, %rdi
                	addq	$0x58, %rdi
-               	movq	%rsi, %rbx
-               	addq	$0x58, %rbx
                	movq	$0x58, %r12
-<L64>:
+<L63>:
+               	subq	$0x8, %rsi
                	subq	$0x8, %rdi
-               	subq	$0x8, %rbx
-               	movq	(%rbx), %r15
-               	movq	%r15, (%rdi)
+               	movq	(%rdi), %r15
+               	movq	%r15, (%rsi)
                	subq	$0x8, %r12
                	cmpq	$0x0, %r12
-               	jne	 <L64>
-               	jmp	 <L67>
-<L65>:
+               	jne	 <L63>
+               	jmp	 <L66>
+<L64>:
+               	addq	$0x0, %rax
                	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L66>:
-               	movq	(%rsi), %rbx
-               	movq	%rbx, (%rdx)
+               	movq	$0x58, %rsi
+<L65>:
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
                	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L66>
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L65>
+<L66>:
+               	movq	-0x378(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L67>
 <L67>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x388(%rbp)
+               	movq	-0x388(%rbp), %r8
+               	movl	(%rbx), %edx
+               	imull	$0x3, %edx, %edx
+               	movl	%edx, (%rbx)
+               	leaq	-0x268(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
                	jb	 <L69>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
-               	movq	%rsi, %rdi
-               	addq	$0x58, %rdi
-               	movq	$0x58, %rbx
+               	movq	%rsi, %rbx
+               	addq	$0x58, %rbx
+               	movq	%rdi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r15
 <L68>:
-               	subq	$0x8, %rcx
-               	subq	$0x8, %rdi
-               	movq	(%rdi), %r12
-               	movq	%r12, (%rcx)
                	subq	$0x8, %rbx
-               	cmpq	$0x0, %rbx
+               	subq	$0x8, %r12
+               	movq	(%r12), %rax
+               	movq	%rax, (%rbx)
+               	subq	$0x8, %r15
+               	cmpq	$0x0, %r15
                	jne	 <L68>
                	jmp	 <L71>
 <L69>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rax
 <L70>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rdi), %rbx
+               	movq	%rbx, (%rsi)
                	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rax
+               	cmpq	$0x0, %rax
                	jne	 <L70>
 <L71>:
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	-0x27c(%rbp), %rbx
-               	leaq	(%r14), %r12
-               	leaq	-0x290(%rbp), %rcx
-               	movq	(%r12), %rdx
-               	movq	0x8(%r12), %rsi
-               	movl	0x10(%r12), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rbx)
-               	movq	%rsi, 0x8(%rbx)
-               	movl	%edi, 0x10(%rbx)
-               	leaq	0x4(%rbx), %rcx
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	$0x1, %ecx
-               	movl	%ecx, (%rdx)
-               	leaq	-0x2a4(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %rsi
-               	movl	0x10(%rbx), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	-0x2b8(%rbp), %rcx
-               	movq	(%r12), %rdx
-               	movq	0x8(%r12), %rsi
-               	movl	0x10(%r12), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%rsp)
-               	movq	%rsi, 0x8(%rsp)
-               	movl	%edi, 0x10(%rsp)
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x2cc(%rbp), %rcx
-               	movq	(%rbx), %rdx
-               	movq	0x8(%rbx), %rsi
-               	movl	0x10(%rbx), %edi
-               	movq	%rdx, (%rcx)
-               	movq	%rsi, 0x8(%rcx)
-               	movl	%edi, 0x10(%rcx)
-               	movq	(%rcx), %rdx
-               	movq	0x8(%rcx), %rsi
-               	movl	0x10(%rcx), %edi
-               	movq	%rdx, (%r12)
-               	movq	%rsi, 0x8(%r12)
-               	movl	%edi, 0x10(%r12)
-               	leaq	-0x328(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	leaq	(%r13), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L76>
-               	movq	%rdx, %rdi
-               	addq	$0x58, %rdi
-               	movq	%rsi, %rbx
-               	addq	$0x58, %rbx
-               	movq	$0x58, %r12
-<L75>:
-               	subq	$0x8, %rdi
-               	subq	$0x8, %rbx
-               	movq	(%rbx), %r13
-               	movq	%r13, (%rdi)
-               	subq	$0x8, %r12
-               	cmpq	$0x0, %r12
-               	jne	 <L75>
-               	jmp	 <L78>
-<L76>:
-               	addq	$0x0, %rdx
-               	addq	$0x0, %rsi
-               	movq	$0x58, %rdi
-<L77>:
-               	movq	(%rsi), %rbx
-               	movq	%rbx, (%rdx)
-               	addq	$0x8, %rdx
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L77>
-<L78>:
-               	leaq	(%rsp), %rdx
-               	leaq	(%rcx), %rsi
-               	cmpq	%rsi, %rdx
-               	jb	 <L80>
-               	movq	%rdx, %rcx
-               	addq	$0x58, %rcx
+               	leaq	(%rsp), %rax
+               	leaq	(%rdx), %rsi
+               	cmpq	%rsi, %rax
+               	jb	 <L73>
+               	movq	%rax, %rdx
+               	addq	$0x58, %rdx
                	movq	%rsi, %rdi
                	addq	$0x58, %rdi
                	movq	$0x58, %rbx
-<L79>:
-               	subq	$0x8, %rcx
+<L72>:
+               	subq	$0x8, %rdx
                	subq	$0x8, %rdi
                	movq	(%rdi), %r12
-               	movq	%r12, (%rcx)
+               	movq	%r12, (%rdx)
                	subq	$0x8, %rbx
                	cmpq	$0x0, %rbx
+               	jne	 <L72>
+               	jmp	 <L75>
+<L73>:
+               	addq	$0x0, %rax
+               	addq	$0x0, %rsi
+               	movq	$0x58, %rdx
+<L74>:
+               	movq	(%rsi), %rdi
+               	movq	%rdi, (%rax)
+               	addq	$0x8, %rax
+               	addq	$0x8, %rsi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L74>
+<L75>:
+               	movq	-0x388(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x27c(%rbp), %rbx
+               	leaq	(%r14), %r12
+               	leaq	-0x290(%rbp), %rdx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movl	0x10(%r12), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rbx)
+               	movq	%rdi, 0x8(%rbx)
+               	movl	%r14d, 0x10(%rbx)
+               	leaq	0x4(%rbx), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	addl	$0x1, %edx
+               	movl	%edx, (%rsi)
+               	leaq	-0x2a4(%rbp), %rdx
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movl	0x10(%rbx), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r14d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
+               	leaq	-0x2b8(%rbp), %rdx
+               	movq	(%r12), %rsi
+               	movq	0x8(%r12), %rdi
+               	movl	0x10(%r12), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %r14d
+               	movq	%rsi, (%rsp)
+               	movq	%rdi, 0x8(%rsp)
+               	movl	%r14d, 0x10(%rsp)
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
+               	leaq	-0x2cc(%rbp), %rdx
+               	movq	(%rbx), %rsi
+               	movq	0x8(%rbx), %rdi
+               	movl	0x10(%rbx), %r14d
+               	movq	%rsi, (%rdx)
+               	movq	%rdi, 0x8(%rdx)
+               	movl	%r14d, 0x10(%rdx)
+               	movq	(%rdx), %rsi
+               	movq	0x8(%rdx), %rdi
+               	movl	0x10(%rdx), %ebx
+               	movq	%rsi, (%r12)
+               	movq	%rdi, 0x8(%r12)
+               	movl	%ebx, 0x10(%r12)
+               	leaq	-0x328(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	leaq	(%r13), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L80>
+               	movq	%rsi, %rbx
+               	addq	$0x58, %rbx
+               	movq	%rdi, %r12
+               	addq	$0x58, %r12
+               	movq	$0x58, %r13
+<L79>:
+               	subq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	movq	(%r12), %r14
+               	movq	%r14, (%rbx)
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
                	jne	 <L79>
                	jmp	 <L82>
 <L80>:
-               	addq	$0x0, %rdx
                	addq	$0x0, %rsi
-               	movq	$0x58, %rcx
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rbx
 <L81>:
-               	movq	(%rsi), %rdi
-               	movq	%rdi, (%rdx)
-               	addq	$0x8, %rdx
+               	movq	(%rdi), %r12
+               	movq	%r12, (%rsi)
                	addq	$0x8, %rsi
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
                	jne	 <L81>
 <L82>:
-               	movq	%rax, %rdi
-               	callq	 <L83>
+               	leaq	(%rsp), %rsi
+               	leaq	(%rdx), %rdi
+               	cmpq	%rdi, %rsi
+               	jb	 <L84>
+               	movq	%rsi, %rdx
+               	addq	$0x58, %rdx
+               	movq	%rdi, %rbx
+               	addq	$0x58, %rbx
+               	movq	$0x58, %r12
 <L83>:
-               	movq	-0x358(%rbp), %rbx
-               	movq	-0x360(%rbp), %r12
-               	movq	-0x368(%rbp), %r13
-               	movq	-0x370(%rbp), %r14
-               	movq	-0x378(%rbp), %r15
+               	subq	$0x8, %rdx
+               	subq	$0x8, %rbx
+               	movq	(%rbx), %r13
+               	movq	%r13, (%rdx)
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L83>
+               	jmp	 <L86>
+<L84>:
+               	addq	$0x0, %rsi
+               	addq	$0x0, %rdi
+               	movq	$0x58, %rdx
+<L85>:
+               	movq	(%rdi), %rbx
+               	movq	%rbx, (%rsi)
+               	addq	$0x8, %rsi
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L85>
+<L86>:
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
+               	movq	-0x398(%rbp), %rbx
+               	movq	-0x3a0(%rbp), %r12
+               	movq	-0x3a8(%rbp), %r13
+               	movq	-0x3b0(%rbp), %r14
+               	movq	-0x3b8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/mem/uni_layout.dis
+++ b/test/golden/x86_64-linux/mem/uni_layout.dis
@@ -23,46 +23,176 @@ Disassembly of section .text:
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0xc(%rbp), %rbx
-               	movl	-0x8(%rbp), %ecx
-               	movl	%ecx, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	leaq	-0xc(%rbp), %rax
+               	movl	-0x8(%rbp), %edx
+               	movl	%edx, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	(%rax), %rdx
+               	leaq	(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+<L7>:
+               	leaq	(%rax), %rdx
+               	leaq	0x1(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	leaq	(%rax), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzbl	(%rsi), %edx
+               	movzbq	%dl, %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L11>:
+               	leaq	(%rax), %rdx
+               	leaq	0x3(%rdx), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
@@ -76,58 +206,166 @@ Disassembly of section .text:
                	movq	%rbx, -0x18(%rbp)
                	movq	%r12, -0x20(%rbp)
                	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
                	movq	%rsi, -0x8(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movq	-0x8(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	leaq	-0x10(%rbp), %rax
+               	movq	-0x8(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
-<L1>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	leaq	(%rbx), %r12
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
-               	jmp	 <L7>
-<L5>:
-               	leaq	(%rbx), %rax
-               	leaq	(%rax,%r13), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
                	movq	%r12, %rdi
-               	callq	 <L6>
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+<L1>:
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	(%rax), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r13
-               	jb	 <L5>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%r12, %rax
+               	leaq	(%rax), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L13>
+<L10>:
+               	leaq	(%rax), %rsi
+               	leaq	(%rsi,%rdx), %rbx
+               	movzbl	(%rbx), %esi
+               	movzbq	%sil, %rbx
+               	movq	%rdi, %rsi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+<L13>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %r12
                	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -135,353 +373,403 @@ Disassembly of section .text:
 <corpus.cases.mem.uni_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x140, %rsp            # imm = 0x140
-               	movq	%rbx, -0x118(%rbp)
-               	movq	%r12, -0x120(%rbp)
-               	movq	%r13, -0x128(%rbp)
-               	movq	%r14, -0x130(%rbp)
-               	movq	%r15, -0x138(%rbp)
+               	subq	$0x110, %rsp            # imm = 0x110
+               	movq	%rbx, -0xe8(%rbp)
+               	movq	%r12, -0xf0(%rbp)
+               	movq	%r13, -0xf8(%rbp)
+               	movq	%r14, -0x100(%rbp)
+               	movq	%r15, -0x108(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r12
+               	movabsq	$-0x340d631b7bdddcdb, %r12 # imm = 0xCBF29CE484222325
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L1>
-               	jmp	 <L8>
-<L1>:
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
                	movq	%r13, %rax
                	addq	$0x1, %rax
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	imulq	%rax, %rcx
-               	movq	%rcx, %r14
+               	movabsq	$-0x61c8864680b583eb, %rdx # imm = 0x9E3779B97F4A7C15
+               	imulq	%rax, %rdx
+               	movq	%rdx, %r14
                	addq	%rbx, %r14
                	leaq	-0x4(%rbp), %r15
                	movl	$0x0, (%r15)
                	movl	%r14d, %eax
                	andl	$0x807fffff, %eax       # imm = 0x807FFFFF
                	orl	$0x3e800000, %eax       # imm = 0x3E800000
-               	leaq	(%r15), %rcx
-               	movl	%eax, (%rcx)
-               	leaq	-0x54(%rbp), %rax
-               	movl	(%r15), %ecx
-               	movl	%ecx, (%rax)
-               	movq	$0x0, -0x60(%rbp)
-               	movl	(%rax), %ecx
-               	movl	%ecx, -0x60(%rbp)
-               	movq	-0x60(%rbp), %rsi
+               	leaq	(%r15), %rdx
+               	movl	%eax, (%rdx)
+               	leaq	-0x4c(%rbp), %rax
+               	movl	(%r15), %edx
+               	movl	%edx, (%rax)
+               	movq	$0x0, -0x58(%rbp)
+               	movl	(%rax), %edx
+               	movl	%edx, -0x58(%rbp)
+               	movq	-0x58(%rbp), %rsi
                	movq	%r12, %rdi
+               	callq	 <L1>
+<L1>:
+               	movq	%r14, %rdx
+               	shrq	$0x7, %rdx
+               	movl	%edx, %esi
+               	andl	$0x807fffff, %esi       # imm = 0x807FFFFF
+               	orl	$0x3e800000, %esi       # imm = 0x3E800000
+               	leaq	(%r15), %rdx
+               	movl	%esi, (%rdx)
+               	leaq	-0x5c(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x68(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x68(%rbp)
+               	movq	-0x68(%rbp), %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%r14, %rcx
-               	shrq	$0x7, %rcx
-               	movl	%ecx, %edx
-               	andl	$0x807fffff, %edx       # imm = 0x807FFFFF
-               	orl	$0x3e800000, %edx       # imm = 0x3E800000
-               	leaq	(%r15), %rcx
-               	movl	%edx, (%rcx)
-               	leaq	-0x74(%rbp), %rcx
-               	movl	(%r15), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x80(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x80(%rbp)
-               	movq	-0x80(%rbp), %rsi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0xfc>
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x6c(%rbp), %rdx
+               	movl	(%r15), %esi
+               	movl	%esi, (%rdx)
+               	movq	$0x0, -0x78(%rbp)
+               	movl	(%rdx), %esi
+               	movl	%esi, -0x78(%rbp)
+               	movq	-0x78(%rbp), %rsi
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0xfa>
-               	movss	%xmm1, (%rcx)
-               	leaq	-0x84(%rbp), %rcx
-               	movl	(%r15), %edx
-               	movl	%edx, (%rcx)
-               	movq	$0x0, -0x90(%rbp)
-               	movl	(%rcx), %edx
-               	movl	%edx, -0x90(%rbp)
-               	movq	-0x90(%rbp), %rsi
+               	leaq	-0x80(%rbp), %r15
+               	movq	$0x0, (%r15)
+               	movq	%r14, %rdx
+               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
+               	andq	%r11, %rdx
+               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
+               	orq	%r11, %rdx
+               	leaq	(%r15), %rsi
+               	movq	%rdx, (%rsi)
+               	leaq	-0x90(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	-0x98(%rbp), %r15
-               	movq	$0x0, (%r15)
-               	movq	%r14, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	(%r15), %rdx
-               	movq	%rcx, (%rdx)
-               	leaq	-0xa0(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
-<L5>:
                	shrq	$0x9, %r14
                	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
                	andq	%r11, %r14
                	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
                	orq	%r11, %r14
-               	leaq	(%r15), %rcx
-               	movq	%r14, (%rcx)
-               	leaq	-0xa8(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
+               	leaq	(%r15), %rdx
+               	movq	%r14, (%rdx)
+               	leaq	-0xa0(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
+               	leaq	(%r15), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1b7>
+               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
+               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1c3>
+               	movsd	%xmm0, (%rdx)
+               	leaq	-0xa8(%rbp), %rdx
+               	movq	(%r15), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	(%r15), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x1c4>
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	addsd	, %xmm0 <corpus.cases.mem.uni_layout.checksum+0x1d0>
-               	movsd	%xmm0, (%rcx)
-               	leaq	-0xb0(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x6, %r13
-               	jb	 <L1>
-<L8>:
+               	jb	 <L0>
+<L7>:
                	leaq	-0xc(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	%ebx, %r14d
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L9>
-               	jmp	 <L17>
-<L9>:
+               	jb	 <L8>
+               	jmp	 <L18>
+<L8>:
                	movl	%r15d, %eax
                	addl	$0x1, %eax
-               	movl	$0x9e3779b1, %ecx       # imm = 0x9E3779B1
-               	imull	%eax, %ecx
-               	movl	%ecx, %r8d
+               	movl	$0x9e3779b1, %edx       # imm = 0x9E3779B1
+               	imull	%eax, %edx
+               	movl	%edx, %r8d
                	addl	%r14d, %r8d
-               	movq	%r8, -0xe8(%rbp)
-               	leaq	-0x14(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	-0xe8(%rbp), %r8
-               	movl	%r8d, (%rdx)
-               	movq	-0xe8(%rbp), %r8
-               	movl	%r8d, %edx
-               	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0xf0(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	-0xf0(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movq	-0xf0(%rbp), %r9
-               	leaq	(%r9), %r8
-               	movq	%r8, -0xf8(%rbp)
-               	movq	-0xf8(%rbp), %r8
-               	movl	(%r8), %esi
-               	movq	%r12, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	movq	-0xf0(%rbp), %r9
-               	leaq	0x4(%r9), %r8
+               	movq	%r8, -0xe0(%rbp)
+               	leaq	-0x14(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movq	-0xe0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movq	-0xe0(%rbp), %r8
+               	movl	%r8d, %esi
+               	xorl	$0xf0f0f0f0, %esi       # imm = 0xF0F0F0F0
+               	leaq	0x4(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	leaq	(%r13), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	leaq	(%rsi), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %r8d
                	movq	%r8, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %edx
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x100(%rbp)
-               	movq	-0x100(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	movq	%r12, %r8
                	movq	%r8, -0xc0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdi, %rdx
+               	imulq	$0x8, %rdx, %rdx
+               	movq	%rdx, %rcx
+               	movq	-0xb8(%rbp), %r8
+               	movq	%r8, %rdx
+               	shrq	%cl, %rdx
+               	andq	$0xff, %rdx
                	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
-               	movzwl	(%rsi), %r8d
+               	xorq	%rdx, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0xc0(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+<L10>:
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %r8d
                	movq	%r8, -0xc8(%rbp)
+               	movq	-0xc0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
                	movq	-0xc8(%rbp), %r8
                	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r8
+               	movq	%r8, -0xd0(%rbp)
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	leaq	(%r13), %rdx
+               	leaq	(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
+               	movq	-0xd0(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rdi
-               	movq	-0x100(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0xd0(%rbp)
-               	movq	-0xd0(%rbp), %r8
-               	movl	%r8d, %esi
+               	leaq	(%r13), %rdx
+               	leaq	0x2(%rdx), %rsi
+               	movzwl	(%rsi), %edx
+               	movzwq	%dx, %rsi
                	callq	 <L14>
 <L14>:
+               	movq	%rax, %rdi
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	callq	 <L15>
+<L15>:
                	movq	%rax, %r8
                	movq	%r8, -0xd8(%rbp)
                	movq	-0xd8(%rbp), %r8
-               	leaq	-0x1c(%rbp), %r8
-               	movq	%r8, -0xe0(%rbp)
-               	movq	-0xe8(%rbp), %r8
-               	movw	%r8w, %di
+               	leaq	-0xb0(%rbp), %rdx
                	movq	-0xe0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movw	%di, (%rsi)
-               	movq	-0xe8(%rbp), %r8
+               	movw	%r8w, %si
+               	leaq	(%rdx), %rdi
+               	movw	%si, (%rdi)
+               	movq	-0xe0(%rbp), %r8
                	movl	%r8d, %esi
                	shrl	$0x10, %esi
                	movw	%si, %di
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x2(%r8), %rsi
+               	leaq	0x2(%rdx), %rsi
                	movw	%di, (%rsi)
-               	movq	-0xe8(%rbp), %r8
+               	movq	-0xe0(%rbp), %r8
                	movl	%r8d, %eax
                	addl	$0x1, %eax
-               	movq	-0xe0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
+               	leaq	0x4(%rdx), %rsi
                	movl	%eax, (%rsi)
-               	movq	-0xe0(%rbp), %r8
-               	movq	(%r8), %rax
-               	movq	-0x100(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0xf8(%rbp), %r8
-               	movl	(%r8), %eax
+               	leaq	(%r13), %rax
+               	movq	(%rdx), %rsi
+               	movq	%rsi, (%rax)
+               	leaq	(%r13), %rax
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %esi
                	movq	-0xd8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	callq	 <L15>
-<L15>:
-               	movq	-0xb8(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
                	callq	 <L16>
 <L16>:
+               	leaq	(%r13), %rdx
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
                	addq	$0x1, %r15
                	movq	%rax, %r12
                	cmpq	$0x4, %r15
-               	jb	 <L9>
-<L17>:
-               	leaq	-0x30(%rbp), %r13
+               	jb	 <L8>
+<L18>:
+               	leaq	-0x28(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, %r14
                	cmpq	$0x4, %r14
-               	jb	 <L18>
-               	jmp	 <L23>
-<L18>:
+               	jb	 <L19>
+               	jmp	 <L25>
+<L19>:
                	movq	%r14, %rax
                	addq	$0x1, %rax
-               	movb	%al, %cl
-               	leaq	(%r13), %rdx
-               	movb	%cl, (%rdx)
-               	movabsq	$-0x340d631b7bdddcdb, %rcx # imm = 0xCBF29CE484222325
-               	imulq	%rax, %rcx
-               	addq	%rbx, %rcx
-               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
-               	andq	%r11, %rcx
-               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
-               	orq	%r11, %rcx
-               	leaq	0x8(%r13), %r15
-               	leaq	(%r15), %rax
-               	movq	%rcx, (%rax)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	movq	%r12, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	-0x68(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	(%r15), %rcx
-               	movsd	(%rcx), %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x4bd>
-               	movsd	%xmm1, (%rcx)
-               	movq	-0x108(%rbp), %r8
-               	movzbl	(%r8), %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	-0x70(%rbp), %rcx
-               	movq	(%r15), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r14
-               	jb	 <L18>
-<L23>:
-               	leaq	-0x48(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	movq	$0x0, 0x10(%r13)
-               	movq	$0x0, %rax
-               	cmpq	$0x3, %rax
-               	jb	 <L24>
-               	jmp	 <L25>
-<L24>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %rcx
-               	movabsq	$0x100000001b3, %rdx    # imm = 0x100000001B3
-               	imulq	%rcx, %rdx
+               	movb	%al, %dl
+               	leaq	(%r13), %rsi
+               	movb	%dl, (%rsi)
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	imulq	%rax, %rdx
                	addq	%rbx, %rdx
                	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
                	andq	%r11, %rdx
                	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
                	orq	%r11, %rdx
-               	leaq	(%r13,%rax,8), %rcx
-               	leaq	(%rcx), %rsi
+               	leaq	0x8(%r13), %rax
+               	leaq	(%rax), %rsi
                	movq	%rdx, (%rsi)
+               	leaq	(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	%r12, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r15
+               	xorq	%rsi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L20>
+<L21>:
+               	leaq	0x8(%r13), %r15
+               	leaq	-0x88(%rbp), %rax
+               	movq	(%r15), %rdx
+               	movq	%rdx, (%rax)
+               	movq	(%rax), %rsi
+               	callq	 <L22>
+<L22>:
+               	leaq	(%r15), %rdx
+               	movsd	(%rdx), %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	addsd	, %xmm1 <corpus.cases.mem.uni_layout.checksum+0x54b>
+               	movsd	%xmm1, (%rdx)
+               	leaq	(%r13), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L23>
+<L23>:
+               	leaq	0x8(%r13), %rdx
+               	leaq	-0x98(%rbp), %rsi
+               	movq	(%rdx), %rdi
+               	movq	%rdi, (%rsi)
+               	movq	(%rsi), %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L24>
+<L24>:
+               	addq	$0x1, %r14
+               	movq	%rax, %r12
+               	cmpq	$0x4, %r14
+               	jb	 <L19>
+<L25>:
+               	leaq	-0x40(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, %rax
+               	cmpq	$0x3, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdx
+               	addq	$0x1, %rdx
+               	movabsq	$0x100000001b3, %rsi    # imm = 0x100000001B3
+               	imulq	%rdx, %rsi
+               	addq	%rbx, %rsi
+               	movabsq	$-0x7ffffbffffe00001, %r11 # imm = 0x80000400001FFFFF
+               	andq	%r11, %rsi
+               	movabsq	$0x3fd9999999999a00, %r11 # imm = 0x3FD9999999999A00
+               	orq	%r11, %rsi
+               	leaq	(%r13,%rax,8), %rdx
+               	leaq	(%rdx), %rdi
+               	movq	%rsi, (%rdi)
                	addq	$0x1, %rax
                	cmpq	$0x3, %rax
-               	jb	 <L24>
-<L25>:
+               	jb	 <L26>
+<L27>:
                	movq	$0x0, %rbx
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-               	jmp	 <L28>
-<L26>:
+               	jb	 <L28>
+               	jmp	 <L30>
+<L28>:
                	leaq	(%r13,%rbx,8), %rax
-               	leaq	-0x50(%rbp), %rcx
-               	movq	(%rax), %rdx
-               	movq	%rdx, (%rcx)
-               	movq	(%rcx), %rsi
+               	leaq	-0x48(%rbp), %rdx
+               	movq	(%rax), %rsi
+               	movq	%rsi, (%rdx)
+               	movq	(%rdx), %rsi
                	movq	%r12, %rdi
-               	callq	 <L27>
-<L27>:
+               	callq	 <L29>
+<L29>:
                	addq	$0x1, %rbx
                	movq	%rax, %r12
                	cmpq	$0x3, %rbx
-               	jb	 <L26>
-<L28>:
+               	jb	 <L28>
+<L30>:
                	movq	%r12, %rax
-               	movq	-0x118(%rbp), %rbx
-               	movq	-0x120(%rbp), %r12
-               	movq	-0x128(%rbp), %r13
-               	movq	-0x130(%rbp), %r14
-               	movq	-0x138(%rbp), %r15
+               	movq	-0xe8(%rbp), %rbx
+               	movq	-0xf0(%rbp), %r12
+               	movq	-0xf8(%rbp), %r13
+               	movq	-0x100(%rbp), %r14
+               	movq	-0x108(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_i16.dis
+++ b/test/golden/x86_64-linux/scalar/arith_i16.dis
@@ -5,118 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_i16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movw	%di, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %edx           # imm = 0xFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpw	$0x20, %di
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %r12w
-               	movl	$0xfff0, %ecx           # imm = 0xFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movswq	%r12w, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpw	$0x20, %r14w
-               	jl	 <L1>
-               	jmp	 <L4>
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movswq	%r12w, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpw	$0x20, %r14w
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpw	$0x8, %r15w
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpw	$0x20, %di
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x3039, %eax, %eax     # imm = 0x3039
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpw	$0x8, %di
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r15w
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x3039, %ebx, %ebx     # imm = 0x3039
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movswq	%r12w, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %di
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %esi           # imm = 0x7FFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %esi           # imm = 0x8000
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movswq	%di, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %esi           # imm = 0xFFFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7fff, %eax           # imm = 0x7FFF
+               	addl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %eax           # imm = 0x8000
+               	subl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %eax           # imm = 0xFFFF
+               	addl	%edx, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movswq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_i32.dis
+++ b/test/golden/x86_64-linux/scalar/arith_i32.dis
@@ -5,125 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %edx       # imm = 0xFFFFFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x20, %edi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %r12d
-               	movl	$0xfffffff0, %ecx       # imm = 0xFFFFFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
-               	jl	 <L1>
-               	jmp	 <L4>
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movslq	%r12d, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpl	$0x20, %r14d
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movl	$0x0, %r15d
-               	cmpl	$0x8, %r15d
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x20, %edi
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x12345678, %eax, %eax # imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %edi
+               	cmpl	$0x8, %edi
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r15d
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x12345678, %ebx, %ebx # imm = 0x12345678
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %ecx
-               	subl	%r15d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %edi
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %ecx
-               	subl	%r12d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %ecx       # imm = 0x7FFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %ecx       # imm = 0x80000000
-               	subl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movslq	%edi, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %ecx       # imm = 0xFFFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %ecx
-               	addl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %ecx
-               	subl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movl	$0x7fffffff, %eax       # imm = 0x7FFFFFFF
+               	addl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %eax       # imm = 0x80000000
+               	subl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %eax       # imm = 0xFFFFFFFF
+               	addl	%edx, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movslq	%eax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_i64.dis
+++ b/test/golden/x86_64-linux/scalar/arith_i64.dis
@@ -5,118 +5,323 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rax
+               	addq	%r8, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	imulq	$0x7, %rbx, %rbx
+               	addq	$0x1, %rbx
                	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x20, %r14
-               	jl	 <L1>
-               	jmp	 <L4>
+               	addq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r14, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%r13, %r15
-               	addq	%rax, %r15
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	movq	%r15, %r13
-               	cmpq	$0x20, %r14
-               	jl	 <L1>
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%rbx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x20, %rsi
+               	jl	 <L0>
 <L5>:
-               	movq	%r15, %rax
-               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r14
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r15
-               	jl	 <L5>
+               	movq	%rbx, %r12
+               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rdx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	$0x0, %r15
-               	subq	%r13, %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0, %rsi
-               	subq	%r15, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addq	$0x1, %rbx
+               	movq	%r12, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jl	 <L6>
 <L9>:
-               	movq	$0x0, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movabsq	$0x7fffffffffffffff, %rsi # imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movabsq	$-0x8000000000000000, %rsi # imm = 0x8000000000000000
-               	subq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movq	$0x0, %rbx
+               	subq	%rdi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	$-0x1, %rsi
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%r13, %rsi
-               	addq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rdi
+               	subq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%r13, %rsi
-               	subq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	subq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movabsq	$0x7fffffffffffffff, %rdi # imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rdi # imm = 0x8000000000000000
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rdi
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rax, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	%rax, %rdi
+               	subq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	subq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rdx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_i8.dis
+++ b/test/golden/x86_64-linux/scalar/arith_i8.dis
@@ -5,118 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_i8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %edx
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpb	$0x20, %dil
+               	jl	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %r12b
-               	movl	$0xf0, %ecx
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movsbq	%r12b, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpb	$0x20, %r14b
-               	jl	 <L1>
-               	jmp	 <L4>
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movsbq	%r12b, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
                	movq	%r15, %r13
-               	cmpb	$0x20, %r14b
-               	jl	 <L1>
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpb	$0x8, %r15b
-               	jl	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpb	$0x20, %dil
+               	jl	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x35, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpb	$0x8, %dil
+               	jl	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r15b
-               	jl	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x35, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movsbq	%r12b, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %dil
+               	jl	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %esi
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movsbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7f, %eax
+               	addl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %eax
+               	addl	%edx, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movsbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_u16.dis
+++ b/test/golden/x86_64-linux/scalar/arith_u16.dis
@@ -5,118 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_u16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movw	%di, %r8w
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfff0, %edx           # imm = 0xFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpw	$0x20, %di
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movw	%bx, %r12w
-               	movl	$0xfff0, %ecx           # imm = 0xFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movzwq	%r12w, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpw	$0x20, %r14w
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpw	$0x20, %r14w
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movzwq	%r12w, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpw	$0x8, %r15w
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpw	$0x20, %di
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0xabcd, %eax, %eax     # imm = 0xABCD
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpw	$0x8, %di
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpw	$0x8, %r15w
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0xabcd, %ebx, %ebx     # imm = 0xABCD
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movzwq	%r12w, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpw	$0x8, %di
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fff, %esi           # imm = 0x7FFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x8000, %esi           # imm = 0x8000
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movzwq	%di, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffff, %esi           # imm = 0xFFFF
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7fff, %eax           # imm = 0x7FFF
+               	addl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x8000, %eax           # imm = 0x8000
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffff, %eax           # imm = 0xFFFF
+               	addl	%edx, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movzwq	%ax, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_u32.dis
+++ b/test/golden/x86_64-linux/scalar/arith_u32.dis
@@ -5,125 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xfffffff0, %edx       # imm = 0xFFFFFFF0
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x20, %edi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movl	%ebx, %r12d
-               	movl	$0xfffffff0, %ecx       # imm = 0xFFFFFFF0
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x20, %r14d
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpl	$0x20, %r14d
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movl	%r12d, %eax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movl	$0x0, %r15d
-               	cmpl	$0x8, %r15d
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x20, %edi
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0x12345678, %eax, %eax # imm = 0x12345678
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movl	$0x0, %edi
+               	cmpl	$0x8, %edi
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpl	$0x8, %r15d
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0x12345678, %ebx, %ebx # imm = 0x12345678
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %ecx
-               	subl	%r15d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpl	$0x8, %edi
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %ecx
-               	subl	%r12d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7fffffff, %ecx       # imm = 0x7FFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80000000, %ecx       # imm = 0x80000000
-               	subl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movl	%edi, %eax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xffffffff, %ecx       # imm = 0xFFFFFFFF
-               	addl	%r13d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %ecx
-               	addl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %ecx
-               	subl	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L16>
+               	movl	$0x7fffffff, %eax       # imm = 0x7FFFFFFF
+               	addl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80000000, %eax       # imm = 0x80000000
+               	subl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xffffffff, %eax       # imm = 0xFFFFFFFF
+               	addl	%edx, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movl	%eax, %edi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_u64.dis
+++ b/test/golden/x86_64-linux/scalar/arith_u64.dis
@@ -5,118 +5,323 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$-0x10, %rax
+               	addq	%r8, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movq	$-0x10, %rcx
-               	addq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	imulq	$0x7, %rbx, %rbx
+               	addq	$0x1, %rbx
                	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x20, %r14
+               	addq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movq	%r14, %rax
-               	imulq	$0x7, %rax, %rax
-               	addq	$0x1, %rax
-               	movq	%r13, %r15
-               	addq	%rax, %r15
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	imulq	$0x3, %rcx, %rcx
-               	addq	$0x2, %rcx
-               	subq	%rcx, %r15
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addq	$0x1, %r14
-               	movq	%rax, %r12
-               	movq	%r15, %r13
-               	cmpq	$0x20, %r14
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
                	jb	 <L1>
+<L2>:
+               	movq	%rsi, %r13
+               	imulq	$0x3, %r13, %r13
+               	addq	$0x2, %r13
+               	subq	%r13, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L3>
 <L4>:
-               	movq	%rbx, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x20, %rsi
+               	jb	 <L0>
 <L5>:
-               	movq	%r15, %rax
-               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
-               	imulq	%r11, %rax
-               	addq	$0x1, %rax
-               	subq	%rax, %r14
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r12
-               	cmpq	$0x8, %r15
-               	jb	 <L5>
+               	movq	%rbx, %r12
+               	movabsq	$0x1234567890abcdef, %r11 # imm = 0x1234567890ABCDEF
+               	imulq	%r11, %r12
+               	addq	$0x1, %r12
+               	movq	%rsi, %r13
+               	subq	%r12, %r13
+               	movq	%rdx, %r12
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movq	$0x0, %r15
-               	subq	%r13, %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r13, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movq	$0x0, %rsi
-               	subq	%r15, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addq	$0x1, %rbx
+               	movq	%r12, %rdx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L6>
 <L9>:
-               	movq	$0x0, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movq	$0x0, %rdi
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movabsq	$0x7fffffffffffffff, %rsi # imm = 0x7FFFFFFFFFFFFFFF
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movabsq	$-0x8000000000000000, %rsi # imm = 0x8000000000000000
-               	subq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movq	$0x0, %rbx
+               	subq	%rdi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	$-0x1, %rsi
-               	addq	%r13, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movq	%r13, %rsi
-               	addq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x0, %rdi
+               	subq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%r13, %rsi
-               	subq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
 <L15>:
-               	subq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movabsq	$0x7fffffffffffffff, %rdi # imm = 0x7FFFFFFFFFFFFFFF
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movabsq	$-0x8000000000000000, %rdi # imm = 0x8000000000000000
+               	subq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	$-0x1, %rdi
+               	addq	%rax, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rax, %rdi
+               	addq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	%rax, %rdi
+               	subq	%rsi, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdx, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	subq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rdx, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/arith_u8.dis
+++ b/test/golden/x86_64-linux/scalar/arith_u8.dis
@@ -5,118 +5,341 @@ Disassembly of section .text:
 <corpus.cases.scalar.arith_u8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x30, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%r15, -0x28(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movb	%dil, %r8b
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xf0, %edx
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rdi
+               	cmpb	$0x20, %dil
+               	jb	 <L0>
+               	jmp	 <L5>
 <L0>:
-               	movb	%bl, %r12b
-               	movl	$0xf0, %ecx
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
+               	movl	%edi, %ebx
+               	imull	$0x7, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movl	%edx, %r12d
+               	addl	%ebx, %r12d
+               	movzbq	%r12b, %rbx
+               	movq	%rsi, %r13
                	movq	$0x0, %r14
-               	cmpb	$0x20, %r14b
+               	cmpq	$0x8, %r14
                	jb	 <L1>
-               	jmp	 <L4>
+               	jmp	 <L2>
 <L1>:
-               	movl	%r14d, %eax
-               	imull	$0x7, %eax, %eax
-               	addl	$0x1, %eax
-               	movl	%r13d, %r15d
-               	addl	%eax, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L2>
-<L2>:
-               	movl	%r14d, %ecx
-               	imull	$0x3, %ecx, %ecx
-               	addl	$0x2, %ecx
-               	subl	%ecx, %r15d
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L3>
-<L3>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	movq	%r15, %r13
-               	cmpb	$0x20, %r14b
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+<L2>:
+               	movl	%edi, %eax
+               	imull	$0x3, %eax, %eax
+               	addl	$0x2, %eax
+               	subl	%eax, %r12d
+               	movzbq	%r12b, %rax
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rax, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
 <L4>:
-               	movq	%r12, %r14
-               	movq	$0x0, %r15
-               	cmpb	$0x8, %r15b
-               	jb	 <L5>
-               	jmp	 <L7>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpb	$0x20, %dil
+               	jb	 <L0>
 <L5>:
-               	movl	%r15d, %eax
-               	imull	$0xb5, %eax, %eax
-               	addl	$0x1, %eax
-               	subl	%eax, %r14d
-               	movq	%rbx, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L6>
+               	movq	-0x8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	$0x0, %rdi
+               	cmpb	$0x8, %dil
+               	jb	 <L6>
+               	jmp	 <L9>
 <L6>:
-               	addl	$0x1, %r15d
-               	movq	%rax, %rbx
-               	cmpb	$0x8, %r15b
-               	jb	 <L5>
+               	movl	%edi, %ebx
+               	imull	$0xb5, %ebx, %ebx
+               	addl	$0x1, %ebx
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %r12d
+               	subl	%ebx, %r12d
+               	movzbq	%r12b, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
+               	jmp	 <L8>
 <L7>:
-               	movl	$0x0, %r15d
-               	subl	%r13d, %r15d
-               	movq	%rbx, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L8>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L7>
 <L8>:
-               	movl	$0x0, %esi
-               	subl	%r15d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %r8
+               	movq	%r8, -0x10(%rbp)
+               	cmpb	$0x8, %dil
+               	jb	 <L6>
 <L9>:
-               	movl	$0x0, %esi
-               	subl	%r12d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
+               	movl	$0x0, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movl	$0x7f, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movl	$0x80, %esi
-               	subl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
+               	movl	$0x0, %edi
+               	subl	%eax, %edi
+               	movzbq	%dil, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movl	$0xff, %esi
-               	addl	%r13d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rax, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
 <L13>:
-               	movl	%r13d, %esi
-               	addl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x0, %eax
+               	subl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movl	%r13d, %esi
-               	subl	%r14d, %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
 <L15>:
-               	subl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L16>
+               	movl	$0x7f, %eax
+               	addl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
-               	movq	-0x28(%rbp), %r15
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L16>
+<L17>:
+               	movl	$0x80, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L18>
+<L19>:
+               	movl	$0xff, %eax
+               	addl	%edx, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L20>
+<L21>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	addl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%edx, %eax
+               	subl	%r8d, %eax
+               	movzbq	%al, %rdi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L24>
+<L25>:
+               	movq	-0x10(%rbp), %r8
+               	movl	%r8d, %eax
+               	subl	%edx, %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L26>
+<L27>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/divrem_i32.dis
+++ b/test/golden/x86_64-linux/scalar/divrem_i32.dis
@@ -5,171 +5,418 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %r8d
+               	subq	$0x90, %rsp
+               	movq	%rbx, -0x68(%rbp)
+               	movq	%r12, -0x70(%rbp)
+               	movq	%r13, -0x78(%rbp)
+               	movq	%r14, -0x80(%rbp)
+               	movq	%r15, -0x88(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x8(%rbp)
                	movq	-0x8(%rbp), %r8
-               	movl	$0x77359400, %esi       # imm = 0x77359400
-               	subl	%r8d, %esi
-               	movq	%rcx, %rbx
-               	movq	%rsi, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r14d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movq	-0x8(%rbp), %r8
-               	movl	%ecx, %r15d
-               	addl	%r8d, %r15d
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r15d
-               	movl	%eax, %r8d
+               	movl	$0x77359400, %edi       # imm = 0x77359400
+               	subl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x10(%rbp)
-               	movl	%r13d, %eax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x0, %r12d
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	cltd
-               	idivl	%r15d
-               	movl	%edx, %r12d
-               	movq	%rbx, %rdi
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r15d
+               	movq	-0x20(%rbp), %r8
+               	movslq	%r8d, %rsi
                	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L3>
+               	movslq	%r15d, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+               	jmp	 <L4>
 <L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r15d, %esi
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %esi
+               	imull	%r9d, %esi
+               	addl	%r15d, %esi
+               	movslq	%esi, %rdi
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rsi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rbx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %esi
+               	subl	%r9d, %esi
+               	addl	$0x1, %r12d
+               	movq	%rbx, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x77359400, %esi       # imm = 0x77359400
+               	addl	%r8d, %esi
+               	movl	$0x0, %edi
+               	subl	%esi, %edi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movl	$0x0, %ebx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %ebx
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movl	%ebx, %r12d
+               	imull	$0xc5, %r12d, %r12d
+               	addl	$0x5, %r12d
+               	movq	-0x8(%rbp), %r9
+               	movl	%r12d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x48(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x48(%rbp), %r8
+               	cltd
+               	idivl	%r8d
+               	movl	%edx, %r14d
+               	movq	-0x40(%rbp), %r8
+               	movslq	%r8d, %r15
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r15, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r12
+               	xorq	%r13, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L9>
+<L10>:
+               	movslq	%r14d, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %rsi
+               	cmpq	$0x8, %r12
+               	jb	 <L11>
+<L12>:
+               	movq	-0x48(%rbp), %r8
+               	movq	-0x40(%rbp), %r9
+               	movl	%r8d, %edi
+               	imull	%r9d, %edi
+               	addl	%r14d, %edi
+               	movslq	%edi, %r12
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%r12, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+<L14>:
+               	movq	-0x38(%rbp), %r8
+               	movq	-0x48(%rbp), %r9
+               	movl	%r8d, %edi
+               	addl	%r9d, %edi
+               	addl	$0x1, %ebx
+               	movq	%rsi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x38(%rbp)
+               	cmpl	$0x8, %ebx
+               	jl	 <L8>
+<L15>:
+               	movq	-0x8(%rbp), %r9
+               	movl	$0x7ffffffc, %r8d       # imm = 0x7FFFFFFC
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x50(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x3, %edi
+               	addl	%r8d, %edi
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%edi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x58(%rbp)
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %eax
+               	cltd
+               	idivl	%edi
+               	movl	%edx, %r12d
+               	movq	-0x58(%rbp), %r8
+               	movslq	%r8d, %r13
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L16>
+<L17>:
+               	movslq	%r12d, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L18>
+<L19>:
+               	movq	-0x58(%rbp), %r8
+               	movl	%edi, %esi
                	imull	%r8d, %esi
                	addl	%r12d, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rbx
-               	subl	%r15d, %r13d
-               	addl	$0x1, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
-<L5>:
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x77359400, %ecx       # imm = 0x77359400
-               	addl	%r8d, %ecx
-               	movl	$0x0, %esi
-               	subl	%ecx, %esi
-               	movl	$0x0, %r12d
-               	movq	%rsi, %r13
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movl	%r12d, %ecx
-               	imull	$0xc5, %ecx, %ecx
-               	addl	$0x5, %ecx
-               	movq	-0x8(%rbp), %r8
-               	movl	%ecx, %r14d
-               	addl	%r8d, %r14d
-               	movl	%r13d, %eax
+               	movslq	%esi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	movl	%edi, %eax
+               	movq	-0x50(%rbp), %r8
                	cltd
-               	idivl	%r14d
-               	movl	%eax, %r15d
-               	movl	%r13d, %eax
+               	idivl	%r8d
+               	movl	%eax, %esi
+               	movl	%edi, %eax
+               	movq	-0x50(%rbp), %r8
                	cltd
-               	idivl	%r14d
-               	movl	%edx, %r8d
-               	movq	%r8, -0x18(%rbp)
-               	movq	%rbx, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	imull	%r15d, %esi
-               	movq	-0x18(%rbp), %r8
-               	addl	%r8d, %esi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rbx
-               	addl	%r14d, %r13d
-               	addl	$0x1, %r12d
-               	cmpl	$0x8, %r12d
-               	jl	 <L6>
-<L10>:
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x7ffffffc, %r12d      # imm = 0x7FFFFFFC
-               	addl	%r8d, %r12d
-               	movq	-0x8(%rbp), %r8
-               	movl	$0x3, %r13d
-               	addl	%r8d, %r13d
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%eax, %r14d
-               	movl	%r12d, %eax
-               	cltd
-               	idivl	%r13d
-               	movl	%edx, %r15d
-               	movq	%rbx, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movl	%r15d, %esi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	addl	%r15d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%eax, %ebx
-               	movl	%r13d, %eax
-               	cltd
-               	idivl	%r12d
-               	movl	%edx, %r13d
-               	movl	%ebx, %esi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	imull	%ebx, %r12d
-               	addl	%r13d, %r12d
-               	movl	%r12d, %esi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	idivl	%r8d
+               	movl	%edx, %edi
+               	movslq	%esi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L22>
+<L23>:
+               	movslq	%edi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L24>
+<L25>:
+               	movq	-0x50(%rbp), %r8
+               	movl	%r8d, %ebx
+               	imull	%esi, %ebx
+               	addl	%edi, %ebx
+               	movslq	%ebx, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L26>
+<L27>:
+               	movq	%r14, %rax
+               	movq	-0x68(%rbp), %rbx
+               	movq	-0x70(%rbp), %r12
+               	movq	-0x78(%rbp), %r13
+               	movq	-0x80(%rbp), %r14
+               	movq	-0x88(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/divrem_i64.dis
+++ b/test/golden/x86_64-linux/scalar/divrem_i64.dis
@@ -5,170 +5,391 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	movq	%r12, -0x30(%rbp)
-               	movq	%r13, -0x38(%rbp)
-               	movq	%r14, -0x40(%rbp)
-               	movq	%r15, -0x48(%rbp)
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
                	movq	%rdi, %r8
                	movq	%r8, -0x8(%rbp)
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
                	movq	-0x8(%rbp), %r8
                	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
                	subq	%r8, %rsi
-               	movq	%rcx, %r12
-               	movq	%rsi, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r14, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%rcx, %r15
-               	addq	%r8, %r15
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r15
-               	movq	%rax, %r8
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x10(%rbp)
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r15
-               	movq	%rdx, %rbx
-               	movq	%r12, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r15, %rsi
-               	imulq	%r8, %rsi
-               	addq	%rbx, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %r12
-               	subq	%r15, %r13
-               	addq	$0x1, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
-<L5>:
-               	movq	-0x8(%rbp), %r8
-               	movabsq	$0x7ce66c50e2840000, %rcx # imm = 0x7CE66C50E2840000
-               	addq	%r8, %rcx
-               	movq	$0x0, %rsi
-               	subq	%rcx, %rsi
-               	movq	$0x0, %rbx
-               	movq	%rsi, %r13
-               	cmpq	$0x8, %rbx
-               	jl	 <L6>
-               	jmp	 <L10>
-<L6>:
-               	movq	%rbx, %rcx
-               	imulq	$0xc5, %rcx, %rcx
-               	addq	$0x5, %rcx
-               	movq	-0x8(%rbp), %r8
-               	movq	%rcx, %r14
-               	addq	%r8, %r14
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r14
-               	movq	%rax, %r15
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%r14
-               	movq	%rdx, %r8
+               	movq	%rsi, %r8
                	movq	%r8, -0x18(%rbp)
-               	movq	%r12, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	-0x18(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L8>
-<L8>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	imulq	%r15, %rsi
-               	movq	-0x18(%rbp), %r8
-               	addq	%r8, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r12
-               	addq	%r14, %r13
-               	addq	$0x1, %rbx
-               	cmpq	$0x8, %rbx
-               	jl	 <L6>
-<L10>:
+               	movq	$0x0, %r12
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
                	movq	-0x8(%rbp), %r8
-               	movabsq	$0x7ffffffffffffffc, %rbx # imm = 0x7FFFFFFFFFFFFFFC
-               	addq	%r8, %rbx
-               	movq	-0x8(%rbp), %r8
-               	movq	$0x3, %r13
                	addq	%r8, %r13
-               	movq	%rbx, %rax
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
-               	movq	%rax, %r14
-               	movq	%rbx, %rax
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	cqto
                	idivq	%r13
                	movq	%rdx, %r15
-               	movq	%r12, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%r15, %rsi
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rcx
-               	imulq	%r14, %rcx
-               	addq	%r15, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%rbx
-               	movq	%rax, %r12
-               	movq	%r13, %rax
-               	cqto
-               	idivq	%rbx
-               	movq	%rdx, %r13
-               	movq	%r12, %rsi
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	imulq	%r12, %rbx
-               	addq	%r13, %rbx
+               	movq	-0x10(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
                	movq	%rbx, %rsi
-               	callq	 <L16>
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r15, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r15, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rbx, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rdi, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rsi
+               	subq	%r13, %rsi
+               	addq	$0x1, %r12
+               	movq	%rdi, %r8
+               	movq	%r8, -0x10(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jl	 <L0>
+<L7>:
+               	movq	-0x8(%rbp), %r8
+               	movabsq	$0x7ce66c50e2840000, %rsi # imm = 0x7CE66C50E2840000
+               	addq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	subq	%rsi, %rdi
+               	movq	-0x10(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	$0x0, %rbx
+               	movq	%rdi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rbx
+               	jl	 <L8>
+               	jmp	 <L15>
+<L8>:
+               	movq	%rbx, %r12
+               	imulq	$0xc5, %r12, %r12
+               	addq	$0x5, %r12
+               	movq	-0x8(%rbp), %r8
+               	addq	%r8, %r12
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rax, %r8
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%r12
+               	movq	%rdx, %r14
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x38(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r14, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r15, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L11>
+<L12>:
+               	movq	-0x38(%rbp), %r8
+               	movq	%r12, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r14, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+               	jmp	 <L14>
+<L13>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r15, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r15
+               	cmpq	$0x8, %rdi
+               	jb	 <L13>
+<L14>:
+               	movq	-0x30(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	%r12, %rsi
+               	addq	$0x1, %rbx
+               	movq	%r15, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x30(%rbp)
+               	cmpq	$0x8, %rbx
+               	jl	 <L8>
+<L15>:
+               	movq	-0x8(%rbp), %r9
+               	movabsq	$0x7ffffffffffffffc, %r8 # imm = 0x7FFFFFFFFFFFFFFC
+               	addq	%r9, %r8
+               	movq	%r8, -0x40(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movq	$0x3, %rdi
+               	addq	%r8, %rdi
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rdi
+               	movq	%rax, %rbx
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rax
+               	cqto
+               	idivq	%rdi
+               	movq	%rdx, %r12
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+               	jmp	 <L17>
 <L16>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x28(%rbp), %rbx
-               	movq	-0x30(%rbp), %r12
-               	movq	-0x38(%rbp), %r13
-               	movq	-0x40(%rbp), %r14
-               	movq	-0x48(%rbp), %r15
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L16>
+<L17>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%rdi, %rsi
+               	imulq	%rbx, %rsi
+               	addq	%r12, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L20>
+<L21>:
+               	movq	%rdi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rax, %rsi
+               	movq	%rdi, %rax
+               	movq	-0x40(%rbp), %r8
+               	cqto
+               	idivq	%r8
+               	movq	%rdx, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L22>
+<L23>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x40(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	%rsi, %rbx
+               	addq	%rdi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	movq	%r13, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/divrem_u32.dis
+++ b/test/golden/x86_64-linux/scalar/divrem_u32.dis
@@ -5,123 +5,300 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movl	%ebx, %r12d
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	subl	%r12d, %esi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rsi, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movl	%r14d, %ecx
-               	imull	$0x83, %ecx, %ecx
-               	addl	$0x3, %ecx
-               	movl	%ecx, %r15d
-               	addl	%r12d, %r15d
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%r15d
-               	movl	%eax, %r8d
+               	subq	$0x70, %rsp
+               	movq	%rbx, -0x48(%rbp)
+               	movq	%r12, -0x50(%rbp)
+               	movq	%r13, -0x58(%rbp)
+               	movq	%r14, -0x60(%rbp)
+               	movq	%r15, -0x68(%rbp)
+               	movl	%edi, %r8d
                	movq	%r8, -0x10(%rbp)
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%r15d
-               	movl	%edx, %ebx
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
                	movq	-0x10(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movl	%r15d, %esi
-               	imull	%r8d, %esi
-               	addl	%ebx, %esi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	subl	%r15d, %r13d
-               	addl	$0x1, %r14d
-               	movq	%rcx, %r8
+               	movl	$0xffffffff, %edi       # imm = 0xFFFFFFFF
+               	subl	%r8d, %edi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
                	movq	%r8, -0x8(%rbp)
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
-<L5>:
-               	movl	$0xfffffffd, %ebx       # imm = 0xFFFFFFFD
-               	addl	%r12d, %ebx
-               	movl	$0x3, %r13d
-               	addl	%r12d, %r13d
-               	movl	%ebx, %eax
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movl	$0x0, %r12d
+               	cmpl	$0x10, %r12d
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movl	%r12d, %r13d
+               	imull	$0x83, %r13d, %r13d
+               	addl	$0x3, %r13d
+               	movq	-0x10(%rbp), %r9
+               	movl	%r13d, %r8d
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
-               	movl	%eax, %r12d
-               	movl	%ebx, %eax
+               	divl	%r8d
+               	movl	%eax, %r8d
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movl	%r8d, %eax
+               	movq	-0x28(%rbp), %r8
                	xorl	%edx, %edx
-               	divl	%r13d
-               	movl	%edx, %r14d
+               	divl	%r8d
+               	movl	%edx, %r15d
+               	movq	-0x20(%rbp), %r8
+               	movl	%r8d, %ebx
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L6>
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rbx, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rsi, %r13
+               	xorq	%r14, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+<L2>:
+               	movl	%r15d, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rdi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L3>
+<L4>:
+               	movq	-0x28(%rbp), %r8
+               	movq	-0x20(%rbp), %r9
+               	movl	%r8d, %edi
+               	imull	%r9d, %edi
+               	addl	%r15d, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rsi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
 <L6>:
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	-0x18(%rbp), %r8
+               	movq	-0x28(%rbp), %r9
+               	movl	%r8d, %edi
+               	subl	%r9d, %edi
+               	addl	$0x1, %r12d
+               	movq	%rsi, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpl	$0x10, %r12d
+               	jb	 <L0>
 <L7>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %ecx
-               	imull	%r12d, %ecx
-               	addl	%r14d, %ecx
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movq	-0x10(%rbp), %r9
+               	movl	$0xfffffffd, %r8d       # imm = 0xFFFFFFFD
+               	addl	%r9d, %r8d
+               	movq	%r8, -0x30(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movl	$0x3, %edi
+               	addl	%r8d, %edi
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%edi
+               	movl	%eax, %r8d
+               	movq	%r8, -0x38(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %eax
+               	xorl	%edx, %edx
+               	divl	%edi
+               	movl	%edx, %r12d
+               	movq	-0x38(%rbp), %r8
+               	movl	%r8d, %r13d
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%eax, %r12d
-               	movl	%r13d, %eax
-               	xorl	%edx, %edx
-               	divl	%ebx
-               	movl	%edx, %r13d
-               	movl	%r12d, %esi
-               	callq	 <L9>
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%r13, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %r15
+               	movq	%rbx, %r14
+               	cmpq	$0x8, %r15
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L10>
+               	movl	%r12d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	imull	%r12d, %ebx
-               	addl	%r13d, %ebx
-               	movl	%ebx, %esi
-               	callq	 <L11>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rbx
+               	movq	%r15, %r14
+               	cmpq	$0x8, %rbx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	-0x38(%rbp), %r8
+               	movl	%edi, %esi
+               	imull	%r8d, %esi
+               	addl	%r12d, %esi
+               	movl	%esi, %ebx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r14, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rsi
+               	movq	%r13, %r14
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	movl	%edi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%eax, %esi
+               	movl	%edi, %eax
+               	movq	-0x30(%rbp), %r8
+               	xorl	%edx, %edx
+               	divl	%r8d
+               	movl	%edx, %edi
+               	movl	%esi, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L14>
+<L15>:
+               	movl	%edi, %ebx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%r14, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r12
+               	movq	%r15, %r14
+               	cmpq	$0x8, %r12
+               	jb	 <L16>
+<L17>:
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %ebx
+               	imull	%esi, %ebx
+               	addl	%edi, %ebx
+               	movl	%ebx, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r14, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %r14
+               	cmpq	$0x8, %rdi
+               	jb	 <L18>
+<L19>:
+               	movq	%r14, %rax
+               	movq	-0x48(%rbp), %rbx
+               	movq	-0x50(%rbp), %r12
+               	movq	-0x58(%rbp), %r13
+               	movq	-0x60(%rbp), %r14
+               	movq	-0x68(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/divrem_u64.dis
+++ b/test/golden/x86_64-linux/scalar/divrem_u64.dis
@@ -5,122 +5,282 @@ Disassembly of section .text:
 <corpus.cases.scalar.divrem_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
-               	movq	%rbx, -0x18(%rbp)
-               	movq	%r12, -0x20(%rbp)
-               	movq	%r13, -0x28(%rbp)
-               	movq	%r14, -0x30(%rbp)
-               	movq	%r15, -0x38(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rcx
-               	movq	$-0x1, %rsi
-               	subq	%rbx, %rsi
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	movq	%rsi, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
-               	jmp	 <L5>
-<L1>:
-               	movq	%r14, %rcx
-               	imulq	$0x83, %rcx, %rcx
-               	addq	$0x3, %rcx
-               	movq	%rcx, %r15
-               	addq	%rbx, %r15
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r15
-               	movq	%rax, %r8
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movq	%r12, -0x40(%rbp)
+               	movq	%r13, -0x48(%rbp)
+               	movq	%r14, -0x50(%rbp)
+               	movq	%r15, -0x58(%rbp)
+               	movq	%rdi, %r8
                	movq	%r8, -0x10(%rbp)
-               	movq	%r13, %rax
+               	movq	-0x10(%rbp), %r8
+               	movq	$-0x1, %rsi
+               	subq	%r8, %rsi
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x10, %r12
+               	jb	 <L0>
+               	jmp	 <L7>
+<L0>:
+               	movq	%r12, %r13
+               	imulq	$0x83, %r13, %r13
+               	addq	$0x3, %r13
+               	movq	-0x10(%rbp), %r8
+               	addq	%r8, %r13
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
                	xorl	%edx, %edx
-               	divq	%r15
+               	divq	%r13
+               	movq	%rax, %r8
+               	movq	%r8, -0x20(%rbp)
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%r13
+               	movq	%rdx, %r15
+               	movq	-0x8(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%rdi, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x20(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rbx, %r14
+               	xorq	%rsi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L1>
+<L2>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+               	jmp	 <L4>
+<L3>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%r15, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rbx, %r14
+               	xorq	%rdi, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rsi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rsi
+               	jb	 <L3>
+<L4>:
+               	movq	-0x20(%rbp), %r8
+               	movq	%r13, %rsi
+               	imulq	%r8, %rsi
+               	addq	%r15, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+               	jmp	 <L6>
+<L5>:
+               	movq	%rdi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%rsi, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L5>
+<L6>:
+               	movq	-0x18(%rbp), %r8
+               	movq	%r8, %rsi
+               	subq	%r13, %rsi
+               	addq	$0x1, %r12
+               	movq	%rbx, %r8
+               	movq	%r8, -0x8(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x18(%rbp)
+               	cmpq	$0x10, %r12
+               	jb	 <L0>
+<L7>:
+               	movq	-0x10(%rbp), %r9
+               	movq	$-0x3, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x28(%rbp)
+               	movq	-0x10(%rbp), %r8
+               	movq	$0x3, %rdi
+               	addq	%r8, %rdi
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rax, %rbx
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rax
+               	xorl	%edx, %edx
+               	divq	%rdi
                	movq	%rdx, %r12
                	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r8, %rsi
-               	callq	 <L2>
-<L2>:
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L3>
-<L3>:
-               	movq	%rax, %rdi
-               	movq	-0x10(%rbp), %r8
-               	movq	%r15, %rsi
-               	imulq	%r8, %rsi
-               	addq	%r12, %rsi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rcx
-               	subq	%r15, %r13
-               	addq	$0x1, %r14
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8(%rbp)
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
-<L5>:
-               	movq	$-0x3, %r12
-               	addq	%rbx, %r12
-               	movq	$0x3, %r13
-               	addq	%rbx, %r13
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%r13
-               	movq	%rax, %rbx
-               	movq	%r12, %rax
-               	xorl	%edx, %edx
-               	divq	%r13
-               	movq	%rdx, %r14
-               	movq	-0x8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	%rbx, %rsi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
-<L7>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rcx
-               	imulq	%rbx, %rcx
-               	addq	%r14, %rcx
-               	movq	%rcx, %rsi
-               	callq	 <L8>
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rax, %rbx
-               	movq	%r13, %rax
-               	xorl	%edx, %edx
-               	divq	%r12
-               	movq	%rdx, %r13
-               	movq	%rbx, %rsi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
                	movq	%r13, %rsi
-               	callq	 <L10>
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r14
+               	movq	%rsi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L8>
+<L9>:
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	imulq	%rbx, %r12
-               	addq	%r13, %r12
-               	movq	%r12, %rsi
-               	callq	 <L11>
+               	movq	%rsi, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%r13, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x18(%rbp), %rbx
-               	movq	-0x20(%rbp), %r12
-               	movq	-0x28(%rbp), %r13
-               	movq	-0x30(%rbp), %r14
-               	movq	-0x38(%rbp), %r15
+               	movq	%rdi, %rsi
+               	imulq	%rbx, %rsi
+               	addq	%r12, %rsi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L12>
+<L13>:
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rax, %rsi
+               	movq	%rdi, %rax
+               	movq	-0x28(%rbp), %r8
+               	xorl	%edx, %edx
+               	divq	%r8
+               	movq	%rdx, %rdi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L14>
+<L15>:
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r13, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %r13
+               	cmpq	$0x8, %rbx
+               	jb	 <L16>
+<L17>:
+               	movq	-0x28(%rbp), %r8
+               	movq	%r8, %rbx
+               	imulq	%rsi, %rbx
+               	addq	%rdi, %rbx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rbx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%r13, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %r13
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	movq	%r13, %rax
+               	movq	-0x38(%rbp), %rbx
+               	movq	-0x40(%rbp), %r12
+               	movq	-0x48(%rbp), %r13
+               	movq	-0x50(%rbp), %r14
+               	movq	-0x58(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/mul_i32.dis
+++ b/test/golden/x86_64-linux/scalar/mul_i32.dis
@@ -5,79 +5,204 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_i32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movl	$0x9e3779b9, %ecx       # imm = 0x9E3779B9
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b9, %edx       # imm = 0x9E3779B9
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x10, %edi
+               	jl	 <L0>
                	jmp	 <L3>
+<L0>:
+               	movl	$0x2, %ebx
+               	imull	%edi, %ebx
+               	addl	$0x3, %ebx
+               	movl	%edx, %r12d
+               	imull	%ebx, %r12d
+               	movslq	%r12d, %rbx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+               	jmp	 <L2>
 <L1>:
-               	movl	$0x2, %eax
-               	imull	%r14d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
 <L2>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r14d
-               	jl	 <L1>
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x10, %edi
+               	jl	 <L0>
 <L3>:
-               	movl	$0xffffffbf, %r14d      # imm = 0xFFFFFFBF
-               	addl	%r12d, %r14d
-               	movl	%r14d, %eax
-               	imull	%r14d, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L4>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %eax       # imm = 0xFFFFFFBF
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	imull	%eax, %edi
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %ecx
-               	imull	$0xffffffff, %ecx, %ecx # imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %edi
+               	imull	$0xffffffff, %edi, %edi # imm = 0xFFFFFFFF
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imull	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          # imm = 0x10001
-               	addl	%r12d, %ebx
-               	movl	%ebx, %ecx
-               	imull	%ebx, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%edx, %edi
+               	imull	%eax, %edi
+               	movslq	%edi, %rbx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffffffff, %ebx, %ebx # imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L9>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
+               	imull	%edx, %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          # imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movslq	%edx, %rdi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffffffff, %eax, %eax # imm = 0xFFFFFFFF
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/mul_i64.dis
+++ b/test/golden/x86_64-linux/scalar/mul_i64.dis
@@ -5,74 +5,192 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
+               	movq	%r15, -0x28(%rbp)
+               	movabsq	$-0x61c8864680b583eb, %rax # imm = 0x9E3779B97F4A7C15
+               	addq	%rdi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r14, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %r13
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r14
+<L0>:
+               	movq	$0x2, %rbx
+               	imulq	%rsi, %rbx
+               	addq	$0x3, %rbx
                	movq	%rax, %r12
-               	cmpq	$0x10, %r14
-               	jl	 <L1>
+               	imulq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x10, %rsi
+               	jl	 <L0>
 <L3>:
-               	movq	$-0x3f, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rsi
-               	imulq	%r14, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L4>
+               	movq	$-0x3f, %rsi
+               	addq	%rdi, %rsi
+               	movq	%rsi, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r14, %rsi
-               	imulq	$-0x1, %rsi, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
 <L5>:
-               	movq	%r13, %rsi
-               	imulq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rsi, %rbx
+               	imulq	$-0x1, %rbx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imulq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %r12      # imm = 0x10000000F
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	imulq	%r12, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rax, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imulq	$-0x1, %r12, %r12
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rax      # imm = 0x10000000F
+               	addq	%rdi, %rax
+               	movq	%rax, %rsi
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	imulq	$-0x1, %rax, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/mul_u32.dis
+++ b/test/golden/x86_64-linux/scalar/mul_u32.dis
@@ -5,79 +5,204 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_u32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
-               	movq	%rbx, -0x8(%rbp)
-               	movq	%r12, -0x10(%rbp)
-               	movq	%r13, -0x18(%rbp)
-               	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %r12d
-               	movl	$0x9e3779b1, %ecx       # imm = 0x9E3779B1
-               	addl	%r12d, %ecx
-               	movq	%rax, %rbx
-               	movq	%rcx, %r13
-               	movl	$0x0, %r14d
-               	cmpl	$0x10, %r14d
-               	jb	 <L1>
+               	subq	$0x40, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
+               	movq	%r13, -0x28(%rbp)
+               	movq	%r14, -0x30(%rbp)
+               	movq	%r15, -0x38(%rbp)
+               	movl	%edi, %r8d
+               	movq	%r8, -0x8(%rbp)
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x9e3779b1, %edx       # imm = 0x9E3779B1
+               	addl	%r8d, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rsi # imm = 0xCBF29CE484222325
+               	movl	$0x0, %edi
+               	cmpl	$0x10, %edi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movl	$0x2, %eax
-               	imull	%r14d, %eax
-               	addl	$0x3, %eax
-               	imull	%eax, %r13d
-               	movq	%rbx, %rdi
-               	movl	%r13d, %esi
-               	callq	 <L2>
-<L2>:
-               	addl	$0x1, %r14d
-               	movq	%rax, %rbx
-               	cmpl	$0x10, %r14d
+<L0>:
+               	movl	$0x2, %ebx
+               	imull	%edi, %ebx
+               	addl	$0x3, %ebx
+               	movl	%edx, %r12d
+               	imull	%ebx, %r12d
+               	movl	%r12d, %ebx
+               	movq	%rsi, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%rbx, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rax
+               	xorq	%r15, %rax
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rax
+               	addq	$0x1, %r14
+               	movq	%rax, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L1>
+<L2>:
+               	addl	$0x1, %edi
+               	movq	%r13, %rsi
+               	movq	%r12, %rdx
+               	cmpl	$0x10, %edi
+               	jb	 <L0>
 <L3>:
-               	movl	$0xffffffbf, %r14d      # imm = 0xFFFFFFBF
-               	addl	%r12d, %r14d
-               	movl	%r14d, %eax
-               	imull	%r14d, %eax
-               	movq	%rbx, %rdi
-               	movl	%eax, %esi
-               	callq	 <L4>
+               	movq	-0x8(%rbp), %r8
+               	movl	$0xffffffbf, %eax       # imm = 0xFFFFFFBF
+               	addl	%r8d, %eax
+               	movl	%eax, %edi
+               	imull	%eax, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movl	%r14d, %ecx
-               	imull	$0xffffffff, %ecx, %ecx # imm = 0xFFFFFFFF
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L5>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L4>
 <L5>:
-               	movl	%r13d, %ecx
-               	imull	%r14d, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L6>
+               	movl	%eax, %edi
+               	imull	$0xffffffff, %edi, %edi # imm = 0xFFFFFFFF
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imull	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L7>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L6>
 <L7>:
-               	movl	$0x10001, %ebx          # imm = 0x10001
-               	addl	%r12d, %ebx
-               	movl	%ebx, %ecx
-               	imull	%ebx, %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L8>
+               	movl	%edx, %edi
+               	imull	%eax, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	imull	$0xffff, %ebx, %ebx     # imm = 0xFFFF
-               	movq	%rax, %rdi
-               	movl	%ebx, %esi
-               	callq	 <L9>
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L8>
 <L9>:
-               	movq	-0x8(%rbp), %rbx
-               	movq	-0x10(%rbp), %r12
-               	movq	-0x18(%rbp), %r13
-               	movq	-0x20(%rbp), %r14
+               	imull	%edx, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movq	-0x8(%rbp), %r8
+               	movl	$0x10001, %eax          # imm = 0x10001
+               	addl	%r8d, %eax
+               	movl	%eax, %edx
+               	imull	%eax, %edx
+               	movl	%edx, %edi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rsi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rsi
+               	cmpq	$0x8, %rdx
+               	jb	 <L12>
+<L13>:
+               	imull	$0xffff, %eax, %eax     # imm = 0xFFFF
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rsi, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rsi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rsi, %rax
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
+               	movq	-0x28(%rbp), %r13
+               	movq	-0x30(%rbp), %r14
+               	movq	-0x38(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/scalar/mul_u64.dis
+++ b/test/golden/x86_64-linux/scalar/mul_u64.dis
@@ -5,75 +5,193 @@ Disassembly of section .text:
 <corpus.cases.scalar.mul_u64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x20, %rsp
+               	subq	$0x30, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%r12, -0x10(%rbp)
                	movq	%r13, -0x18(%rbp)
                	movq	%r14, -0x20(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movabsq	$-0x61c8864680b583eb, %rcx # imm = 0x9E3779B97F4A7C15
-               	addq	%rbx, %rcx
-               	movq	%rax, %r12
-               	movq	%rcx, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x10, %r14
-               	jb	 <L1>
+               	movq	%r15, -0x28(%rbp)
+               	movabsq	$-0x61c8864680b583eb, %rax # imm = 0x9E3779B97F4A7C15
+               	addq	%rdi, %rax
+               	movabsq	$-0x340d631b7bdddcdb, %rdx # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
                	jmp	 <L3>
-<L1>:
-               	movq	$0x2, %rax
-               	imulq	%r14, %rax
-               	addq	$0x3, %rax
-               	imulq	%rax, %r13
-               	movq	%r12, %rdi
-               	movq	%r13, %rsi
-               	callq	 <L2>
-<L2>:
-               	addq	$0x1, %r14
+<L0>:
+               	movq	$0x2, %rbx
+               	imulq	%rsi, %rbx
+               	addq	$0x3, %rbx
                	movq	%rax, %r12
-               	cmpq	$0x10, %r14
+               	imulq	%rbx, %r12
+               	movq	%rdx, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
                	jb	 <L1>
+               	jmp	 <L2>
+<L1>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L1>
+<L2>:
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	movq	%r12, %rax
+               	cmpq	$0x10, %rsi
+               	jb	 <L0>
 <L3>:
-               	movq	$-0x3f, %r14
-               	addq	%rbx, %r14
-               	movq	%r14, %rsi
-               	imulq	%r14, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L4>
+               	movq	$-0x3f, %rsi
+               	addq	%rdi, %rsi
+               	movq	%rsi, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%r14, %rsi
-               	imulq	$-0x1, %rsi, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L5>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L4>
 <L5>:
-               	movq	%r13, %rsi
-               	imulq	%r14, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
+               	movq	%rsi, %rbx
+               	imulq	$-0x1, %rbx, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	imulq	%r13, %r14
-               	movq	%rax, %rdi
-               	movq	%r14, %rsi
-               	callq	 <L7>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L6>
 <L7>:
-               	movabsq	$0x10000000f, %r12      # imm = 0x10000000F
-               	addq	%rbx, %r12
-               	movq	%r12, %rsi
-               	imulq	%r12, %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
+               	movq	%rax, %rbx
+               	imulq	%rsi, %rbx
+               	movq	$0x0, %r12
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
-               	imulq	%r11, %r12
-               	movq	%rax, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L9>
+               	movq	%r12, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdx, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %r12
+               	movq	%r14, %rdx
+               	cmpq	$0x8, %r12
+               	jb	 <L8>
 <L9>:
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	movabsq	$0x10000000f, %rax      # imm = 0x10000000F
+               	addq	%rdi, %rax
+               	movq	%rax, %rsi
+               	imulq	%rax, %rsi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdx, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdi
+               	movq	%r12, %rdx
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	movabsq	$0xffffffff, %r11       # imm = 0xFFFFFFFF
+               	imulq	%r11, %rax
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rax, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rdx, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rdx
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+<L15>:
+               	movq	%rdx, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12
                	movq	-0x18(%rbp), %r13
                	movq	-0x20(%rbp), %r14
+               	movq	-0x28(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/autovec_loop.dis
+++ b/test/golden/x86_64-linux/vec/autovec_loop.dis
@@ -5,749 +5,929 @@ Disassembly of section .text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x9b0, %rsp            # imm = 0x9B0
-               	movq	%rbx, -0x988(%rbp)
-               	movq	%r12, -0x990(%rbp)
-               	movq	%r13, -0x998(%rbp)
-               	movq	%r14, -0x9a0(%rbp)
-               	movq	%r15, -0x9a8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8a0(%rbp)
-               	movq	-0x8a0(%rbp), %r8
-               	movq	%rbx, %rsi
+               	subq	$0x940, %rsp            # imm = 0x940
+               	movq	%rbx, -0x918(%rbp)
+               	movq	%r12, -0x920(%rbp)
+               	movq	%r13, -0x928(%rbp)
+               	movq	%r14, -0x930(%rbp)
+               	movq	%r15, -0x938(%rbp)
+               	movq	%rdi, %rsi
                	andq	$0x1, %rsi
-               	movq	$0x43, %r12
-               	subq	%rsi, %r12
-               	movq	$0x25, %r13
-               	subq	%rsi, %r13
-               	movl	%ebx, %r8d
-               	movq	%r8, -0x8a8(%rbp)
-               	movq	%rbx, %r11
+               	movq	$0x43, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8c0(%rbp)
+               	movq	$0x25, %r8
+               	subq	%rsi, %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movl	%edi, %esi
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
-               	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jl	 <L0>
+               	cvtsi2ss	%r11, %xmm0
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm14
-               	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x960(%rbp)
-               	leaq	-0x10c(%rbp), %rbx
-               	leaq	(%rbx), %rdi
-               	addq	$0x0, %rdi
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x680(%rbp), %r8
+               	movq	%r8, -0x8a0(%rbp)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	addq	$0x0, %r13
                	movq	$0x108, %r14            # imm = 0x108
-<L3>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
+<L2>:
+               	movq	$0x0, (%r13)
+               	addq	$0x8, %r13
                	subq	$0x8, %r14
                	cmpq	$0x0, %r14
-               	jne	 <L3>
-               	movl	$0x0, (%rdi)
-               	leaq	-0x218(%rbp), %r14
-               	leaq	(%r14), %rdi
-               	addq	$0x0, %rdi
+               	jne	 <L2>
+               	movl	$0x0, (%r13)
+               	leaq	-0x78c(%rbp), %r8
+               	movq	%r8, -0x8a8(%rbp)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	addq	$0x0, %r14
                	movq	$0x108, %r15            # imm = 0x108
-<L4>:
-               	movq	$0x0, (%rdi)
-               	addq	$0x8, %rdi
+<L3>:
+               	movq	$0x0, (%r14)
+               	addq	$0x8, %r14
                	subq	$0x8, %r15
                	cmpq	$0x0, %r15
-               	jne	 <L4>
+               	jne	 <L3>
+               	movl	$0x0, (%r14)
+               	movq	$0x0, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movl	%r14d, %r15d
+               	movl	%r15d, %edi
+               	imull	$0x9e3779b1, %edi, %edi # imm = 0x9E3779B1
+               	addl	$0x3039, %edi           # imm = 0x3039
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%edi, (%r13)
+               	imull	$0x9e37, %r15d, %r15d   # imm = 0x9E37
+               	movl	$0xffffffff, %edi       # imm = 0xFFFFFFFF
+               	subl	%r15d, %edi
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%r14,4), %r13
+               	movl	%edi, (%r13)
+               	addq	$0x1, %r14
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r14
+               	jb	 <L4>
+<L5>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	(%rdi), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rdi)
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movl	(%rdi), %r13d
+               	addl	%esi, %r13d
+               	movl	%r13d, (%rdi)
+               	leaq	-0x10c(%rbp), %r8
+               	movq	%r8, -0x8b0(%rbp)
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %r13            # imm = 0x108
+<L6>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L6>
                	movl	$0x0, (%rdi)
                	movq	$0x0, %rdi
-               	cmpq	%r12, %rdi
-               	jb	 <L5>
-               	jmp	 <L6>
-<L5>:
-               	movl	%edi, %r15d
-               	movl	%r15d, %ecx
-               	imull	$0x9e3779b1, %ecx, %ecx # imm = 0x9E3779B1
-               	addl	$0x3039, %ecx           # imm = 0x3039
-               	leaq	(%rbx,%rdi,4), %rsi
-               	movl	%ecx, (%rsi)
-               	imull	$0x9e37, %r15d, %r15d   # imm = 0x9E37
-               	movl	$0xffffffff, %ecx       # imm = 0xFFFFFFFF
-               	subl	%r15d, %ecx
-               	leaq	(%r14,%rdi,4), %rsi
-               	movl	%ecx, (%rsi)
-               	addq	$0x1, %rdi
-               	cmpq	%r12, %rdi
-               	jb	 <L5>
-<L6>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8a8(%rbp), %r8
-               	addl	%r8d, %esi
-               	movl	%esi, (%rcx)
-               	leaq	-0x324(%rbp), %r8
-               	movq	%r8, -0x8b8(%rbp)
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            # imm = 0x108
-<L7>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L7>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L8>
-               	jmp	 <L9>
-<L8>:
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
-               	movl	(%rsi), %edi
-               	imull	$0x3, %edi, %edi
-               	movq	-0x8b0(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rsi
-               	movl	(%rsi), %ecx
-               	addl	%ecx, %edi
-               	movq	-0x8b8(%rbp), %r8
-               	movq	-0x8b0(%rbp), %r9
-               	leaq	(%r8,%r9,4), %rcx
-               	movl	%edi, (%rcx)
-               	movq	-0x8b0(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8b0(%rbp)
-               	movq	-0x8b0(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L8>
-<L9>:
-               	movq	-0x8a0(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x968(%rbp)
-               	movq	$0x0, %r15
-               	cmpq	%r12, %r15
-               	jb	 <L10>
-               	jmp	 <L12>
-<L10>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%r15,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x968(%rbp), %r8
-               	movq	%r8, %rdi
                	movq	-0x8c0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rcx
-               	addq	$0x1, %r15
-               	movq	%rcx, %r8
-               	movq	%r8, -0x968(%rbp)
-               	cmpq	%r12, %r15
+               	cmpq	%r8, %rdi
+               	jb	 <L7>
+               	jmp	 <L8>
+<L7>:
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	(%r13), %r14d
+               	imull	$0x3, %r14d, %r14d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	(%r13), %r15d
+               	addl	%r15d, %r14d
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r13
+               	movl	%r14d, (%r13)
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L7>
+<L8>:
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r13
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
+               	jmp	 <L12>
+<L9>:
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%r13,4), %r14
+               	movl	(%r14), %r15d
+               	movl	%r15d, %r14d
+               	movq	%rdi, %r15
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
                	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%r14, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%r15, %rbx
+               	xorq	%r12, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %r15
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	addq	$0x1, %r13
+               	movq	%r15, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %r13
+               	jb	 <L9>
 <L12>:
                	movq	$0x0, %rsi
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	movl	$0x0, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	cmpq	%r12, %rsi
+               	movl	$0x0, %ebx
+               	movl	$0x0, %r12d
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
                	jb	 <L13>
                	jmp	 <L14>
 <L13>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%rsi,4), %rdi
-               	movl	(%rdi), %r15d
-               	movq	-0x8d0(%rbp), %r9
-               	movl	%r9d, %r8d
-               	addl	%r15d, %r8d
-               	movq	%r8, -0x8d8(%rbp)
-               	leaq	(%rbx,%rsi,4), %r15
-               	movl	(%r15), %edi
-               	movq	-0x8c8(%rbp), %r8
-               	movl	%r8d, %r15d
-               	xorl	%edi, %r15d
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r14d
+               	addl	%r14d, %ebx
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %r13
+               	movl	(%r13), %r14d
+               	xorl	%r14d, %r12d
                	addq	$0x1, %rsi
-               	movq	-0x8d8(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0x8d0(%rbp)
-               	movq	%r15, %r8
-               	movq	%r8, -0x8c8(%rbp)
-               	cmpq	%r12, %rsi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rsi
                	jb	 <L13>
 <L14>:
-               	movq	-0x968(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x8d0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L15>
+               	movl	%ebx, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	movq	%rax, %rdi
-               	movq	-0x8c8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L16>
+               	movq	%rbx, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	%rdi, %r14
+               	xorq	%r13, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rbx
+               	movq	%r14, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
 <L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x8e0(%rbp)
-               	movq	-0x8e0(%rbp), %r8
-               	leaq	-0x430(%rbp), %r15
-               	leaq	(%r15), %rsi
-               	addq	$0x0, %rsi
-               	movq	$0x108, %rdi            # imm = 0x108
+               	movl	%r12d, %esi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	movq	$0x0, (%rsi)
-               	addq	$0x8, %rsi
-               	subq	$0x8, %rdi
-               	cmpq	$0x0, %rdi
-               	jne	 <L17>
-               	movl	$0x0, (%rsi)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L18>
-               	jmp	 <L21>
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rdi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rdi
+               	cmpq	$0x8, %rbx
+               	jb	 <L17>
 <L18>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rdi
-               	movl	(%rdi), %ecx
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rdi
-               	movl	(%rdi), %esi
-               	cmpl	%ecx, %esi
-               	jb	 <L19>
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %edi
-               	subl	%edi, %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
-               	jmp	 <L20>
+               	leaq	-0x898(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x108, %r12            # imm = 0x108
 <L19>:
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r14,%r8,4), %rcx
-               	movl	(%rcx), %edi
-               	subl	%edi, %esi
-               	movq	-0x8e8(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L19>
+               	movl	$0x0, (%rbx)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L20>
+               	jmp	 <L23>
 <L20>:
-               	movq	-0x8e8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x8e8(%rbp)
-               	movq	-0x8e8(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L18>
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	cmpl	%r13d, %r14d
+               	jb	 <L21>
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	%r13d, (%r12)
+               	jmp	 <L22>
 <L21>:
-               	movq	-0x8e0(%rbp), %r8
-               	movq	%r8, %r14
-               	movq	$0x0, %r8
-               	movq	%r8, -0x970(%rbp)
-               	movq	-0x970(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L22>
-               	jmp	 <L24>
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movq	-0x8a8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movl	(%r12), %r14d
+               	subl	%r14d, %r13d
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	%r13d, (%r12)
 <L22>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8f0(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x8f0(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L23>
+               	addq	$0x1, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L20>
 <L23>:
-               	movq	%rax, %r14
-               	movq	-0x970(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x970(%rbp)
-               	movq	-0x970(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L22>
-<L24>:
-               	leaq	-0x53c(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            # imm = 0x108
-<L25>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L25>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L26>
+               	movq	%rdi, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L24>
                	jmp	 <L27>
+<L24>:
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8c8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L25>
 <L26>:
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	$0xaaaaaaaa, (%rsi)     # imm = 0xAAAAAAAA
-               	addq	$0x1, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L26>
+               	addq	$0x1, %rbx
+               	movq	%r13, %r8
+               	movq	%r8, -0x8c8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L24>
 <L27>:
-               	movq	$0x0, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L28>
-               	jmp	 <L29>
+               	leaq	-0x218(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %rbx            # imm = 0x108
 <L28>:
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r8,%rcx,4), %rsi
-               	movl	(%rsi), %edi
-               	xorl	$0x1, %edi
-               	leaq	(%r15,%rcx,4), %rsi
-               	movl	%edi, (%rsi)
-               	addq	$0x2, %rcx
-               	cmpq	%r12, %rcx
-               	jb	 <L28>
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L28>
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L29>
+               	jmp	 <L30>
 <L29>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x978(%rbp)
-               	movq	-0x978(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L30>
-               	jmp	 <L32>
+               	leaq	(%rsi,%rdi,4), %rbx
+               	movl	$0xaaaaaaaa, (%rbx)     # imm = 0xAAAAAAAA
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L29>
 <L30>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x8f8(%rbp)
-               	movq	%r14, %rdi
-               	movq	-0x8f8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L31>
+               	movq	$0x0, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L31>
+               	jmp	 <L32>
 <L31>:
-               	movq	%rax, %r14
-               	movq	-0x978(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x978(%rbp)
-               	movq	-0x978(%rbp), %r8
-               	cmpq	%r12, %r8
-               	jb	 <L30>
+               	movq	-0x8b0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movl	(%rbx), %r12d
+               	xorl	$0x1, %r12d
+               	leaq	(%rsi,%rdi,4), %rbx
+               	movl	%r12d, (%rbx)
+               	addq	$0x2, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L31>
 <L32>:
-               	leaq	-0x648(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x108, %rsi            # imm = 0x108
+               	movq	-0x8c8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L33>
+               	jmp	 <L36>
 <L33>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L33>
-               	movl	$0x0, (%rcx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	leaq	(%r15), %rcx
-               	movl	%esi, (%rcx)
-               	movq	$0x1, %r8
-               	movq	%r8, -0x900(%rbp)
-               	movq	-0x900(%rbp), %r8
-               	cmpq	%r12, %r8
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d0(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
                	jb	 <L34>
                	jmp	 <L35>
 <L34>:
-               	movq	-0x900(%rbp), %r8
-               	movq	%r8, %rsi
-               	subq	$0x1, %rsi
-               	leaq	(%r15,%rsi,4), %rdi
-               	movl	(%rdi), %esi
-               	imull	$0x1f, %esi, %esi
-               	movq	-0x900(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rdi
-               	movl	(%rdi), %ecx
-               	addl	%ecx, %esi
-               	movq	-0x900(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rcx
-               	movl	%esi, (%rcx)
-               	movq	-0x900(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x900(%rbp)
-               	movq	-0x900(%rbp), %r8
-               	cmpq	%r12, %r8
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
                	jb	 <L34>
 <L35>:
-               	movq	$0x0, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L36>
-               	jmp	 <L38>
-<L36>:
-               	leaq	(%r15,%rbx,4), %rcx
-               	movl	(%rcx), %esi
-               	movq	%r14, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r14
                	addq	$0x1, %rbx
-               	cmpq	%r12, %rbx
-               	jb	 <L36>
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d0(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L33>
+<L36>:
+               	leaq	-0x324(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x108, %rbx            # imm = 0x108
+<L37>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L37>
+               	movl	$0x0, (%rdi)
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movl	(%rdi), %ebx
+               	leaq	(%rsi), %rdi
+               	movl	%ebx, (%rdi)
+               	movq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L38>
+               	jmp	 <L39>
 <L38>:
-               	leaq	-0x6dc(%rbp), %rbx
-               	leaq	(%rbx), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
+               	movq	%rdi, %rbx
+               	subq	$0x1, %rbx
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %ebx
+               	imull	$0x1f, %ebx, %ebx
+               	movq	-0x8a0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %r12
+               	movl	(%r12), %r13d
+               	addl	%r13d, %ebx
+               	leaq	(%rsi,%rdi,4), %r12
+               	movl	%ebx, (%r12)
+               	addq	$0x1, %rdi
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L38>
 <L39>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L39>
-               	movl	$0x0, (%rcx)
-               	leaq	-0x770(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L40>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L40>
-               	movl	$0x0, (%rcx)
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L41>
-               	jmp	 <L44>
-<L41>:
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L42>
-               	cvtsi2ss	%r11, %xmm1
+               	movq	-0x8d0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	$0x0, %rbx
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L40>
                	jmp	 <L43>
+<L40>:
+               	leaq	(%rsi,%rbx,4), %r12
+               	movl	(%r12), %r13d
+               	movl	%r13d, %r12d
+               	movq	-0x8d8(%rbp), %r8
+               	movq	%r8, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
+               	jmp	 <L42>
+<L41>:
+               	movq	%r14, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	%r12, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%r13, %rdi
+               	xorq	%r15, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r14
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %r14
+               	jb	 <L41>
 <L42>:
+               	addq	$0x1, %rbx
+               	movq	%r13, %r8
+               	movq	%r8, -0x8d8(%rbp)
+               	movq	-0x8c0(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L40>
+<L43>:
+               	leaq	-0x3b8(%rbp), %r8
+               	movq	%r8, -0x8e0(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x90, %rbx
+<L44>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %rbx
+               	cmpq	$0x0, %rbx
+               	jne	 <L44>
+               	movl	$0x0, (%rdi)
+               	leaq	-0x44c(%rbp), %r8
+               	movq	%r8, -0x8e8(%rbp)
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x90, %r12
+<L45>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L45>
+               	movl	$0x0, (%rbx)
+               	movq	$0x0, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
+               	jb	 <L46>
+               	jmp	 <L49>
+<L46>:
+               	movq	%rbx, %r11
+               	testq	%r11, %r11
+               	jl	 <L47>
+               	cvtsi2ss	%r11, %xmm1
+               	jmp	 <L48>
+<L47>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm1
                	addss	%xmm1, %xmm1
-<L43>:
+<L48>:
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	-0x960(%rbp), %xmm2
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0x7ac>
+               	addss	%xmm0, %xmm2
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movss	%xmm2, (%r12)
+               	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0x92a>
                	subss	%xmm1, %xmm2
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L41>
-<L44>:
-               	leaq	-0x804(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L45>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L45>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r13
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x908(%rbp)
-               	leaq	(%rbx), %rsi
-               	leaq	(%rbx,%r13,4), %rdi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x920(%rbp)
-               	leaq	(%r12,%r13,4), %r8
-               	movq	%r8, -0x910(%rbp)
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x918(%rbp)
-               	leaq	(%r15,%r13,4), %rcx
-               	cmpq	%rsi, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x928(%rbp)
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%r8, %rdi
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x928(%rbp), %r8
-               	movl	%r8d, %edi
-               	orl	%esi, %edi
-               	movq	-0x920(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x910(%rbp), %r8
-               	movq	-0x918(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %esi
-               	andl	%esi, %edi
-               	movq	-0x908(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%edi, %ecx
-               	testb	%cl, %cl
-               	jne	 <L47>
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rbx,4), %r12
+               	movss	%xmm2, (%r12)
+               	addq	$0x1, %rbx
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rbx
                	jb	 <L46>
-               	jmp	 <L51>
-<L46>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+<L49>:
+               	leaq	-0x4e0(%rbp), %r8
+               	movq	%r8, -0x8f0(%rbp)
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	addq	$0x0, %r12
+               	movq	$0x90, %r13
+<L50>:
+               	movq	$0x0, (%r12)
+               	addq	$0x8, %r12
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L50>
+               	movl	$0x0, (%r12)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	andl	$0x1, %r12d
+               	movl	%r12d, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rsi
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movq	-0x8f0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rbx
+               	cmpq	%r13, %rbx
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rdi, %r14
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	orl	%r13d, %r12d
+               	cmpq	%r15, %rbx
+               	setbe	%r13b
+               	movzbq	%r13b, %r13
+               	cmpq	%rdi, %rsi
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	orl	%ebx, %r13d
+               	andl	%r13d, %r12d
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%r12d, %esi
+               	testb	%sil, %sil
+               	jne	 <L52>
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L51>
+               	jmp	 <L56>
+<L51>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L46>
-               	jmp	 <L51>
-<L47>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L48>
-               	jmp	 <L49>
-<L48>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movups	(%rsi), %xmm1
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L51>
+               	jmp	 <L56>
+<L52>:
+               	movq	$0x0, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L53>
+               	jmp	 <L54>
+<L53>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%r15,%rcx,4), %rsi
-               	movups	%xmm0, (%rsi)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %rsi
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	%xmm0, (%rdi)
                	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L48>
-<L49>:
-               	cmpq	%r13, %rcx
-               	jb	 <L50>
-               	jmp	 <L51>
-<L50>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L53>
+<L54>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L55>
+               	jmp	 <L56>
+<L55>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L50>
-<L51>:
-               	movq	$0x0, %r8
-               	movq	%r8, -0x980(%rbp)
-               	movq	-0x980(%rbp), %r8
-               	cmpq	%r13, %r8
-               	jb	 <L52>
-               	jmp	 <L54>
-<L52>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r15,%r8,4), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%r14, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r14
-               	movq	-0x980(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, %r8
-               	movq	%r8, -0x980(%rbp)
-               	movq	-0x980(%rbp), %r8
-               	cmpq	%r13, %r8
-               	jb	 <L52>
-<L54>:
-               	leaq	-0x898(%rbp), %r15
-               	leaq	(%r15), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x90, %rsi
-<L55>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L55>
-               	movl	$0x0, (%rcx)
-               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	cmpq	%r11, %r13
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	andl	$0x1, %ecx
-               	movl	%ecx, %r8d
-               	andl	$0x1, %r8d
-               	movq	%r8, -0x930(%rbp)
-               	leaq	(%rbx), %rsi
-               	leaq	(%rbx,%r13,4), %rdi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x948(%rbp)
-               	leaq	(%r12,%r13,4), %r8
-               	movq	%r8, -0x938(%rbp)
-               	leaq	(%r15), %r8
-               	movq	%r8, -0x940(%rbp)
-               	leaq	(%r15,%r13,4), %rcx
-               	cmpq	%rsi, %rcx
-               	setbe	%r8b
-               	movzbq	%r8b, %r8
-               	movq	%r8, -0x950(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	cmpq	%r8, %rdi
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x950(%rbp), %r8
-               	movl	%r8d, %edi
-               	orl	%esi, %edi
-               	movq	-0x948(%rbp), %r8
-               	cmpq	%r8, %rcx
-               	setbe	%sil
-               	movzbq	%sil, %rsi
-               	movq	-0x938(%rbp), %r8
-               	movq	-0x940(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	orl	%ecx, %esi
-               	andl	%esi, %edi
-               	movq	-0x930(%rbp), %r8
-               	movl	%r8d, %ecx
-               	andl	%edi, %ecx
-               	testb	%cl, %cl
-               	jne	 <L57>
-               	movq	$0x0, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L55>
 <L56>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L56>
-               	jmp	 <L61>
+               	movq	-0x8d8(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	$0x0, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L57>
+               	jmp	 <L60>
 <L57>:
-               	movq	$0x0, %rcx
-               	movq	%rcx, %rsi
-               	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L58>
+               	movq	-0x8f0(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r12d
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
                	jmp	 <L59>
 <L58>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movups	(%rsi), %xmm1
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L58>
+<L59>:
+               	addq	$0x1, %rdi
+               	movq	%rbx, %r8
+               	movq	%r8, -0x900(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L57>
+<L60>:
+               	leaq	-0x574(%rbp), %r8
+               	movq	%r8, -0x908(%rbp)
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	addq	$0x0, %rbx
+               	movq	$0x90, %r12
+<L61>:
+               	movq	$0x0, (%rbx)
+               	addq	$0x8, %rbx
+               	subq	$0x8, %r12
+               	cmpq	$0x0, %r12
+               	jne	 <L61>
+               	movl	$0x0, (%rbx)
+               	movq	-0x8b8(%rbp), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	andl	$0x1, %ebx
+               	andl	$0x1, %ebx
+               	andl	$0x1, %ebx
+               	movl	%ebx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x910(%rbp)
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8), %r12
+               	movq	-0x8e0(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r13
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8), %r14
+               	movq	-0x8e8(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %r15
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	-0x908(%rbp), %r8
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r8,%r9,4), %rdi
+               	cmpq	%r12, %rdi
+               	setbe	%bl
+               	movzbq	%bl, %rbx
+               	cmpq	%rsi, %r13
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	orl	%r12d, %ebx
+               	cmpq	%r14, %rdi
+               	setbe	%r12b
+               	movzbq	%r12b, %r12
+               	cmpq	%rsi, %r15
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %r12d
+               	andl	%r12d, %ebx
+               	movq	-0x910(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ebx, %esi
+               	testb	%sil, %sil
+               	jne	 <L63>
+               	movq	$0x0, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L62>
+               	jmp	 <L67>
+<L62>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L62>
+               	jmp	 <L67>
+<L63>:
+               	movq	$0x0, %rsi
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	(%rdi), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movups	%xmm2, (%rsi)
-               	addq	$0x4, %rcx
-               	movq	%rcx, %rsi
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movups	%xmm2, (%rdi)
                	addq	$0x4, %rsi
-               	cmpq	%r13, %rsi
-               	jbe	 <L58>
-<L59>:
-               	cmpq	%r13, %rcx
-               	jb	 <L60>
-               	jmp	 <L61>
-<L60>:
-               	leaq	(%rbx,%rcx,4), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r12,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
+               	movq	%rsi, %rdi
+               	addq	$0x4, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jbe	 <L64>
+<L65>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L66>
+               	jmp	 <L67>
+<L66>:
+               	movq	-0x8e0(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm0
+               	movq	-0x8e8(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	(%rdi), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	%xmm2, (%rsi)
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L60>
-<L61>:
-               	movq	$0x0, %rbx
-               	cmpq	%r13, %rbx
-               	jb	 <L62>
-               	jmp	 <L64>
-<L62>:
-               	leaq	(%r15,%rbx,4), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%r14, %rdi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r14
-               	addq	$0x1, %rbx
-               	cmpq	%r13, %rbx
-               	jb	 <L62>
-<L64>:
-               	movq	$0x0, %rcx
-               	xorps	%xmm0, %xmm0
-               	cmpq	%r13, %rcx
-               	jb	 <L65>
-               	jmp	 <L66>
-<L65>:
-               	leaq	(%r15,%rcx,4), %rsi
-               	movss	(%rsi), %xmm1
-               	addss	%xmm1, %xmm0
-               	addq	$0x1, %rcx
-               	cmpq	%r13, %rcx
-               	jb	 <L65>
-<L66>:
-               	movq	%r14, %rdi
-               	callq	 <L67>
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rsi,4), %rdi
+               	movss	%xmm2, (%rdi)
+               	addq	$0x1, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rsi
+               	jb	 <L66>
 <L67>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x988(%rbp), %rbx
-               	movq	-0x990(%rbp), %r12
-               	movq	-0x998(%rbp), %r13
-               	movq	-0x9a0(%rbp), %r14
-               	movq	-0x9a8(%rbp), %r15
+               	movq	-0x900(%rbp), %r8
+               	movq	%r8, %rsi
+               	movq	$0x0, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L68>
+               	jmp	 <L71>
+<L68>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm0
+               	movd	%xmm0, %ebx
+               	movl	%ebx, %r12d
+               	movq	%rsi, %rbx
+               	movq	$0x0, %r13
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	%r13, %r14
+               	imulq	$0x8, %r14, %r14
+               	movq	%r14, %rcx
+               	movq	%r12, %r14
+               	shrq	%cl, %r14
+               	andq	$0xff, %r14
+               	movq	%rbx, %r15
+               	xorq	%r14, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %r13
+               	movq	%r15, %rbx
+               	cmpq	$0x8, %r13
+               	jb	 <L69>
+<L70>:
+               	addq	$0x1, %rdi
+               	movq	%rbx, %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L68>
+<L71>:
+               	movq	$0x0, %rdi
+               	xorps	%xmm0, %xmm0
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L72>
+               	jmp	 <L73>
+<L72>:
+               	movq	-0x908(%rbp), %r8
+               	leaq	(%r8,%rdi,4), %rbx
+               	movss	(%rbx), %xmm1
+               	addss	%xmm1, %xmm0
+               	addq	$0x1, %rdi
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rdi
+               	jb	 <L72>
+<L73>:
+               	movd	%xmm0, %edi
+               	movl	%edi, %ebx
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L74>
+               	jmp	 <L75>
+<L74>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rbx, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdi
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rdi
+               	jb	 <L74>
+<L75>:
+               	movq	%rsi, %rax
+               	movq	-0x918(%rbp), %rbx
+               	movq	-0x920(%rbp), %r12
+               	movq	-0x928(%rbp), %r13
+               	movq	-0x930(%rbp), %r14
+               	movq	-0x938(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-linux/vec/vec_cmp_i64.dis
@@ -7,18 +7,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -28,18 +66,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,787 +123,624 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_i64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x510, %rsp            # imm = 0x510
-               	movq	%rbx, -0x4e8(%rbp)
-               	movq	%r12, -0x4f0(%rbp)
-               	movq	%r13, -0x4f8(%rbp)
-               	movq	%r14, -0x500(%rbp)
-               	movq	%r15, -0x508(%rbp)
+               	subq	$0x400, %rsp            # imm = 0x400
+               	movq	%rbx, -0x3d8(%rbp)
+               	movq	%r12, -0x3e0(%rbp)
+               	movq	%r13, -0x3e8(%rbp)
+               	movq	%r14, -0x3f0(%rbp)
+               	movq	%r15, -0x3f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
+               	leaq	-0x230(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x60, %rdx
 <L0>:
-               	leaq	-0x60(%rbp), %r12
-               	leaq	(%r12), %rcx
-               	addq	$0x0, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L0>
+               	leaq	-0x290(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
                	movq	$0x60, %rdx
 <L1>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
                	subq	$0x8, %rdx
                	cmpq	$0x0, %rdx
                	jne	 <L1>
-               	leaq	-0xc0(%rbp), %r13
-               	leaq	(%r13), %rcx
-               	addq	$0x0, %rcx
-               	movq	$0x60, %rdx
-<L2>:
-               	movq	$0x0, (%rcx)
-               	addq	$0x8, %rcx
-               	subq	$0x8, %rdx
-               	cmpq	$0x0, %rdx
-               	jne	 <L2>
-               	leaq	-0xd0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0xf0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x110(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x120(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x20(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x130(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x140(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
-               	movq	%r11, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x30(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x150(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x200000000, %r11      # imm = 0x200000000
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x160(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x40(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x170(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0x10a, (%rdx)          # imm = 0x10A
-               	leaq	0x8(%rcx), %rdx
-               	movq	$-0x1, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x180(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movq	$0xa, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	$0x0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	0x50(%r13), %rcx
-               	movups	%xmm0, (%rcx)
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L3>
-               	jmp	 <L18>
-<L3>:
-               	movq	%r15, %rax
-               	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	movq	%r15, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
-               	addq	%rbx, %rax
-               	leaq	-0x1b0(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movq	%rax, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x1c0(%rbp), %rax
-               	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x1d0(%rbp), %r8
-               	movq	%r8, -0x428(%rbp)
-               	movq	-0x428(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x428(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%r14, %rdi
-               	callq	 <L4>
-<L4>:
-               	movq	%rax, %rdi
-               	movq	-0x428(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L5>
-<L5>:
-               	movaps	-0x440(%rbp), %xmm15
-               	pxor	-0x450(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpgtd	-0x450(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpeqd	-0x450(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpgtd	-0x450(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x370(%rbp), %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x458(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	-0x458(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L7>
-<L7>:
-               	movaps	-0x440(%rbp), %xmm15
-               	pxor	-0x450(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpgtd	-0x450(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	pcmpeqd	-0x450(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpgtd	-0x450(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x390(%rbp), %r8
-               	movq	%r8, -0x460(%rbp)
-               	movq	-0x460(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x460(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	movq	-0x460(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3b0(%rbp), %r8
-               	movq	%r8, -0x468(%rbp)
-               	movq	-0x468(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x468(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	-0x468(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3d0(%rbp), %r8
-               	movq	%r8, -0x470(%rbp)
-               	movq	-0x470(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x470(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movq	-0x470(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3f0(%rbp), %r8
-               	movq	%r8, -0x478(%rbp)
-               	movq	-0x478(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x478(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	movq	-0x478(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	movaps	-0x450(%rbp), %xmm15
-               	pxor	-0x440(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpgtd	-0x440(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x450(%rbp), %xmm15
-               	pcmpeqd	-0x440(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	movaps	-0x450(%rbp), %xmm14
-               	pcmpgtd	-0x440(%rbp), %xmm14
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x440(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x450(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x410(%rbp), %r8
-               	movq	%r8, -0x480(%rbp)
-               	movq	-0x480(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x480(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movq	-0x480(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x6, %r15
-               	jb	 <L3>
-<L18>:
-               	leaq	-0x220(%rbp), %r12
-               	leaq	(%r12), %rax
-               	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L19>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L19>
-               	leaq	-0x270(%rbp), %r13
-               	leaq	(%r13), %rax
-               	addq	$0x0, %rax
-               	movq	$0x50, %rcx
-<L20>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L20>
-               	leaq	-0x280(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	(%r12), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	-0x290(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
-               	movq	%r11, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	(%r13), %rax
-               	movups	%xmm0, (%rax)
                	leaq	-0x2a0(%rbp), %rax
-               	leaq	(%rax), %rcx
+               	leaq	(%rax), %rdx
                	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
                	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rcx)
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2b0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2c0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2b0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$0x100000001, %r11      # imm = 0x100000001
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
-               	movq	%r11, (%rcx)
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x10(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2c0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$-0x1, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x2e0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2d0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x0, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x2f0(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x20(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2e0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
-               	movq	%r11, (%rcx)
+               	leaq	-0x300(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x2f0(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
-               	movq	%r11, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
-               	movq	%r11, (%rcx)
+               	leaq	-0x310(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x30(%r13), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x300(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0x10a, (%rcx)          # imm = 0x10A
-               	leaq	0x8(%rax), %rcx
-               	movq	$-0x1, (%rcx)
+               	leaq	-0x320(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x200000000, %r11      # imm = 0x200000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%r12), %rax
                	movups	%xmm0, (%rax)
-               	leaq	-0x310(%rbp), %rax
-               	leaq	(%rax), %rcx
-               	movq	$0xa, (%rcx)
-               	leaq	0x8(%rax), %rcx
-               	movq	$0x0, (%rcx)
+               	leaq	-0x330(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x340(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x10a, (%rdx)          # imm = 0x10A
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x350(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x50(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %r14 # imm = 0xCBF29CE484222325
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L2>
+               	jmp	 <L13>
+<L2>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r13,%rdx), %rsi
+               	movups	(%rsi), %xmm1
+               	leaq	-0x20(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x30(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x40(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pxor	-0x390(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpgtd	-0x390(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpeqd	-0x390(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, -0x380(%rbp)
+               	movq	%r14, %rdi
+               	movups	-0x380(%rbp), %xmm0
+               	callq	 <L3>
+<L3>:
+               	movaps	-0x390(%rbp), %xmm15
+               	pxor	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpgtd	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpeqd	-0x3a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
+               	movaps	-0x390(%rbp), %xmm15
+               	pxor	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpgtd	-0x3a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x390(%rbp), %xmm15
+               	pcmpeqd	-0x3a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pxor	-0x390(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpgtd	-0x390(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3a0(%rbp), %xmm15
+               	pcmpeqd	-0x390(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x380(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm0, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x50(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x360(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x360(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movq	(%rsi), %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+               	jmp	 <L10>
+<L9>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x358(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rdx
+               	xorq	%rdi, %rdx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdx
+               	addq	$0x1, %rsi
+               	movq	%rdx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L9>
+<L10>:
+               	movq	-0x360(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+               	jmp	 <L12>
+<L11>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdx
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L11>
+<L12>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x6, %r15
+               	jb	 <L2>
+<L13>:
+               	leaq	-0xa0(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rdx
+<L14>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L14>
+               	leaq	-0xf0(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rdx
+<L15>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L15>
+               	leaq	-0x100(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x110(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x120(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x130(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x140(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x150(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x160(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x170(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x180(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0x10a, (%rdx)          # imm = 0x10A
+               	leaq	0x8(%rax), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x190(%rbp), %rax
+               	leaq	(%rax), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movq	$0x0, (%rdx)
                	movups	(%rax), %xmm0
                	leaq	0x40(%r13), %rax
                	movups	%xmm0, (%rax)
                	movq	$0x0, %r15
                	cmpq	$0x5, %r15
-               	jb	 <L21>
-               	jmp	 <L36>
-<L21>:
+               	jb	 <L16>
+               	jmp	 <L24>
+<L16>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rax
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	movq	%r15, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r13,%rcx), %rdx
-               	movups	(%rdx), %xmm1
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rax), %rdx
-               	movq	(%rdx), %rax
+               	movq	%r15, %rdx
+               	imulq	$0x10, %rdx, %rdx
+               	leaq	(%r13,%rdx), %rsi
+               	movups	(%rsi), %xmm1
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
                	addq	%rbx, %rax
-               	leaq	-0x340(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movq	%rax, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
-               	leaq	0x8(%rcx), %rax
-               	movq	(%rax), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x350(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movq	%rax, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rbx, %rdx
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm1, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movq	%rcx, (%rdx)
+               	leaq	0x8(%rax), %rsi
+               	movq	%rdx, (%rsi)
                	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x4b0(%rbp)
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
+               	movups	%xmm14, -0x3d0(%rbp)
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pxor	-0x3c0(%rbp), %xmm15
                	pxor	%xmm14, %xmm14
                	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpgtd	-0x3c0(%rbp), %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpeqd	-0x3c0(%rbp), %xmm15
                	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
                	pand	%xmm14, %xmm15
                	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
                	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
                	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x360(%rbp), %r8
-               	movq	%r8, -0x488(%rbp)
-               	movq	-0x488(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x488(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%r14, %rdi
+               	movups	-0x3b0(%rbp), %xmm0
+               	callq	 <L17>
+<L17>:
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pxor	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpgtd	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpeqd	-0x3d0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pxor	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpgtd	-0x3d0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	pcmpeqd	-0x3d0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pxor	-0x3c0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpgtd	-0x3c0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x3d0(%rbp), %xmm15
+               	pcmpeqd	-0x3c0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pcmpeqd	-0x3d0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L21>
+<L21>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pcmpeqd	-0x3d0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x3d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm0, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movq	-0x488(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movq	(%rcx), %rsi
                	callq	 <L23>
 <L23>:
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pxor	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpgtd	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpeqd	-0x4b0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x380(%rbp), %r8
-               	movq	%r8, -0x4b8(%rbp)
-               	movq	-0x4b8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4b8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	-0x4b8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pxor	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpgtd	-0x4b0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	pcmpeqd	-0x4b0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3a0(%rbp), %r8
-               	movq	%r8, -0x4c0(%rbp)
-               	movq	-0x4c0(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4c0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0x4c0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3c0(%rbp), %r8
-               	movq	%r8, -0x4c8(%rbp)
-               	movq	-0x4c8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4c8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0x4c8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqd	-0x4b0(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3e0(%rbp), %r8
-               	movq	%r8, -0x4d0(%rbp)
-               	movq	-0x4d0(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x4d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqd	-0x4b0(%rbp), %xmm14
-               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
-               	pand	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x400(%rbp), %r8
-               	movq	%r8, -0x4d8(%rbp)
-               	movq	-0x4d8(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x4d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0x4d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pxor	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm14, %xmm14
-               	pcmpgtd	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpgtd	-0x4a0(%rbp), %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	pcmpeqd	-0x4a0(%rbp), %xmm15
-               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
-               	pand	%xmm14, %xmm15
-               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
-               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
-               	por	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x4b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x420(%rbp), %r8
-               	movq	%r8, -0x4e0(%rbp)
-               	movq	-0x4e0(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x4e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0x4e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x5, %r15
-               	jb	 <L21>
-<L36>:
+               	jb	 <L16>
+<L24>:
                	movq	%r14, %rax
-               	movq	-0x4e8(%rbp), %rbx
-               	movq	-0x4f0(%rbp), %r12
-               	movq	-0x4f8(%rbp), %r13
-               	movq	-0x500(%rbp), %r14
-               	movq	-0x508(%rbp), %r15
+               	movq	-0x3d8(%rbp), %rbx
+               	movq	-0x3e0(%rbp), %r12
+               	movq	-0x3e8(%rbp), %r13
+               	movq	-0x3f0(%rbp), %r14
+               	movq	-0x3f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-linux/vec/vec_cmp_select.dis
@@ -7,88 +7,380 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -100,43 +392,51 @@ Disassembly of section .text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	leaq	(%rbx), %rax
+               	movzwl	(%rax), %ecx
+               	movzwq	%cx, %rsi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
                	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movq	%rax, %rdi
                	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movzwl	(%rcx), %edx
+               	movzwq	%dx, %rsi
+               	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
                	movq	-0x18(%rbp), %rbx
@@ -151,27 +451,27 @@ Disassembly of section .text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
+               	leaq	(%rbx), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
                	movl	(%rcx), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
                	movq	-0x18(%rbp), %rbx
@@ -207,23 +507,31 @@ Disassembly of section .text:
                	movq	%rbx, -0x18(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%rbx), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %esi
                	callq	 <L0>
 <L0>:
-               	movq	%rax, %rdi
                	leaq	0x4(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L1>
 <L1>:
-               	movq	%rax, %rdi
                	leaq	0x8(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L2>
 <L2>:
-               	movq	%rax, %rdi
                	leaq	0xc(%rbx), %rcx
                	movss	(%rcx), %xmm0
+               	movd	%xmm0, %ecx
+               	movl	%ecx, %esi
+               	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
                	movq	-0x18(%rbp), %rbx
@@ -234,171 +542,169 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x510, %rsp            # imm = 0x510
-               	movq	%rbx, -0x4e8(%rbp)
-               	movq	%r12, -0x4f0(%rbp)
-               	movq	%r13, -0x4f8(%rbp)
-               	movq	%r14, -0x500(%rbp)
-               	movq	%r15, -0x508(%rbp)
+               	subq	$0x4a0, %rsp            # imm = 0x4A0
+               	movq	%rbx, -0x478(%rbp)
+               	movq	%r12, -0x480(%rbp)
+               	movq	%r13, -0x488(%rbp)
+               	movq	%r14, -0x490(%rbp)
+               	movq	%r15, -0x498(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
                	movl	%ebx, %r12d
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x3d0(%rbp)
+<L1>:
+               	movss	%xmm14, -0x350(%rbp)
                	movw	%bx, %r13w
                	movb	%bl, %r14b
-               	leaq	-0x10(%rbp), %rcx
+               	leaq	-0x10(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movl	$0xa, (%rcx)
+               	leaq	0x4(%rax), %rcx
+               	movl	$0x14, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movl	$0x1e, (%rcx)
+               	leaq	0xc(%rax), %rcx
+               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
+               	movups	(%rax), %xmm1
+               	leaq	-0x20(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	-0x30(%rbp), %rcx
                	leaq	(%rcx), %rdx
-               	movl	$0xa, (%rdx)
+               	movl	$0x14, (%rdx)
                	leaq	0x4(%rcx), %rdx
                	movl	$0x14, (%rdx)
                	leaq	0x8(%rcx), %rdx
-               	movl	$0x1e, (%rdx)
+               	movl	$0xa, (%rdx)
                	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movl	$0x14, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movl	$0x14, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movl	$0xa, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movl	$0x1, (%rsi)
-               	movups	(%rdx), %xmm2
-               	leaq	-0x40(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	(%rcx), %rsi
-               	movl	(%rsi), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x50(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	(%rsi), %rdi
-               	movl	%ecx, (%rdi)
-               	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	leaq	0xc(%rdx), %rcx
-               	movl	(%rcx), %edx
-               	addl	%r12d, %edx
-               	leaq	-0x60(%rbp), %rcx
+               	movl	$0x1, (%rdx)
+               	movups	(%rcx), %xmm2
+               	leaq	-0x40(%rbp), %rcx
                	movups	%xmm2, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %eax
+               	addl	%r12d, %eax
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	%eax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x360(%rbp)
+               	leaq	0xc(%rcx), %rax
+               	movl	(%rax), %ecx
+               	addl	%r12d, %ecx
+               	leaq	-0x60(%rbp), %rax
+               	movups	%xmm2, (%rax)
+               	leaq	0xc(%rax), %rdx
+               	movl	%ecx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x370(%rbp)
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x70(%rbp), %r15
                	movups	%xmm3, (%r15)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L3>
-<L3>:
+               	leaq	(%r15), %rax
+               	movl	(%rax), %ecx
+               	movl	%ecx, %esi
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	callq	 <L2>
+<L2>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L4>
-<L4>:
+               	movq	%rax, %rdi
+               	callq	 <L3>
+<L3>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
+               	movq	%rax, %rdi
+               	callq	 <L4>
+<L4>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
+               	movq	%rax, %rdi
+               	callq	 <L5>
+<L5>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3f0(%rbp), %xmm14
+               	movaps	-0x370(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3e0(%rbp), %xmm15
+               	pxor	-0x360(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x80(%rbp), %r15
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	pcmpeqd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x360(%rbp), %xmm14
+               	pcmpeqd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x90(%rbp), %r15
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
+               	movq	%rax, %rdi
+               	callq	 <L11>
+<L11>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
+               	movq	%rax, %rdi
+               	callq	 <L12>
+<L12>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	pcmpeqd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x360(%rbp), %xmm14
+               	pcmpeqd	-0x370(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -406,33 +712,33 @@ Disassembly of section .text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -441,33 +747,33 @@ Disassembly of section .text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
+               	movq	%rax, %rdi
+               	callq	 <L20>
+<L20>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
+               	movq	%rax, %rdi
+               	callq	 <L21>
+<L21>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3f0(%rbp), %xmm14
+               	movaps	-0x370(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3e0(%rbp), %xmm15
+               	pxor	-0x360(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -476,44 +782,44 @@ Disassembly of section .text:
                	movups	%xmm3, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
+               	movq	%rax, %rdi
+               	callq	 <L22>
+<L22>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
+               	movq	%rax, %rdi
+               	callq	 <L23>
+<L23>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x3e0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x3f0(%rbp), %xmm15
+               	pxor	-0x370(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
-               	movaps	%xmm15, -0x400(%rbp)
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x3e0(%rbp), %xmm14
+               	movaps	%xmm15, -0x380(%rbp)
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x3f0(%rbp), %xmm14
+               	pand	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -522,37 +828,37 @@ Disassembly of section .text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	pand	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x3e0(%rbp), %xmm14
+               	pand	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -561,66 +867,66 @@ Disassembly of section .text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3f0(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movaps	-0x360(%rbp), %xmm14
+               	paddd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm14
                	pand	%xmm4, %xmm14
                	movaps	%xmm14, %xmm5
                	leaq	-0xf0(%rbp), %r15
                	movups	%xmm5, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	movaps	-0x400(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L37>
+<L37>:
+               	movaps	-0x380(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x3e0(%rbp), %xmm14
-               	psubd	-0x3f0(%rbp), %xmm14
+               	movaps	-0x360(%rbp), %xmm14
+               	psubd	-0x370(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
                	movaps	%xmm4, %xmm14
                	por	%xmm1, %xmm14
@@ -629,28 +935,28 @@ Disassembly of section .text:
                	movups	%xmm4, (%r15)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L41>
-<L41>:
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
                	leaq	-0x110(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
@@ -683,7 +989,7 @@ Disassembly of section .text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -692,96 +998,96 @@ Disassembly of section .text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x420(%rbp)
-               	movaps	-0x420(%rbp), %xmm14
-               	pcmpgtd	-0x410(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x170(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L43>
-<L43>:
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L44>
-<L44>:
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L45>
-<L45>:
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpgtd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x180(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L47>
-<L47>:
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x190(%rbp), %r12
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
+               	movq	%rax, %rdi
+               	callq	 <L51>
+<L51>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	-0x3a0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -789,30 +1095,30 @@ Disassembly of section .text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpgtd	-0x420(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpgtd	-0x3a0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -820,30 +1126,30 @@ Disassembly of section .text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	movaps	-0x420(%rbp), %xmm14
-               	pcmpgtd	-0x410(%rbp), %xmm14
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpgtd	-0x390(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -851,39 +1157,39 @@ Disassembly of section .text:
                	movups	%xmm3, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
-               	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	leaq	-0x1d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
                	xorps	%xmm1, %xmm1
-               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x95c>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x95e>
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm1, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40400000, (%rdx)     # imm = 0x40400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x976>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x97d>
+               	movss	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x978>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_cmp_select.checksum+0x97f>
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm1, (%rdx)
                	movups	(%rcx), %xmm1
@@ -896,202 +1202,111 @@ Disassembly of section .text:
                	movl	$0x0, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movl	$0x40400000, (%rsi)     # imm = 0x40400000
-               	movss	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9be>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c5>
+               	movss	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c0>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_cmp_select.checksum+0x9c7>
                	leaq	0xc(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	-0x200(%rbp), %r12
-               	movups	-0x430(%rbp), %xmm14
-               	movups	%xmm14, (%r12)
+               	movups	%xmm14, -0x3b0(%rbp)
                	leaq	(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x3d0(%rbp), %xmm4
-               	leaq	-0x210(%rbp), %r15
-               	movups	%xmm1, (%r15)
-               	leaq	(%r15), %rcx
-               	movss	%xmm4, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	addss	-0x350(%rbp), %xmm4
+               	leaq	-0x200(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movss	%xmm4, (%rdx)
+               	movups	(%rcx), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L66>
+<L66>:
+               	movq	%rax, %rdi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L67>
 <L67>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x3d0(%rbp), %xmm0
                	callq	 <L68>
 <L68>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L69>
 <L69>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x450(%rbp), %xmm0
-               	callq	 <L75>
-<L75>:
-               	movaps	-0x430(%rbp), %xmm14
-               	movaps	-0x440(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	callq	 <L70>
+<L70>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movaps	-0x440(%rbp), %xmm14
-               	movaps	-0x430(%rbp), %xmm15
+               	callq	 <L71>
+<L71>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	movaps	-0x3b0(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movaps	-0x430(%rbp), %xmm14
-               	movaps	-0x440(%rbp), %xmm15
+               	callq	 <L72>
+<L72>:
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x450(%rbp), %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3d0(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3d0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm4, %xmm14
-               	pand	-0x430(%rbp), %xmm14
+               	pand	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm0, %xmm14
                	por	%xmm5, %xmm14
-               	movaps	%xmm14, -0x460(%rbp)
-               	leaq	-0x220(%rbp), %r12
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, (%r12)
-               	movaps	-0x450(%rbp), %xmm14
-               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
+               	movaps	-0x3d0(%rbp), %xmm14
+               	pand	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	movaps	%xmm4, %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	pand	-0x3c0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm3, %xmm14
                	por	%xmm4, %xmm14
-               	movaps	%xmm14, -0x470(%rbp)
-               	leaq	-0x230(%rbp), %r15
-               	movups	-0x470(%rbp), %xmm14
-               	movups	%xmm14, (%r15)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	%xmm14, -0x3f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L74>
+<L74>:
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movaps	-0x470(%rbp), %xmm14
-               	subps	-0x460(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm0
+               	callq	 <L75>
+<L75>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	subps	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x240(%rbp), %r12
-               	movups	%xmm1, (%r12)
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	-0x250(%rbp), %rcx
+               	movaps	%xmm1, %xmm0
+               	callq	 <L76>
+<L76>:
+               	leaq	-0x210(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1099,104 +1314,104 @@ Disassembly of section .text:
                	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
+               	leaq	-0x220(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x270(%rbp), %rdx
+               	leaq	-0x230(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0x4004000000000000, %r11 # imm = 0x4004000000000000
                	movq	%r11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$0x0, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	%xmm14, -0x400(%rbp)
                	leaq	(%rcx), %rdx
                	movsd	(%rdx), %xmm2
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L93>
+               	jl	 <L77>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L94>
-<L93>:
+               	jmp	 <L78>
+<L77>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L94>:
+<L78>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
                	addsd	%xmm3, %xmm4
-               	leaq	-0x280(%rbp), %rcx
+               	leaq	-0x240(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	%xmm4, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	movups	%xmm14, -0x410(%rbp)
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpltpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x290(%rbp), %rbx
+               	leaq	-0x250(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L79>
+<L79>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	callq	 <L80>
+<L80>:
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpeqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2a0(%rbp), %rbx
+               	leaq	-0x260(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x480(%rbp), %xmm15
+               	callq	 <L82>
+<L82>:
+               	movaps	-0x410(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm15
                	cmpneqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2b0(%rbp), %rbx
+               	leaq	-0x270(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
+               	callq	 <L83>
+<L83>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	movaps	-0x480(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L84>
+<L84>:
+               	movaps	-0x400(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm15
                	cmplepd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2c0(%rbp), %rbx
+               	leaq	-0x280(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
+               	callq	 <L85>
+<L85>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	-0x2d0(%rbp), %rcx
+               	callq	 <L86>
+<L86>:
+               	leaq	-0x290(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
                	leaq	0x2(%rcx), %rdx
@@ -1214,9 +1429,9 @@ Disassembly of section .text:
                	leaq	0xe(%rcx), %rdx
                	movw	$0xfffe, (%rdx)         # imm = 0xFFFE
                	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	-0x2a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x2f0(%rbp), %rdx
+               	leaq	-0x2b0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x2, (%rsi)
                	leaq	0x2(%rdx), %rsi
@@ -1234,232 +1449,70 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xffff, (%rsi)         # imm = 0xFFFF
                	movups	(%rdx), %xmm1
-               	leaq	-0x300(%rbp), %rdx
+               	leaq	-0x2c0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzwl	(%rsi), %ecx
                	addl	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rsi
+               	leaq	-0x2d0(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movw	%cx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	0xe(%rdx), %rcx
                	movzwl	(%rcx), %edx
                	addl	%r13d, %edx
-               	leaq	-0x320(%rbp), %rcx
+               	leaq	-0x2e0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movw	%dx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4b0(%rbp)
-               	movaps	-0x4b0(%rbp), %xmm14
-               	psubusw	-0x4a0(%rbp), %xmm14
+               	movups	%xmm14, -0x440(%rbp)
+               	movaps	-0x440(%rbp), %xmm14
+               	psubusw	-0x430(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x330(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	%xmm14, -0x420(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x420(%rbp), %xmm0
+               	callq	 <L87>
+<L87>:
+               	movaps	-0x430(%rbp), %xmm14
+               	pcmpeqw	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	pcmpeqw	-0x4b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	psubusw	-0x4b0(%rbp), %xmm14
+               	callq	 <L88>
+<L88>:
+               	movaps	-0x430(%rbp), %xmm14
+               	psubusw	-0x440(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x350(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	movaps	-0x4b0(%rbp), %xmm14
-               	psubusw	-0x4a0(%rbp), %xmm14
-               	pxor	%xmm15, %xmm15
-               	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm2, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
+               	movaps	-0x420(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
-               	pand	-0x4b0(%rbp), %xmm14
+               	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	%xmm3, %xmm14
-               	por	%xmm0, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	-0x370(%rbp), %rcx
+               	callq	 <L90>
+<L90>:
+               	leaq	-0x2f0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1493,9 +1546,9 @@ Disassembly of section .text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x1d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
+               	leaq	-0x300(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x390(%rbp), %rdx
+               	leaq	-0x310(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movb	$0x2, (%rsi)
                	leaq	0x1(%rdx), %rsi
@@ -1529,72 +1582,72 @@ Disassembly of section .text:
                	leaq	0xf(%rdx), %rsi
                	movb	$0x1e, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x3a0(%rbp), %rdx
+               	leaq	-0x320(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzbl	(%rsi), %ecx
                	addl	%r14d, %ecx
-               	leaq	-0x3b0(%rbp), %rsi
+               	leaq	-0x330(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movb	%cl, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4d0(%rbp)
+               	movups	%xmm14, -0x460(%rbp)
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
                	addl	%r14d, %edx
-               	leaq	-0x3c0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4e0(%rbp)
-               	movaps	-0x4e0(%rbp), %xmm14
-               	psubusb	-0x4d0(%rbp), %xmm14
+               	movups	%xmm14, -0x470(%rbp)
+               	movaps	-0x470(%rbp), %xmm14
+               	psubusb	-0x460(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, -0x4c0(%rbp)
+               	movaps	%xmm14, -0x450(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x4c0(%rbp), %xmm0
-               	callq	 <L135>
-<L135>:
-               	movaps	-0x4d0(%rbp), %xmm14
-               	pcmpeqb	-0x4e0(%rbp), %xmm14
+               	movups	-0x450(%rbp), %xmm0
+               	callq	 <L91>
+<L91>:
+               	movaps	-0x460(%rbp), %xmm14
+               	pcmpeqb	-0x470(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	psubusb	-0x4d0(%rbp), %xmm14
+               	callq	 <L92>
+<L92>:
+               	movaps	-0x470(%rbp), %xmm14
+               	psubusb	-0x460(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	movaps	-0x4c0(%rbp), %xmm14
-               	pand	-0x4d0(%rbp), %xmm14
+               	callq	 <L93>
+<L93>:
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x460(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x4c0(%rbp), %xmm14
+               	movaps	-0x450(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x4e0(%rbp), %xmm14
+               	pand	-0x470(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	movq	-0x4e8(%rbp), %rbx
-               	movq	-0x4f0(%rbp), %r12
-               	movq	-0x4f8(%rbp), %r13
-               	movq	-0x500(%rbp), %r14
-               	movq	-0x508(%rbp), %r15
+               	callq	 <L94>
+<L94>:
+               	movq	-0x478(%rbp), %rbx
+               	movq	-0x480(%rbp), %r12
+               	movq	-0x488(%rbp), %r13
+               	movq	-0x490(%rbp), %r14
+               	movq	-0x498(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f32x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_f32x2.dis
@@ -7,18 +7,60 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,396 +68,290 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x190, %rsp            # imm = 0x190
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%r12, -0x180(%rbp)
-               	movq	%r13, -0x188(%rbp)
-               	movq	%r14, -0x190(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x120, %rsp            # imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x8(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movsd	(%rcx), %xmm1
-               	leaq	-0x10(%rbp), %rcx
-               	movsd	%xmm1, (%rcx)
-               	leaq	-0x18(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x48(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x2.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	movsd	(%rsi), %xmm1
+               	leaq	-0x50(%rbp), %rsi
+               	movsd	%xmm1, (%rsi)
+               	leaq	-0x58(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movsd	(%rsi), %xmm2
-               	leaq	-0x20(%rbp), %rsi
-               	movsd	%xmm2, (%rsi)
-               	leaq	-0x28(%rbp), %rbx
+               	movsd	(%rdi), %xmm2
+               	leaq	-0x60(%rbp), %rdi
+               	movsd	%xmm2, (%rdi)
+               	leaq	-0x68(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movl	$0x3f800000, (%r12)     # imm = 0x3F800000
                	leaq	0x4(%rbx), %r12
                	movl	$0x41d80000, (%r12)     # imm = 0x41D80000
                	movq	(%rbx), %r11
-               	movq	%r11, -0x100(%rbp)
-               	leaq	(%rcx), %rbx
+               	movq	%r11, -0x90(%rbp)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x30(%rbp), %rbx
-               	movsd	%xmm1, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	%xmm5, (%rcx)
-               	movq	(%rbx), %r11
-               	movq	%r11, -0x110(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm4
+               	leaq	-0x70(%rbp), %rsi
+               	movsd	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
+               	movss	%xmm5, (%rbx)
+               	movq	(%rsi), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	leaq	0x4(%rdi), %rsi
+               	movss	(%rsi), %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x38(%rbp), %r12
-               	movsd	%xmm2, (%r12)
-               	leaq	0x4(%r12), %rcx
-               	movss	%xmm5, (%rcx)
-               	movq	(%r12), %r11
-               	movq	%r11, -0x120(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x78(%rbp), %rsi
+               	movsd	%xmm2, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movq	(%rsi), %r11
+               	movq	%r11, -0xb0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0xa0(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0xb0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	addps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xb0(%rbp), %xmm14
+               	subps	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	addps	-0x120(%rbp), %xmm14
+               	movaps	-0xa0(%rbp), %xmm14
+               	mulps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xa0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	divps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
+               	movaps	-0xb0(%rbp), %xmm14
+               	divps	-0xa0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xa0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x120(%rbp), %xmm14
-               	subps	-0x110(%rbp), %xmm14
+               	movaps	-0x90(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0xb8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x90(%rbp), %xmm14
+               	divps	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	mulps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0x80(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	movsd	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0xa0(%rbp), %xmm14
+               	movups	%xmm14, -0xd0(%rbp)
+               	movups	%xmm0, -0xe0(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xd0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
+               	movaps	%xmm14, -0xc0(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0xc0(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	divps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xe0(%rbp), %xmm14
+               	addps	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, -0xf0(%rbp)
+               	movups	-0xf0(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0xd0(%rbp), %xmm14
+               	subps	-0xb0(%rbp), %xmm14
+               	movaps	%xmm14, -0x100(%rbp)
+               	movups	-0x100(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x120(%rbp), %xmm14
-               	divps	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x110(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x100(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe0(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x100(%rbp), %xmm14
-               	divps	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0xf0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	movsd	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x110(%rbp), %xmm14
-               	movups	%xmm14, -0x140(%rbp)
-               	movups	%xmm0, -0x150(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
-               	movaps	-0x140(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
-               	movaps	%xmm14, -0x130(%rbp)
-               	leaq	-0x40(%rbp), %r13
-               	movq	-0x130(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	-0x150(%rbp), %xmm14
-               	addps	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, -0x160(%rbp)
-               	leaq	-0x98(%rbp), %r13
-               	movq	-0x160(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	-0x140(%rbp), %xmm14
-               	subps	-0x120(%rbp), %xmm14
-               	movaps	%xmm14, -0x170(%rbp)
-               	leaq	-0xa8(%rbp), %r13
-               	movq	-0x170(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x170(%rbp), %xmm14
-               	movups	%xmm14, -0x140(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x150(%rbp)
+               	movups	-0x100(%rbp), %xmm14
+               	movups	%xmm14, -0xd0(%rbp)
+               	movups	-0xf0(%rbp), %xmm14
+               	movups	%xmm14, -0xe0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L32>:
-               	leaq	-0x70(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
                	movq	$0x0, 0x18(%r12)
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rcx
-               	movq	-0x140(%rbp), %r11
-               	movq	%r11, (%rcx)
-               	movaps	-0x140(%rbp), %xmm14
-               	addps	-0x120(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movq	-0xd0(%rbp), %r11
+               	movq	%r11, (%rsi)
+               	movaps	-0xd0(%rbp), %xmm14
+               	addps	-0xb0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x8(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	movaps	-0x140(%rbp), %xmm14
-               	mulps	-0x100(%rbp), %xmm14
+               	leaq	0x8(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	movaps	-0xd0(%rbp), %xmm14
+               	mulps	-0x90(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movq	-0x150(%rbp), %r11
-               	movq	%r11, (%rcx)
-               	movaps	-0x120(%rbp), %xmm14
-               	subps	-0x140(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	leaq	0x18(%r12), %rsi
+               	movq	-0xe0(%rbp), %r11
+               	movq	%r11, (%rsi)
+               	movaps	-0xb0(%rbp), %xmm14
+               	subps	-0xd0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rcx
-               	movsd	%xmm0, (%rcx)
-               	leaq	0x28(%r12), %rcx
-               	movq	-0x120(%rbp), %r11
-               	movq	%r11, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movsd	%xmm0, (%rsi)
+               	leaq	0x28(%r12), %rsi
+               	movq	-0xb0(%rbp), %r11
+               	movq	%r11, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	leaq	(%r12,%r13,8), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	-0x78(%rbp), %r14
-               	movsd	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	leaq	(%r12,%r13,8), %rsi
+               	movsd	(%rsi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x88(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x40(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x10(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x10(%r12), %rdi
+               	movsd	(%rdi), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	movsd	%xmm0, (%rdi)
+               	leaq	0xc(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x4(%r13), %rsi
                	movsd	(%rsi), %xmm0
-               	leaq	0x4(%r13), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0xc(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movsd	(%r12), %xmm0
-               	leaq	-0x90(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %r12
-               	movq	-0x188(%rbp), %r13
-               	movq	-0x190(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0xc(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f32x3.dis
+++ b/test/golden/x86_64-linux/vec/vec_f32x3.dis
@@ -7,27 +7,88 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x30, %rsp
                	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r12, -0x30(%rbp)
+               	leaq	-0xc(%rbp), %rax
                	movups	%xmm0, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	-0x1c(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	movl	-0x14(%rbp), %edx
+               	movl	%edx, 0x8(%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -35,409 +96,292 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x3.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            # imm = 0x290
-               	movq	%rbx, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movq	%r13, -0x288(%rbp)
-               	movq	%r14, -0x290(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x1f0, %rsp            # imm = 0x1F0
+               	movq	%rbx, -0x1d8(%rbp)
+               	movq	%r12, -0x1e0(%rbp)
+               	movq	%r13, -0x1e8(%rbp)
+               	movq	%r14, -0x1f0(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0xc(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     # imm = 0x40700000
-               	movq	$0x0, -0x1c(%rbp)
-               	movq	$0x0, -0x14(%rbp)
-               	movq	(%rcx), %rsi
-               	movq	%rsi, -0x1c(%rbp)
-               	movl	0x8(%rcx), %esi
-               	movl	%esi, -0x14(%rbp)
-               	movups	-0x1c(%rbp), %xmm1
-               	leaq	-0x28(%rbp), %rcx
-               	movups	%xmm1, -0x38(%rbp)
-               	movq	-0x38(%rbp), %rsi
-               	movq	%rsi, (%rcx)
-               	movl	-0x30(%rbp), %esi
-               	movl	%esi, 0x8(%rcx)
-               	leaq	-0x44(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x50(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x3.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     # imm = 0x40700000
+               	movq	$0x0, -0x60(%rbp)
+               	movq	$0x0, -0x58(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x60(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x58(%rbp)
+               	movups	-0x60(%rbp), %xmm1
+               	leaq	-0x6c(%rbp), %rsi
+               	movups	%xmm1, -0x7c(%rbp)
+               	movq	-0x7c(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x74(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	-0x88(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe1>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe8>
-               	leaq	0x8(%rsi), %rbx
+               	movss	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xd9>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x3.checksum+0xe0>
+               	leaq	0x8(%rdi), %rbx
                	movss	%xmm2, (%rbx)
-               	movq	$0x0, -0x54(%rbp)
-               	movq	$0x0, -0x4c(%rbp)
-               	movq	(%rsi), %rbx
-               	movq	%rbx, -0x54(%rbp)
-               	movl	0x8(%rsi), %ebx
-               	movl	%ebx, -0x4c(%rbp)
-               	movups	-0x54(%rbp), %xmm2
-               	leaq	-0x60(%rbp), %rsi
-               	movups	%xmm2, -0x70(%rbp)
-               	movq	-0x70(%rbp), %rbx
-               	movq	%rbx, (%rsi)
-               	movl	-0x68(%rbp), %ebx
-               	movl	%ebx, 0x8(%rsi)
-               	leaq	(%rcx), %rbx
+               	movq	$0x0, -0x98(%rbp)
+               	movq	$0x0, -0x90(%rbp)
+               	movq	(%rdi), %rbx
+               	movq	%rbx, -0x98(%rbp)
+               	movl	0x8(%rdi), %ebx
+               	movl	%ebx, -0x90(%rbp)
+               	movups	-0x98(%rbp), %xmm2
+               	leaq	-0xa4(%rbp), %rdi
+               	movups	%xmm2, -0xb4(%rbp)
+               	movq	-0xb4(%rbp), %rbx
+               	movq	%rbx, (%rdi)
+               	movl	-0xac(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdi)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x7c(%rbp), %rbx
-               	movups	%xmm1, -0x8c(%rbp)
-               	movq	-0x8c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x84(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	%xmm4, (%rcx)
-               	movq	$0x0, -0x9c(%rbp)
-               	movq	$0x0, -0x94(%rbp)
-               	movq	(%rbx), %rcx
-               	movq	%rcx, -0x9c(%rbp)
-               	movl	0x8(%rbx), %ecx
-               	movl	%ecx, -0x94(%rbp)
-               	movups	-0x9c(%rbp), %xmm14
-               	movups	%xmm14, -0x260(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movss	(%rcx), %xmm3
+               	leaq	-0xc0(%rbp), %rsi
+               	movups	%xmm1, -0xd0(%rbp)
+               	movq	-0xd0(%rbp), %rbx
+               	movq	%rbx, (%rsi)
+               	movl	-0xc8(%rbp), %ebx
+               	movl	%ebx, 0x8(%rsi)
+               	leaq	(%rsi), %rbx
+               	movss	%xmm4, (%rbx)
+               	movq	$0x0, -0xe0(%rbp)
+               	movq	$0x0, -0xd8(%rbp)
+               	movq	(%rsi), %rbx
+               	movq	%rbx, -0xe0(%rbp)
+               	movl	0x8(%rsi), %ebx
+               	movl	%ebx, -0xd8(%rbp)
+               	movups	-0xe0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	leaq	0x8(%rdi), %rsi
+               	movss	(%rsi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0xa8(%rbp), %r12
-               	movups	%xmm2, -0xb8(%rbp)
-               	movq	-0xb8(%rbp), %rcx
-               	movq	%rcx, (%r12)
-               	movl	-0xb0(%rbp), %ecx
-               	movl	%ecx, 0x8(%r12)
-               	leaq	0x8(%r12), %rcx
-               	movss	%xmm4, (%rcx)
-               	movq	$0x0, -0xc8(%rbp)
-               	movq	$0x0, -0xc0(%rbp)
-               	movq	(%r12), %rcx
-               	movq	%rcx, -0xc8(%rbp)
-               	movl	0x8(%r12), %ecx
-               	movl	%ecx, -0xc0(%rbp)
-               	movups	-0xc8(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0xec(%rbp), %rsi
+               	movups	%xmm2, -0xfc(%rbp)
+               	movq	-0xfc(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0xf4(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm4, (%rdi)
+               	movq	$0x0, -0x10c(%rbp)
+               	movq	$0x0, -0x104(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x10c(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x104(%rbp)
+               	movups	-0x10c(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x1a0(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x1b0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	addps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1c0(%rbp)
+               	movups	-0x1c0(%rbp), %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	subps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1b0(%rbp), %xmm14
+               	subps	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	mulps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x1a0(%rbp), %xmm14
+               	divps	-0x1b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	addps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, -0x170(%rbp)
-               	movq	-0x170(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x168(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	subps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x17c(%rbp), %rbx
-               	movups	%xmm0, -0x18c(%rbp)
-               	movq	-0x18c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x184(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L12>
-<L12>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
-<L13>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L14>
-<L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x270(%rbp), %xmm14
-               	subps	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x198(%rbp), %rbx
-               	movups	%xmm0, -0x1a8(%rbp)
-               	movq	-0x1a8(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1a0(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L15>
-<L15>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	mulps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b4(%rbp), %rbx
-               	movups	%xmm0, -0x1c4(%rbp)
-               	movq	-0x1c4(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1bc(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x260(%rbp), %xmm14
-               	divps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x1d8(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rcx
-               	leaq	-0x210(%rbp), %rbx
+               	movq	%rax, %rsi
+               	leaq	-0x13c(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
                	movq	$0x0, 0x10(%rbx)
                	movq	$0x0, 0x18(%rbx)
                	movq	$0x0, 0x20(%rbx)
                	movq	$0x0, 0x28(%rbx)
-               	leaq	(%rbx), %rsi
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movq	-0x220(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x218(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	-0x260(%rbp), %xmm14
-               	addps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	0xc(%rbx), %rsi
-               	movups	%xmm0, -0x230(%rbp)
-               	movq	-0x230(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x228(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movaps	-0x260(%rbp), %xmm14
-               	mulps	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm1
-               	leaq	0x18(%rbx), %rsi
-               	movups	%xmm1, -0x240(%rbp)
-               	movq	-0x240(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x238(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	leaq	0x24(%rbx), %rsi
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, -0x250(%rbp)
-               	movq	-0x250(%rbp), %rdi
-               	movq	%rdi, (%rsi)
-               	movl	-0x248(%rbp), %edi
-               	movl	%edi, 0x8(%rsi)
-               	movq	%rcx, %r12
+               	leaq	(%rbx), %rdi
+               	movups	-0x1a0(%rbp), %xmm14
+               	movups	%xmm14, -0x14c(%rbp)
+               	movq	-0x14c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x144(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0xc(%rbx), %rdi
+               	movups	-0x1c0(%rbp), %xmm14
+               	movups	%xmm14, -0x15c(%rbp)
+               	movq	-0x15c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x154(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x18(%rbx), %rdi
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x16c(%rbp)
+               	movq	-0x16c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x164(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	leaq	0x24(%rbx), %rdi
+               	movups	-0x1b0(%rbp), %xmm14
+               	movups	%xmm14, -0x17c(%rbp)
+               	movq	-0x17c(%rbp), %r12
+               	movq	%r12, (%rdi)
+               	movl	-0x174(%rbp), %r12d
+               	movl	%r12d, 0x8(%rdi)
+               	movq	%rsi, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L24>
-               	jmp	 <L28>
-<L24>:
-               	movq	%r13, %rcx
-               	imulq	$0xc, %rcx, %rcx
-               	leaq	(%rbx,%rcx), %rsi
-               	movq	$0x0, -0xd8(%rbp)
-               	movq	$0x0, -0xd0(%rbp)
-               	movq	(%rsi), %rcx
-               	movq	%rcx, -0xd8(%rbp)
-               	movl	0x8(%rsi), %ecx
-               	movl	%ecx, -0xd0(%rbp)
-               	movups	-0xd8(%rbp), %xmm0
-               	leaq	-0xe4(%rbp), %r14
-               	movups	%xmm0, -0xf4(%rbp)
-               	movq	-0xf4(%rbp), %rcx
-               	movq	%rcx, (%r14)
-               	movl	-0xec(%rbp), %ecx
-               	movl	%ecx, 0x8(%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L9>
+               	jmp	 <L11>
+<L9>:
+               	movq	%r13, %rsi
+               	imulq	$0xc, %rsi, %rsi
+               	leaq	(%rbx,%rsi), %rdi
+               	movq	$0x0, -0x10(%rbp)
+               	movq	$0x0, -0x8(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x10(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x8(%rbp)
+               	movups	-0x10(%rbp), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	movq	%rax, %r12
                	addq	$0x1, %r13
-               	movq	%rcx, %r12
                	cmpq	$0x4, %r13
-               	jb	 <L24>
-<L28>:
-               	leaq	-0x108(%rbp), %r13
+               	jb	 <L9>
+<L11>:
+               	leaq	-0x24(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movl	$0x0, 0x10(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x18(%rbx), %rsi
-               	movq	$0x0, -0x118(%rbp)
-               	movq	$0x0, -0x110(%rbp)
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x18(%rbx), %rdi
+               	movq	$0x0, -0x34(%rbp)
+               	movq	$0x0, -0x2c(%rbp)
+               	movq	(%rdi), %rbx
+               	movq	%rbx, -0x34(%rbp)
+               	movl	0x8(%rdi), %ebx
+               	movl	%ebx, -0x2c(%rbp)
+               	movups	-0x34(%rbp), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	movups	%xmm0, -0x44(%rbp)
+               	movq	-0x44(%rbp), %rbx
+               	movq	%rbx, (%rdi)
+               	movl	-0x3c(%rbp), %ebx
+               	movl	%ebx, 0x8(%rdi)
+               	leaq	0x10(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rdi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%r12, %r14
+               	xorq	%rbx, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %r12
+               	cmpq	$0x8, %rdi
+               	jb	 <L12>
+<L13>:
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x18c(%rbp)
+               	movq	$0x0, -0x184(%rbp)
                	movq	(%rsi), %rdi
-               	movq	%rdi, -0x118(%rbp)
+               	movq	%rdi, -0x18c(%rbp)
                	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x110(%rbp)
-               	movups	-0x118(%rbp), %xmm0
-               	leaq	0x4(%r13), %rbx
-               	movups	%xmm0, -0x128(%rbp)
-               	movq	-0x128(%rbp), %rsi
-               	movq	%rsi, (%rbx)
-               	movl	-0x120(%rbp), %esi
-               	movl	%esi, 0x8(%rbx)
-               	leaq	0x10(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rcx), %esi
+               	movl	%edi, -0x184(%rbp)
+               	movups	-0x18c(%rbp), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movq	$0x0, -0x138(%rbp)
-               	movq	$0x0, -0x130(%rbp)
-               	movq	(%rbx), %rcx
-               	movq	%rcx, -0x138(%rbp)
-               	movl	0x8(%rbx), %ecx
-               	movl	%ecx, -0x130(%rbp)
-               	movups	-0x138(%rbp), %xmm0
-               	leaq	-0x144(%rbp), %rbx
-               	movups	%xmm0, -0x154(%rbp)
-               	movq	-0x154(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14c(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x278(%rbp), %rbx
-               	movq	-0x280(%rbp), %r12
-               	movq	-0x288(%rbp), %r13
-               	movq	-0x290(%rbp), %r14
+               	callq	 <L14>
+<L14>:
+               	movq	%rax, %rsi
+               	leaq	0x10(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+               	jmp	 <L16>
+<L15>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L15>
+<L16>:
+               	movq	%rsi, %rax
+               	movq	-0x1d8(%rbp), %rbx
+               	movq	-0x1e0(%rbp), %r12
+               	movq	-0x1e8(%rbp), %r13
+               	movq	-0x1f0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f32x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_f32x4.dis
@@ -7,28 +7,108 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -36,59 +116,55 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x290, %rsp            # imm = 0x290
-               	movq	%rbx, -0x278(%rbp)
-               	movq	%r12, -0x280(%rbp)
-               	movq	%r13, -0x288(%rbp)
-               	movq	%r14, -0x290(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x1b0, %rsp            # imm = 0x1B0
+               	movq	%rbx, -0x198(%rbp)
+               	movq	%r12, -0x1a0(%rbp)
+               	movq	%r13, -0x1a8(%rbp)
+               	movq	%r14, -0x1b0(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rsi
-               	movl	$0x3fc00000, (%rsi)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x73>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x7a>
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	leaq	0x8(%rcx), %rsi
-               	movl	$0x40700000, (%rsi)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x94>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x9b>
-               	leaq	0xc(%rcx), %rsi
-               	movss	%xmm1, (%rsi)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+<L1>:
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x68>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x6f>
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	$0x40700000, (%rdi)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x89>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x4.checksum+0x90>
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	movups	(%rsi), %xmm1
+               	leaq	-0x90(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	-0xa0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rsi), %rbx
+               	leaq	0x4(%rdi), %rbx
                	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xcc>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xd3>
-               	leaq	0x8(%rsi), %rbx
+               	movss	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xc7>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_f32x4.checksum+0xce>
+               	leaq	0x8(%rdi), %rbx
                	movss	%xmm2, (%rbx)
-               	leaq	0xc(%rsi), %rbx
+               	leaq	0xc(%rdi), %rbx
                	movl	$0x41000000, (%rbx)     # imm = 0x41000000
-               	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
+               	movups	(%rdi), %xmm2
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm2, (%rdi)
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movl	$0x3f800000, (%r12)     # imm = 0x3F800000
                	leaq	0x4(%rbx), %r12
@@ -98,418 +174,158 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %r12
                	movl	$0x41d80000, (%r12)     # imm = 0x41D80000
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	(%rcx), %rbx
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	(%rcx), %rbx
+               	leaq	-0xd0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
                	movss	%xmm5, (%rbx)
-               	movups	(%rcx), %xmm1
-               	leaq	0xc(%rcx), %rbx
+               	movups	(%rsi), %xmm1
+               	leaq	0xc(%rsi), %rbx
                	movss	(%rbx), %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x70(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movss	%xmm5, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
-               	leaq	0x4(%rsi), %rcx
-               	movss	(%rcx), %xmm4
-               	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
-               	addss	%xmm0, %xmm5
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movss	%xmm5, (%rsi)
-               	movups	(%rcx), %xmm2
-               	leaq	0x8(%rcx), %rsi
+               	leaq	-0xe0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	0xc(%rsi), %rbx
+               	movss	%xmm5, (%rbx)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	leaq	0x4(%rdi), %rsi
                	movss	(%rsi), %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	addss	%xmm0, %xmm5
-               	leaq	-0x90(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movss	%xmm5, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0xf0(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	0x8(%rsi), %rdi
+               	movss	(%rdi), %xmm4
+               	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
+               	addss	%xmm0, %xmm5
+               	leaq	-0x100(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x130(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x140(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	addps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	subps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	mulps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	divps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	divps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x130(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	addps	-0x220(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	divps	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0x110(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x4(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0x8(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	leaq	0xc(%rdi), %rbx
+               	movl	$0x0, (%rbx)
+               	movups	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x160(%rbp)
+               	movups	%xmm0, -0x170(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x160(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x170(%rbp), %xmm14
+               	addps	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movups	-0x180(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x160(%rbp), %xmm14
+               	subps	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
+               	movups	-0x190(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	subps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	mulps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	divps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	divps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L32>
-<L32>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	movaps	-0x210(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	divps	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L44>
-<L44>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L46>
-<L46>:
-               	movq	%rax, %rcx
-               	leaq	-0x1f0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	movups	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x240(%rbp)
-               	movups	%xmm0, -0x250(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L47>
-               	jmp	 <L60>
-<L47>:
-               	movaps	-0x240(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x230(%rbp)
-               	leaq	-0xa0(%rbp), %r13
-               	movups	-0x230(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-               	movaps	-0x250(%rbp), %xmm14
-               	addps	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0x140(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L54>
-<L54>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rdi
-               	movaps	-0x240(%rbp), %xmm14
-               	subps	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, -0x270(%rbp)
-               	leaq	-0x160(%rbp), %r13
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L56>
-<L56>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L58>
-<L58>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x270(%rbp), %xmm14
-               	movups	%xmm14, -0x240(%rbp)
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, -0x250(%rbp)
+               	movups	-0x190(%rbp), %xmm14
+               	movups	%xmm14, -0x160(%rbp)
+               	movups	-0x180(%rbp), %xmm14
+               	movups	%xmm14, -0x170(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L47>
-<L60>:
-               	leaq	-0xe0(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -518,112 +334,110 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rcx
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	movaps	-0x240(%rbp), %xmm14
-               	addps	-0x220(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movaps	-0x160(%rbp), %xmm14
+               	addps	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	movaps	-0x240(%rbp), %xmm14
-               	mulps	-0x200(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movups	%xmm0, (%rsi)
+               	movaps	-0x160(%rbp), %xmm14
+               	mulps	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm4, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movups	%xmm4, (%rsi)
+               	leaq	0x30(%r12), %rsi
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L61>
-               	jmp	 <L66>
-<L61>:
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	-0xf0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%r13, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L64>
-<L64>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L61>
-<L66>:
-               	leaq	-0x120(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r12), %rdi
+               	movups	(%rdi), %xmm0
+               	leaq	0x10(%r13), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x20(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r13), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-               	movups	(%r12), %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L70>
-<L70>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L72>
-<L72>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x278(%rbp), %rbx
-               	movq	-0x280(%rbp), %r12
-               	movq	-0x288(%rbp), %r13
-               	movq	-0x290(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0x20(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x198(%rbp), %rbx
+               	movq	-0x1a0(%rbp), %r12
+               	movq	-0x1a8(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f32x5.dis
+++ b/test/golden/x86_64-linux/vec/vec_f32x5.dis
@@ -7,39 +7,137 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0xa0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x34(%rbp), %rcx
-               	leaq	-0x48(%rbp), %rcx
-               	leaq	-0x5c(%rbp), %rcx
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	-0x84(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0xa0(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x34(%rbp), %rax
+               	leaq	-0x48(%rbp), %rax
+               	leaq	-0x5c(%rbp), %rax
+               	leaq	-0x70(%rbp), %rax
+               	leaq	-0x84(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -47,1992 +145,1449 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x5.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xd80, %rsp            # imm = 0xD80
-               	movq	%rbx, -0xd58(%rbp)
-               	movq	%r12, -0xd60(%rbp)
-               	movq	%r13, -0xd68(%rbp)
-               	movq	%r14, -0xd70(%rbp)
-               	movq	%r15, -0xd78(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	-0x14(%rbp), %r12
-               	leaq	-0x28(%rbp), %r13
-               	leaq	-0x3c(%rbp), %r14
-               	leaq	-0x50(%rbp), %rcx
-               	leaq	-0x64(%rbp), %rcx
-               	leaq	-0x78(%rbp), %r15
-               	leaq	-0x8c(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xb4(%rbp), %r8
-               	movq	%r8, -0xd40(%rbp)
-               	leaq	-0xc8(%rbp), %rdx
-               	leaq	-0xdc(%rbp), %rdx
-               	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0xd48(%rbp)
-               	leaq	-0x104(%rbp), %rsi
-               	leaq	-0x118(%rbp), %rsi
-               	leaq	-0x12c(%rbp), %rsi
-               	leaq	-0x140(%rbp), %rsi
-               	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0xd50(%rbp)
-               	leaq	-0x168(%rbp), %rdi
-               	leaq	-0x17c(%rbp), %rdi
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0xcb0(%rbp)
+               	subq	$0x740, %rsp            # imm = 0x740
+               	movq	%rbx, -0x718(%rbp)
+               	movq	%r12, -0x720(%rbp)
+               	movq	%r13, -0x728(%rbp)
+               	movq	%r14, -0x730(%rbp)
+               	movq	%r15, -0x738(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x668(%rbp)
+               	leaq	-0x14(%rbp), %rax
+               	leaq	-0x28(%rbp), %r8
+               	movq	%r8, -0x6f8(%rbp)
+               	leaq	-0x3c(%rbp), %rbx
+               	leaq	-0x50(%rbp), %rsi
+               	leaq	-0x64(%rbp), %rsi
+               	leaq	-0x78(%rbp), %rsi
+               	leaq	-0x8c(%rbp), %r12
+               	leaq	-0xa0(%rbp), %r12
+               	leaq	-0xb4(%rbp), %r12
+               	leaq	-0xc8(%rbp), %r13
+               	leaq	-0xdc(%rbp), %r13
+               	leaq	-0xf0(%rbp), %r13
+               	leaq	-0x104(%rbp), %r14
+               	leaq	-0x118(%rbp), %r14
+               	leaq	-0x12c(%rbp), %r14
+               	leaq	-0x140(%rbp), %r14
+               	leaq	-0x154(%rbp), %r14
+               	leaq	-0x168(%rbp), %r15
+               	leaq	-0x17c(%rbp), %r15
+               	leaq	-0x190(%rbp), %r15
                	leaq	-0x1a4(%rbp), %rdi
                	leaq	-0x1b8(%rbp), %rdi
                	leaq	-0x1cc(%rbp), %r8
-               	movq	%r8, -0xcb8(%rbp)
+               	movq	%r8, -0x670(%rbp)
                	leaq	-0x1e0(%rbp), %rdi
                	leaq	-0x1f4(%rbp), %rdi
                	leaq	-0x208(%rbp), %r8
-               	movq	%r8, -0xcc0(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	-0x21c(%rbp), %rdi
                	leaq	-0x230(%rbp), %rdi
                	leaq	-0x244(%rbp), %r8
-               	movq	%r8, -0xcc8(%rbp)
+               	movq	%r8, -0x680(%rbp)
                	leaq	-0x258(%rbp), %rdi
                	leaq	-0x26c(%rbp), %rdi
                	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0xcd0(%rbp)
+               	movq	%r8, -0x688(%rbp)
                	leaq	-0x294(%rbp), %rdi
                	leaq	-0x2a8(%rbp), %rdi
                	leaq	-0x2bc(%rbp), %r8
-               	movq	%r8, -0xcd8(%rbp)
+               	movq	%r8, -0x690(%rbp)
                	leaq	-0x2d0(%rbp), %rdi
                	leaq	-0x2e4(%rbp), %rdi
                	leaq	-0x2f8(%rbp), %r8
-               	movq	%r8, -0xce0(%rbp)
+               	movq	%r8, -0x698(%rbp)
                	leaq	-0x30c(%rbp), %rdi
                	leaq	-0x320(%rbp), %rdi
                	leaq	-0x334(%rbp), %r8
-               	movq	%r8, -0xce8(%rbp)
+               	movq	%r8, -0x6a0(%rbp)
                	leaq	-0x348(%rbp), %r8
-               	movq	%r8, -0xcf0(%rbp)
+               	movq	%r8, -0x6a8(%rbp)
                	leaq	-0x35c(%rbp), %rdi
                	leaq	-0x370(%rbp), %rdi
                	leaq	-0x384(%rbp), %r8
-               	movq	%r8, -0xcf8(%rbp)
+               	movq	%r8, -0x6b0(%rbp)
                	leaq	-0x398(%rbp), %rdi
                	leaq	-0x3ac(%rbp), %rdi
                	leaq	-0x3c0(%rbp), %rdi
                	leaq	-0x3d4(%rbp), %r8
-               	movq	%r8, -0xd00(%rbp)
+               	movq	%r8, -0x6b8(%rbp)
                	leaq	-0x3e8(%rbp), %rdi
                	leaq	-0x3fc(%rbp), %rdi
                	leaq	-0x410(%rbp), %rdi
                	leaq	-0x424(%rbp), %r8
-               	movq	%r8, -0xd08(%rbp)
+               	movq	%r8, -0x6c0(%rbp)
                	leaq	-0x438(%rbp), %rdi
                	leaq	-0x44c(%rbp), %rdi
                	leaq	-0x460(%rbp), %rdi
                	leaq	-0x474(%rbp), %rdi
                	leaq	-0x488(%rbp), %r8
-               	movq	%r8, -0xd10(%rbp)
+               	movq	%r8, -0x6c8(%rbp)
                	leaq	-0x49c(%rbp), %rdi
                	leaq	-0x4b0(%rbp), %rdi
                	leaq	-0x4c4(%rbp), %r8
-               	movq	%r8, -0xd18(%rbp)
+               	movq	%r8, -0x6d0(%rbp)
                	leaq	-0x4d8(%rbp), %rdi
                	leaq	-0x4ec(%rbp), %rdi
                	leaq	-0x500(%rbp), %rdi
                	leaq	-0x514(%rbp), %r8
-               	movq	%r8, -0xd20(%rbp)
+               	movq	%r8, -0x6d8(%rbp)
                	leaq	-0x528(%rbp), %rdi
                	leaq	-0x53c(%rbp), %r8
-               	movq	%r8, -0xd28(%rbp)
+               	movq	%r8, -0x6e0(%rbp)
                	leaq	-0x550(%rbp), %r8
-               	movq	%r8, -0xd30(%rbp)
+               	movq	%r8, -0x6e8(%rbp)
                	leaq	-0x564(%rbp), %r8
-               	movq	%r8, -0xd38(%rbp)
-               	leaq	-0x578(%rbp), %rdi
-               	leaq	-0x58c(%rbp), %rdi
-               	leaq	-0x5a0(%rbp), %rdi
-               	leaq	-0x5b4(%rbp), %rdi
-               	leaq	-0x5c8(%rbp), %rdi
-               	leaq	-0x5dc(%rbp), %rdi
-               	leaq	-0x5f0(%rbp), %rdi
-               	leaq	-0x604(%rbp), %rdi
-               	leaq	-0x618(%rbp), %rdi
-               	leaq	-0x62c(%rbp), %rdi
-               	leaq	-0x640(%rbp), %rdi
-               	leaq	-0x654(%rbp), %rdi
-               	leaq	-0x668(%rbp), %rdi
-               	leaq	-0x67c(%rbp), %rdi
-               	leaq	-0x690(%rbp), %rdi
-               	leaq	-0x6a4(%rbp), %rdi
-               	leaq	-0x6b8(%rbp), %rdi
-               	leaq	-0x6cc(%rbp), %rdi
-               	leaq	-0x6e0(%rbp), %rdi
-               	leaq	-0x6f4(%rbp), %rdi
-               	leaq	-0x708(%rbp), %rdi
-               	leaq	-0x71c(%rbp), %rdi
-               	leaq	-0x730(%rbp), %rdi
-               	leaq	-0x744(%rbp), %rdi
-               	leaq	-0x758(%rbp), %rdi
-               	leaq	-0x76c(%rbp), %rdi
-               	leaq	-0x780(%rbp), %rdi
-               	leaq	-0x794(%rbp), %rdi
-               	leaq	-0x7a8(%rbp), %rdi
-               	leaq	-0x7bc(%rbp), %rdi
-               	leaq	-0x7d0(%rbp), %rdi
-               	leaq	-0x7e4(%rbp), %rdi
-               	leaq	-0x7f8(%rbp), %rdi
-               	leaq	-0x80c(%rbp), %rdi
-               	leaq	-0x820(%rbp), %rdi
-               	leaq	-0x834(%rbp), %rdi
-               	leaq	-0x848(%rbp), %rdi
-               	leaq	-0x85c(%rbp), %rdi
-               	leaq	-0x870(%rbp), %rdi
-               	leaq	-0x884(%rbp), %rdi
-               	leaq	-0x898(%rbp), %rdi
-               	leaq	-0x8ac(%rbp), %rdi
-               	leaq	-0x8c0(%rbp), %rdi
-               	leaq	-0x8d4(%rbp), %rdi
-               	leaq	-0x8e8(%rbp), %rdi
-               	leaq	-0x8fc(%rbp), %rdi
-               	leaq	-0x910(%rbp), %rdi
-               	leaq	-0x924(%rbp), %rdi
-               	leaq	-0x938(%rbp), %rdi
-               	leaq	-0x94c(%rbp), %rdi
-               	leaq	-0x960(%rbp), %rdi
-               	leaq	-0x974(%rbp), %rdi
-               	leaq	-0x988(%rbp), %rdi
-               	leaq	-0x99c(%rbp), %rdi
-               	leaq	-0x9b0(%rbp), %rdi
-               	leaq	-0x9c4(%rbp), %rdi
-               	leaq	-0x9d8(%rbp), %rdi
-               	leaq	-0x9ec(%rbp), %rdi
-               	leaq	-0xa00(%rbp), %rdi
-               	leaq	-0xa14(%rbp), %rdi
-               	leaq	-0xa28(%rbp), %rdi
-               	leaq	-0xa3c(%rbp), %rdi
-               	leaq	-0xa50(%rbp), %rdi
-               	leaq	-0xa64(%rbp), %rdi
-               	leaq	-0xa78(%rbp), %rdi
-               	leaq	-0xa8c(%rbp), %rdi
-               	leaq	-0xaa0(%rbp), %rdi
-               	leaq	-0xab4(%rbp), %rdi
-               	leaq	-0xac8(%rbp), %rdi
-               	leaq	-0xadc(%rbp), %rdi
-               	leaq	-0xaf0(%rbp), %rdi
-               	leaq	-0xb04(%rbp), %rdi
-               	leaq	-0xb18(%rbp), %rdi
-               	leaq	-0xb2c(%rbp), %rdi
-               	leaq	-0xb40(%rbp), %rdi
-               	leaq	-0xb54(%rbp), %rdi
-               	leaq	-0xb68(%rbp), %rdi
-               	leaq	-0xb7c(%rbp), %rdi
-               	leaq	-0xb90(%rbp), %rdi
-               	leaq	-0xba4(%rbp), %rdi
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x668(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x624(%rbp), %rdi
+               	leaq	(%rdi), %rdx
+               	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2d2>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2d9>
+               	leaq	0x4(%rdi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movl	$0x40700000, (%rdx)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2f3>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x2fa>
+               	leaq	0xc(%rdi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movl	$0x40c80000, (%rdx)     # imm = 0x40C80000
+               	leaq	(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x4(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0xc(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rdi), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rax), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x638(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x3f000000, (%rdi)     # imm = 0x3F000000
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x40800000, (%rdi)     # imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x37c>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x383>
+               	leaq	0x8(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x41000000, (%rdi)     # imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x39d>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x3a4>
+               	leaq	0x10(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	-0x64c(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x3f800000, (%rdi)     # imm = 0x3F800000
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x40400000, (%rdi)     # imm = 0x40400000
+               	leaq	0x8(%rdx), %rdi
+               	movl	$0x41100000, (%rdi)     # imm = 0x41100000
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x41d80000, (%rdi)     # imm = 0x41D80000
+               	leaq	0x10(%rdx), %rdi
+               	movl	$0x42a20000, (%rdi)     # imm = 0x42A20000
+               	leaq	(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x8(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0xc(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rdx), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x10(%rbx), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x4(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x8(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0xc(%rsi), %rdx
+               	movss	%xmm1, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm1
+               	leaq	0x10(%rsi), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	(%rsi), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x4(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x8(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0xc(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm2, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0x6f8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%r13), %rax
+               	movss	%xmm2, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	%r12, %rsi
+               	callq	 <L2>
 <L2>:
-               	leaq	-0xbb8(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3fc00000, (%rbx)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x50e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x515>
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x40700000, (%rbx)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x52f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x536>
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x40c80000, (%rbx)     # imm = 0x40C80000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0xbcc(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5bd>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5c4>
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41000000, (%rbx)     # imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5de>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x5.checksum+0x5e5>
-               	leaq	0x10(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r13), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0xbe0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f800000, (%rbx)     # imm = 0x3F800000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40400000, (%rbx)     # imm = 0x40400000
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x41100000, (%rbx)     # imm = 0x41100000
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41d80000, (%rbx)     # imm = 0x41D80000
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x42a20000, (%rbx)     # imm = 0x42A20000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r14), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	movq	%r13, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r14), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r14), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
                	callq	 <L4>
 <L4>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x688(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x690(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x690(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x698(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x698(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x6a0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0xd50(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	-0x660(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x6a8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %r14
+               	movq	-0x6a8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	%r14, %rdi
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6b8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x6b8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	-0xd50(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rax, %r14
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	-0x6c0(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0x6b8(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x700(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
 <L17>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
+               	leaq	-0x5e0(%rbp), %r8
+               	movq	%r8, -0x708(%rbp)
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x78, %rsi
 <L18>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movq	-0xcb0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0xcb8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0xcc0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0xcc8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0xcd0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0xcd8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xce0(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	movq	-0xce0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x4(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x8(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0xc(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	leaq	0x10(%r14), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	-0xd40(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	-0xce8(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movq	-0xce8(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	-0xca4(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xcf0(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L18>
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	leaq	(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
                	movss	%xmm0, (%rsi)
-               	movq	%rax, %rbx
-               	movq	-0xd40(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0xcf0(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L58>
-               	jmp	 <L74>
-<L58>:
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xcf8(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd00(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0xd00(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0xd08(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0xd08(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	addq	$0x1, %r15
-               	movq	%rax, %rbx
-               	movq	-0xd08(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0xd00(%rbp), %r8
-               	movq	%r8, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L58>
-<L74>:
-               	leaq	-0xc60(%rbp), %r15
-               	leaq	(%r15), %rax
-               	addq	$0x0, %rax
-               	movq	$0x78, %rcx
-<L75>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L75>
-               	leaq	(%r15), %rax
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r15), %rax
-               	movq	-0xd10(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd10(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x28(%r15), %rax
-               	movq	-0xd18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x3c(%r15), %rax
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x50(%r15), %rax
-               	movq	-0xd20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x64(%r15), %rax
-               	movq	-0xd48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L76>
-               	jmp	 <L82>
-<L76>:
-               	movq	%r12, %rax
-               	imulq	$0x14, %rax, %rax
-               	leaq	(%r15,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	movq	-0xd28(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0xd28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x6, %r12
-               	jb	 <L76>
-<L82>:
-               	leaq	-0xc90(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x28(%r15), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	0x4(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6c8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x28(%r8), %rdx
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x3c(%r8), %rdx
+               	leaq	(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x50(%r8), %rdx
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x64(%r8), %rdx
+               	leaq	(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r13), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	$0x0, %rbx
+               	cmpq	$0x6, %rbx
+               	jb	 <L19>
+               	jmp	 <L21>
+<L19>:
+               	movq	%rbx, %rdx
+               	imulq	$0x14, %rdx, %rdx
+               	movq	-0x708(%rbp), %r8
+               	leaq	(%r8,%rdx), %rsi
+               	leaq	(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6e0(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %r13
-               	movq	-0xd30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%r12), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L83>
-<L83>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0xd38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0xd38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	leaq	0x24(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
-               	movq	-0xd58(%rbp), %rbx
-               	movq	-0xd60(%rbp), %r12
-               	movq	-0xd68(%rbp), %r13
-               	movq	-0xd70(%rbp), %r14
-               	movq	-0xd78(%rbp), %r15
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%r14, %rdi
+               	movq	-0x6e0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L20>
+<L20>:
+               	movq	%rax, %r14
+               	addq	$0x1, %rbx
+               	cmpq	$0x6, %rbx
+               	jb	 <L19>
+<L21>:
+               	leaq	-0x610(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	movq	$0x0, 0x18(%rbx)
+               	movq	$0x0, 0x20(%rbx)
+               	movq	$0x0, 0x28(%rbx)
+               	leaq	(%rbx), %rdx
+               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
+               	movq	-0x708(%rbp), %r8
+               	leaq	0x28(%r8), %rsi
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rbx), %rax
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x6e8(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x24(%rbx), %rax
+               	movl	$0x12345678, (%rax)     # imm = 0x12345678
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r14, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r14
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+<L23>:
+               	leaq	0x10(%rbx), %rax
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x6f0(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r14, %rdi
+               	movq	-0x6f0(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L24>
+<L24>:
+               	leaq	0x24(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+<L26>:
+               	movq	-0x718(%rbp), %rbx
+               	movq	-0x720(%rbp), %r12
+               	movq	-0x728(%rbp), %r13
+               	movq	-0x730(%rbp), %r14
+               	movq	-0x738(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f32x8.dis
+++ b/test/golden/x86_64-linux/vec/vec_f32x8.dis
@@ -7,57 +7,212 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x130, %rsp            # imm = 0x130
                	movq	%rbx, -0x128(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x40(%rbp), %rcx
-               	leaq	-0x60(%rbp), %rcx
-               	leaq	-0x80(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xc0(%rbp), %rcx
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	-0x120(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x130(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x40(%rbp), %rax
+               	leaq	-0x60(%rbp), %rax
+               	leaq	-0x80(%rbp), %rax
+               	leaq	-0xa0(%rbp), %rax
+               	leaq	-0xc0(%rbp), %rax
+               	leaq	-0xe0(%rbp), %rax
+               	leaq	-0x100(%rbp), %rax
+               	leaq	-0x120(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x14(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L5>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x18(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L6>
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x1c(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L7>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
 <L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L10>
+<L11>:
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L12>
+<L13>:
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x128(%rbp), %rbx
+               	movq	-0x130(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -65,2952 +220,2016 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1aa0, %rsp           # imm = 0x1AA0
-               	movq	%rbx, -0x1a78(%rbp)
-               	movq	%r12, -0x1a80(%rbp)
-               	movq	%r13, -0x1a88(%rbp)
-               	movq	%r14, -0x1a90(%rbp)
-               	movq	%r15, -0x1a98(%rbp)
-               	movq	%rdi, %rbx
-               	leaq	-0x20(%rbp), %r12
-               	leaq	-0x40(%rbp), %r13
-               	leaq	-0x60(%rbp), %r14
-               	leaq	-0x80(%rbp), %rcx
-               	leaq	-0xa0(%rbp), %rcx
-               	leaq	-0xc0(%rbp), %r15
-               	leaq	-0xe0(%rbp), %rcx
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	-0x120(%rbp), %r8
-               	movq	%r8, -0x1a58(%rbp)
-               	leaq	-0x140(%rbp), %rdx
-               	leaq	-0x160(%rbp), %rdx
+               	subq	$0xaa0, %rsp            # imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x9c8(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
+               	leaq	-0xc0(%rbp), %rsi
+               	leaq	-0xe0(%rbp), %r12
+               	leaq	-0x100(%rbp), %r12
+               	leaq	-0x120(%rbp), %r12
+               	leaq	-0x140(%rbp), %r13
+               	leaq	-0x160(%rbp), %r13
                	leaq	-0x180(%rbp), %r8
-               	movq	%r8, -0x1a60(%rbp)
-               	leaq	-0x1a0(%rbp), %rsi
-               	leaq	-0x1c0(%rbp), %rsi
-               	leaq	-0x1e0(%rbp), %r8
-               	movq	%r8, -0x1a68(%rbp)
-               	leaq	-0x200(%rbp), %rdi
-               	leaq	-0x220(%rbp), %rdi
-               	leaq	-0x240(%rbp), %rdi
-               	leaq	-0x260(%rbp), %rdi
-               	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0x19c8(%rbp)
+               	movq	%r8, -0xa58(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	leaq	-0x1c0(%rbp), %r14
+               	leaq	-0x1e0(%rbp), %r14
+               	leaq	-0x200(%rbp), %r15
+               	leaq	-0x220(%rbp), %r15
+               	leaq	-0x240(%rbp), %r15
+               	leaq	-0x260(%rbp), %r15
+               	leaq	-0x280(%rbp), %r15
                	leaq	-0x2a0(%rbp), %rdi
                	leaq	-0x2c0(%rbp), %rdi
                	leaq	-0x2e0(%rbp), %r8
-               	movq	%r8, -0x19d0(%rbp)
+               	movq	%r8, -0x9d0(%rbp)
                	leaq	-0x300(%rbp), %rdi
                	leaq	-0x320(%rbp), %rdi
                	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x19d8(%rbp)
+               	movq	%r8, -0x9d8(%rbp)
                	leaq	-0x360(%rbp), %rdi
                	leaq	-0x380(%rbp), %rdi
                	leaq	-0x3a0(%rbp), %r8
-               	movq	%r8, -0x19e0(%rbp)
+               	movq	%r8, -0x9e0(%rbp)
                	leaq	-0x3c0(%rbp), %rdi
                	leaq	-0x3e0(%rbp), %rdi
                	leaq	-0x400(%rbp), %r8
-               	movq	%r8, -0x19e8(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	leaq	-0x420(%rbp), %rdi
                	leaq	-0x440(%rbp), %rdi
                	leaq	-0x460(%rbp), %r8
-               	movq	%r8, -0x19f0(%rbp)
+               	movq	%r8, -0x9f0(%rbp)
                	leaq	-0x480(%rbp), %rdi
                	leaq	-0x4a0(%rbp), %rdi
                	leaq	-0x4c0(%rbp), %r8
-               	movq	%r8, -0x19f8(%rbp)
+               	movq	%r8, -0x9f8(%rbp)
                	leaq	-0x4e0(%rbp), %rdi
                	leaq	-0x500(%rbp), %rdi
                	leaq	-0x520(%rbp), %r8
-               	movq	%r8, -0x1a00(%rbp)
+               	movq	%r8, -0xa00(%rbp)
                	leaq	-0x540(%rbp), %rdi
                	leaq	-0x560(%rbp), %rdi
                	leaq	-0x580(%rbp), %r8
-               	movq	%r8, -0x1a08(%rbp)
+               	movq	%r8, -0xa08(%rbp)
                	leaq	-0x5a0(%rbp), %r8
-               	movq	%r8, -0x1a10(%rbp)
+               	movq	%r8, -0xa10(%rbp)
                	leaq	-0x5c0(%rbp), %rdi
                	leaq	-0x5e0(%rbp), %rdi
                	leaq	-0x600(%rbp), %r8
-               	movq	%r8, -0x1a18(%rbp)
+               	movq	%r8, -0xa18(%rbp)
                	leaq	-0x620(%rbp), %rdi
                	leaq	-0x640(%rbp), %rdi
                	leaq	-0x660(%rbp), %rdi
                	leaq	-0x680(%rbp), %r8
-               	movq	%r8, -0x1a20(%rbp)
+               	movq	%r8, -0xa20(%rbp)
                	leaq	-0x6a0(%rbp), %rdi
                	leaq	-0x6c0(%rbp), %rdi
                	leaq	-0x6e0(%rbp), %rdi
                	leaq	-0x700(%rbp), %r8
-               	movq	%r8, -0x1a28(%rbp)
+               	movq	%r8, -0xa28(%rbp)
                	leaq	-0x720(%rbp), %rdi
                	leaq	-0x740(%rbp), %rdi
                	leaq	-0x760(%rbp), %rdi
                	leaq	-0x780(%rbp), %rdi
                	leaq	-0x7a0(%rbp), %r8
-               	movq	%r8, -0x1a30(%rbp)
+               	movq	%r8, -0xa30(%rbp)
                	leaq	-0x7c0(%rbp), %rdi
                	leaq	-0x7e0(%rbp), %rdi
                	leaq	-0x800(%rbp), %r8
-               	movq	%r8, -0x1a38(%rbp)
+               	movq	%r8, -0xa38(%rbp)
                	leaq	-0x820(%rbp), %rdi
                	leaq	-0x840(%rbp), %r8
-               	movq	%r8, -0x1a40(%rbp)
+               	movq	%r8, -0xa40(%rbp)
                	leaq	-0x860(%rbp), %r8
-               	movq	%r8, -0x1a48(%rbp)
+               	movq	%r8, -0xa48(%rbp)
                	leaq	-0x880(%rbp), %r8
-               	movq	%r8, -0x1a50(%rbp)
-               	leaq	-0x8a0(%rbp), %rdi
-               	leaq	-0x8c0(%rbp), %rdi
-               	leaq	-0x8e0(%rbp), %rdi
-               	leaq	-0x900(%rbp), %rdi
-               	leaq	-0x920(%rbp), %rdi
-               	leaq	-0x940(%rbp), %rdi
-               	leaq	-0x960(%rbp), %rdi
-               	leaq	-0x980(%rbp), %rdi
-               	leaq	-0x9a0(%rbp), %rdi
-               	leaq	-0x9c0(%rbp), %rdi
-               	leaq	-0x9e0(%rbp), %rdi
-               	leaq	-0xa00(%rbp), %rdi
-               	leaq	-0xa20(%rbp), %rdi
-               	leaq	-0xa40(%rbp), %rdi
-               	leaq	-0xa60(%rbp), %rdi
-               	leaq	-0xa80(%rbp), %rdi
-               	leaq	-0xaa0(%rbp), %rdi
-               	leaq	-0xac0(%rbp), %rdi
-               	leaq	-0xae0(%rbp), %rdi
-               	leaq	-0xb00(%rbp), %rdi
-               	leaq	-0xb20(%rbp), %rdi
-               	leaq	-0xb40(%rbp), %rdi
-               	leaq	-0xb60(%rbp), %rdi
-               	leaq	-0xb80(%rbp), %rdi
-               	leaq	-0xba0(%rbp), %rdi
-               	leaq	-0xbc0(%rbp), %rdi
-               	leaq	-0xbe0(%rbp), %rdi
-               	leaq	-0xc00(%rbp), %rdi
-               	leaq	-0xc20(%rbp), %rdi
-               	leaq	-0xc40(%rbp), %rdi
-               	leaq	-0xc60(%rbp), %rdi
-               	leaq	-0xc80(%rbp), %rdi
-               	leaq	-0xca0(%rbp), %rdi
-               	leaq	-0xcc0(%rbp), %rdi
-               	leaq	-0xce0(%rbp), %rdi
-               	leaq	-0xd00(%rbp), %rdi
-               	leaq	-0xd20(%rbp), %rdi
-               	leaq	-0xd40(%rbp), %rdi
-               	leaq	-0xd60(%rbp), %rdi
-               	leaq	-0xd80(%rbp), %rdi
-               	leaq	-0xda0(%rbp), %rdi
-               	leaq	-0xdc0(%rbp), %rdi
-               	leaq	-0xde0(%rbp), %rdi
-               	leaq	-0xe00(%rbp), %rdi
-               	leaq	-0xe20(%rbp), %rdi
-               	leaq	-0xe40(%rbp), %rdi
-               	leaq	-0xe60(%rbp), %rdi
-               	leaq	-0xe80(%rbp), %rdi
-               	leaq	-0xea0(%rbp), %rdi
-               	leaq	-0xec0(%rbp), %rdi
-               	leaq	-0xee0(%rbp), %rdi
-               	leaq	-0xf00(%rbp), %rdi
-               	leaq	-0xf20(%rbp), %rdi
-               	leaq	-0xf40(%rbp), %rdi
-               	leaq	-0xf60(%rbp), %rdi
-               	leaq	-0xf80(%rbp), %rdi
-               	leaq	-0xfa0(%rbp), %rdi
-               	leaq	-0xfc0(%rbp), %rdi
-               	leaq	-0xfe0(%rbp), %rdi
-               	leaq	-0x1000(%rbp), %rdi
-               	leaq	-0x1020(%rbp), %rdi
-               	leaq	-0x1040(%rbp), %rdi
-               	leaq	-0x1060(%rbp), %rdi
-               	leaq	-0x1080(%rbp), %rdi
-               	leaq	-0x10a0(%rbp), %rdi
-               	leaq	-0x10c0(%rbp), %rdi
-               	leaq	-0x10e0(%rbp), %rdi
-               	leaq	-0x1100(%rbp), %rdi
-               	leaq	-0x1120(%rbp), %rdi
-               	leaq	-0x1140(%rbp), %rdi
-               	leaq	-0x1160(%rbp), %rdi
-               	leaq	-0x1180(%rbp), %rdi
-               	leaq	-0x11a0(%rbp), %rdi
-               	leaq	-0x11c0(%rbp), %rdi
-               	leaq	-0x11e0(%rbp), %rdi
-               	leaq	-0x1200(%rbp), %rdi
-               	leaq	-0x1220(%rbp), %rdi
-               	leaq	-0x1240(%rbp), %rdi
-               	leaq	-0x1260(%rbp), %rdi
-               	leaq	-0x1280(%rbp), %rdi
-               	leaq	-0x12a0(%rbp), %rdi
-               	leaq	-0x12c0(%rbp), %rdi
-               	leaq	-0x12e0(%rbp), %rdi
-               	leaq	-0x1300(%rbp), %rdi
-               	leaq	-0x1320(%rbp), %rdi
-               	leaq	-0x1340(%rbp), %rdi
-               	leaq	-0x1360(%rbp), %rdi
-               	leaq	-0x1380(%rbp), %rdi
-               	leaq	-0x13a0(%rbp), %rdi
-               	leaq	-0x13c0(%rbp), %rdi
-               	leaq	-0x13e0(%rbp), %rdi
-               	leaq	-0x1400(%rbp), %rdi
-               	leaq	-0x1420(%rbp), %rdi
-               	leaq	-0x1440(%rbp), %rdi
-               	leaq	-0x1460(%rbp), %rdi
-               	leaq	-0x1480(%rbp), %rdi
-               	leaq	-0x14a0(%rbp), %rdi
-               	leaq	-0x14c0(%rbp), %rdi
-               	leaq	-0x14e0(%rbp), %rdi
-               	leaq	-0x1500(%rbp), %rdi
-               	leaq	-0x1520(%rbp), %rdi
-               	leaq	-0x1540(%rbp), %rdi
-               	leaq	-0x1560(%rbp), %rdi
-               	leaq	-0x1580(%rbp), %rdi
-               	leaq	-0x15a0(%rbp), %rdi
-               	leaq	-0x15c0(%rbp), %rdi
-               	leaq	-0x15e0(%rbp), %rdi
-               	leaq	-0x1600(%rbp), %rdi
-               	leaq	-0x1620(%rbp), %rdi
-               	leaq	-0x1640(%rbp), %rdi
-               	leaq	-0x1660(%rbp), %rdi
-               	leaq	-0x1680(%rbp), %rdi
-               	leaq	-0x16a0(%rbp), %rdi
-               	leaq	-0x16c0(%rbp), %rdi
-               	leaq	-0x16e0(%rbp), %rdi
-               	leaq	-0x1700(%rbp), %rdi
-               	leaq	-0x1720(%rbp), %rdi
-               	leaq	-0x1740(%rbp), %rdi
-               	leaq	-0x1760(%rbp), %rdi
-               	leaq	-0x1780(%rbp), %rdi
-               	leaq	-0x17a0(%rbp), %rdi
-               	leaq	-0x17c0(%rbp), %rdi
-               	leaq	-0x17e0(%rbp), %rdi
-               	leaq	-0x1800(%rbp), %rdi
-               	leaq	-0x1820(%rbp), %rdi
-               	leaq	-0x1840(%rbp), %rdi
-               	leaq	-0x1860(%rbp), %rdi
-               	leaq	-0x1880(%rbp), %rdi
-               	callq	 <L0>
-<L0>:
-               	movq	%rbx, %r11
+               	movq	%r8, -0xa50(%rbp)
+               	movq	-0x9c8(%rbp), %r8
+               	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
+<L1>:
+               	leaq	-0x960(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3fc00000, (%r13)     # imm = 0x3FC00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2d3>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2da>
+               	leaq	0x4(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movl	$0x40700000, (%r13)     # imm = 0x40700000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2f8>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x2ff>
+               	leaq	0xc(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movl	$0x40c80000, (%r13)     # imm = 0x40C80000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x31d>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x324>
+               	leaq	0x14(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movl	$0x3f400000, (%r13)     # imm = 0x3F400000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x342>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x349>
+               	leaq	0x1c(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rax), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rax), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	-0x980(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3f000000, (%r13)     # imm = 0x3F000000
+               	leaq	0x4(%rdi), %r13
+               	movl	$0x40800000, (%r13)     # imm = 0x40800000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x415>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x41c>
+               	leaq	0x8(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movl	$0x41000000, (%r13)     # imm = 0x41000000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x43a>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x441>
+               	leaq	0x10(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movl	$0x3fa00000, (%r13)     # imm = 0x3FA00000
+               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x45f>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x466>
+               	leaq	0x18(%rdi), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movl	$0x3d800000, (%r13)     # imm = 0x3D800000
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rdx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rdx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	-0x9a0(%rbp), %rdi
+               	leaq	(%rdi), %r13
+               	movl	$0x3f800000, (%r13)     # imm = 0x3F800000
+               	leaq	0x4(%rdi), %r13
+               	movl	$0x40400000, (%r13)     # imm = 0x40400000
+               	leaq	0x8(%rdi), %r13
+               	movl	$0x41100000, (%r13)     # imm = 0x41100000
+               	leaq	0xc(%rdi), %r13
+               	movl	$0x41d80000, (%r13)     # imm = 0x41D80000
+               	leaq	0x10(%rdi), %r13
+               	movl	$0x42a20000, (%r13)     # imm = 0x42A20000
+               	leaq	0x14(%rdi), %r13
+               	movl	$0x43730000, (%r13)     # imm = 0x43730000
+               	leaq	0x18(%rdi), %r13
+               	movl	$0x44364000, (%r13)     # imm = 0x44364000
+               	leaq	0x1c(%rdi), %r13
+               	movl	$0x4508b000, (%r13)     # imm = 0x4508B000
+               	leaq	(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x4(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x4(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x8(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x8(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0xc(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0xc(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x10(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x10(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x14(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x14(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x18(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x18(%rbx), %r13
+               	movss	%xmm1, (%r13)
+               	leaq	0x1c(%rdi), %r13
+               	movss	(%r13), %xmm1
+               	leaq	0x1c(%rbx), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x4(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x8(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0xc(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0xc(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x10(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x10(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x14(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x14(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x18(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x18(%rsi), %rdi
+               	movss	%xmm1, (%rdi)
+               	leaq	0x1c(%rax), %rdi
+               	movss	(%rdi), %xmm1
+               	leaq	0x1c(%rsi), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	(%rsi), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x4(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x8(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0xc(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x10(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x14(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x18(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm1
+               	leaq	0x1c(%r12), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%r12), %rax
+               	movss	%xmm2, (%rax)
+               	leaq	0xc(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	leaq	(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x4(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x8(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0xc(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x10(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x14(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x18(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	leaq	0x1c(%rdx), %rax
+               	movss	(%rax), %xmm1
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm1, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm2, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm1
+               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
+               	addss	%xmm0, %xmm2
+               	movq	-0xa58(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x10(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x14(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x18(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	movq	-0xa58(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x1c(%r14), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%r14), %rax
+               	movss	%xmm2, (%rax)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movq	%r12, %rsi
+               	callq	 <L2>
 <L2>:
-               	leaq	-0x18a0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3fc00000, (%rbx)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x65d>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x664>
-               	leaq	0x4(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x40700000, (%rbx)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x67e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x685>
-               	leaq	0xc(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x40c80000, (%rbx)     # imm = 0x40C80000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x69f>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6a6>
-               	leaq	0x14(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movl	$0x3f400000, (%rbx)     # imm = 0x3F400000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6c0>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x6c7>
-               	leaq	0x1c(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r12), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r12), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0x18c0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f000000, (%rbx)     # imm = 0x3F000000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40800000, (%rbx)     # imm = 0x40800000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x777>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x77e>
-               	leaq	0x8(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41000000, (%rbx)     # imm = 0x41000000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x798>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x79f>
-               	leaq	0x10(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movl	$0x3fa00000, (%rbx)     # imm = 0x3FA00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7b9>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_f32x8.checksum+0x7c0>
-               	leaq	0x18(%rdi), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movl	$0x3d800000, (%rbx)     # imm = 0x3D800000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r13), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r13), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	-0x18e0(%rbp), %rdi
-               	leaq	(%rdi), %rbx
-               	movl	$0x3f800000, (%rbx)     # imm = 0x3F800000
-               	leaq	0x4(%rdi), %rbx
-               	movl	$0x40400000, (%rbx)     # imm = 0x40400000
-               	leaq	0x8(%rdi), %rbx
-               	movl	$0x41100000, (%rbx)     # imm = 0x41100000
-               	leaq	0xc(%rdi), %rbx
-               	movl	$0x41d80000, (%rbx)     # imm = 0x41D80000
-               	leaq	0x10(%rdi), %rbx
-               	movl	$0x42a20000, (%rbx)     # imm = 0x42A20000
-               	leaq	0x14(%rdi), %rbx
-               	movl	$0x43730000, (%rbx)     # imm = 0x43730000
-               	leaq	0x18(%rdi), %rbx
-               	movl	$0x44364000, (%rbx)     # imm = 0x44364000
-               	leaq	0x1c(%rdi), %rbx
-               	movl	$0x4508b000, (%rbx)     # imm = 0x4508B000
-               	leaq	(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x4(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x4(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x8(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x8(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0xc(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0xc(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x10(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x10(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x14(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x14(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x18(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x18(%r14), %rbx
-               	movss	%xmm1, (%rbx)
-               	leaq	0x1c(%rdi), %rbx
-               	movss	(%rbx), %xmm1
-               	leaq	0x1c(%r14), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x14(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x18(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r12), %rdi
-               	movss	(%rdi), %xmm1
-               	leaq	0x1c(%r15), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x1c(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r15), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x14(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x18(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	leaq	0x1c(%r13), %rdi
-               	movss	(%rdi), %xmm1
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	%xmm1, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm1
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	%xmm0, %xmm2
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	movq	-0x1a60(%rbp), %r8
-               	leaq	0x1c(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	movq	%r14, %rsi
                	callq	 <L3>
 <L3>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x4(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x8(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0xc(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x10(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x14(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x18(%r15), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	leaq	0x1c(%r15), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	%r15, %rsi
                	callq	 <L4>
 <L4>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L5>
 <L5>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0x9d8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9d8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L6>
 <L6>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9e0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9e0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L7>
 <L7>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9e8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9e8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L8>
 <L8>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0x9f0(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9f0(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L9>
 <L9>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0x9f8(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0x9f8(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L10>
 <L10>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa00(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0xa00(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L11>
 <L11>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	%xmm1, %xmm2
+               	movq	-0xa08(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
                	movq	%rax, %rdi
+               	movq	-0xa08(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L12>
 <L12>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	-0x9c0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x14(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	0x1c(%rdx), %rsi
+               	movl	$0x0, (%rsi)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0xa10(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %r13
+               	movq	-0xa10(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0xa60(%rbp)
+               	movq	-0xa60(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	%r13, %rdi
+               	movq	-0xa18(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L14>
 <L14>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r15), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa18(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa20(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa20(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L15>
 <L15>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
                	movq	%rax, %rdi
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	subss	%xmm1, %xmm2
+               	movq	-0xa28(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa28(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L16>
 <L16>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	movq	%rax, %r13
+               	movq	-0xa60(%rbp), %r8
+               	movq	%r8, %rax
+               	addq	$0x1, %rax
+               	movq	-0xa28(%rbp), %r8
+               	movq	%r8, %r12
+               	movq	-0xa20(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rax, %r8
+               	movq	%r8, -0xa60(%rbp)
+               	movq	-0xa60(%rbp), %r8
+               	cmpq	$0x6, %r8
+               	jb	 <L13>
 <L17>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L18>
+               	leaq	-0x900(%rbp), %r8
+               	movq	%r8, -0xa68(%rbp)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	addq	$0x0, %rdx
+               	movq	$0x80, %rsi
 <L18>:
-               	movq	-0x1a58(%rbp), %r8
+               	movq	$0x0, (%rdx)
+               	addq	$0x8, %rdx
+               	subq	$0x8, %rsi
+               	cmpq	$0x0, %rsi
+               	jne	 <L18>
+               	movq	-0xa68(%rbp), %r8
                	leaq	(%r8), %rdx
+               	leaq	(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%r12), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	addss	%xmm1, %xmm2
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
+               	leaq	0x8(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
+               	leaq	0xc(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
+               	leaq	0x10(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x14(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x14(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x14(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
+               	leaq	0x18(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	0x1c(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
+               	leaq	0x1c(%r14), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
                	leaq	0x1c(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x19c8(%rbp), %r8
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
                	leaq	(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x4(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L19>
+               	leaq	0x4(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x8(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0xc(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x10(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x14(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x14(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x18(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x18(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	leaq	0x1c(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	leaq	0x1c(%rbx), %rdx
+               	movss	(%rdx), %xmm1
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	%xmm1, %xmm2
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm2, (%rdx)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x40(%r8), %rdx
+               	movq	-0xa38(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa38(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x60(%r8), %rdx
+               	leaq	(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x14(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x18(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x1c(%r15), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	$0x0, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L19>
+               	jmp	 <L21>
 <L19>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	movq	%rbx, %rdx
+               	imulq	$0x20, %rdx, %rdx
+               	movq	-0xa68(%rbp), %r8
+               	leaq	(%r8,%rdx), %rsi
+               	leaq	(%rsi), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	movq	-0xa40(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%rsi), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa40(%rbp), %r8
+               	leaq	0x1c(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%r13, %rdi
+               	movq	-0xa40(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L20>
 <L20>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
+               	movq	%rax, %r13
+               	addq	$0x1, %rbx
+               	cmpq	$0x4, %rbx
+               	jb	 <L19>
 <L21>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
+               	leaq	-0x940(%rbp), %rbx
+               	movq	$0x0, (%rbx)
+               	movq	$0x0, 0x8(%rbx)
+               	movq	$0x0, 0x10(%rbx)
+               	movq	$0x0, 0x18(%rbx)
+               	movq	$0x0, 0x20(%rbx)
+               	movq	$0x0, 0x28(%rbx)
+               	movq	$0x0, 0x30(%rbx)
+               	movq	$0x0, 0x38(%rbx)
+               	leaq	(%rbx), %rdx
+               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
+               	movq	-0xa68(%rbp), %r8
+               	leaq	0x40(%r8), %rsi
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x4(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x8(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0xc(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x14(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x14(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x18(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x18(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x1c(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x10(%rbx), %rax
+               	movq	-0xa48(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x14(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x14(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x18(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x18(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0xa48(%rbp), %r8
+               	leaq	0x1c(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x1c(%rax), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x30(%rbx), %rax
+               	movl	$0x12345678, (%rax)     # imm = 0x12345678
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
+               	jmp	 <L23>
 <L22>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%r13, %rdi
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rax
+               	movq	%rdi, %r13
+               	cmpq	$0x8, %rax
+               	jb	 <L22>
 <L23>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
+               	leaq	0x10(%rbx), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
+               	movq	-0xa50(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x14(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x14(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x18(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x18(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x1c(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0xa50(%rbp), %r8
+               	leaq	0x1c(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r13, %rdi
+               	movq	-0xa50(%rbp), %r8
+               	movq	%r8, %rsi
                	callq	 <L24>
 <L24>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
+               	leaq	0x30(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	movq	-0x19c8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L25>
 <L26>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0x19d0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0x19d8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	-0x19e0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	-0x19e8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0x19f0(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	-0x19f8(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x1a00(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x4(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x8(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0xc(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x10(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x14(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x18(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	leaq	0x1c(%r14), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a58(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	%xmm1, %xmm2
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm2, (%rdx)
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movq	-0x1a08(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	-0x19c0(%rbp), %rdx
-               	leaq	(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x4(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x8(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0xc(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x10(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x14(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x18(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	0x1c(%rdx), %rdi
-               	movl	$0x0, (%rdi)
-               	leaq	(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x14(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x14(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x18(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x18(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x1c(%rdx), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x1a10(%rbp), %r8
-               	leaq	0x1c(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	movq	%rax, %rbx
-               	movq	-0x1a58(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0x1a10(%rbp), %r8
-               	movq	%r8, %r13
-               	movq	$0x0, %r15
-               	cmpq	$0x6, %r15
-               	jb	 <L91>
-               	jmp	 <L116>
-<L91>:
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L92>
-<L92>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a18(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	movq	-0x1a20(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm1, %xmm2
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm2, (%rcx)
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	movq	-0x1a28(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	addq	$0x1, %r15
-               	movq	%rax, %rbx
-               	movq	-0x1a28(%rbp), %r8
-               	movq	%r8, %r12
-               	movq	-0x1a20(%rbp), %r8
-               	movq	%r8, %r13
-               	cmpq	$0x6, %r15
-               	jb	 <L91>
-<L116>:
-               	leaq	-0x1960(%rbp), %r15
-               	leaq	(%r15), %rax
-               	addq	$0x0, %rax
-               	movq	$0x80, %rcx
-<L117>:
-               	movq	$0x0, (%rax)
-               	addq	$0x8, %rax
-               	subq	$0x8, %rcx
-               	cmpq	$0x0, %rcx
-               	jne	 <L117>
-               	leaq	(%r15), %rax
-               	leaq	(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r12), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a68(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	%xmm1, %xmm2
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x20(%r15), %rax
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a30(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x4(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x4(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x8(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x8(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0xc(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0xc(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x10(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x10(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x14(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x14(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x18(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x18(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x1c(%r12), %rax
-               	movss	(%rax), %xmm0
-               	leaq	0x1c(%r14), %rax
-               	movss	(%rax), %xmm1
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	%xmm1, %xmm2
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm2, (%rax)
-               	leaq	0x40(%r15), %rax
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a38(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x60(%r15), %rax
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L118>
-               	jmp	 <L127>
-<L118>:
-               	movq	%r12, %rax
-               	imulq	$0x20, %rax, %rax
-               	leaq	(%r15,%rax), %rcx
-               	leaq	(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x4(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0xc(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x10(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x14(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x14(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x18(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x18(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	leaq	0x1c(%rcx), %rax
-               	movss	(%rax), %xmm0
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x1c(%r8), %rax
-               	movss	%xmm0, (%rax)
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	movq	-0x1a40(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	addq	$0x1, %r12
-               	movq	%rax, %rbx
-               	cmpq	$0x4, %r12
-               	jb	 <L118>
-<L127>:
-               	leaq	-0x19a0(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, 0x30(%r12)
-               	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rax
-               	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x40(%r15), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x10(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x14(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x14(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x18(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x18(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x1c(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r12), %r13
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x14(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x18(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a48(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x1c(%r13), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %ecx
-               	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L128>
-<L128>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x14(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x18(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x1c(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x14(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x18(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	-0x1a50(%rbp), %r8
-               	leaq	0x1c(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x30(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L137>
-<L137>:
-               	movq	-0x1a78(%rbp), %rbx
-               	movq	-0x1a80(%rbp), %r12
-               	movq	-0x1a88(%rbp), %r13
-               	movq	-0x1a90(%rbp), %r14
-               	movq	-0x1a98(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_f64x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_f64x2.dis
@@ -7,18 +7,58 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,49 +66,45 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x270, %rsp            # imm = 0x270
-               	movq	%rbx, -0x258(%rbp)
-               	movq	%r12, -0x260(%rbp)
-               	movq	%r13, -0x268(%rbp)
-               	movq	%r14, -0x270(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movq	%rbx, %r11
+               	subq	$0x190, %rsp            # imm = 0x190
+               	movq	%rbx, -0x178(%rbp)
+               	movq	%r12, -0x180(%rbp)
+               	movq	%r13, -0x188(%rbp)
+               	movq	%r14, -0x190(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L2>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rsi
+<L1>:
+               	leaq	-0x80(%rbp), %rsi
+               	leaq	(%rsi), %rdi
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
-               	movq	%r11, (%rsi)
-               	leaq	0x8(%rcx), %rsi
+               	movq	%r11, (%rdi)
+               	leaq	0x8(%rsi), %rdi
                	movabsq	$-0x3ffe000000000000, %r11 # imm = 0xC002000000000000
-               	movq	%r11, (%rsi)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
+               	movq	%r11, (%rdi)
+               	movups	(%rsi), %xmm1
+               	leaq	-0x90(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	-0xa0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
                	movabsq	$0x3fe0000000000000, %r11 # imm = 0x3FE0000000000000
                	movq	%r11, (%rbx)
-               	leaq	0x8(%rsi), %rbx
+               	leaq	0x8(%rdi), %rbx
                	movabsq	$0x4010000000000000, %r11 # imm = 0x4010000000000000
                	movq	%r11, (%rbx)
-               	movups	(%rsi), %xmm2
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
+               	movups	(%rdi), %xmm2
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm2, (%rdi)
+               	leaq	-0xc0(%rbp), %rbx
                	leaq	(%rbx), %r12
                	movabsq	$0x3ff0000000000000, %r11 # imm = 0x3FF0000000000000
                	movq	%r11, (%r12)
@@ -76,256 +112,136 @@ Disassembly of section .text:
                	movabsq	$0x403b000000000000, %r11 # imm = 0x403B000000000000
                	movq	%r11, (%r12)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x1e0(%rbp)
-               	leaq	(%rcx), %rbx
+               	movups	%xmm14, -0x100(%rbp)
+               	leaq	(%rsi), %rbx
                	movsd	(%rbx), %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	addsd	%xmm0, %xmm5
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	%xmm5, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x1f0(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movsd	(%rcx), %xmm4
+               	leaq	-0xd0(%rbp), %rsi
+               	movups	%xmm1, (%rsi)
+               	leaq	(%rsi), %rbx
+               	movsd	%xmm5, (%rbx)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x110(%rbp)
+               	leaq	0x8(%rdi), %rsi
+               	movsd	(%rsi), %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	addsd	%xmm0, %xmm5
-               	leaq	-0x70(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	0x8(%r12), %rcx
-               	movsd	%xmm5, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	leaq	-0xe0(%rbp), %rsi
+               	movups	%xmm2, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movsd	%xmm5, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x110(%rbp), %xmm0
+               	callq	 <L2>
+<L2>:
+               	movq	%rax, %rdi
+               	movups	-0x120(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	addpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rdi
-               	leaq	(%r12), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L5>
 <L5>:
                	movq	%rax, %rdi
-               	leaq	0x8(%r12), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	subpd	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	addpd	-0x200(%rbp), %xmm14
+               	movaps	-0x110(%rbp), %xmm14
+               	mulpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x130(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L7>
 <L7>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	divpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm14
+               	divpd	-0x110(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x150(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x110(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	subpd	-0x1f0(%rbp), %xmm14
+               	movaps	-0x100(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x100(%rbp), %xmm14
+               	divpd	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	callq	 <L12>
 <L12>:
-               	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	mulpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x170(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L13>
+               	movq	%rax, %rsi
+               	leaq	-0xf0(%rbp), %rdi
+               	leaq	(%rdi), %rbx
+               	movq	$0x0, (%rbx)
+               	leaq	0x8(%rdi), %rbx
+               	movq	$0x0, (%rbx)
+               	movups	(%rdi), %xmm0
+               	movq	%rsi, %rbx
+               	movups	-0x110(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movups	%xmm0, -0x150(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L13>
+               	jmp	 <L17>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, -0x130(%rbp)
+               	movq	%rbx, %rdi
+               	movups	-0x130(%rbp), %xmm0
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	divpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x150(%rbp), %xmm14
+               	addpd	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movaps	-0x140(%rbp), %xmm14
+               	subpd	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movups	-0x170(%rbp), %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x200(%rbp), %xmm14
-               	divpd	-0x1f0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L17>
-<L17>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %rdi
-               	movaps	-0x1f0(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L20>
-<L20>:
-               	movq	%rax, %rdi
-               	movaps	-0x1e0(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L21>
-<L21>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movq	%rax, %rdi
-               	movaps	-0x1e0(%rbp), %xmm14
-               	divpd	-0x1f0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L24>
-<L24>:
-               	movq	%rax, %rcx
-               	leaq	-0x1d0(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	movups	(%rsi), %xmm0
-               	movq	%rcx, %rbx
-               	movups	-0x1f0(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movups	%xmm0, -0x230(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L25>
-               	jmp	 <L32>
-<L25>:
-               	movaps	-0x220(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
-               	movaps	%xmm14, -0x210(%rbp)
-               	leaq	-0x80(%rbp), %r13
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rbx, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-               	movaps	-0x230(%rbp), %xmm14
-               	addpd	-0x210(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	leaq	-0x120(%rbp), %r13
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L28>
-<L28>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rdi
-               	movaps	-0x220(%rbp), %xmm14
-               	subpd	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	leaq	-0x140(%rbp), %r13
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r13), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rcx
+               	movq	%rax, %rbx
                	addq	$0x1, %r12
-               	movq	%rcx, %rbx
-               	movups	-0x250(%rbp), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
-               	movups	-0x240(%rbp), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L25>
-<L32>:
-               	leaq	-0xc0(%rbp), %r12
+               	jb	 <L13>
+<L17>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -334,92 +250,110 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r12)
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
-               	leaq	(%r12), %rcx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	movaps	-0x220(%rbp), %xmm14
-               	addpd	-0x200(%rbp), %xmm14
+               	leaq	(%r12), %rsi
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
+               	movaps	-0x140(%rbp), %xmm14
+               	addpd	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x10(%r12), %rcx
-               	movups	%xmm0, (%rcx)
-               	movaps	-0x220(%rbp), %xmm14
-               	mulpd	-0x1e0(%rbp), %xmm14
+               	leaq	0x10(%r12), %rsi
+               	movups	%xmm0, (%rsi)
+               	movaps	-0x140(%rbp), %xmm14
+               	mulpd	-0x100(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	leaq	0x20(%r12), %rcx
-               	movups	%xmm4, (%rcx)
-               	leaq	0x30(%r12), %rcx
-               	movups	-0x230(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+               	leaq	0x20(%r12), %rsi
+               	movups	%xmm4, (%rsi)
+               	leaq	0x30(%r12), %rsi
+               	movups	-0x150(%rbp), %xmm14
+               	movups	%xmm14, (%rsi)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L33>
-               	jmp	 <L36>
-<L33>:
-               	movq	%r13, %rcx
-               	imulq	$0x10, %rcx, %rcx
-               	leaq	(%r12,%rcx), %rsi
-               	movups	(%rsi), %xmm0
-               	leaq	-0xd0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movsd	(%rcx), %xmm0
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	%r13, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r12,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L34>
-<L34>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%r14), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	movq	%rax, %rbx
                	addq	$0x1, %r13
-               	movq	%rcx, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L33>
-<L36>:
-               	leaq	-0x100(%rbp), %r13
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
                	movq	$0x0, 0x18(%r13)
                	movq	$0x0, 0x20(%r13)
                	movq	$0x0, 0x28(%r13)
-               	leaq	(%r13), %rcx
-               	movl	$0xffffffff, (%rcx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rsi
+               	leaq	(%r13), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r12), %rdi
+               	movups	(%rdi), %xmm0
+               	leaq	0x10(%r13), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x20(%r13), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rsi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rbx, %r14
+               	xorq	%r12, %r14
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r14
+               	addq	$0x1, %rdi
+               	movq	%r14, %rbx
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	leaq	0x10(%r13), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rcx), %esi
                	movq	%rbx, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rdi
-               	movups	(%r12), %xmm0
-               	leaq	-0x110(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rdi
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %esi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rcx
-               	movq	%rcx, %rax
-               	movq	-0x258(%rbp), %rbx
-               	movq	-0x260(%rbp), %r12
-               	movq	-0x268(%rbp), %r13
-               	movq	-0x270(%rbp), %r14
+               	callq	 <L23>
+<L23>:
+               	movq	%rax, %rsi
+               	leaq	0x20(%r13), %rdi
+               	movl	(%rdi), %ebx
+               	movl	%ebx, %edi
+               	movq	$0x0, %rbx
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rbx, %r12
+               	imulq	$0x8, %r12, %r12
+               	movq	%r12, %rcx
+               	movq	%rdi, %r12
+               	shrq	%cl, %r12
+               	andq	$0xff, %r12
+               	movq	%rsi, %r13
+               	xorq	%r12, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rbx
+               	movq	%r13, %rsi
+               	cmpq	$0x8, %rbx
+               	jb	 <L24>
+<L25>:
+               	movq	%rsi, %rax
+               	movq	-0x178(%rbp), %rbx
+               	movq	-0x180(%rbp), %r12
+               	movq	-0x188(%rbp), %r13
+               	movq	-0x190(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_i16x4.dis
@@ -7,28 +7,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x8(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -36,16 +112,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x1f0, %rsp            # imm = 0x1F0
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%r12, -0x1e0(%rbp)
-               	movq	%r13, -0x1e8(%rbp)
-               	movq	%r14, -0x1f0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x8(%rbp), %rdx
+               	subq	$0x190, %rsp            # imm = 0x190
+               	movq	%rbx, -0x178(%rbp)
+               	movq	%r12, -0x180(%rbp)
+               	movq	%r13, -0x188(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x44(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x3e9, (%rsi)          # imm = 0x3E9
                	leaq	0x2(%rdx), %rsi
@@ -55,9 +127,9 @@ Disassembly of section .text:
                	leaq	0x6(%rdx), %rsi
                	movw	$0xfaeb, (%rsi)         # imm = 0xFAEB
                	movsd	(%rdx), %xmm0
-               	leaq	-0x10(%rbp), %rdx
+               	leaq	-0x4c(%rbp), %rdx
                	movsd	%xmm0, (%rdx)
-               	leaq	-0x18(%rbp), %rsi
+               	leaq	-0x54(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0xd, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -67,9 +139,9 @@ Disassembly of section .text:
                	leaq	0x6(%rsi), %rdi
                	movw	$0xfff9, (%rdi)         # imm = 0xFFF9
                	movsd	(%rsi), %xmm1
-               	leaq	-0x20(%rbp), %rsi
+               	leaq	-0x5c(%rbp), %rsi
                	movsd	%xmm1, (%rsi)
-               	leaq	-0x28(%rbp), %rdi
+               	leaq	-0x64(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -79,8 +151,8 @@ Disassembly of section .text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x4, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x110(%rbp)
-               	leaq	-0x30(%rbp), %rdi
+               	movq	%r11, -0xa0(%rbp)
+               	leaq	-0x6c(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -90,459 +162,198 @@ Disassembly of section .text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x120(%rbp)
+               	movq	%r11, -0xb0(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x38(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x74(%rbp), %rdi
                	movsd	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movsd	(%rdi), %xmm0
                	leaq	0x6(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x40(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	0x6(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movq	(%rbx), %r11
-               	movq	%r11, -0x130(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0x7c(%rbp), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	0x6(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movq	(%rdx), %r11
+               	movq	%r11, -0xc0(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x48(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x84(%rbp), %rdx
                	movsd	%xmm1, (%rdx)
                	leaq	0x2(%rdx), %rdi
                	movw	%si, (%rdi)
                	movsd	(%rdx), %xmm0
                	leaq	0x4(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x50(%rbp), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0x4(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movq	(%r12), %r11
-               	movq	%r11, -0x140(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x8c(%rbp), %rax
+               	movsd	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movq	(%rax), %r11
+               	movq	%r11, -0xd0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0xc0(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0xd0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0xe0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0xe0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	psubw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xd0(%rbp), %xmm14
+               	psubw	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	pmullw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xc0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0xd0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x130(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xb4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x130(%rbp), %xmm14
-               	psubw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xc4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x140(%rbp), %xmm14
-               	psubw	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xd4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pmullw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xdc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xe4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x140(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xec(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x130(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xf4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x120(%rbp), %xmm14
-               	psubw	-0x130(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0xfc(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x120(%rbp), %xmm14
-               	psubw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pand	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x150(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x150(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x130(%rbp), %xmm14
-               	por	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x160(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x160(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pxor	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x130(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x140(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x150(%rbp), %xmm14
-               	pxor	-0x160(%rbp), %xmm14
+               	movaps	-0xe0(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0xb0(%rbp), %xmm14
+               	psubw	-0xc0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0xb0(%rbp), %xmm14
+               	psubw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pand	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0xf0(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xf0(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	por	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0x100(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x100(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pxor	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0xc0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0xd0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0xf0(%rbp), %xmm14
+               	pxor	-0x100(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x130(%rbp), %xmm14
-               	movups	%xmm14, -0x180(%rbp)
-               	movups	-0x120(%rbp), %xmm14
-               	movups	%xmm14, -0x190(%rbp)
-               	movups	-0x120(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0xc0(%rbp), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movups	-0xb0(%rbp), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	movups	-0xb0(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L48>
-               	jmp	 <L65>
-<L48>:
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, -0x170(%rbp)
-               	leaq	-0x58(%rbp), %r13
-               	movq	-0x170(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x120(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, -0x110(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x110(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x130(%rbp), %xmm14
+               	pxor	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x150(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x160(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x120(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x190(%rbp), %xmm14
-               	pxor	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, -0x1b0(%rbp)
-               	leaq	-0xac(%rbp), %r13
-               	movq	-0x1b0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, -0x1c0(%rbp)
-               	leaq	-0xbc(%rbp), %r13
-               	movq	-0x1c0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x180(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, -0x1d0(%rbp)
-               	leaq	-0xcc(%rbp), %r13
-               	movq	-0x1d0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x1d0(%rbp), %xmm14
-               	movups	%xmm14, -0x180(%rbp)
-               	movups	-0x1b0(%rbp), %xmm14
-               	movups	%xmm14, -0x190(%rbp)
-               	movups	-0x1c0(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x170(%rbp), %xmm14
+               	movups	%xmm14, -0x120(%rbp)
+               	movups	-0x150(%rbp), %xmm14
+               	movups	%xmm14, -0x130(%rbp)
+               	movups	-0x160(%rbp), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L48>
-<L65>:
-               	leaq	-0x88(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x30(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -550,110 +361,108 @@ Disassembly of section .text:
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
                	leaq	(%r12), %rax
-               	movq	-0x180(%rbp), %r11
+               	movq	-0x120(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	paddw	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x120(%rbp), %xmm14
+               	paddw	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x8(%r12), %rax
-               	movsd	%xmm3, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x110(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movsd	%xmm0, (%rax)
+               	movaps	-0x120(%rbp), %xmm14
+               	pmullw	-0xa0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r12), %rax
-               	movsd	%xmm3, (%rax)
+               	movsd	%xmm0, (%rax)
                	leaq	0x18(%r12), %rax
-               	movq	-0x190(%rbp), %r11
+               	movq	-0x130(%rbp), %r11
                	movq	%r11, (%rax)
                	leaq	0x20(%r12), %rax
-               	movq	-0x1a0(%rbp), %r11
+               	movq	-0x140(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x180(%rbp), %xmm14
-               	pxor	-0x140(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movaps	-0x120(%rbp), %xmm14
+               	pxor	-0xd0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	leaq	0x28(%r12), %rax
-               	movsd	%xmm0, (%rax)
+               	movsd	%xmm5, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L66>
-               	jmp	 <L71>
-<L66>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	leaq	(%r12,%r13,8), %rax
                	movsd	(%rax), %xmm0
-               	leaq	-0x90(%rbp), %r14
-               	movsd	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L66>
-<L71>:
-               	leaq	-0x9c(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x3c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	$0x0, 0x8(%r13)
                	leaq	(%r13), %rax
                	movb	$-0x25, (%rax)
-               	leaq	0x10(%r12), %rcx
-               	movsd	(%rcx), %xmm0
-               	leaq	0x2(%r13), %r12
-               	movsd	%xmm0, (%r12)
-               	leaq	0xa(%r13), %rcx
-               	movb	$-0x53, (%rcx)
-               	movzbl	(%rax), %esi
+               	leaq	0x10(%r12), %rdx
+               	movsd	(%rdx), %xmm0
+               	leaq	0x2(%r13), %rdx
+               	movsd	%xmm0, (%rdx)
+               	leaq	0xa(%r13), %rdx
+               	movb	$-0x53, (%rdx)
+               	movzbl	(%rax), %edx
+               	movzbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	callq	 <L72>
-<L72>:
-               	movsd	(%r12), %xmm0
-               	leaq	-0xa4(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %r12
-               	movq	-0x1e8(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x2(%r13), %rax
+               	movsd	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0xa(%r13), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x178(%rbp), %rbx
+               	movq	-0x180(%rbp), %r12
+               	movq	-0x188(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-linux/vec/vec_i16x8.dis
@@ -7,48 +7,196 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
+               	leaq	0x8(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movswq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movswq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -56,16 +204,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            # imm = 0x2E0
-               	movq	%rbx, -0x2c8(%rbp)
-               	movq	%r12, -0x2d0(%rbp)
-               	movq	%r13, -0x2d8(%rbp)
-               	movq	%r14, -0x2e0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x210, %rsp            # imm = 0x210
+               	movq	%rbx, -0x1f8(%rbp)
+               	movq	%r12, -0x200(%rbp)
+               	movq	%r13, -0x208(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x3e9, (%rsi)          # imm = 0x3E9
                	leaq	0x2(%rdx), %rsi
@@ -83,9 +227,9 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xf953, (%rsi)         # imm = 0xF953
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0xd, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -103,9 +247,9 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0xffff, (%rdi)         # imm = 0xFFFF
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xb0(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0xc0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -123,8 +267,8 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x8, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	-0x60(%rbp), %rdi
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	-0xd0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -142,739 +286,198 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
+               	movups	%xmm14, -0x130(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0xe0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movups	(%rdi), %xmm0
                	leaq	0xc(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x80(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0xf0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x90(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xe(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x140(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x220(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x230(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pand	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x240(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x220(%rbp), %xmm14
-               	por	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x250(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pxor	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x240(%rbp), %xmm14
-               	pxor	-0x250(%rbp), %xmm14
+               	movaps	-0x160(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L87>
-<L87>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pand	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x140(%rbp), %xmm14
+               	por	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x180(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pxor	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x150(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x170(%rbp), %xmm14
+               	pxor	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x190(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x1b0(%rbp), %xmm14
+               	pxor	-0x190(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1d0(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x1c0(%rbp), %xmm14
+               	paddw	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1e0(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x1f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x280(%rbp), %xmm14
-               	pxor	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, -0x2a0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
+               	movups	-0x1f0(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x1f0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x1e0(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -884,78 +487,39 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x270(%rbp), %xmm14
+               	movups	-0x1a0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x10(%r12), %rax
-               	movups	%xmm3, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rax
+               	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm5, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x280(%rbp), %xmm14
+               	movups	-0x1b0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -964,70 +528,65 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x20(%r12), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L132>
-<L132>:
-               	movups	(%r12), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L141>
-<L141>:
-               	movq	-0x2c8(%rbp), %rbx
-               	movq	-0x2d0(%rbp), %r12
-               	movq	-0x2d8(%rbp), %r13
-               	movq	-0x2e0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%r13), %rax
+               	movups	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x1f8(%rbp), %rbx
+               	movq	-0x200(%rbp), %r12
+               	movq	-0x208(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_i32x4.dis
@@ -7,32 +7,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,17 +112,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x480, %rsp            # imm = 0x480
-               	movq	%rbx, -0x458(%rbp)
-               	movq	%r12, -0x460(%rbp)
-               	movq	%r13, -0x468(%rbp)
-               	movq	%r14, -0x470(%rbp)
-               	movq	%r15, -0x478(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x410, %rsp            # imm = 0x410
+               	movq	%rbx, -0x3e8(%rbp)
+               	movq	%r12, -0x3f0(%rbp)
+               	movq	%r13, -0x3f8(%rbp)
+               	movq	%r14, -0x400(%rbp)
+               	movq	%r15, -0x408(%rbp)
+               	movl	%edi, %eax
+               	leaq	-0x110(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0x2717, (%rsi)         # imm = 0x2717
                	leaq	0x4(%rdx), %rsi
@@ -60,9 +129,9 @@ Disassembly of section .text:
                	leaq	0xc(%rdx), %rsi
                	movl	$0xffff8000, (%rsi)     # imm = 0xFFFF8000
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x120(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x130(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0xfffffff9, (%rdi)     # imm = 0xFFFFFFF9
                	leaq	0x4(%rsi), %rdi
@@ -72,9 +141,9 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x3, (%rdi)
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0x140(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x150(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movl	$0x1, (%rbx)
                	leaq	0x4(%rdi), %rbx
@@ -84,9 +153,9 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %rbx
                	movl	$0x1b, (%rbx)
                	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x160(%rbp), %rbx
                	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x170(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -96,529 +165,324 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x380(%rbp)
+               	movups	%xmm14, -0x310(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x180(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
                	movl	%edx, (%r12)
                	movups	(%rdi), %xmm0
                	leaq	0x8(%rdi), %rdx
                	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	addl	%eax, %edi
+               	leaq	-0x190(%rbp), %r12
                	movups	%xmm0, (%r12)
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x320(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r13
+               	addl	%eax, %edx
+               	leaq	-0x1b0(%rbp), %r13
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%r13), %rax
+               	movl	%edx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm14, -0x330(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x320(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x330(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x340(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x340(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x330(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rax, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%r13), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r13), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x390(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x3a0(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm0
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r12), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %edi
                	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x210(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%esi, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x220(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r13), %rdx
                	movl	(%rdx), %edi
                	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r12d
                	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r13), %rdx
                	movl	(%rdx), %r12d
                	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r12d
+               	leaq	0xc(%r13), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%esi, (%r13)
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r13d
+               	leaq	-0x250(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%esi, (%r15)
                	movups	(%rdx), %xmm0
-               	leaq	-0x320(%rbp), %rdx
+               	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x330(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %edi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	-0x290(%rbp), %rdx
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%esi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movl	%r12d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pand	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3b0(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x390(%rbp), %xmm14
-               	por	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3c0(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x390(%rbp), %xmm14
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pand	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x350(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x320(%rbp), %xmm14
+               	por	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x360(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x320(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x3a0(%rbp), %xmm14
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x330(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x3b0(%rbp), %xmm14
-               	pxor	-0x3c0(%rbp), %xmm14
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x350(%rbp), %xmm14
+               	pxor	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r12
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
                	movq	$0x0, %r13
-<L48>:
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x3e0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x90(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -628,356 +492,258 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rbx), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x358(%rbp)
+               	movl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x2e0(%rbp)
                	leaq	0x4(%r14), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %esi
                	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2e8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %edi
+               	leaq	0xc(%r14), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
                	movl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0x8(%r14), %rax
-               	movl	(%rax), %esi
-               	leaq	0x8(%rbx), %rax
-               	movl	(%rax), %edi
-               	imull	%edi, %esi
-               	leaq	0xc(%r14), %rax
-               	movl	(%rax), %edi
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %edi
-               	leaq	-0x150(%rbp), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	leaq	-0xa0(%rbp), %rax
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x160(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x170(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x180(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%edi, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rsi
+               	movq	-0x2e0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xb0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x2e8(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x3f0(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x3f8(%rbp)
-               	movq	-0x3f8(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
-               	movq	-0x3f8(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x400(%rbp)
-               	movq	-0x400(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x400(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x360(%rbp)
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x398(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x398(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	-0x368(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%r8, %rdi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x398(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x398(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x100(%rbp), %r8
+               	movq	%r8, -0x3a0(%rbp)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x400(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
+               	callq	 <L23>
+<L23>:
+               	movq	-0x3a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdx
-               	movq	-0x3f8(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x3f8(%rbp)
-               	movq	-0x3f8(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x408(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x408(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L55>
-<L55>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x1d0(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x408(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x458(%rbp), %rbx
-               	movq	-0x460(%rbp), %r12
-               	movq	-0x468(%rbp), %r13
-               	movq	-0x470(%rbp), %r14
-               	movq	-0x478(%rbp), %r15
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x3e8(%rbp), %rbx
+               	movq	-0x3f0(%rbp), %r12
+               	movq	-0x3f8(%rbp), %r13
+               	movq	-0x400(%rbp), %r14
+               	movq	-0x408(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2f8(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %edi
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x3e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x420(%rbp)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r15d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%r8d, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r14
+               	movl	%edi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3b0(%rbp)
                	movq	%r12, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x3c0(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	paddd	-0x420(%rbp), %xmm14
-               	movaps	%xmm14, -0x430(%rbp)
-               	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L69>
-<L69>:
-               	movaps	-0x430(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x440(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	jmp	 <L48>
+               	movups	-0x3e0(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-linux/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_i64x2.dis
@@ -7,18 +7,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,24 +64,21 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3a0, %rsp            # imm = 0x3A0
-               	movq	%rbx, -0x378(%rbp)
-               	movq	%r12, -0x380(%rbp)
-               	movq	%r13, -0x388(%rbp)
-               	movq	%r14, -0x390(%rbp)
-               	movq	%r15, -0x398(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x310, %rsp            # imm = 0x310
+               	movq	%rbx, -0x2e8(%rbp)
+               	movq	%r12, -0x2f0(%rbp)
+               	movq	%r13, -0x2f8(%rbp)
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x308(%rbp)
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$0x3b9aca07, (%rdx)     # imm = 0x3B9ACA07
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$-0x7735940b, (%rdx)    # imm = 0x88CA6BF5
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0xb2d05e13, %r11       # imm = 0xB2D05E13
                	movq	%r11, (%rsi)
@@ -51,311 +86,235 @@ Disassembly of section .text:
                	movabsq	$-0xee6b2825, %r11      # imm = 0xFFFFFFFF1194D7DB
                	movq	%r11, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x1, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x3, (%rdi)
+               	leaq	-0x110(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movq	$0x1, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x3, (%rbx)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	-0x70(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
+               	leaq	-0x120(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x130(%rbp), %rsi
+               	leaq	(%rsi), %r12
+               	movq	$0x0, (%r12)
+               	leaq	0x8(%rsi), %r12
+               	movq	$0x0, (%r12)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movq	%rcx, (%rsi)
+               	movups	%xmm14, -0x200(%rbp)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rdi, %rax
+               	leaq	-0x140(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	(%r12), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x210(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rdi, %rdx
+               	leaq	-0x150(%rbp), %r13
+               	movups	%xmm1, (%r13)
+               	leaq	0x8(%r13), %rax
+               	movq	%rdx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x2b0(%rbp)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movups	%xmm14, -0x220(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x210(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x220(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x230(%rbp)
+               	leaq	-0x160(%rbp), %r14
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
+               	movups	-0x230(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %rdi
+               	leaq	-0x170(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%rsi, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x190(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1d0(%rbp), %rdx
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pand	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	por	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pxor	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x220(%rbp), %rcx
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pand	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2c0(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	por	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2d0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2d0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r12
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	movq	$0x0, %r13
-<L28>:
-               	leaq	-0xa0(%rbp), %r14
-               	movups	-0x2f0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x70(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -365,231 +324,211 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movq	(%rax), %rcx
-               	leaq	(%r12), %rax
                	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r14), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r12), %rax
+               	leaq	(%rbx), %rax
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
-               	leaq	-0x110(%rbp), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	-0x80(%rbp), %rax
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rsi
-               	movq	%rcx, (%rsi)
-               	movups	(%rax), %xmm2
-               	leaq	-0x120(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rdi
+               	movq	%rdx, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x90(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rsi, (%rdx)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x300(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x2d8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x320(%rbp)
-               	movq	-0x320(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x320(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x278(%rbp)
-               	movq	-0x2d8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x278(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x298(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdx
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x2d8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x328(%rbp)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x328(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x2d8(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x258(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L33>
-<L33>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x170(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movq	(%rdx), %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r15), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x378(%rbp), %rbx
-               	movq	-0x380(%rbp), %r12
-               	movq	-0x388(%rbp), %r13
-               	movq	-0x390(%rbp), %r14
-               	movq	-0x398(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x2e8(%rbp), %rbx
+               	movq	-0x2f0(%rbp), %r12
+               	movq	-0x2f8(%rbp), %r13
+               	movq	-0x300(%rbp), %r14
+               	movq	-0x308(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
+<L26>:
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	imulq	%rdi, %rsi
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xc0(%rbp), %r14
-               	movups	%xmm2, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x270(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rsi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x2b0(%rbp)
+               	movq	%r12, %rdi
+               	movups	-0x2b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movaps	-0x300(%rbp), %xmm14
-               	pxor	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x350(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x290(%rbp), %xmm14
+               	paddq	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x2e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x2f0(%rbp), %xmm14
-               	movaps	%xmm14, -0x360(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x370(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
+               	movups	-0x2e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
-               	jmp	 <L28>
+               	movq	%rax, %r12
+               	movups	-0x2e0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2d0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-linux/vec/vec_i8x16.dis
+++ b/test/golden/x86_64-linux/vec/vec_i8x16.dis
@@ -7,88 +7,380 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movsbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -96,1101 +388,1086 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xac0, %rsp            # imm = 0xAC0
-               	movq	%rbx, -0xa98(%rbp)
-               	movq	%r12, -0xaa0(%rbp)
-               	movq	%r13, -0xaa8(%rbp)
-               	movq	%r14, -0xab0(%rbp)
-               	movq	%r15, -0xab8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0xaa0, %rsp            # imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movb	%dil, %al
+               	leaq	-0x290(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x9, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x5, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$0x3, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x4, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x6, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$-0x8, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x9, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x3, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x2, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x4, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$0x8, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x2b0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movb	$0x2, (%rsi)
+               	leaq	0x1(%rdx), %rsi
+               	movb	$-0x3, (%rsi)
+               	leaq	0x2(%rdx), %rsi
+               	movb	$0x4, (%rsi)
+               	leaq	0x3(%rdx), %rsi
+               	movb	$-0x5, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movb	$0x6, (%rsi)
+               	leaq	0x5(%rdx), %rsi
+               	movb	$-0x7, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movb	$0x8, (%rsi)
+               	leaq	0x7(%rdx), %rsi
+               	movb	$-0x9, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movb	$0x1, (%rsi)
+               	leaq	0x9(%rdx), %rsi
+               	movb	$-0x2, (%rsi)
+               	leaq	0xa(%rdx), %rsi
+               	movb	$0x3, (%rsi)
+               	leaq	0xb(%rdx), %rsi
+               	movb	$-0x4, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movb	$0x5, (%rsi)
+               	leaq	0xd(%rdx), %rsi
+               	movb	$-0x6, (%rsi)
+               	leaq	0xe(%rdx), %rsi
+               	movb	$0x7, (%rsi)
+               	leaq	0xf(%rdx), %rsi
+               	movb	$-0x1, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	-0x2d0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	-0x2e0(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x2f0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x990(%rbp)
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x300(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x310(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x7(%r12), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x9a0(%rbp)
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x330(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0xc(%r13), %rax
+               	movb	%cl, (%rax)
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, -0x9b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x9a0(%rbp), %xmm0
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movb	$-0x9, (%rsi)
-               	leaq	0x1(%rdx), %rsi
-               	movb	$0x7, (%rsi)
-               	leaq	0x2(%rdx), %rsi
-               	movb	$-0x5, (%rsi)
-               	leaq	0x3(%rdx), %rsi
-               	movb	$0x3, (%rsi)
-               	leaq	0x4(%rdx), %rsi
-               	movb	$-0x1, (%rsi)
-               	leaq	0x5(%rdx), %rsi
-               	movb	$0x2, (%rsi)
-               	leaq	0x6(%rdx), %rsi
-               	movb	$-0x4, (%rsi)
-               	leaq	0x7(%rdx), %rsi
-               	movb	$0x6, (%rsi)
-               	leaq	0x8(%rdx), %rsi
-               	movb	$-0x8, (%rsi)
-               	leaq	0x9(%rdx), %rsi
-               	movb	$0x9, (%rsi)
-               	leaq	0xa(%rdx), %rsi
-               	movb	$-0x3, (%rsi)
-               	leaq	0xb(%rdx), %rsi
-               	movb	$0x1, (%rsi)
-               	leaq	0xc(%rdx), %rsi
-               	movb	$-0x2, (%rsi)
-               	leaq	0xd(%rdx), %rsi
-               	movb	$0x4, (%rsi)
-               	leaq	0xe(%rdx), %rsi
-               	movb	$-0x6, (%rsi)
-               	leaq	0xf(%rdx), %rsi
-               	movb	$0x8, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	$0x2, (%rbx)
-               	leaq	0x1(%rsi), %rbx
-               	movb	$-0x3, (%rbx)
-               	leaq	0x2(%rsi), %rbx
-               	movb	$0x4, (%rbx)
-               	leaq	0x3(%rsi), %rbx
-               	movb	$-0x5, (%rbx)
-               	leaq	0x4(%rsi), %rbx
-               	movb	$0x6, (%rbx)
-               	leaq	0x5(%rsi), %rbx
-               	movb	$-0x7, (%rbx)
-               	leaq	0x6(%rsi), %rbx
-               	movb	$0x8, (%rbx)
-               	leaq	0x7(%rsi), %rbx
-               	movb	$-0x9, (%rbx)
-               	leaq	0x8(%rsi), %rbx
-               	movb	$0x1, (%rbx)
-               	leaq	0x9(%rsi), %rbx
-               	movb	$-0x2, (%rbx)
-               	leaq	0xa(%rsi), %rbx
-               	movb	$0x3, (%rbx)
-               	leaq	0xb(%rsi), %rbx
-               	movb	$-0x4, (%rbx)
-               	leaq	0xc(%rsi), %rbx
-               	movb	$0x5, (%rbx)
-               	leaq	0xd(%rsi), %rbx
-               	movb	$-0x6, (%rbx)
-               	leaq	0xe(%rsi), %rbx
-               	movb	$0x7, (%rbx)
-               	leaq	0xf(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x3(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x4(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x5(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x6(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x7(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x9(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xa(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xb(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xc(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0xd(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0xe(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0xf(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9b0(%rbp)
-               	leaq	(%rdx), %r12
-               	movzbl	(%r12), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%dl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rdx
-               	movzbl	(%rdx), %r12d
-               	addl	%ecx, %r12d
-               	leaq	-0x90(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x7(%r13), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x9c0(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
-               	movups	%xmm1, (%rdx)
-               	leaq	0x3(%rdx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rsi
-               	movzbl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rcx
-               	movb	%dl, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9d0(%rbp)
-               	movups	-0x9c0(%rbp), %xmm0
+               	movups	-0x9b0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9c0(%rbp)
+               	leaq	-0x340(%rbp), %r14
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movups	-0x9d0(%rbp), %xmm0
+               	movups	-0x9c0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9e0(%rbp)
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
-               	movaps	-0x9d0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L5>
-<L5>:
                	movq	%rax, %r8
                	movq	%r8, -0x748(%rbp)
                	movq	-0x748(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
                	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
                	movq	%r8, -0x750(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
                	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %r15d
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%r13), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
+               	imull	%edi, %r8d
                	movq	%r8, -0x758(%rbp)
-               	leaq	0x2(%r13), %rcx
-               	movzbl	(%rcx), %r15d
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x760(%rbp)
-               	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x768(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x770(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x780(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x788(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x790(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7a0(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x7a8(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7b0(%rbp)
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rdx
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rdx
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rdx
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rdx
-               	movq	-0x778(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rdx
-               	movq	-0x780(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rdx
-               	movq	-0x788(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	-0x790(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rdx
-               	movq	-0x798(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rdx
-               	movq	-0x7a0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rdx
-               	movq	-0x7a8(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movq	-0x7b0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x748(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7c0(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x2(%r13), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x760(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
                	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x768(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7d8(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x770(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x7e0(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x778(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x7f0(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	movq	%r8, -0x780(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %r15d
                	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x788(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f8(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x800(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x810(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x818(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x7a8(%rbp)
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x7f0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x7f8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x800(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x808(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x810(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x818(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x7b8(%rbp), %r8
+               	leaq	-0x350(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x750(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x360(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rsi
+               	movq	-0x758(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x370(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rsi
+               	movq	-0x760(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x380(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rsi
+               	movq	-0x768(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x390(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x770(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rsi
+               	movq	-0x778(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rsi
+               	movq	-0x780(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rsi
+               	movq	-0x788(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	-0x790(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rsi
+               	movq	-0x798(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rsi
+               	movq	-0x7a0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rsi
+               	movq	-0x7a8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x748(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
-<L7>:
+               	callq	 <L5>
+<L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x7b8(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7c0(%rbp)
                	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %eax
                	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x840(%rbp)
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x7d0(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x848(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x7e0(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7e8(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x7f8(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x800(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x808(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x450(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movq	-0x7b8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
+               	movq	-0x7c0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x7c8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x7d0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0x7d8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0x7e0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0x7e8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0x7f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0x7f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movq	-0x800(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r12
+               	movq	-0x808(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r12
+               	movb	%sil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	-0x810(%rbp), %r8
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x5(%rbx), %rcx
+               	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x850(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	movq	%r8, -0x818(%rbp)
+               	leaq	0x1(%r13), %rcx
                	movzbl	(%rcx), %esi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x858(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x7(%rbx), %rcx
+               	imull	%edi, %r8d
+               	movq	%r8, -0x820(%rbp)
+               	leaq	0x2(%r13), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x828(%rbp)
+               	leaq	0x3(%r13), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%r12d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x830(%rbp)
+               	leaq	0x4(%r13), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x838(%rbp)
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x840(%rbp)
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x848(%rbp)
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x850(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x858(%rbp)
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r12d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0x860(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x868(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x870(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x878(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %edx
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	-0x9d0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r12
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r12
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r12
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r12
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r12
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r12
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r12
-               	movq	-0x860(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r12
-               	movq	-0x868(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r12
-               	movq	-0x870(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r12
-               	movq	-0x878(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dil, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x550(%rbp), %rax
+               	movups	-0x9b0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x818(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x820(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
+               	movq	-0x828(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
+               	movq	-0x830(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movq	-0x838(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
+               	movq	-0x840(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
+               	movq	-0x848(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
+               	movq	-0x850(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movq	-0x858(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
+               	movq	-0x860(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
+               	movb	%r15b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x600(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%r12b, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x810(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x868(%rbp), %r8
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x870(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x878(%rbp)
                	leaq	0x2(%r14), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x880(%rbp)
+               	leaq	0x3(%r14), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%r12d, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x898(%rbp)
-               	leaq	0x3(%r14), %rcx
+               	movq	%r8, -0x888(%rbp)
+               	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x3(%rbx), %rcx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r13d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
-               	leaq	0x4(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0x890(%rbp)
                	leaq	0x5(%r14), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %r15d
                	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x898(%rbp)
+               	leaq	0x6(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
-               	leaq	0x6(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x8a0(%rbp)
+               	leaq	0x7(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
-               	leaq	0x7(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x8(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x9(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0xa(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xb(%r14), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xc(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0xd(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %esi
-               	leaq	0xe(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x8b0(%rbp)
+               	leaq	0x9(%r14), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xa(%r14), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xf(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
+               	leaq	0xb(%r14), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r13d
+               	leaq	0xc(%r14), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x650(%rbp), %rax
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r14
+               	movq	-0x870(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x878(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x880(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
                	movq	-0x888(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
                	movq	-0x890(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
                	movq	-0x898(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
                	movq	-0x8a0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
                	movq	-0x8a8(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
                	movq	-0x8b0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
                	movb	%dil, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdi
-               	movb	%dl, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r12b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x710(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x868(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pand	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9d0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	-0x9d0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	por	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9e0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pand	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9f0(%rbp)
-               	movups	-0x9f0(%rbp), %xmm0
+               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pxor	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	por	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa00(%rbp)
-               	movups	-0xa00(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pxor	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movaps	-0x9d0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	pxor	-0x9e0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
+               	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x9f0(%rbp), %xmm14
-               	pxor	-0xa00(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm0
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %r12
-               	movups	-0x9c0(%rbp), %xmm14
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0x990(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0x990(%rbp), %xmm14
                	movups	%xmm14, -0xa20(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
                	movq	$0x0, %r13
-<L18>:
-               	leaq	-0x4d0(%rbp), %r14
-               	movups	-0xa20(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x3, %r13
-               	jb	 <L25>
-               	leaq	-0x610(%rbp), %r15
+               	jb	 <L24>
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -1200,10 +1477,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
                	movups	%xmm0, (%rax)
@@ -1213,91 +1490,91 @@ Disassembly of section .text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0x8b8(%rbp)
                	leaq	0x1(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x2(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x2(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x3(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x3(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x4(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x5(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x6(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x7(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x8(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x9(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0xa(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xb(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xc(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xd(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rbx), %rax
@@ -1313,96 +1590,96 @@ Disassembly of section .text:
                	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %edi
-               	leaq	-0x620(%rbp), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x160(%rbp), %rax
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0x8b8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0x8c0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0x8c8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0x8d0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x1b0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x1e0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%sil, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%dil, (%rcx)
@@ -1410,163 +1687,175 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0xa30(%rbp), %xmm14
+               	movups	-0xa10(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	movq	-0xa48(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm0
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xa48(%rbp), %r8
+               	callq	 <L19>
+<L19>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x740(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	movq	$0x0, 0x10(%rcx)
-               	movq	$0x0, 0x18(%rcx)
-               	movq	$0x0, 0x20(%rcx)
-               	movq	$0x0, 0x28(%rcx)
-               	leaq	(%rcx), %rdx
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x280(%rbp), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%rcx), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0x20(%rcx), %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	movl	$0x12345678, (%r8)      # imm = 0x12345678
-               	movl	(%rdx), %ecx
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%ecx, %esi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movups	(%r15), %xmm0
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movl	(%rdx), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x940(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xa98(%rbp), %rbx
-               	movq	-0xaa0(%rbp), %r12
-               	movq	-0xaa8(%rbp), %r13
-               	movq	-0xab0(%rbp), %r14
-               	movq	-0xab8(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x928(%rbp)
                	leaq	0x2(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x3(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x5(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x6(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x7(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x8(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x9(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0xa(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0xb(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x9a0(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xc(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rbx), %rcx
@@ -1587,131 +1876,131 @@ Disassembly of section .text:
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x20(%rbp), %rcx
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x70(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r15
                	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0x960(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0x968(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0x970(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0x978(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%dil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0xa60(%rbp)
+               	movups	%xmm14, -0xa40(%rbp)
                	movq	%r12, %rdi
-               	movups	-0xa60(%rbp), %xmm0
+               	movups	-0xa40(%rbp), %xmm0
+               	callq	 <L25>
+<L25>:
+               	movaps	-0xa10(%rbp), %xmm14
+               	pxor	-0xa40(%rbp), %xmm14
+               	movaps	%xmm14, -0xa50(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa50(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
-               	movaps	-0xa30(%rbp), %xmm14
-               	pxor	-0xa60(%rbp), %xmm14
+               	movaps	-0xa20(%rbp), %xmm14
+               	paddb	-0xa00(%rbp), %xmm14
+               	movaps	%xmm14, -0xa60(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa60(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, -0xa70(%rbp)
                	movq	%rax, %rdi
                	movups	-0xa70(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movaps	-0xa40(%rbp), %xmm14
-               	paddb	-0xa20(%rbp), %xmm14
-               	movaps	%xmm14, -0xa80(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa80(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa90(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa90(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0xa90(%rbp), %xmm14
-               	movups	%xmm14, -0xa20(%rbp)
                	movups	-0xa70(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0xa80(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
-               	jmp	 <L18>
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0xa50(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0xa60(%rbp), %xmm14
+               	movups	%xmm14, -0xa20(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-linux/vec/vec_lane_ops.dis
+++ b/test/golden/x86_64-linux/vec/vec_lane_ops.dis
@@ -7,32 +7,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -42,28 +114,108 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -73,18 +225,58 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movsd	(%rdx), %xmm0
+               	movq	%xmm0, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -94,88 +286,217 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movq	%r12, -0x20(%rbp)
                	leaq	-0x10(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	leaq	(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %r12
+               	xorq	%rsi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movsbq	%dl, %rsi
                	callq	 <L12>
 <L12>:
+               	leaq	0x7(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L13>
 <L13>:
+               	leaq	0x8(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L14>
 <L14>:
+               	leaq	0x9(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
                	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%rdx, %rsi
                	callq	 <L15>
 <L15>:
+               	leaq	0xa(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L16>
+<L16>:
+               	leaq	0xb(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L17>
+<L17>:
+               	leaq	0xc(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L18>
+<L18>:
+               	leaq	0xd(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L19>
+<L19>:
+               	leaq	0xe(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L20>
+<L20>:
+               	leaq	0xf(%rbx), %rdx
+               	movzbl	(%rdx), %esi
+               	movsbq	%sil, %rdx
+               	movq	%rax, %rdi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -183,958 +504,615 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x710, %rsp            # imm = 0x710
-               	movq	%rbx, -0x6e8(%rbp)
-               	movq	%r12, -0x6f0(%rbp)
-               	movq	%r13, -0x6f8(%rbp)
-               	movq	%r14, -0x700(%rbp)
-               	movq	%r15, -0x708(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	movq	%rbx, %r11
+               	subq	$0x650, %rsp            # imm = 0x650
+               	movq	%rbx, -0x628(%rbp)
+               	movq	%r12, -0x630(%rbp)
+               	movq	%r13, -0x638(%rbp)
+               	movq	%r14, -0x640(%rbp)
+               	movq	%r15, -0x648(%rbp)
+               	movl	%edi, %eax
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0x608(%rbp)
-               	movq	%rbx, %r11
+<L1>:
+               	movss	%xmm14, -0x558(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L3>
+               	jl	 <L2>
                	cvtsi2sd	%r11, %xmm14
-               	jmp	 <L4>
-<L3>:
+               	jmp	 <L3>
+<L2>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm14
                	addsd	%xmm14, %xmm14
+<L3>:
+               	movsd	%xmm14, -0x568(%rbp)
+               	movb	%dil, %bl
+               	leaq	-0x10(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movl	$0x11111111, (%rdx)     # imm = 0x11111111
+               	leaq	0x4(%rcx), %rdx
+               	movl	$0x22222222, (%rdx)     # imm = 0x22222222
+               	leaq	0x8(%rcx), %rdx
+               	movl	$0x33333333, (%rdx)     # imm = 0x33333333
+               	leaq	0xc(%rcx), %rdx
+               	movl	$0x44444444, (%rdx)     # imm = 0x44444444
+               	movups	(%rcx), %xmm0
+               	leaq	-0x20(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	%ecx, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%rdx), %rcx
+               	movl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x40(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0xc(%r12), %rax
+               	movl	%edx, (%rax)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x580(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x580(%rbp), %xmm0
+               	callq	 <L4>
 <L4>:
-               	movsd	%xmm14, -0x618(%rbp)
-               	movb	%bl, %r12b
-               	leaq	-0x10(%rbp), %rdx
-               	leaq	(%rdx), %rsi
-               	movl	$0x11111111, (%rsi)     # imm = 0x11111111
-               	leaq	0x4(%rdx), %rsi
-               	movl	$0x22222222, (%rsi)     # imm = 0x22222222
-               	leaq	0x8(%rdx), %rsi
-               	movl	$0x33333333, (%rsi)     # imm = 0x33333333
-               	leaq	0xc(%rdx), %rsi
-               	movl	$0x44444444, (%rsi)     # imm = 0x44444444
-               	movups	(%rdx), %xmm2
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	(%rdx), %rsi
-               	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x30(%rbp), %rsi
-               	movups	%xmm2, (%rsi)
-               	leaq	(%rsi), %rdi
-               	movl	%edx, (%rdi)
-               	movups	(%rsi), %xmm2
-               	leaq	0xc(%rsi), %rdx
-               	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x40(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0xc(%rbx), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x630(%rbp)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L5>
-<L5>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
                	leaq	-0x50(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	leaq	0xc(%r12), %rcx
+               	movl	(%rcx), %r14d
+               	movups	(%r13), %xmm0
                	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movups	%xmm0, (%rcx)
+               	leaq	(%rcx), %rdx
+               	movl	%r14d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %r15d
+               	movups	(%r13), %xmm0
                	leaq	-0x70(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rdx
+               	movl	%r15d, (%rdx)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x4(%r12), %rcx
+               	movl	(%rcx), %r8d
+               	movq	%r8, -0x588(%rbp)
+               	movups	(%r13), %xmm0
                	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r13), %xmm3
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	(%r12), %rcx
+               	movl	(%rcx), %r8d
+               	movq	%r8, -0x590(%rbp)
+               	movups	(%r13), %xmm0
                	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r13)
-               	movups	(%r13), %xmm3
-               	leaq	-0xa0(%rbp), %r14
-               	movups	%xmm3, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rcx), %xmm0
+               	movups	%xmm0, (%r13)
+               	movups	(%r13), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	callq	 <L5>
+<L5>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x528(%rbp)
+               	movq	-0x528(%rbp), %r8
+               	leaq	-0xa0(%rbp), %r8
+               	movq	%r8, -0x598(%rbp)
+               	movq	-0x598(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xb0(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movq	-0x528(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x538(%rbp)
+               	movq	-0x538(%rbp), %r8
+               	leaq	-0xf0(%rbp), %r8
+               	movq	%r8, -0x530(%rbp)
+               	movq	-0x530(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x100(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movl	%r15d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x120(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x130(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movq	-0x588(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movq	-0x530(%rbp), %r8
+               	movups	%xmm0, (%r8)
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movq	-0x538(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L7>
+<L7>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x540(%rbp)
+               	movq	-0x540(%rbp), %r8
+               	leaq	-0x140(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x150(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	(%rdi), %rax
+               	movl	%r15d, (%rax)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x160(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rax), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	movq	-0x540(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	leaq	-0x190(%rbp), %rdx
+               	movq	$0x0, (%rdx)
+               	movq	$0x0, 0x8(%rdx)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdi
+               	movups	%xmm0, (%rdi)
+               	leaq	0x4(%rdi), %r15
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%r15)
+               	movups	(%rdi), %xmm0
+               	movups	%xmm0, (%rdx)
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x580(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rdi
+               	movl	%r14d, (%rdi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L10>
 <L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x1d0(%rbp), %rdx
+               	leaq	(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x4(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0x8(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	leaq	0xc(%rdx), %rdi
+               	movl	$0x0, (%rdi)
+               	movups	(%rdx), %xmm0
+               	movq	-0x590(%rbp), %r8
+               	movl	%r8d, %esi
+               	addl	$0x1, %esi
+               	leaq	-0x1e0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5b0(%rbp)
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L11>
 <L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	addl	%edi, %esi
+               	leaq	-0x1f0(%rbp), %r14
+               	movups	-0x5b0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	0x4(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5c0(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L12>
 <L12>:
-               	leaq	-0xb0(%rbp), %r14
-               	movq	$0x0, (%r14)
-               	movq	$0x0, 0x8(%r14)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r14), %xmm3
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r14)
-               	movups	(%r14), %xmm3
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm3, (%r15)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %edi
+               	xorl	%edi, %esi
+               	leaq	-0x200(%rbp), %r14
+               	movups	-0x5c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	0x8(%r14), %rdx
+               	movl	%esi, (%rdx)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x5d0(%rbp)
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rdx, %rsi
                	callq	 <L13>
 <L13>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%r12), %rdx
+               	movl	(%rdx), %edi
+               	subl	%edi, %esi
+               	leaq	-0x210(%rbp), %rdx
+               	movups	-0x5d0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x5e0(%rbp)
+               	leaq	0xc(%rdx), %rsi
+               	movl	(%rsi), %edx
                	movl	%edx, %esi
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x5e0(%rbp), %xmm0
                	callq	 <L15>
 <L15>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	(%r13), %xmm0
+               	movaps	%xmm0, %xmm14
+               	paddd	-0x580(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	leaq	-0x110(%rbp), %r15
-               	movq	$0x0, (%r15)
-               	movq	$0x0, 0x8(%r15)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movups	(%r15), %xmm3
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	movups	%xmm3, (%r15)
-               	movups	(%r15), %xmm3
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x638(%rbp)
-               	movq	-0x638(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x638(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	movaps	%xmm0, %xmm14
+               	psubd	-0x580(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
+               	movq	%rax, %r8
+               	movq	%r8, -0x548(%rbp)
+               	movq	-0x548(%rbp), %r8
+               	movq	-0x530(%rbp), %r8
+               	movups	(%r8), %xmm0
+               	leaq	-0x220(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	(%rsi), %edi
+               	leaq	(%r12), %rsi
+               	movl	(%rsi), %r14d
+               	imull	%r14d, %edi
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %r14d
+               	leaq	0x4(%r12), %rsi
+               	movl	(%rsi), %r15d
+               	imull	%r15d, %r14d
+               	leaq	0x8(%rdx), %rsi
+               	movl	(%rsi), %r15d
+               	leaq	0x8(%r12), %rsi
+               	movl	(%rsi), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%rdx), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%r14d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x250(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x260(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x548(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L18>
 <L18>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
+               	movups	(%r13), %xmm0
+               	movq	-0x598(%rbp), %r8
+               	movups	(%r8), %xmm3
+               	movaps	%xmm0, %xmm14
+               	pxor	%xmm3, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	-0x638(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	-0x170(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movups	(%rcx), %xmm3
-               	leaq	-0x180(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x190(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x4(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1a0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x8(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1b0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0xc(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x640(%rbp)
-               	movq	-0x640(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x640(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0x640(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	-0x1d0(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1e0(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
-               	leaq	0x4(%rdx), %rdi
-               	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm3
-               	movups	%xmm3, (%rcx)
-               	movups	(%rcx), %xmm3
-               	leaq	-0x1f0(%rbp), %r8
-               	movq	%r8, -0x648(%rbp)
-               	movq	-0x648(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x648(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	movq	-0x648(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x630(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm3
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	leaq	-0x210(%rbp), %r8
-               	movq	%r8, -0x650(%rbp)
-               	movq	-0x650(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	%edx, (%rsi)
-               	movq	-0x650(%rbp), %r8
-               	movups	(%r8), %xmm3
-               	movq	-0x650(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	movq	-0x650(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L32>
-<L32>:
-               	leaq	-0x220(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x0, (%rdx)
-               	movups	(%rcx), %xmm3
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	addl	$0x1, %edx
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x660(%rbp)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x668(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x668(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0x668(%rbp), %r8
-               	movl	%r8d, %ecx
-               	addl	%esi, %ecx
-               	leaq	-0x240(%rbp), %rdx
-               	movups	-0x660(%rbp), %xmm14
-               	movups	%xmm14, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x680(%rbp)
-               	leaq	0x4(%rdx), %rcx
-               	movl	(%rcx), %r8d
-               	movq	%r8, -0x688(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x688(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	movq	-0x688(%rbp), %r8
-               	movl	%r8d, %edx
-               	xorl	%esi, %edx
-               	leaq	-0x250(%rbp), %rcx
-               	movups	-0x680(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movl	%edx, (%rsi)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x6a0(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r8d
-               	movq	%r8, -0x6a8(%rbp)
-               	movq	%rax, %rdi
-               	movq	-0x6a8(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %esi
-               	movq	-0x6a8(%rbp), %r8
-               	movl	%r8d, %ecx
-               	subl	%esi, %ecx
-               	leaq	-0x260(%rbp), %r8
-               	movq	%r8, -0x6b0(%rbp)
-               	movq	-0x6b0(%rbp), %r8
-               	movups	-0x6a0(%rbp), %xmm14
-               	movups	%xmm14, (%r8)
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movl	%ecx, (%rsi)
-               	movq	-0x6b0(%rbp), %r8
-               	movups	(%r8), %xmm3
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	-0x6b0(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movups	(%r13), %xmm3
-               	movaps	%xmm3, %xmm14
-               	paddd	-0x630(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x270(%rbp), %r8
-               	movq	%r8, -0x6b8(%rbp)
-               	movq	-0x6b8(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x6b8(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L44>
-<L44>:
-               	movups	(%r14), %xmm3
-               	movaps	%xmm3, %xmm14
-               	psubd	-0x630(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %r8
-               	movq	%r8, -0x6c0(%rbp)
-               	movq	-0x6c0(%rbp), %r8
-               	movups	%xmm3, (%r8)
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	movq	-0x6c0(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L48>
-<L48>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x5f8(%rbp)
-               	movq	-0x5f8(%rbp), %r8
-               	movups	(%r15), %xmm2
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
-               	leaq	(%rbx), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
-               	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %r15d
-               	imull	%r15d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r15d
-               	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %eax
-               	imull	%eax, %r15d
-               	leaq	0xc(%rcx), %rax
-               	movl	(%rax), %ecx
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %edx
-               	imull	%edx, %ecx
-               	leaq	-0x2a0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	(%rax), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2b0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2c0(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rdx
-               	movl	%r15d, (%rdx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0xc(%rbx), %rax
-               	movl	%ecx, (%rax)
-               	movups	(%rbx), %xmm2
-               	leaq	(%rbx), %rax
-               	movl	(%rax), %ecx
-               	movq	-0x5f8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movups	(%r13), %xmm2
-               	movups	(%r14), %xmm3
-               	movaps	%xmm2, %xmm14
-               	pxor	%xmm3, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2f0(%rbp), %rcx
+               	leaq	-0x270(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xaab>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xab2>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7b9>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7c0>
                	leaq	0x4(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
+               	movss	%xmm0, (%rdx)
                	leaq	0x8(%rcx), %rdx
                	movl	$0x40700000, (%rdx)     # imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xacc>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_lane_ops.checksum+0xad3>
+               	movss	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7da>
+               	xorps	, %xmm0 <corpus.cases.vec.vec_lane_ops.checksum+0x7e1>
                	leaq	0xc(%rcx), %rdx
-               	movss	%xmm2, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movss	%xmm0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x280(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x608(%rbp), %xmm4
-               	leaq	-0x310(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	0x4(%rbx), %rcx
+               	addss	-0x558(%rbp), %xmm4
+               	leaq	-0x290(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	0x4(%r12), %rcx
                	movss	%xmm4, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
+               	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	-0x320(%rbp), %r13
+               	callq	 <L20>
+<L20>:
+               	leaq	-0x2a0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm1
+               	leaq	-0x2b0(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	leaq	0x8(%r12), %rcx
+               	movl	(%rcx), %r11d
+               	movl	%r11d, -0x5f0(%rbp)
+               	movups	(%r13), %xmm0
+               	leaq	-0x2c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x5f0(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm3
+               	leaq	-0x2d0(%rbp), %rcx
+               	movups	%xmm3, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	leaq	(%r12), %rcx
+               	movl	(%rcx), %r11d
+               	movl	%r11d, -0x600(%rbp)
+               	movups	(%r13), %xmm0
+               	leaq	-0x2e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x600(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r13)
                	movups	(%r13), %xmm0
-               	leaq	-0x370(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	leaq	-0x380(%rbp), %r14
+               	callq	 <L21>
+<L21>:
+               	leaq	-0x2f0(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm0
+               	leaq	-0x300(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x600(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
+               	leaq	-0x310(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	(%rdx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm4
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm4, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm0
+               	leaq	-0x330(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	movl	-0x5f0(%rbp), %r11d
+               	movl	%r11d, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x3d0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	(%rdx), %xmm0
-               	movups	(%r14), %xmm2
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r14), %xmm1
+               	leaq	-0x350(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movss	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%r14)
                	movups	(%r14), %xmm0
-               	leaq	-0x3f0(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	(%r15), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r15), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
+               	callq	 <L22>
+<L22>:
                	movups	(%r14), %xmm0
-               	movups	(%r13), %xmm2
+               	movups	(%r13), %xmm1
                	movaps	%xmm0, %xmm14
-               	mulps	%xmm2, %xmm14
+               	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x400(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	callq	 <L23>
+<L23>:
+               	movups	(%r13), %xmm0
+               	leaq	-0x360(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm2
-               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	subss	%xmm2, %xmm3
+               	movss	(%rdx), %xmm0
+               	movss	-0x600(%rbp), %xmm1
+               	subss	%xmm0, %xmm1
+               	movd	%xmm1, %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	leaq	0xc(%rbx), %rcx
+               	callq	 <L24>
+<L24>:
+               	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movups	(%r13), %xmm1
+               	leaq	-0x370(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
                	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm2
+               	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	subss	%xmm2, %xmm3
+               	subss	%xmm1, %xmm3
+               	movd	%xmm3, %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
-               	movss	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L74>
-<L74>:
-               	leaq	-0x430(%rbp), %rcx
+               	callq	 <L25>
+<L25>:
+               	leaq	-0x380(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1142,79 +1120,55 @@ Disassembly of section .text:
                	movabsq	$-0x3ffe000000000000, %r11 # imm = 0xC002000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
+               	leaq	-0x390(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movsd	(%rdx), %xmm2
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	addsd	-0x618(%rbp), %xmm3
-               	leaq	-0x450(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	%xmm3, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x6d0(%rbp)
-               	leaq	-0x460(%rbp), %r13
-               	movq	$0x0, (%r13)
-               	movq	$0x0, 0x8(%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
+               	movsd	(%rdx), %xmm1
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	addsd	-0x568(%rbp), %xmm3
+               	leaq	-0x3a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
-               	movsd	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movups	(%r13), %xmm2
-               	leaq	-0x480(%rbp), %rcx
+               	movsd	%xmm3, (%rdx)
+               	movups	(%rcx), %xmm14
+               	movups	%xmm14, -0x610(%rbp)
+               	leaq	-0x3b0(%rbp), %r12
+               	movq	$0x0, (%r12)
+               	movq	$0x0, 0x8(%r12)
+               	leaq	0x8(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%r12), %xmm2
+               	leaq	-0x3c0(%rbp), %rdx
+               	movups	%xmm2, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movsd	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
+               	movups	%xmm0, (%r12)
+               	leaq	(%rcx), %rdx
+               	movsd	(%rdx), %xmm0
+               	movups	(%r12), %xmm2
+               	leaq	-0x3d0(%rbp), %rcx
                	movups	%xmm2, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movsd	%xmm0, (%rdx)
                	movups	(%rcx), %xmm0
-               	movups	%xmm0, (%r13)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movups	%xmm0, (%r12)
                	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
+               	movups	-0x610(%rbp), %xmm0
+               	callq	 <L26>
+<L26>:
+               	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	movups	(%r13), %xmm0
-               	leaq	-0x490(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movups	(%r13), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	subpd	-0x6d0(%rbp), %xmm14
+               	subpd	-0x610(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x4a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x8(%rbx), %rcx
-               	movsd	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	leaq	-0x4b0(%rbp), %rcx
+               	callq	 <L28>
+<L28>:
+               	leaq	-0x3e0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$-0x9, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1248,36 +1202,36 @@ Disassembly of section .text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x8, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
+               	leaq	-0x3f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movzbl	(%rdx), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x4d0(%rbp), %rdx
+               	addl	%ebx, %ecx
+               	leaq	-0x400(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rsi
                	movb	%cl, (%rsi)
                	movups	(%rdx), %xmm0
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
-               	addl	%r12d, %edx
-               	leaq	-0x4e0(%rbp), %rbx
+               	addl	%ebx, %edx
+               	leaq	-0x410(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	0xf(%rbx), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x6e0(%rbp)
+               	movups	%xmm14, -0x620(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x6e0(%rbp), %xmm0
-               	callq	 <L81>
-<L81>:
-               	leaq	-0x4f0(%rbp), %r12
+               	movups	-0x620(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	leaq	-0x420(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1286,7 +1240,7 @@ Disassembly of section .text:
                	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x440(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1295,7 +1249,7 @@ Disassembly of section .text:
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x450(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1304,7 +1258,7 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x460(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1313,7 +1267,7 @@ Disassembly of section .text:
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x470(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1322,7 +1276,7 @@ Disassembly of section .text:
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x480(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1331,7 +1285,7 @@ Disassembly of section .text:
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x490(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1340,7 +1294,7 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x4a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1349,7 +1303,7 @@ Disassembly of section .text:
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x4b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1358,7 +1312,7 @@ Disassembly of section .text:
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x4c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1367,7 +1321,7 @@ Disassembly of section .text:
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x4d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1376,7 +1330,7 @@ Disassembly of section .text:
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x4e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1385,7 +1339,7 @@ Disassembly of section .text:
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x4f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1394,7 +1348,7 @@ Disassembly of section .text:
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x500(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1403,7 +1357,7 @@ Disassembly of section .text:
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5e0(%rbp), %rcx
+               	leaq	-0x510(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1412,7 +1366,7 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%r12), %xmm0
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
@@ -1420,27 +1374,27 @@ Disassembly of section .text:
                	movups	%xmm0, (%r12)
                	movups	(%r12), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
+               	callq	 <L30>
+<L30>:
                	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	paddb	-0x6e0(%rbp), %xmm14
+               	paddb	-0x620(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L31>
+<L31>:
                	movups	(%r12), %xmm0
                	movaps	%xmm0, %xmm14
-               	pxor	-0x6e0(%rbp), %xmm14
+               	pxor	-0x620(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x6e8(%rbp), %rbx
-               	movq	-0x6f0(%rbp), %r12
-               	movq	-0x6f8(%rbp), %r13
-               	movq	-0x700(%rbp), %r14
-               	movq	-0x708(%rbp), %r15
+               	callq	 <L32>
+<L32>:
+               	movq	-0x628(%rbp), %rbx
+               	movq	-0x630(%rbp), %r12
+               	movq	-0x638(%rbp), %r13
+               	movq	-0x640(%rbp), %r14
+               	movq	-0x648(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_mem.dis
+++ b/test/golden/x86_64-linux/vec/vec_mem.dis
@@ -7,27 +7,88 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x30, %rsp
                	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
+               	movq	%r12, -0x30(%rbp)
+               	leaq	-0xc(%rbp), %rax
                	movups	%xmm0, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rcx
-               	movq	%rcx, (%rbx)
-               	movl	-0x14(%rbp), %ecx
-               	movl	%ecx, 0x8(%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	-0x1c(%rbp), %rdx
+               	movq	%rdx, (%rax)
+               	movl	-0x14(%rbp), %edx
+               	movl	%edx, 0x8(%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	movq	%rdi, %rax
                	movq	-0x28(%rbp), %rbx
+               	movq	-0x30(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -37,39 +98,137 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0xa0, %rsp
                	movq	%rbx, -0x98(%rbp)
-               	movq	%rsi, %rbx
-               	leaq	-0x20(%rbp), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	-0x34(%rbp), %rcx
-               	leaq	-0x48(%rbp), %rcx
-               	leaq	-0x5c(%rbp), %rcx
-               	leaq	-0x70(%rbp), %rcx
-               	leaq	-0x84(%rbp), %rcx
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0xa0(%rbp)
+               	leaq	-0x20(%rbp), %rax
+               	movq	%rsi, (%rax)
+               	leaq	-0x34(%rbp), %rax
+               	leaq	-0x48(%rbp), %rax
+               	leaq	-0x5c(%rbp), %rax
+               	leaq	-0x70(%rbp), %rax
+               	leaq	-0x84(%rbp), %rax
+               	leaq	(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x10(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L4>
+               	leaq	0x8(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rax
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	leaq	0x10(%rsi), %rax
+               	movss	(%rax), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L8>
+<L9>:
+               	movq	%rdi, %rax
                	movq	-0x98(%rbp), %rbx
+               	movq	-0xa0(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -77,1543 +236,1436 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xae0, %rsp            # imm = 0xAE0
-               	movq	%rbx, -0xab8(%rbp)
-               	movq	%r12, -0xac0(%rbp)
-               	movq	%r13, -0xac8(%rbp)
-               	movq	%r14, -0xad0(%rbp)
-               	movq	%r15, -0xad8(%rbp)
-               	movq	%rdi, %rbx
+               	subq	$0x850, %rsp            # imm = 0x850
+               	movq	%rbx, -0x828(%rbp)
+               	movq	%r12, -0x830(%rbp)
+               	movq	%r13, -0x838(%rbp)
+               	movq	%r14, -0x840(%rbp)
+               	movq	%r15, -0x848(%rbp)
                	leaq	-0x14(%rbp), %r8
-               	movq	%r8, -0x918(%rbp)
-               	leaq	-0x28(%rbp), %r8
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x688(%rbp)
+               	leaq	-0x28(%rbp), %r12
                	leaq	-0x3c(%rbp), %r8
-               	movq	%r8, -0x928(%rbp)
-               	leaq	-0x50(%rbp), %r8
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x6a0(%rbp)
+               	leaq	-0x50(%rbp), %r14
                	leaq	-0x64(%rbp), %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x6d8(%rbp)
                	leaq	-0x78(%rbp), %r8
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x7e8(%rbp)
                	leaq	-0x8c(%rbp), %r8
-               	movq	%r8, -0x9a8(%rbp)
-               	leaq	-0xa0(%rbp), %r13
-               	leaq	-0xb4(%rbp), %r14
-               	leaq	-0xc8(%rbp), %r15
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	-0xa0(%rbp), %r8
+               	movq	%r8, -0x620(%rbp)
+               	leaq	-0xb4(%rbp), %r8
+               	movq	%r8, -0x628(%rbp)
+               	leaq	-0xc8(%rbp), %r8
+               	movq	%r8, -0x630(%rbp)
                	leaq	-0xdc(%rbp), %r8
-               	movq	%r8, -0xa30(%rbp)
+               	movq	%r8, -0x638(%rbp)
                	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0x940(%rbp)
+               	movq	%r8, -0x640(%rbp)
                	leaq	-0x104(%rbp), %r8
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x648(%rbp)
                	leaq	-0x118(%rbp), %r8
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x650(%rbp)
                	leaq	-0x12c(%rbp), %r8
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x658(%rbp)
                	leaq	-0x140(%rbp), %r8
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x660(%rbp)
                	leaq	-0x154(%rbp), %r8
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x668(%rbp)
                	leaq	-0x168(%rbp), %r8
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x670(%rbp)
                	leaq	-0x17c(%rbp), %r8
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x980(%rbp)
-               	leaq	-0x1a4(%rbp), %rsi
-               	leaq	-0x1b8(%rbp), %rsi
-               	leaq	-0x1cc(%rbp), %rsi
-               	leaq	-0x1e0(%rbp), %rsi
-               	leaq	-0x1f4(%rbp), %rsi
-               	leaq	-0x208(%rbp), %rsi
-               	leaq	-0x21c(%rbp), %rsi
-               	leaq	-0x230(%rbp), %rsi
-               	leaq	-0x244(%rbp), %rsi
-               	leaq	-0x258(%rbp), %rsi
-               	leaq	-0x26c(%rbp), %rsi
-               	leaq	-0x280(%rbp), %rsi
-               	leaq	-0x294(%rbp), %rsi
-               	leaq	-0x2a8(%rbp), %rsi
-               	leaq	-0x2bc(%rbp), %rsi
-               	leaq	-0x2d0(%rbp), %rsi
-               	leaq	-0x2e4(%rbp), %rsi
-               	leaq	-0x2f8(%rbp), %rsi
-               	leaq	-0x30c(%rbp), %rsi
-               	leaq	-0x320(%rbp), %rsi
-               	leaq	-0x334(%rbp), %rsi
-               	leaq	-0x348(%rbp), %rsi
-               	leaq	-0x35c(%rbp), %rsi
-               	leaq	-0x370(%rbp), %rsi
-               	leaq	-0x384(%rbp), %rsi
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x988(%rbp)
-               	movq	-0x988(%rbp), %r8
-               	movq	%rbx, %r11
+               	movq	%r8, -0x680(%rbp)
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm14
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
-<L2>:
-               	movss	%xmm14, -0xa40(%rbp)
-               	leaq	-0x3d8(%rbp), %rbx
+<L1>:
+               	movss	%xmm14, -0x7d8(%rbp)
+               	leaq	-0x404(%rbp), %rbx
                	leaq	(%rbx), %rsi
                	addq	$0x0, %rsi
                	movq	$0x50, %rdi
-<L3>:
+<L2>:
                	movq	$0x0, (%rsi)
                	addq	$0x8, %rsi
                	subq	$0x8, %rdi
                	cmpq	$0x0, %rdi
-               	jne	 <L3>
+               	jne	 <L2>
                	movl	$0x0, (%rsi)
                	movq	$0x0, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0x690(%rbp), %r8
                	cmpq	$0x7, %r8
-               	jb	 <L4>
-               	jmp	 <L7>
-<L4>:
-               	movq	-0x990(%rbp), %r8
+               	jb	 <L3>
+               	jmp	 <L6>
+<L3>:
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %r11
                	testq	%r11, %r11
-               	jl	 <L5>
+               	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L6>
-<L5>:
+               	jmp	 <L5>
+<L4>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L6>:
-               	leaq	-0x3e4(%rbp), %rdi
-               	movq	$0x0, (%rdi)
-               	movl	$0x0, 0x8(%rdi)
+<L5>:
+               	leaq	-0x19c(%rbp), %r8
+               	movq	%r8, -0x698(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x698(%rbp), %r8
+               	movl	$0x0, 0x8(%r8)
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	-0xa40(%rbp), %xmm2
-               	movq	$0x0, -0x3f4(%rbp)
-               	movq	$0x0, -0x3ec(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x3f4(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x3ec(%rbp)
-               	movups	-0x3f4(%rbp), %xmm3
-               	leaq	-0x400(%rbp), %rax
-               	movups	%xmm3, -0x410(%rbp)
-               	movq	-0x410(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x408(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x420(%rbp)
-               	movq	$0x0, -0x418(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x420(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x418(%rbp)
-               	movups	-0x420(%rbp), %xmm2
-               	movups	%xmm2, -0x430(%rbp)
-               	movq	-0x430(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x428(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
+               	addss	-0x7d8(%rbp), %xmm2
+               	movq	$0x0, -0x1ac(%rbp)
+               	movq	$0x0, -0x1a4(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x1ac(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x1a4(%rbp)
+               	movups	-0x1ac(%rbp), %xmm3
+               	leaq	-0x1b8(%rbp), %rsi
+               	movups	%xmm3, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x1c0(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x1d8(%rbp)
+               	movq	$0x0, -0x1d0(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x1d8(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x1d0(%rbp)
+               	movups	-0x1d8(%rbp), %xmm2
+               	movups	%xmm2, -0x1e8(%rbp)
+               	movq	-0x1e8(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x1e0(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x377>
-               	movq	$0x0, -0x440(%rbp)
-               	movq	$0x0, -0x438(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x440(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x438(%rbp)
-               	movups	-0x440(%rbp), %xmm3
-               	leaq	-0x44c(%rbp), %rax
-               	movups	%xmm3, -0x45c(%rbp)
-               	movq	-0x45c(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x454(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x4(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x46c(%rbp)
-               	movq	$0x0, -0x464(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x46c(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x464(%rbp)
-               	movups	-0x46c(%rbp), %xmm2
-               	movups	%xmm2, -0x47c(%rbp)
-               	movq	-0x47c(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x474(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x422>
+               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x2ea>
+               	movq	$0x0, -0x1f8(%rbp)
+               	movq	$0x0, -0x1f0(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x1f8(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x1f0(%rbp)
+               	movups	-0x1f8(%rbp), %xmm3
+               	leaq	-0x204(%rbp), %rsi
+               	movups	%xmm3, -0x214(%rbp)
+               	movq	-0x214(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x20c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x224(%rbp)
+               	movq	$0x0, -0x21c(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x224(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x21c(%rbp)
+               	movups	-0x224(%rbp), %xmm2
+               	movups	%xmm2, -0x234(%rbp)
+               	movq	-0x234(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x22c(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x3b3>
                	subss	%xmm0, %xmm2
-               	movq	$0x0, -0x48c(%rbp)
-               	movq	$0x0, -0x484(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x48c(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x484(%rbp)
-               	movups	-0x48c(%rbp), %xmm0
-               	leaq	-0x498(%rbp), %rax
-               	movups	%xmm0, -0x4a8(%rbp)
-               	movq	-0x4a8(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x4a0(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x8(%rax), %rsi
-               	movss	%xmm2, (%rsi)
-               	movq	$0x0, -0x4b8(%rbp)
-               	movq	$0x0, -0x4b0(%rbp)
-               	movq	(%rax), %rsi
-               	movq	%rsi, -0x4b8(%rbp)
-               	movl	0x8(%rax), %esi
-               	movl	%esi, -0x4b0(%rbp)
-               	movups	-0x4b8(%rbp), %xmm0
-               	movups	%xmm0, -0x4c8(%rbp)
-               	movq	-0x4c8(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x4c0(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	movq	$0x0, -0x4d8(%rbp)
-               	movq	$0x0, -0x4d0(%rbp)
-               	movq	(%rdi), %rax
-               	movq	%rax, -0x4d8(%rbp)
-               	movl	0x8(%rdi), %eax
-               	movl	%eax, -0x4d0(%rbp)
-               	movups	-0x4d8(%rbp), %xmm0
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	imulq	$0xc, %rax, %rax
-               	leaq	(%rbx,%rax), %rsi
-               	movups	%xmm0, -0x4e8(%rbp)
-               	movq	-0x4e8(%rbp), %rax
-               	movq	%rax, (%rsi)
-               	movl	-0x4e0(%rbp), %eax
-               	movl	%eax, 0x8(%rsi)
-               	movq	-0x990(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rax, %r8
-               	movq	%r8, -0x990(%rbp)
-               	movq	-0x990(%rbp), %r8
-               	cmpq	$0x7, %r8
-               	jb	 <L4>
-<L7>:
-               	movq	-0x988(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa50(%rbp)
-               	movq	$0x7, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-               	jmp	 <L12>
-<L8>:
-               	movq	-0xa58(%rbp), %r9
-               	movq	%r9, %r8
-               	subq	$0x1, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
-               	movq	%r8, %rdi
-               	imulq	$0xc, %rdi, %rdi
-               	leaq	(%rbx,%rdi), %r8
-               	movq	%r8, -0x9a0(%rbp)
-               	movq	$0x0, -0x4f8(%rbp)
-               	movq	$0x0, -0x4f0(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movq	(%r8), %rdi
-               	movq	%rdi, -0x4f8(%rbp)
-               	movq	-0x9a0(%rbp), %r8
-               	movl	0x8(%r8), %edi
-               	movl	%edi, -0x4f0(%rbp)
-               	movups	-0x4f8(%rbp), %xmm0
-               	leaq	-0x504(%rbp), %r12
-               	movups	%xmm0, -0x514(%rbp)
-               	movq	-0x514(%rbp), %rdi
-               	movq	%rdi, (%r12)
-               	movl	-0x50c(%rbp), %edi
-               	movl	%edi, 0x8(%r12)
-               	leaq	(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa50(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L9>
-<L9>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b0(%rbp)
-               	movq	-0x9b0(%rbp), %r8
-               	leaq	0x4(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9b0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L10>
-<L10>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9b8(%rbp)
-               	movq	-0x9b8(%rbp), %r8
-               	leaq	0x8(%r12), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9b8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L11>
-<L11>:
-               	movq	%rax, %rdi
-               	movq	%rdi, %r8
-               	movq	%r8, -0xa50(%rbp)
-               	movq	-0xa48(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa58(%rbp)
-               	movq	-0xa58(%rbp), %r8
-               	movq	$0x0, %r11
-               	cmpq	%r8, %r11
-               	jb	 <L8>
-<L12>:
-               	leaq	-0x554(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movq	$0x0, 0x28(%r12)
-               	movq	$0x0, 0x30(%r12)
-               	movq	$0x0, 0x38(%r12)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L13>
-               	jmp	 <L14>
-<L13>:
-               	movq	-0x9c0(%rbp), %r8
+               	movq	$0x0, -0x244(%rbp)
+               	movq	$0x0, -0x23c(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x244(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x23c(%rbp)
+               	movups	-0x244(%rbp), %xmm0
+               	leaq	-0x250(%rbp), %rsi
+               	movups	%xmm0, -0x260(%rbp)
+               	movq	-0x260(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x258(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movss	%xmm2, (%rdi)
+               	movq	$0x0, -0x270(%rbp)
+               	movq	$0x0, -0x268(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x270(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x268(%rbp)
+               	movups	-0x270(%rbp), %xmm0
+               	movups	%xmm0, -0x280(%rbp)
+               	movq	-0x280(%rbp), %rsi
+               	movq	-0x698(%rbp), %r8
+               	movq	%rsi, (%r8)
+               	movl	-0x278(%rbp), %esi
+               	movq	-0x698(%rbp), %r8
+               	movl	%esi, 0x8(%r8)
+               	movq	$0x0, -0x290(%rbp)
+               	movq	$0x0, -0x288(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	%rsi, -0x290(%rbp)
+               	movq	-0x698(%rbp), %r8
+               	movl	0x8(%r8), %esi
+               	movl	%esi, -0x288(%rbp)
+               	movups	-0x290(%rbp), %xmm0
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %rsi
                	imulq	$0xc, %rsi, %rsi
                	leaq	(%rbx,%rsi), %rdi
-               	movq	$0x0, -0x564(%rbp)
-               	movq	$0x0, -0x55c(%rbp)
-               	movq	(%rdi), %rsi
-               	movq	%rsi, -0x564(%rbp)
-               	movl	0x8(%rdi), %esi
-               	movl	%esi, -0x55c(%rbp)
-               	movups	-0x564(%rbp), %xmm0
-               	movq	-0x9c0(%rbp), %r8
+               	movups	%xmm0, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %rsi
+               	movq	%rsi, (%rdi)
+               	movl	-0x298(%rbp), %esi
+               	movl	%esi, 0x8(%rdi)
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	(%rdi), %rsi
-               	movups	%xmm0, -0x574(%rbp)
-               	movq	-0x574(%rbp), %rdx
-               	movq	%rdx, (%rsi)
-               	movl	-0x56c(%rbp), %edx
-               	movl	%edx, 0x8(%rsi)
-               	movq	-0x9c0(%rbp), %r8
-               	movl	%r8d, %edx
-               	movl	$0xaaaaaaaa, %esi       # imm = 0xAAAAAAAA
-               	subl	%edx, %esi
-               	leaq	0xc(%rdi), %rdx
-               	movl	%esi, (%rdx)
-               	movq	-0x9c0(%rbp), %r8
-               	movq	%r8, %rdx
-               	addq	$0x1, %rdx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x9c0(%rbp)
-               	movq	-0x9c0(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L13>
-<L14>:
-               	movq	-0xa50(%rbp), %r9
-               	movq	%r9, %r8
-               	movq	%r8, -0xa60(%rbp)
+               	addq	$0x1, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0x690(%rbp), %r8
+               	cmpq	$0x7, %r8
+               	jb	 <L3>
+<L6>:
+               	movabsq	$-0x340d631b7bdddcdb, %r8 # imm = 0xCBF29CE484222325
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	$0x7, %r13
+               	movq	$0x0, %r11
+               	cmpq	%r13, %r11
+               	jb	 <L7>
+               	jmp	 <L9>
+<L7>:
+               	subq	$0x1, %r13
+               	movq	%r13, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%rbx,%rdi), %r8
+               	movq	%r8, -0x6a8(%rbp)
+               	movq	$0x0, -0x2b0(%rbp)
+               	movq	$0x0, -0x2a8(%rbp)
+               	movq	-0x6a8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x2b0(%rbp)
+               	movq	-0x6a8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x2a8(%rbp)
+               	movups	-0x2b0(%rbp), %xmm0
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movq	%rax, %rsi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x7e0(%rbp)
+               	movq	$0x0, %r11
+               	cmpq	%r13, %r11
+               	jb	 <L7>
+<L9>:
+               	leaq	-0x2f0(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, 0x18(%r13)
+               	movq	$0x0, 0x20(%r13)
+               	movq	$0x0, 0x28(%r13)
+               	movq	$0x0, 0x30(%r13)
+               	movq	$0x0, 0x38(%r13)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa68(%rbp)
-               	movq	-0xa68(%rbp), %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	-0x6b0(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L15>
-               	jmp	 <L20>
-<L15>:
-               	movq	-0xa68(%rbp), %r8
-               	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	(%rdi), %rsi
-               	movq	$0x0, -0x584(%rbp)
-               	movq	$0x0, -0x57c(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x584(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x57c(%rbp)
-               	movups	-0x584(%rbp), %xmm0
-               	leaq	-0x590(%rbp), %r8
-               	movq	%r8, -0xa70(%rbp)
-               	movups	%xmm0, -0x5a0(%rbp)
-               	movq	-0x5a0(%rbp), %rdi
-               	movq	-0xa70(%rbp), %r8
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0xc, %rdi, %rdi
+               	leaq	(%rbx,%rdi), %r8
+               	movq	%r8, -0x6b8(%rbp)
+               	movq	$0x0, -0x300(%rbp)
+               	movq	$0x0, -0x2f8(%rbp)
+               	movq	-0x6b8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x300(%rbp)
+               	movq	-0x6b8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x2f8(%rbp)
+               	movups	-0x300(%rbp), %xmm0
+               	movq	-0x6b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x6c0(%rbp)
+               	movq	-0x6c0(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x6c8(%rbp)
+               	movups	%xmm0, -0x310(%rbp)
+               	movq	-0x310(%rbp), %rdi
+               	movq	-0x6c8(%rbp), %r8
                	movq	%rdi, (%r8)
-               	movl	-0x598(%rbp), %edi
-               	movq	-0xa70(%rbp), %r8
+               	movl	-0x308(%rbp), %edi
+               	movq	-0x6c8(%rbp), %r8
                	movl	%edi, 0x8(%r8)
-               	movq	-0xa70(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa60(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
+               	movl	%r8d, %edi
+               	movl	$0xaaaaaaaa, %r8d       # imm = 0xAAAAAAAA
+               	subl	%edi, %r8d
+               	movq	%r8, -0x6d0(%rbp)
+               	movq	-0x6c0(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movq	-0x6d0(%rbp), %r8
+               	movl	%r8d, (%rdi)
+               	movq	-0x6b0(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L16>
-<L16>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9c8(%rbp)
-               	movq	-0x9c8(%rbp), %r8
-               	movq	-0xa70(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9c8(%rbp), %r8
+               	addq	$0x1, %rdi
+               	movq	%rdi, %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	-0x6b0(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L10>
+<L11>:
+               	movq	-0x7e0(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	$0x0, %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	-0x7f8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L12>
+               	jmp	 <L16>
+<L12>:
+               	movq	-0x7f8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L17>
-<L17>:
+               	imulq	$0x10, %rdi, %rdi
+               	leaq	(%r13,%rdi), %r8
+               	movq	%r8, -0x6e0(%rbp)
+               	movq	-0x6e0(%rbp), %r9
+               	leaq	(%r9), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	$0x0, -0x320(%rbp)
+               	movq	$0x0, -0x318(%rbp)
+               	movq	-0x6e8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x320(%rbp)
+               	movq	-0x6e8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x318(%rbp)
+               	movups	-0x320(%rbp), %xmm0
+               	movq	%r15, %rdi
+               	callq	 <L13>
+<L13>:
                	movq	%rax, %r8
-               	movq	%r8, -0x9d0(%rbp)
-               	movq	-0x9d0(%rbp), %r8
-               	movq	-0xa70(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0x9d0(%rbp), %r8
+               	movq	%r8, -0x6f0(%rbp)
+               	movq	-0x6f0(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
+               	leaq	0xc(%r8), %rdi
+               	movl	(%rdi), %r8d
+               	movq	%r8, -0x6f8(%rbp)
+               	movq	-0x6f8(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x708(%rbp)
+               	movq	-0x6f0(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x710(%rbp)
+               	movq	-0x710(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	-0x710(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L18>
-<L18>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9d8(%rbp)
-               	movq	-0x9d8(%rbp), %r8
-               	movq	-0xa68(%rbp), %r8
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x708(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x700(%rbp), %r9
+               	movq	%r9, %r8
+               	xorq	%rdi, %r8
+               	movq	%r8, -0x718(%rbp)
+               	movq	-0x718(%rbp), %r8
+               	movq	%r8, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	movq	-0x710(%rbp), %r9
+               	movq	%r9, %r8
+               	addq	$0x1, %r8
+               	movq	%r8, -0x720(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x700(%rbp)
+               	movq	-0x720(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x710(%rbp)
+               	movq	-0x710(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L14>
+<L15>:
+               	movq	-0x7f8(%rbp), %r8
                	movq	%r8, %rsi
-               	imulq	$0x10, %rsi, %rsi
-               	leaq	(%r12,%rsi), %rdi
-               	leaq	0xc(%rdi), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x9e0(%rbp)
-               	movq	-0x9d8(%rbp), %r8
+               	addq	$0x1, %rsi
+               	movq	-0x700(%rbp), %r8
+               	movq	%r8, %r15
+               	movq	%rsi, %r8
+               	movq	%r8, -0x7f8(%rbp)
+               	movq	-0x7f8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L12>
+<L16>:
+               	leaq	-0x334(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movl	$0x0, 0x10(%r13)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x728(%rbp)
+               	movq	-0x728(%rbp), %r8
+               	movb	$-0x25, (%r8)
+               	leaq	0x3c(%rbx), %rdi
+               	movq	$0x0, -0x344(%rbp)
+               	movq	$0x0, -0x33c(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x344(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x33c(%rbp)
+               	movups	-0x344(%rbp), %xmm0
+               	leaq	0x4(%r13), %rsi
+               	movups	%xmm0, -0x354(%rbp)
+               	movq	-0x354(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x34c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x10(%r13), %rsi
+               	movb	$-0x53, (%rsi)
+               	movq	-0x728(%rbp), %r8
+               	movzbl	(%r8), %esi
+               	movzbq	%sil, %r8
+               	movq	%r8, -0x730(%rbp)
+               	movq	%r15, %r8
+               	movq	%r8, -0x738(%rbp)
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+               	jmp	 <L18>
+<L17>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x730(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x9e0(%rbp), %r8
-               	movl	%r8d, %esi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %r8
+               	movq	%r8, -0x738(%rbp)
+               	cmpq	$0x8, %rsi
+               	jb	 <L17>
+<L18>:
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x414(%rbp)
+               	movq	$0x0, -0x40c(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x414(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x40c(%rbp)
+               	movups	-0x414(%rbp), %xmm0
+               	movq	-0x738(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L19>
 <L19>:
-               	movq	%rax, %rdx
-               	movq	-0xa68(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
-               	movq	%rdx, %r8
-               	movq	%r8, -0xa60(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0xa68(%rbp)
-               	movq	-0xa68(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L15>
+               	movq	%rax, %rsi
+               	leaq	0x10(%r13), %rdi
+               	movzbl	(%rdi), %r15d
+               	movzbq	%r15b, %r8
+               	movq	%r8, -0x748(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x740(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L20>
+               	jmp	 <L21>
 <L20>:
-               	leaq	-0x5b4(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movl	$0x0, 0x10(%r12)
-               	leaq	(%r12), %rax
-               	movb	$-0x25, (%rax)
-               	leaq	0x3c(%rbx), %rsi
-               	movq	$0x0, -0x5c4(%rbp)
-               	movq	$0x0, -0x5bc(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x5c4(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x5bc(%rbp)
-               	movups	-0x5c4(%rbp), %xmm0
-               	leaq	0x4(%r12), %r8
-               	movq	%r8, -0x9e8(%rbp)
-               	movups	%xmm0, -0x5d4(%rbp)
-               	movq	-0x5d4(%rbp), %rsi
-               	movq	-0x9e8(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x5cc(%rbp), %esi
-               	movq	-0x9e8(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	leaq	0x10(%r12), %rsi
-               	movb	$-0x53, (%rsi)
-               	movzbl	(%rax), %esi
-               	movq	-0xa60(%rbp), %r8
+               	movq	%r15, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	-0x748(%rbp), %r8
+               	movq	%r8, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	-0x740(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L21>
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %r15
+               	movq	%rdi, %r8
+               	movq	%r8, -0x740(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L20>
 <L21>:
-               	movq	$0x0, -0x5e4(%rbp)
-               	movq	$0x0, -0x5dc(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movq	(%r8), %rdx
-               	movq	%rdx, -0x5e4(%rbp)
-               	movq	-0x9e8(%rbp), %r8
-               	movl	0x8(%r8), %edx
-               	movl	%edx, -0x5dc(%rbp)
-               	movups	-0x5e4(%rbp), %xmm0
-               	leaq	-0x5f0(%rbp), %r8
-               	movq	%r8, -0xa78(%rbp)
-               	movups	%xmm0, -0x600(%rbp)
-               	movq	-0x600(%rbp), %rsi
-               	movq	-0xa78(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x5f8(%rbp), %esi
-               	movq	-0xa78(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa78(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	movq	-0xa78(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	movq	-0xa78(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	leaq	0x10(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x9f0(%rbp)
-               	movq	-0x9f0(%rbp), %r8
-               	leaq	-0x6c4(%rbp), %r8
-               	movq	%r8, -0xa80(%rbp)
-               	leaq	-0x6d8(%rbp), %rsi
-               	movq	(%r12), %rdi
-               	movq	0x8(%r12), %rax
-               	movl	0x10(%r12), %r8d
-               	movq	%r8, -0x9f8(%rbp)
+               	leaq	-0x524(%rbp), %r15
+               	leaq	-0x538(%rbp), %rsi
+               	movq	(%r13), %rdi
+               	movq	0x8(%r13), %r8
+               	movq	%r8, -0x750(%rbp)
+               	movl	0x10(%r13), %r8d
+               	movq	%r8, -0x758(%rbp)
                	movq	%rdi, (%rsi)
-               	movq	%rax, 0x8(%rsi)
-               	movq	-0x9f8(%rbp), %r8
+               	movq	-0x750(%rbp), %r8
+               	movq	%r8, 0x8(%rsi)
+               	movq	-0x758(%rbp), %r8
                	movl	%r8d, 0x10(%rsi)
-               	movq	(%rsi), %rax
-               	movq	0x8(%rsi), %rdi
-               	movl	0x10(%rsi), %r8d
-               	movq	%r8, -0xa00(%rbp)
-               	movq	-0xa80(%rbp), %r8
-               	movq	%rax, (%r8)
-               	movq	-0xa80(%rbp), %r8
-               	movq	%rdi, 0x8(%r8)
-               	movq	-0xa80(%rbp), %r8
-               	movq	-0xa00(%rbp), %r9
-               	movl	%r9d, 0x10(%r8)
-               	movq	-0xa80(%rbp), %r9
-               	leaq	0x4(%r9), %r8
-               	movq	%r8, -0xa88(%rbp)
-               	movq	$0x0, -0x6e8(%rbp)
-               	movq	$0x0, -0x6e0(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x6e8(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x6e0(%rbp)
-               	movups	-0x6e8(%rbp), %xmm0
-               	leaq	0xc(%rbx), %rsi
-               	movq	$0x0, -0x6f8(%rbp)
-               	movq	$0x0, -0x6f0(%rbp)
                	movq	(%rsi), %rdi
-               	movq	%rdi, -0x6f8(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x6f0(%rbp)
-               	movups	-0x6f8(%rbp), %xmm2
+               	movq	0x8(%rsi), %r8
+               	movq	%r8, -0x760(%rbp)
+               	movl	0x10(%rsi), %r8d
+               	movq	%r8, -0x768(%rbp)
+               	movq	%rdi, (%r15)
+               	movq	-0x760(%rbp), %r8
+               	movq	%r8, 0x8(%r15)
+               	movq	-0x768(%rbp), %r8
+               	movl	%r8d, 0x10(%r15)
+               	leaq	0x4(%r15), %r8
+               	movq	%r8, -0x770(%rbp)
+               	movq	$0x0, -0x548(%rbp)
+               	movq	$0x0, -0x540(%rbp)
+               	movq	-0x770(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x548(%rbp)
+               	movq	-0x770(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x540(%rbp)
+               	movups	-0x548(%rbp), %xmm0
+               	leaq	0xc(%rbx), %rdi
+               	movq	$0x0, -0x558(%rbp)
+               	movq	$0x0, -0x550(%rbp)
+               	movq	(%rdi), %rsi
+               	movq	%rsi, -0x558(%rbp)
+               	movl	0x8(%rdi), %esi
+               	movl	%esi, -0x550(%rbp)
+               	movups	-0x558(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	addps	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x708(%rbp)
-               	movq	-0x708(%rbp), %rsi
-               	movq	-0xa88(%rbp), %r8
+               	movups	%xmm0, -0x568(%rbp)
+               	movq	-0x568(%rbp), %rsi
+               	movq	-0x770(%rbp), %r8
                	movq	%rsi, (%r8)
-               	movl	-0x700(%rbp), %esi
-               	movq	-0xa88(%rbp), %r8
+               	movl	-0x560(%rbp), %esi
+               	movq	-0x770(%rbp), %r8
                	movl	%esi, 0x8(%r8)
-               	movq	-0xa80(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movzbl	(%rsi), %r8d
-               	movq	%r8, -0xa08(%rbp)
-               	movq	-0x9f0(%rbp), %r8
+               	leaq	(%r15), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %r8
+               	movq	%r8, -0x778(%rbp)
+               	movq	-0x740(%rbp), %r9
+               	movq	%r9, %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	-0x788(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	-0x788(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0xa08(%rbp), %r8
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x778(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x780(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L26>
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	movq	-0x788(%rbp), %r8
+               	movq	%r8, %rdi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %r8
+               	movq	%r8, -0x780(%rbp)
+               	movq	%rdi, %r8
+               	movq	%r8, -0x788(%rbp)
+               	movq	-0x788(%rbp), %r8
+               	cmpq	$0x8, %r8
+               	jb	 <L22>
+<L23>:
+               	leaq	0x4(%r15), %rsi
+               	movq	$0x0, -0x578(%rbp)
+               	movq	$0x0, -0x570(%rbp)
+               	movq	(%rsi), %rdi
+               	movq	%rdi, -0x578(%rbp)
+               	movl	0x8(%rsi), %edi
+               	movl	%edi, -0x570(%rbp)
+               	movups	-0x578(%rbp), %xmm0
+               	movq	-0x780(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L24>
+<L24>:
+               	movq	%rax, %rsi
+               	leaq	0x10(%r15), %rdi
+               	movzbl	(%rdi), %r15d
+               	movzbq	%r15b, %r8
+               	movq	%r8, -0x790(%rbp)
+               	movq	%rsi, %r8
+               	movq	%r8, -0x798(%rbp)
+               	movq	$0x0, %r15
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
+               	jmp	 <L26>
+<L25>:
+               	movq	%r15, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	-0x790(%rbp), %r8
+               	movq	%r8, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rsi
+               	xorq	%rdi, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %r15
+               	movq	%rsi, %r8
+               	movq	%r8, -0x798(%rbp)
+               	cmpq	$0x8, %r15
+               	jb	 <L25>
 <L26>:
-               	movq	%rax, %rdi
-               	movq	$0x0, -0x718(%rbp)
-               	movq	$0x0, -0x710(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x718(%rbp)
-               	movq	-0xa88(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x710(%rbp)
-               	movups	-0x718(%rbp), %xmm0
-               	leaq	-0x724(%rbp), %r8
-               	movq	%r8, -0xa90(%rbp)
-               	movups	%xmm0, -0x734(%rbp)
-               	movq	-0x734(%rbp), %rsi
-               	movq	-0xa90(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x72c(%rbp), %esi
-               	movq	-0xa90(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa90(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	(%r13), %rsi
+               	movzbl	(%rsi), %edi
+               	movzbq	%dil, %rsi
+               	movq	-0x798(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L27>
 <L27>:
                	movq	%rax, %rdi
-               	movq	-0xa90(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	0x4(%r13), %rsi
+               	movq	$0x0, -0x588(%rbp)
+               	movq	$0x0, -0x580(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x588(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x580(%rbp)
+               	movups	-0x588(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
                	movq	%rax, %rdi
-               	movq	-0xa90(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
+               	leaq	0x10(%r13), %rsi
+               	movzbl	(%rsi), %r13d
+               	movzbq	%r13b, %rsi
                	callq	 <L29>
 <L29>:
-               	movq	-0xa80(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movzbl	(%rsi), %edx
-               	movq	%rax, %rdi
-               	movq	%rdx, %rsi
+               	movq	%rax, %r8
+               	movq	%r8, -0x7a0(%rbp)
+               	movq	-0x7a0(%rbp), %r8
+               	leaq	-0x5b4(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movq	$0x0, 0x10(%r13)
+               	movq	$0x0, 0x18(%r13)
+               	movq	$0x0, 0x20(%r13)
+               	movl	$0x0, 0x28(%r13)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x7a8(%rbp)
+               	movq	-0x7a8(%rbp), %r8
+               	movl	$0xffffffff, (%r8)      # imm = 0xFFFFFFFF
+               	leaq	(%rbx), %r15
+               	movq	$0x0, -0x5c4(%rbp)
+               	movq	$0x0, -0x5bc(%rbp)
+               	movq	(%r15), %rdi
+               	movq	%rdi, -0x5c4(%rbp)
+               	movl	0x8(%r15), %edi
+               	movl	%edi, -0x5bc(%rbp)
+               	movups	-0x5c4(%rbp), %xmm0
+               	leaq	0x4(%r13), %rdi
+               	leaq	(%rdi), %r15
+               	movups	%xmm0, -0x5d4(%rbp)
+               	movq	-0x5d4(%rbp), %rsi
+               	movq	%rsi, (%r15)
+               	movl	-0x5cc(%rbp), %esi
+               	movl	%esi, 0x8(%r15)
+               	leaq	0x24(%rbx), %rsi
+               	movq	$0x0, -0x5e4(%rbp)
+               	movq	$0x0, -0x5dc(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x5e4(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x5dc(%rbp)
+               	movups	-0x5e4(%rbp), %xmm0
+               	leaq	0xc(%rdi), %rsi
+               	movups	%xmm0, -0x5f4(%rbp)
+               	movq	-0x5f4(%rbp), %r15
+               	movq	%r15, (%rsi)
+               	movl	-0x5ec(%rbp), %r15d
+               	movl	%r15d, 0x8(%rsi)
+               	leaq	0x48(%rbx), %rsi
+               	movq	$0x0, -0x604(%rbp)
+               	movq	$0x0, -0x5fc(%rbp)
+               	movq	(%rsi), %r15
+               	movq	%r15, -0x604(%rbp)
+               	movl	0x8(%rsi), %r15d
+               	movl	%r15d, -0x5fc(%rbp)
+               	movups	-0x604(%rbp), %xmm0
+               	leaq	0x18(%rdi), %rsi
+               	movups	%xmm0, -0x614(%rbp)
+               	movq	-0x614(%rbp), %rdi
+               	movq	%rdi, (%rsi)
+               	movl	-0x60c(%rbp), %edi
+               	movl	%edi, 0x8(%rsi)
+               	leaq	0x28(%r13), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movq	-0x7a8(%rbp), %r8
+               	movl	(%r8), %esi
+               	movl	%esi, %r15d
+               	movq	-0x7a0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movq	%r15, %rsi
                	callq	 <L30>
 <L30>:
-               	leaq	(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x4(%r12), %rdx
-               	movq	$0x0, -0x744(%rbp)
-               	movq	$0x0, -0x73c(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x744(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x73c(%rbp)
-               	movups	-0x744(%rbp), %xmm0
-               	leaq	-0x750(%rbp), %r8
-               	movq	%r8, -0xa98(%rbp)
-               	movups	%xmm0, -0x760(%rbp)
-               	movq	-0x760(%rbp), %rsi
-               	movq	-0xa98(%rbp), %r8
-               	movq	%rsi, (%r8)
-               	movl	-0x758(%rbp), %esi
-               	movq	-0xa98(%rbp), %r8
-               	movl	%esi, 0x8(%r8)
-               	movq	-0xa98(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movq	-0xa98(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	-0xa98(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x10(%r12), %rdx
-               	movzbl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa10(%rbp)
-               	movq	-0xa10(%rbp), %r8
-               	leaq	-0x7f4(%rbp), %r12
-               	movq	$0x0, (%r12)
-               	movq	$0x0, 0x8(%r12)
-               	movq	$0x0, 0x10(%r12)
-               	movq	$0x0, 0x18(%r12)
-               	movq	$0x0, 0x20(%r12)
-               	movl	$0x0, 0x28(%r12)
-               	leaq	(%r12), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	(%rbx), %rsi
-               	movq	$0x0, -0x804(%rbp)
-               	movq	$0x0, -0x7fc(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x804(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x7fc(%rbp)
-               	movups	-0x804(%rbp), %xmm0
-               	leaq	0x4(%r12), %rsi
-               	leaq	(%rsi), %rdi
-               	movups	%xmm0, -0x814(%rbp)
-               	movq	-0x814(%rbp), %rax
-               	movq	%rax, (%rdi)
-               	movl	-0x80c(%rbp), %eax
-               	movl	%eax, 0x8(%rdi)
-               	leaq	0x24(%rbx), %rax
-               	movq	$0x0, -0x824(%rbp)
-               	movq	$0x0, -0x81c(%rbp)
-               	movq	(%rax), %rdi
-               	movq	%rdi, -0x824(%rbp)
-               	movl	0x8(%rax), %edi
-               	movl	%edi, -0x81c(%rbp)
-               	movups	-0x824(%rbp), %xmm0
-               	leaq	0xc(%rsi), %rax
-               	movups	%xmm0, -0x834(%rbp)
-               	movq	-0x834(%rbp), %rdi
-               	movq	%rdi, (%rax)
-               	movl	-0x82c(%rbp), %edi
-               	movl	%edi, 0x8(%rax)
-               	leaq	0x48(%rbx), %rax
-               	movq	$0x0, -0x844(%rbp)
-               	movq	$0x0, -0x83c(%rbp)
-               	movq	(%rax), %rdi
-               	movq	%rdi, -0x844(%rbp)
-               	movl	0x8(%rax), %edi
-               	movl	%edi, -0x83c(%rbp)
-               	movups	-0x844(%rbp), %xmm0
-               	leaq	0x18(%rsi), %rax
-               	movups	%xmm0, -0x854(%rbp)
-               	movq	-0x854(%rbp), %rsi
-               	movq	%rsi, (%rax)
-               	movl	-0x84c(%rbp), %esi
-               	movl	%esi, 0x8(%rax)
-               	leaq	0x28(%r12), %rax
-               	movl	$0x12345678, (%rax)     # imm = 0x12345678
-               	movl	(%rdx), %eax
-               	movq	-0xa10(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xaa0(%rbp)
+               	movq	%rax, %rsi
+               	movq	%rsi, %r15
                	movq	$0x0, %r8
-               	movq	%r8, -0xaa8(%rbp)
-               	movq	-0xaa8(%rbp), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	-0x800(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L37>
-               	jmp	 <L41>
-<L37>:
-               	leaq	0x4(%r12), %rsi
-               	movq	-0xaa8(%rbp), %r8
+               	jb	 <L31>
+               	jmp	 <L33>
+<L31>:
+               	leaq	0x4(%r13), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x800(%rbp), %r8
                	movq	%r8, %rdi
                	imulq	$0xc, %rdi, %rdi
-               	leaq	(%rsi,%rdi), %r8
-               	movq	%r8, -0xa18(%rbp)
-               	movq	$0x0, -0x610(%rbp)
-               	movq	$0x0, -0x608(%rbp)
-               	movq	-0xa18(%rbp), %r8
-               	movq	(%r8), %rsi
-               	movq	%rsi, -0x610(%rbp)
-               	movq	-0xa18(%rbp), %r8
-               	movl	0x8(%r8), %esi
-               	movl	%esi, -0x608(%rbp)
-               	movups	-0x610(%rbp), %xmm0
-               	leaq	-0x61c(%rbp), %r8
-               	movq	%r8, -0xab0(%rbp)
-               	movups	%xmm0, -0x62c(%rbp)
-               	movq	-0x62c(%rbp), %rdi
-               	movq	-0xab0(%rbp), %r8
-               	movq	%rdi, (%r8)
-               	movl	-0x624(%rbp), %edi
-               	movq	-0xab0(%rbp), %r8
-               	movl	%edi, 0x8(%r8)
-               	movq	-0xab0(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xaa0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa20(%rbp)
-               	movq	-0xa20(%rbp), %r8
-               	movq	-0xab0(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa20(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r8
-               	movq	%r8, -0xa28(%rbp)
-               	movq	-0xa28(%rbp), %r8
-               	movq	-0xab0(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa28(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
-               	movq	%rax, %rsi
-               	movq	-0xaa8(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x1, %rax
+               	movq	-0x7b0(%rbp), %r9
+               	leaq	(%r9,%rdi), %r8
+               	movq	%r8, -0x7b8(%rbp)
+               	movq	$0x0, -0x364(%rbp)
+               	movq	$0x0, -0x35c(%rbp)
+               	movq	-0x7b8(%rbp), %r8
+               	movq	(%r8), %rdi
+               	movq	%rdi, -0x364(%rbp)
+               	movq	-0x7b8(%rbp), %r8
+               	movl	0x8(%r8), %edi
+               	movl	%edi, -0x35c(%rbp)
+               	movups	-0x364(%rbp), %xmm0
+               	movq	%r15, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rax, %r15
+               	movq	-0x800(%rbp), %r8
+               	movq	%r8, %rsi
+               	addq	$0x1, %rsi
                	movq	%rsi, %r8
-               	movq	%r8, -0xaa0(%rbp)
-               	movq	%rax, %r8
-               	movq	%r8, -0xaa8(%rbp)
-               	movq	-0xaa8(%rbp), %r8
+               	movq	%r8, -0x800(%rbp)
+               	movq	-0x800(%rbp), %r8
                	cmpq	$0x3, %r8
-               	jb	 <L37>
-<L41>:
-               	leaq	0x28(%r12), %rax
-               	movl	(%rax), %esi
-               	movq	-0xaa0(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x18(%rbx), %rdx
-               	movq	$0x0, -0x63c(%rbp)
-               	movq	$0x0, -0x634(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x63c(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x634(%rbp)
-               	movups	-0x63c(%rbp), %xmm0
-               	leaq	0x30(%rbx), %rdx
-               	movq	$0x0, -0x64c(%rbp)
-               	movq	$0x0, -0x644(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x64c(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x644(%rbp)
-               	movups	-0x64c(%rbp), %xmm2
+               	jb	 <L31>
+<L33>:
+               	leaq	0x28(%r13), %rsi
+               	movl	(%rsi), %edi
+               	movl	%edi, %esi
+               	movq	%r15, %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+               	jmp	 <L35>
+<L34>:
+               	movq	%rdi, %r13
+               	imulq	$0x8, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rsi, %r13
+               	shrq	%cl, %r13
+               	andq	$0xff, %r13
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, %r15
+               	xorq	%r13, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdi
+               	movq	%r15, %r8
+               	movq	%r8, -0x7c0(%rbp)
+               	cmpq	$0x8, %rdi
+               	jb	 <L34>
+<L35>:
+               	leaq	0x18(%rbx), %r13
+               	movq	$0x0, -0x424(%rbp)
+               	movq	$0x0, -0x41c(%rbp)
+               	movq	(%r13), %rsi
+               	movq	%rsi, -0x424(%rbp)
+               	movl	0x8(%r13), %esi
+               	movl	%esi, -0x41c(%rbp)
+               	movups	-0x424(%rbp), %xmm0
+               	leaq	0x30(%rbx), %r15
+               	movq	$0x0, -0x434(%rbp)
+               	movq	$0x0, -0x42c(%rbp)
+               	movq	(%r15), %rsi
+               	movq	%rsi, -0x434(%rbp)
+               	movl	0x8(%r15), %esi
+               	movl	%esi, -0x42c(%rbp)
+               	movups	-0x434(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	addps	%xmm2, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x658(%rbp), %r12
-               	movups	%xmm0, -0x668(%rbp)
-               	movq	-0x668(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x660(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movaps	%xmm14, -0x810(%rbp)
+               	movq	-0x7c0(%rbp), %r8
+               	movq	%r8, %rdi
+               	movups	-0x810(%rbp), %xmm0
+               	callq	 <L36>
+<L36>:
                	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	leaq	0x24(%rbx), %rdx
-               	movq	$0x0, -0x770(%rbp)
-               	movq	$0x0, -0x768(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x770(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x768(%rbp)
-               	movups	-0x770(%rbp), %xmm0
-               	leaq	-0x77c(%rbp), %rsi
-               	leaq	(%rsi), %rdi
+               	movups	-0x810(%rbp), %xmm0
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x7c8(%rbp)
+               	movq	-0x7c8(%rbp), %r8
+               	leaq	0x24(%rbx), %r8
+               	movq	%r8, -0x818(%rbp)
+               	movq	$0x0, -0x444(%rbp)
+               	movq	$0x0, -0x43c(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	%rbx, -0x444(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movl	%ebx, -0x43c(%rbp)
+               	movups	-0x444(%rbp), %xmm0
+               	leaq	-0x450(%rbp), %rbx
+               	leaq	(%rbx), %rdi
                	movl	$0x40000000, (%rdi)     # imm = 0x40000000
-               	leaq	0x4(%rsi), %rdi
+               	leaq	0x4(%rbx), %rdi
                	movl	$0x40800000, (%rdi)     # imm = 0x40800000
-               	leaq	0x8(%rsi), %rdi
+               	leaq	0x8(%rbx), %rdi
                	movl	$0x41000000, (%rdi)     # imm = 0x41000000
-               	movq	$0x0, -0x78c(%rbp)
-               	movq	$0x0, -0x784(%rbp)
-               	movq	(%rsi), %rdi
-               	movq	%rdi, -0x78c(%rbp)
-               	movl	0x8(%rsi), %edi
-               	movl	%edi, -0x784(%rbp)
-               	movups	-0x78c(%rbp), %xmm2
+               	movq	$0x0, -0x460(%rbp)
+               	movq	$0x0, -0x458(%rbp)
+               	movq	(%rbx), %rdi
+               	movq	%rdi, -0x460(%rbp)
+               	movl	0x8(%rbx), %edi
+               	movl	%edi, -0x458(%rbp)
+               	movups	-0x460(%rbp), %xmm2
                	movaps	%xmm0, %xmm14
                	mulps	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
-               	movups	%xmm0, -0x79c(%rbp)
-               	movq	-0x79c(%rbp), %rsi
-               	movq	%rsi, (%rdx)
-               	movl	-0x794(%rbp), %esi
-               	movl	%esi, 0x8(%rdx)
-               	leaq	0x18(%rbx), %rdx
-               	movq	$0x0, -0x7ac(%rbp)
-               	movq	$0x0, -0x7a4(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x7ac(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x7a4(%rbp)
-               	movups	-0x7ac(%rbp), %xmm0
-               	leaq	-0x7b8(%rbp), %r12
-               	movups	%xmm0, -0x7c8(%rbp)
-               	movq	-0x7c8(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x7c0(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movups	%xmm0, -0x470(%rbp)
+               	movq	-0x470(%rbp), %rdi
+               	movq	-0x818(%rbp), %r8
+               	movq	%rdi, (%r8)
+               	movl	-0x468(%rbp), %edi
+               	movq	-0x818(%rbp), %r8
+               	movl	%edi, 0x8(%r8)
+               	movq	$0x0, -0x480(%rbp)
+               	movq	$0x0, -0x478(%rbp)
+               	movq	(%r13), %rdi
+               	movq	%rdi, -0x480(%rbp)
+               	movl	0x8(%r13), %edi
+               	movl	%edi, -0x478(%rbp)
+               	movups	-0x480(%rbp), %xmm0
+               	movq	-0x7c8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L38>
+<L38>:
                	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
+               	movq	$0x0, -0x490(%rbp)
+               	movq	$0x0, -0x488(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movq	(%r8), %rbx
+               	movq	%rbx, -0x490(%rbp)
+               	movq	-0x818(%rbp), %r8
+               	movl	0x8(%r8), %ebx
+               	movl	%ebx, -0x488(%rbp)
+               	movups	-0x490(%rbp), %xmm0
+               	callq	 <L39>
+<L39>:
                	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x24(%rbx), %rdx
-               	movq	$0x0, -0x864(%rbp)
-               	movq	$0x0, -0x85c(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x864(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x85c(%rbp)
-               	movups	-0x864(%rbp), %xmm0
-               	leaq	-0x870(%rbp), %r12
-               	movups	%xmm0, -0x880(%rbp)
-               	movq	-0x880(%rbp), %rdx
-               	movq	%rdx, (%r12)
-               	movl	-0x878(%rbp), %edx
-               	movl	%edx, 0x8(%r12)
-               	leaq	(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x4(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x8(%r12), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x30(%rbx), %rdx
-               	movq	$0x0, -0x890(%rbp)
-               	movq	$0x0, -0x888(%rbp)
-               	movq	(%rdx), %rsi
-               	movq	%rsi, -0x890(%rbp)
-               	movl	0x8(%rdx), %esi
-               	movl	%esi, -0x888(%rbp)
-               	movups	-0x890(%rbp), %xmm0
-               	leaq	-0x89c(%rbp), %rbx
-               	movups	%xmm0, -0x8ac(%rbp)
-               	movq	-0x8ac(%rbp), %rdx
-               	movq	%rdx, (%rbx)
-               	movl	-0x8a4(%rbp), %edx
-               	movl	%edx, 0x8(%rbx)
-               	leaq	(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0x4(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x8(%rbx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	-0x910(%rbp), %rbx
-               	leaq	(%rbx), %rdx
-               	addq	$0x0, %rdx
-               	movq	$0x60, %rsi
-<L58>:
-               	movq	$0x0, (%rdx)
-               	addq	$0x8, %rdx
-               	subq	$0x8, %rsi
-               	cmpq	$0x0, %rsi
-               	jne	 <L58>
-               	movl	$0x0, (%rdx)
-               	movq	$0x0, %rdx
-               	cmpq	$0x5, %rdx
-               	jb	 <L59>
-               	jmp	 <L62>
-<L59>:
-               	movq	%rdx, %r11
+               	movq	$0x0, -0x4a0(%rbp)
+               	movq	$0x0, -0x498(%rbp)
+               	movq	(%r15), %rsi
+               	movq	%rsi, -0x4a0(%rbp)
+               	movl	0x8(%r15), %esi
+               	movl	%esi, -0x498(%rbp)
+               	movups	-0x4a0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rsi
+               	leaq	-0x510(%rbp), %rbx
+               	leaq	(%rbx), %rdi
+               	addq	$0x0, %rdi
+               	movq	$0x60, %r13
+<L41>:
+               	movq	$0x0, (%rdi)
+               	addq	$0x8, %rdi
+               	subq	$0x8, %r13
+               	cmpq	$0x0, %r13
+               	jne	 <L41>
+               	movl	$0x0, (%rdi)
+               	movq	$0x0, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L42>
+               	jmp	 <L45>
+<L42>:
+               	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L60>
+               	jl	 <L43>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L61>
-<L60>:
+               	jmp	 <L44>
+<L43>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L61>:
-               	leaq	-0x67c(%rbp), %rsi
-               	movq	$0x0, (%rsi)
-               	movq	$0x0, 0x8(%rsi)
-               	movl	$0x0, 0x10(%rsi)
+<L44>:
+               	leaq	-0x378(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movl	$0x0, 0x10(%r13)
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	-0xa40(%rbp), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x918(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x920(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	addss	-0x7d8(%rbp), %xmm2
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x4(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x8(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0xc(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x688(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x10(%r12), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	(%r12), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x4(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x8(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0xc(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x10(%r12), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1674>
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x928(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x930(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1801>
+               	subss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x150a>
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x4(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x8(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0xc(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6a0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	leaq	0x10(%r14), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r14), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x4(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x8(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0xc(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	leaq	0x10(%r14), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x166b>
                	subss	%xmm0, %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x938(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	movq	-0x998(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x6d8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x7e8(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	addss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1996>
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm3
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x4(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x8(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0xc(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	movq	-0x9a8(%rbp), %r8
-               	leaq	0x10(%r8), %rdi
-               	movss	(%rdi), %xmm3
-               	leaq	0x10(%r13), %rdi
-               	movss	%xmm3, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x4(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x8(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0xc(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	0x10(%r13), %rdi
-               	movss	(%rdi), %xmm2
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm2, (%rdi)
+               	addss	, %xmm2 <corpus.cases.vec.vec_mem.checksum+0x1821>
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x7f0(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm3
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm3, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x620(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm2
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm2, (%r15)
                	xorps	%xmm2, %xmm2
                	subss	%xmm0, %xmm2
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%r14), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r14), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	%xmm2, (%rdi)
-               	leaq	(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x4(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x8(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0xc(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%r15), %rdi
-               	movss	(%rdi), %xmm0
-               	leaq	0x10(%rsi), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x4(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x4(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x8(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0xc(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0xc(%r8), %rdi
-               	movss	%xmm0, (%rdi)
-               	leaq	0x10(%rsi), %rdi
-               	movss	(%rdi), %xmm0
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	%rdx, %rsi
-               	imulq	$0x14, %rsi, %rsi
-               	leaq	(%rbx,%rsi), %rdi
-               	movq	-0xa30(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x4(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x8(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0xc(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	movq	-0xa30(%rbp), %r8
-               	leaq	0x10(%r8), %rsi
-               	movss	(%rsi), %xmm0
-               	leaq	0x10(%rdi), %rsi
-               	movss	%xmm0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x5, %rdx
-               	jb	 <L59>
-<L62>:
-               	movq	%rax, %r12
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x628(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	%xmm2, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x4(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x8(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0xc(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	movq	-0x630(%rbp), %r8
+               	leaq	0x10(%r8), %r15
+               	movss	(%r15), %xmm0
+               	leaq	0x10(%r13), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x4(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x4(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x8(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x8(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0xc(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0xc(%r8), %r15
+               	movss	%xmm0, (%r15)
+               	leaq	0x10(%r13), %r15
+               	movss	(%r15), %xmm0
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	%xmm0, (%r13)
+               	movq	%rdi, %r13
+               	imulq	$0x14, %r13, %r13
+               	leaq	(%rbx,%r13), %r15
+               	movq	-0x638(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x4(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x4(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x8(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x8(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0xc(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0xc(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	movq	-0x638(%rbp), %r8
+               	leaq	0x10(%r8), %r13
+               	movss	(%r13), %xmm0
+               	leaq	0x10(%r15), %r13
+               	movss	%xmm0, (%r13)
+               	addq	$0x1, %rdi
+               	cmpq	$0x5, %rdi
+               	jb	 <L42>
+<L45>:
+               	movq	%rsi, %r12
                	movq	$0x5, %r13
                	movq	$0x0, %r11
                	cmpq	%r13, %r11
-               	jb	 <L63>
-               	jmp	 <L69>
-<L63>:
-               	movq	%r13, %r14
-               	subq	$0x1, %r14
-               	movq	%r14, %rax
+               	jb	 <L46>
+               	jmp	 <L48>
+<L46>:
+               	subq	$0x1, %r13
+               	movq	%r13, %rax
                	imulq	$0x14, %rax, %rax
-               	leaq	(%rbx,%rax), %rcx
-               	leaq	(%rcx), %rax
+               	leaq	(%rbx,%rax), %rdx
+               	leaq	(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x4(%rcx), %rax
+               	leaq	0x4(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x8(%rcx), %rax
+               	leaq	0x8(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0xc(%rcx), %rax
+               	leaq	0xc(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0xc(%r8), %rax
                	movss	%xmm0, (%rax)
-               	leaq	0x10(%rcx), %rax
+               	leaq	0x10(%rdx), %rax
                	movss	(%rax), %xmm0
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	leaq	0x10(%r8), %rax
                	movss	%xmm0, (%rax)
-               	movq	-0x940(%rbp), %r8
-               	leaq	(%r8), %rax
-               	movss	(%rax), %xmm0
                	movq	%r12, %rdi
-               	callq	 <L64>
-<L64>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	movq	-0x940(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
+               	movq	-0x640(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %r12
-               	movq	%r14, %r13
                	movq	$0x0, %r11
                	cmpq	%r13, %r11
-               	jb	 <L63>
-<L69>:
-               	leaq	-0x6b0(%rbp), %r13
+               	jb	 <L46>
+<L48>:
+               	leaq	-0x3b0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1622,431 +1674,365 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x3c(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	leaq	0x3c(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r13), %r14
-               	movq	-0x948(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x8(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x948(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x10(%r14), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x24(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x10(%r13), %rdx
+               	movq	-0x648(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x648(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x10(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x24(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+               	jmp	 <L50>
+<L49>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%r12, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x10(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x950(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	movq	-0x950(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x24(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %r12
+               	cmpq	$0x8, %rdx
+               	jb	 <L49>
+<L50>:
+               	leaq	0x10(%r13), %rax
+               	leaq	(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%rax), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
+               	leaq	0x10(%r8), %rax
+               	movss	%xmm0, (%rax)
+               	movq	%r12, %rdi
+               	movq	-0x650(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L51>
+<L51>:
+               	leaq	0x24(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+               	jmp	 <L53>
+<L52>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r12
+               	xorq	%rdi, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L52>
+<L53>:
+               	leaq	0x14(%rbx), %r12
+               	leaq	(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x4(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x8(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0xc(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
+               	leaq	0xc(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	leaq	0x10(%r12), %rdx
+               	movss	(%rdx), %xmm0
+               	movq	-0x658(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x50(%rbx), %rdx
                	leaq	(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x4(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movss	%xmm0, (%rsi)
                	leaq	0x10(%rdx), %rsi
                	movss	(%rsi), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x958(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x960(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	addss	%xmm1, %xmm2
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	%xmm2, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	(%rcx), %rdx
+               	leaq	(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	movq	-0x968(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movss	(%rdx), %xmm0
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	(%rbx), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x670(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movss	%xmm0, (%rdx)
+               	movq	%rax, %rdi
+               	movq	-0x670(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L54>
+<L54>:
+               	leaq	(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0x4(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
+               	leaq	0xc(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
+               	leaq	0x10(%r12), %rdx
                	movss	(%rdx), %xmm0
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x970(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x970(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	leaq	0x14(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rdx
+               	movq	-0x678(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
+               	movq	%rax, %rdi
+               	movq	-0x678(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L55>
+<L55>:
+               	leaq	0x28(%rbx), %rdx
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x8(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0xc(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	leaq	0x10(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movq	-0x680(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x978(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	-0x978(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	leaq	0x28(%rbx), %rcx
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x10(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	-0x980(%rbp), %r8
-               	leaq	(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L87>
-<L87>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x4(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L88>
-<L88>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x8(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0xc(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	movq	-0x980(%rbp), %r8
-               	leaq	0x10(%r8), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	-0xab8(%rbp), %rbx
-               	movq	-0xac0(%rbp), %r12
-               	movq	-0xac8(%rbp), %r13
-               	movq	-0xad0(%rbp), %r14
-               	movq	-0xad8(%rbp), %r15
+               	movq	-0x680(%rbp), %r8
+               	movq	%r8, %rsi
+               	callq	 <L56>
+<L56>:
+               	movq	-0x828(%rbp), %rbx
+               	movq	-0x830(%rbp), %r12
+               	movq	-0x838(%rbp), %r13
+               	movq	-0x840(%rbp), %r14
+               	movq	-0x848(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_scalar_mix.dis
+++ b/test/golden/x86_64-linux/vec/vec_scalar_mix.dis
@@ -7,28 +7,108 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movss	(%rcx), %xmm0
-               	callq	 <L3>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movss	(%rdx), %xmm0
+               	movd	%xmm0, %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -38,32 +118,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movslq	%eax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -73,32 +225,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -106,847 +330,734 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4c0, %rsp            # imm = 0x4C0
-               	movq	%rbx, -0x498(%rbp)
-               	movq	%r12, -0x4a0(%rbp)
-               	movq	%r13, -0x4a8(%rbp)
-               	movq	%r14, -0x4b0(%rbp)
-               	movq	%r15, -0x4b8(%rbp)
+               	subq	$0x400, %rsp            # imm = 0x400
+               	movq	%rbx, -0x3d8(%rbp)
+               	movq	%r12, -0x3e0(%rbp)
+               	movq	%r13, -0x3e8(%rbp)
+               	movq	%r14, -0x3f0(%rbp)
+               	movq	%r15, -0x3f8(%rbp)
                	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L1>
+               	jl	 <L0>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L2>
-<L1>:
+               	jmp	 <L1>
+<L0>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L2>:
+<L1>:
                	movl	%ebx, %r12d
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	leaq	-0x60(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movl	$0x3fc00000, (%rdx)     # imm = 0x3FC00000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7d>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x84>
-               	leaq	0x4(%rcx), %rdx
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x75>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x7c>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movl	$0x40700000, (%rdx)     # imm = 0x40700000
-               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x9e>
-               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0xa5>
-               	leaq	0xc(%rcx), %rdx
+               	movss	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x96>
+               	xorps	, %xmm1 <corpus.cases.vec.vec_scalar_mix.checksum+0x9d>
+               	leaq	0xc(%rax), %rdx
                	movss	%xmm1, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm1
+               	leaq	-0x70(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0x3f000000, (%rsi)     # imm = 0x3F000000
                	leaq	0x4(%rdx), %rsi
                	movl	$0x40800000, (%rsi)     # imm = 0x40800000
-               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xd6>
-               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xdd>
+               	movss	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xce>
+               	xorps	, %xmm2 <corpus.cases.vec.vec_scalar_mix.checksum+0xd5>
                	leaq	0x8(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movl	$0x41000000, (%rsi)     # imm = 0x41000000
                	movups	(%rdx), %xmm2
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm2, (%rdx)
-               	leaq	(%rcx), %rsi
+               	leaq	(%rax), %rsi
                	movss	(%rsi), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x50(%rbp), %r13
+               	leaq	-0xa0(%rbp), %r13
                	movups	%xmm1, (%r13)
-               	leaq	(%r13), %rcx
-               	movss	%xmm4, (%rcx)
+               	leaq	(%r13), %rax
+               	movss	%xmm4, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movss	(%rcx), %xmm3
+               	movups	%xmm14, -0x330(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movss	(%rax), %xmm3
                	movss	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1,2,3]
                	addss	%xmm0, %xmm4
-               	leaq	-0x60(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r13), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3b0(%rbp)
+               	leaq	-0xb0(%rbp), %r14
+               	movups	%xmm2, (%r14)
+               	leaq	0x8(%r14), %rax
+               	movss	%xmm4, (%rax)
+               	movups	(%r14), %xmm14
+               	movups	%xmm14, -0x340(%rbp)
+               	leaq	(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	(%r14), %rax
+               	movss	(%rax), %xmm3
                	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	-0x3b0(%rbp), %xmm14
-               	movss	%xmm14, -0x350(%rbp)
-               	leaq	0x4(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3c0(%rbp)
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3d0(%rbp)
-               	movss	-0x3c0(%rbp), %xmm14
-               	mulss	-0x3d0(%rbp), %xmm14
-               	movss	%xmm14, -0x360(%rbp)
-               	leaq	0x8(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3e0(%rbp)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	-0x3e0(%rbp), %xmm14
-               	mulss	%xmm0, %xmm14
-               	movss	%xmm14, -0x370(%rbp)
-               	leaq	0xc(%r13), %rdx
-               	movl	(%rdx), %r11d
-               	movl	%r11d, -0x3f0(%rbp)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	-0x3f0(%rbp), %xmm14
-               	mulss	%xmm0, %xmm14
-               	movss	%xmm14, -0x380(%rbp)
-               	movss	-0x350(%rbp), %xmm0
-               	callq	 <L3>
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x2e8(%rbp)
+               	leaq	0x4(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x4(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x2f8(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0x8(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x308(%rbp)
+               	leaq	0xc(%r13), %rax
+               	movss	(%rax), %xmm0
+               	leaq	0xc(%r14), %rax
+               	movss	(%rax), %xmm3
+               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	%xmm3, %xmm14
+               	movss	%xmm14, -0x318(%rbp)
+               	movl	-0x2e8(%rbp), %eax
+               	movl	%eax, %edx
+               	movabsq	$-0x340d631b7bdddcdb, %rax # imm = 0xCBF29CE484222325
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rsi
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	movss	-0x360(%rbp), %xmm0
-               	callq	 <L4>
+               	movl	-0x2f8(%rbp), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	movss	-0x370(%rbp), %xmm0
-               	callq	 <L5>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L4>
 <L5>:
+               	movl	-0x308(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x380(%rbp), %xmm0
                	callq	 <L6>
 <L6>:
+               	movl	-0x318(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x350(%rbp), %xmm14
-               	addss	-0x360(%rbp), %xmm14
-               	movss	%xmm14, -0x400(%rbp)
-               	movss	-0x400(%rbp), %xmm0
                	callq	 <L7>
 <L7>:
+               	movss	-0x2e8(%rbp), %xmm14
+               	addss	-0x2f8(%rbp), %xmm14
+               	movss	%xmm14, -0x350(%rbp)
+               	movl	-0x350(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x400(%rbp), %xmm14
-               	addss	-0x370(%rbp), %xmm14
-               	movss	%xmm14, -0x410(%rbp)
-               	movss	-0x410(%rbp), %xmm0
                	callq	 <L8>
 <L8>:
+               	movss	-0x350(%rbp), %xmm14
+               	addss	-0x308(%rbp), %xmm14
+               	movss	%xmm14, -0x360(%rbp)
+               	movl	-0x360(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
-               	movss	-0x410(%rbp), %xmm14
-               	addss	-0x380(%rbp), %xmm14
-               	movss	%xmm14, -0x420(%rbp)
-               	movss	-0x420(%rbp), %xmm0
                	callq	 <L9>
 <L9>:
-               	leaq	-0x70(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	-0x420(%rbp), %r11d
-               	movl	%r11d, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movss	-0x3f0(%rbp), %xmm4
-               	subss	-0x3b0(%rbp), %xmm4
-               	leaq	-0x80(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm4, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movss	-0x3d0(%rbp), %xmm3
-               	addss	-0x3e0(%rbp), %xmm3
-               	leaq	-0x90(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm3, (%rdx)
-               	movups	(%rcx), %xmm0
-               	xorps	%xmm3, %xmm3
-               	subss	-0x3c0(%rbp), %xmm3
-               	leaq	-0xa0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movss	%xmm3, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	movss	-0x360(%rbp), %xmm14
+               	addss	-0x318(%rbp), %xmm14
+               	movss	%xmm14, -0x370(%rbp)
+               	movl	-0x370(%rbp), %edx
+               	movl	%edx, %esi
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movl	-0x370(%rbp), %r11d
+               	movl	%r11d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	leaq	(%r14), %rdx
+               	movss	(%rdx), %xmm4
+               	movss	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1,2,3]
+               	subss	%xmm4, %xmm5
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%r14), %rdx
+               	movss	(%rdx), %xmm3
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm4
+               	movss	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1,2,3]
+               	addss	%xmm4, %xmm5
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r11d
+               	movl	%r11d, -0x380(%rbp)
+               	xorps	%xmm4, %xmm4
+               	subss	-0x380(%rbp), %xmm4
+               	leaq	-0x2d0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm4, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x390(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
+               	movaps	-0x390(%rbp), %xmm14
+               	mulps	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L13>
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm0
+               	movss	-0x380(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L13>
+               	jmp	 <L14>
 <L13>:
-               	movaps	-0x430(%rbp), %xmm14
-               	mulps	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L14>
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L14>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L15>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm0, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L15>
+               	jmp	 <L16>
 <L15>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L16>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L16>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L17>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	ucomiss	%xmm0, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L17>
+               	jmp	 <L18>
 <L17>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L18>
-               	jmp	 <L19>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm0
 <L18>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	(%r13), %rdx
+               	movss	(%rdx), %xmm2
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L19>
+               	jmp	 <L20>
 <L19>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L20>
-               	jmp	 <L21>
+               	leaq	0x4(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L20>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L21>
+               	jmp	 <L22>
 <L21>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	ucomiss	%xmm0, %xmm2
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L22>
-               	movsd	%xmm0, -0x440(%rbp)
-               	jmp	 <L23>
+               	leaq	0x8(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L22>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm2
-               	movsd	%xmm2, -0x440(%rbp)
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm3
+               	ucomiss	%xmm3, %xmm2
+               	seta	%dl
+               	movzbq	%dl, %rdx
+               	testb	%dl, %dl
+               	jne	 <L23>
+               	jmp	 <L24>
 <L23>:
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L24>
-               	jmp	 <L25>
+               	leaq	0xc(%r13), %rdx
+               	movss	(%rdx), %xmm2
 <L24>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm0, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
+               	jmp	 <L26>
 <L25>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L26>
-               	jmp	 <L27>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L25>
 <L26>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	movd	%xmm2, %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
+               	jmp	 <L28>
 <L27>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	ucomiss	%xmm3, %xmm0
-               	seta	%cl
-               	movzbq	%cl, %rcx
-               	testb	%cl, %cl
-               	jne	 <L28>
-               	movsd	%xmm0, -0x450(%rbp)
-               	jmp	 <L29>
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r13
+               	xorq	%rdi, %r13
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r13
+               	addq	$0x1, %rdx
+               	movq	%r13, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L27>
 <L28>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm3
-               	movsd	%xmm3, -0x450(%rbp)
+               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
+               	subss	%xmm2, %xmm3
+               	movd	%xmm3, %edx
+               	movl	%edx, %esi
+               	movq	%rax, %rdi
+               	callq	 <L29>
 <L29>:
-               	movq	%rax, %rdi
-               	movss	-0x440(%rbp), %xmm0
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movss	-0x450(%rbp), %xmm0
-               	callq	 <L31>
-<L31>:
-               	movss	-0x440(%rbp), %xmm0
-               	subss	-0x450(%rbp), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	leaq	-0xb0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0x7, (%rdx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0xfffffff3, (%rdx)     # imm = 0xFFFFFFF3
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0x15, (%rdx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0xffffffe1, (%rdx)     # imm = 0xFFFFFFE1
-               	movups	(%rcx), %xmm0
-               	leaq	-0xc0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	movl	%ebx, %edx
-               	addl	%edx, %ecx
-               	leaq	-0xd0(%rbp), %rbx
+               	leaq	-0xc0(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0x7, (%rsi)
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0xfffffff3, (%rsi)     # imm = 0xFFFFFFF3
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0x15, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0xffffffe1, (%rsi)     # imm = 0xFFFFFFE1
+               	movups	(%rdx), %xmm0
+               	leaq	-0xd0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	(%rsi), %edx
+               	movl	%ebx, %esi
+               	addl	%esi, %edx
+               	leaq	-0xe0(%rbp), %rbx
                	movups	%xmm0, (%rbx)
-               	leaq	0x4(%rbx), %rdx
-               	movl	%ecx, (%rdx)
+               	leaq	0x4(%rbx), %rsi
+               	movl	%edx, (%rsi)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x460(%rbp)
-               	leaq	-0xe0(%rbp), %r13
+               	movups	%xmm14, -0x3a0(%rbp)
+               	leaq	-0xf0(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x100(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x110(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x120(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movslq	%edx, %r11
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movslq	%esi, %r11
                	cvtsi2ss	%r11, %xmm0
                	movups	(%r13), %xmm3
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
+               	leaq	-0x130(%rbp), %rdx
+               	movups	%xmm3, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
                	movups	%xmm0, (%r13)
                	movups	(%r13), %xmm0
-               	leaq	-0x130(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
+               	callq	 <L30>
+<L30>:
                	movups	(%r13), %xmm0
                	movaps	%xmm0, %xmm14
-               	mulps	-0x390(%rbp), %xmm14
+               	mulps	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r14), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	-0x1b0(%rbp), %r14
+               	callq	 <L31>
+<L31>:
+               	leaq	-0x140(%rbp), %r14
                	movq	$0x0, (%r14)
                	movq	$0x0, 0x8(%r14)
                	movups	(%r13), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
+               	leaq	-0x150(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
                	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x75c>
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x76f>
                	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x160(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x170(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7b4>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x180(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x190(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7fa>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x1a0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r13), %xmm0
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
+               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x840>
+               	cvttss2si	%xmm3, %r11d
+               	movl	%r11d, %edx
+               	movups	(%r14), %xmm0
+               	leaq	-0x1c0(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0xc(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r14)
+               	movups	(%r14), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movups	(%r14), %xmm0
                	leaq	-0x1d0(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7a1>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r14), %xmm0
-               	leaq	-0x1f0(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
+               	movl	(%rsi), %edi
+               	leaq	(%rbx), %rsi
+               	movl	(%rsi), %r13d
+               	imull	%r13d, %edi
                	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x7e7>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
-               	movups	(%r14), %xmm0
-               	leaq	-0x210(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
+               	movl	(%rsi), %r13d
+               	leaq	0x4(%rbx), %rsi
+               	movl	(%rsi), %r15d
+               	imull	%r15d, %r13d
                	leaq	0x8(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r13), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	mulss	, %xmm3 <corpus.cases.vec.vec_scalar_mix.checksum+0x82d>
-               	cvttss2si	%xmm3, %r11d
-               	movl	%r11d, %ecx
+               	movl	(%rsi), %r15d
+               	leaq	0x8(%rbx), %rsi
+               	movl	(%rsi), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%rdx), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x210(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L33>
+<L33>:
                	movups	(%r14), %xmm0
+               	movaps	%xmm0, %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	leaq	-0x220(%rbp), %rdx
+               	leaq	(%rdx), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x4(%rdx), %rsi
+               	movl	$0x1, (%rsi)
+               	leaq	0x8(%rdx), %rsi
+               	movl	$0xaaaaaaaa, (%rsi)     # imm = 0xAAAAAAAA
+               	leaq	0xc(%rdx), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movups	(%rdx), %xmm0
                	leaq	-0x230(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0xc(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm0
-               	movups	%xmm0, (%r14)
-               	movups	(%r14), %xmm0
-               	leaq	-0x240(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L44>
-<L44>:
-               	movups	(%r14), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	(%rdx), %esi
+               	movl	(%rsi), %edx
+               	addl	%r12d, %edx
+               	leaq	-0x240(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	0xc(%rbx), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rbx), %xmm14
+               	movups	%xmm14, -0x3b0(%rbp)
                	leaq	(%rbx), %rdx
-               	movl	(%rdx), %edi
-               	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
-               	movl	(%rdx), %edi
+               	movl	(%rdx), %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
                	leaq	0x4(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %edi
-               	leaq	0x8(%rcx), %rdx
-               	movl	(%rdx), %r13d
+               	movl	(%rdx), %esi
+               	xorl	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
                	leaq	0x8(%rbx), %rdx
-               	movl	(%rdx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L37>
+<L37>:
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %ebx
-               	imull	%ebx, %ecx
+               	movl	(%rdx), %esi
+               	subl	%esi, %r12d
+               	movl	%r12d, %esi
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	-0x250(%rbp), %r13
+               	movq	$0x0, (%r13)
+               	movq	$0x0, 0x8(%r13)
+               	movups	(%r13), %xmm0
                	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rbx
-               	movl	%esi, (%rbx)
+               	leaq	(%rdx), %rsi
+               	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x270(%rbp), %rdx
+               	movups	%xmm0, (%r13)
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%r12d, %edx
+               	xorl	%esi, %edx
+               	movups	(%r13), %xmm0
+               	leaq	-0x270(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x4(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	movl	%r12d, %edx
+               	addl	%esi, %edx
+               	movups	(%r13), %xmm0
+               	leaq	-0x280(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	0x8(%rsi), %rdi
+               	movl	%edx, (%rdi)
+               	movups	(%rsi), %xmm0
+               	movups	%xmm0, (%r13)
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	subl	%esi, %r12d
+               	movups	(%r13), %xmm0
+               	leaq	-0x290(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%edi, (%rsi)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x280(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	0x8(%rdx), %rsi
-               	movl	%r13d, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, (%r13)
+               	movups	(%r13), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movups	(%r14), %xmm0
+               	callq	 <L39>
+<L39>:
+               	movups	(%r13), %xmm0
                	movaps	%xmm0, %xmm14
-               	psubd	-0x460(%rbp), %xmm14
+               	paddd	-0x3b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	leaq	-0x2b0(%rbp), %rcx
-               	leaq	(%rcx), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x4(%rcx), %rdx
-               	movl	$0x1, (%rdx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	$0xaaaaaaaa, (%rdx)     # imm = 0xAAAAAAAA
-               	leaq	0xc(%rcx), %rdx
-               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
-               	addl	%r12d, %ecx
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	movq	%rax, %rdi
-               	movl	%r12d, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	movl	%r12d, %r14d
-               	xorl	%r13d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	subl	%edx, %r14d
-               	movq	%rax, %rdi
-               	movl	%r14d, %esi
-               	callq	 <L56>
-<L56>:
-               	leaq	-0x2e0(%rbp), %rbx
-               	movq	$0x0, (%rbx)
-               	movq	$0x0, 0x8(%rbx)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movl	%r14d, %ecx
-               	xorl	%r12d, %ecx
-               	movups	(%rbx), %xmm2
-               	leaq	-0x300(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	0x4(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movl	%r14d, %ecx
-               	addl	%r13d, %ecx
-               	movups	(%rbx), %xmm2
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm2, (%rdx)
-               	leaq	0x8(%rdx), %rsi
-               	movl	%ecx, (%rsi)
-               	movups	(%rdx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	subl	%r15d, %r14d
-               	movups	(%rbx), %xmm2
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movl	%r14d, (%rdx)
-               	movups	(%rcx), %xmm2
-               	movups	%xmm2, (%rbx)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x330(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movups	(%rbx), %xmm2
-               	movaps	%xmm2, %xmm14
-               	paddd	-0x470(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x340(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rbx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	$0x0, %r12
-<L65>:
-               	leaq	-0x140(%rbp), %rcx
-               	movups	-0x480(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
+<L41>:
+               	leaq	-0x10(%rbp), %rdx
+               	movups	-0x3c0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
                	cmpq	$0x4, %r12
-               	jb	 <L66>
+               	jb	 <L42>
                	movq	%rbx, %rax
-               	movq	-0x498(%rbp), %rbx
-               	movq	-0x4a0(%rbp), %r12
-               	movq	-0x4a8(%rbp), %r13
-               	movq	-0x4b0(%rbp), %r14
-               	movq	-0x4b8(%rbp), %r15
+               	movq	-0x3d8(%rbp), %rbx
+               	movq	-0x3e0(%rbp), %r12
+               	movq	-0x3e8(%rbp), %r13
+               	movq	-0x3f0(%rbp), %r14
+               	movq	-0x3f8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L66>:
-               	leaq	(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0xc(%rcx), %rdx
-               	movss	(%rdx), %xmm1
+<L42>:
+               	leaq	(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0xc(%rdx), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
                	addss	%xmm1, %xmm3
-               	leaq	0x4(%rcx), %rdx
-               	movss	(%rdx), %xmm0
-               	leaq	0x8(%rcx), %rdx
-               	movss	(%rdx), %xmm4
+               	leaq	0x4(%rdx), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	0x8(%rdx), %rsi
+               	movss	(%rsi), %xmm4
                	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
                	subss	%xmm4, %xmm5
                	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xc5f>
+               	mulss	, %xmm0 <corpus.cases.vec.vec_scalar_mix.checksum+0xb65>
                	movss	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1,2,3]
-               	addss	, %xmm4 <corpus.cases.vec.vec_scalar_mix.checksum+0xc6b>
-               	leaq	-0x150(%rbp), %rcx
-               	movups	-0x480(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movss	%xmm3, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm5, (%rdx)
-               	movups	(%rcx), %xmm1
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm1, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movss	%xmm4, (%rcx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
-               	leaq	(%r13), %rcx
-               	movss	(%rcx), %xmm0
+               	addss	, %xmm4 <corpus.cases.vec.vec_scalar_mix.checksum+0xb71>
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x3c0(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movss	%xmm3, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movss	%xmm5, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm1, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movss	%xmm0, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movss	%xmm4, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3d0(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x4(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xc(%r13), %rcx
-               	movss	(%rcx), %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L43>
+<L43>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
-               	jmp	 <L65>
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
+               	jmp	 <L41>

--- a/test/golden/x86_64-linux/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-linux/vec/vec_u16x8.dis
@@ -7,48 +7,196 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x2(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x4(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x6(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
+               	leaq	0x8(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
+<L8>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+<L9>:
+               	leaq	0xa(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
+<L10>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+<L11>:
+               	leaq	0xc(%rax), %rdx
+               	movzwl	(%rdx), %esi
+               	movzwq	%si, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
+<L12>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+<L13>:
+               	leaq	0xe(%rax), %rdx
+               	movzwl	(%rdx), %eax
+               	movzwq	%ax, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+               	jmp	 <L15>
+<L14>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L14>
+<L15>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -56,16 +204,12 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x2e0, %rsp            # imm = 0x2E0
-               	movq	%rbx, -0x2c8(%rbp)
-               	movq	%r12, -0x2d0(%rbp)
-               	movq	%r13, -0x2d8(%rbp)
-               	movq	%r14, -0x2e0(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movw	%bx, %cx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x210, %rsp            # imm = 0x210
+               	movq	%rbx, -0x1f8(%rbp)
+               	movq	%r12, -0x200(%rbp)
+               	movq	%r13, -0x208(%rbp)
+               	movw	%di, %ax
+               	leaq	-0x80(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0xfff0, (%rsi)         # imm = 0xFFF0
                	leaq	0x2(%rdx), %rsi
@@ -83,9 +227,9 @@ Disassembly of section .text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0x3039, (%rsi)         # imm = 0x3039
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x90(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0xa0(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movw	$0x11, (%rdi)
                	leaq	0x2(%rsi), %rdi
@@ -103,9 +247,9 @@ Disassembly of section .text:
                	leaq	0xe(%rsi), %rdi
                	movw	$0xd431, (%rdi)         # imm = 0xD431
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0xb0(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0xc0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x1, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -123,8 +267,8 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x88b, (%rbx)          # imm = 0x88B
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x200(%rbp)
-               	leaq	-0x60(%rbp), %rdi
+               	movups	%xmm14, -0x120(%rbp)
+               	leaq	-0xd0(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	leaq	0x2(%rdi), %rbx
@@ -142,739 +286,198 @@ Disassembly of section .text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x210(%rbp)
+               	movups	%xmm14, -0x130(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x70(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0xe0(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rbx
                	movw	%dx, (%rbx)
                	movups	(%rdi), %xmm0
                	leaq	0xc(%rdi), %rdx
                	movzwl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x80(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0xc(%rbx), %rdx
-               	movw	%di, (%rdx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x220(%rbp)
+               	addl	%eax, %edi
+               	leaq	-0xf0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rbx
+               	movw	%di, (%rbx)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x140(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0x90(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xe(%r12), %rcx
-               	movw	%dx, (%rcx)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x230(%rbp)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	addl	%eax, %edx
+               	leaq	-0x110(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movw	%dx, (%rsi)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x150(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x140(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L8>
-<L8>:
-               	leaq	(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x2(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x4(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L11>
-<L11>:
-               	leaq	0x6(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L12>
-<L12>:
-               	leaq	0x8(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L13>
-<L13>:
-               	leaq	0xa(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L14>
-<L14>:
-               	leaq	0xc(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xe(%r12), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L22>
-<L22>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x220(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L27>
-<L27>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x230(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L36>
-<L36>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L37>
-<L37>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L53>
-<L53>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L54>
-<L54>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L60>
-<L60>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x220(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L69>
-<L69>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x220(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movaps	-0x210(%rbp), %xmm14
-               	psubw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pand	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x240(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x240(%rbp), %xmm0
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x220(%rbp), %xmm14
-               	por	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x250(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x250(%rbp), %xmm0
-               	callq	 <L83>
-<L83>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pxor	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	movaps	-0x220(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
-               	movaps	-0x230(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x240(%rbp), %xmm14
-               	pxor	-0x250(%rbp), %xmm14
+               	movaps	-0x160(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
                	movaps	%xmm5, %xmm0
-               	callq	 <L87>
-<L87>:
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pand	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x170(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x140(%rbp), %xmm14
+               	por	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x180(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x180(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pxor	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x150(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x170(%rbp), %xmm14
+               	pxor	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %rbx
-               	movups	-0x220(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x210(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x140(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	movq	$0x0, %r12
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-               	jmp	 <L121>
-<L88>:
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
-               	movaps	%xmm14, -0x260(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x260(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
+               	jb	 <L17>
+               	jmp	 <L22>
+<L17>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, -0x190(%rbp)
                	movq	%rbx, %rdi
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x190(%rbp), %xmm0
+               	callq	 <L18>
+<L18>:
+               	movaps	-0x1b0(%rbp), %xmm14
+               	pxor	-0x190(%rbp), %xmm14
+               	movaps	%xmm14, -0x1d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1d0(%rbp), %xmm0
+               	callq	 <L19>
+<L19>:
+               	movaps	-0x1c0(%rbp), %xmm14
+               	paddw	-0x1a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x1e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
+               	movups	-0x1e0(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
+               	movaps	%xmm14, -0x1f0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
-               	movaps	-0x280(%rbp), %xmm14
-               	pxor	-0x260(%rbp), %xmm14
-               	movaps	%xmm14, -0x2a0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L112>
-<L112>:
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
+               	movups	-0x1f0(%rbp), %xmm0
+               	callq	 <L21>
+<L21>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x2c0(%rbp), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	-0x1f0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movups	-0x1d0(%rbp), %xmm14
+               	movups	%xmm14, -0x1b0(%rbp)
+               	movups	-0x1e0(%rbp), %xmm14
+               	movups	%xmm14, -0x1c0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L88>
-<L121>:
-               	leaq	-0xf0(%rbp), %r12
+               	jb	 <L17>
+<L22>:
+               	leaq	-0x40(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
                	movq	$0x0, 0x10(%r12)
@@ -884,78 +487,39 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x270(%rbp), %xmm14
+               	movups	-0x1a0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	paddw	-0x230(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	0x10(%r12), %rax
-               	movups	%xmm3, (%rax)
-               	movaps	-0x270(%rbp), %xmm14
-               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x150(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x20(%r12), %rax
+               	leaq	0x10(%r12), %rax
                	movups	%xmm0, (%rax)
+               	movaps	-0x1a0(%rbp), %xmm14
+               	pmullw	-0x120(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm5, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x280(%rbp), %xmm14
+               	movups	-0x1b0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-               	jmp	 <L131>
-<L122>:
+               	jb	 <L23>
+               	jmp	 <L25>
+<L23>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
-               	leaq	(%r12,%rax), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rax
-               	movzwl	(%rax), %esi
+               	leaq	(%r12,%rax), %rdx
+               	movups	(%rdx), %xmm0
                	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x2(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x4(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0x6(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0x8(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xa(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	leaq	0xc(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0xe(%r14), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
+               	callq	 <L24>
+<L24>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L122>
-<L131>:
-               	leaq	-0x130(%rbp), %r13
+               	jb	 <L23>
+<L25>:
+               	leaq	-0x70(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -964,70 +528,65 @@ Disassembly of section .text:
                	movq	$0x0, 0x28(%r13)
                	leaq	(%r13), %rax
                	movl	$0xffffffff, (%rax)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r12), %rcx
-               	movups	(%rcx), %xmm0
-               	leaq	0x10(%r13), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0x20(%r13), %rcx
-               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
-               	movl	(%rax), %ecx
+               	leaq	0x20(%r12), %rdx
+               	movups	(%rdx), %xmm0
+               	leaq	0x10(%r13), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x20(%r13), %rdx
+               	movl	$0x12345678, (%rdx)     # imm = 0x12345678
+               	movl	(%rax), %edx
+               	movl	%edx, %eax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
                	movq	%rbx, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L132>
-<L132>:
-               	movups	(%r12), %xmm0
-               	leaq	-0x140(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x20(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L141>
-<L141>:
-               	movq	-0x2c8(%rbp), %rbx
-               	movq	-0x2d0(%rbp), %r12
-               	movq	-0x2d8(%rbp), %r13
-               	movq	-0x2e0(%rbp), %r14
+               	xorq	%rsi, %rdi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rdi
+               	addq	$0x1, %rdx
+               	movq	%rdi, %rbx
+               	cmpq	$0x8, %rdx
+               	jb	 <L26>
+<L27>:
+               	leaq	0x10(%r13), %rax
+               	movups	(%rax), %xmm0
+               	movq	%rbx, %rdi
+               	callq	 <L28>
+<L28>:
+               	leaq	0x20(%r13), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+               	jmp	 <L30>
+<L29>:
+               	movq	%rsi, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rdx, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %rbx
+               	xorq	%rdi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rsi
+               	movq	%rbx, %rax
+               	cmpq	$0x8, %rsi
+               	jb	 <L29>
+<L30>:
+               	movq	-0x1f8(%rbp), %rbx
+               	movq	-0x200(%rbp), %r12
+               	movq	-0x208(%rbp), %r13
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-linux/vec/vec_u32x4.dis
@@ -7,32 +7,104 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L2>
+               	leaq	0x4(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movl	%edx, %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
+               	leaq	0x8(%rax), %rdx
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
+<L4>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+<L5>:
+               	leaq	0xc(%rax), %rdx
+               	movl	(%rdx), %eax
+               	movl	%eax, %edx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+               	jmp	 <L7>
+<L6>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L6>
+<L7>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -40,17 +112,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x490, %rsp            # imm = 0x490
-               	movq	%rbx, -0x468(%rbp)
-               	movq	%r12, -0x470(%rbp)
-               	movq	%r13, -0x478(%rbp)
-               	movq	%r14, -0x480(%rbp)
-               	movq	%r15, -0x488(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movl	%ebx, %ecx
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0x420, %rsp            # imm = 0x420
+               	movq	%rbx, -0x3f8(%rbp)
+               	movq	%r12, -0x400(%rbp)
+               	movq	%r13, -0x408(%rbp)
+               	movq	%r14, -0x410(%rbp)
+               	movq	%r15, -0x418(%rbp)
+               	movl	%edi, %eax
+               	leaq	-0x110(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movl	$0xfffffff0, (%rsi)     # imm = 0xFFFFFFF0
                	leaq	0x4(%rdx), %rsi
@@ -60,9 +129,9 @@ Disassembly of section .text:
                	leaq	0xc(%rdx), %rsi
                	movl	$0x12345678, (%rsi)     # imm = 0x12345678
                	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
+               	leaq	-0x120(%rbp), %rdx
                	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
+               	leaq	-0x130(%rbp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x11, (%rdi)
                	leaq	0x4(%rsi), %rdi
@@ -72,9 +141,9 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdi
                	movl	$0x1, (%rdi)
                	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
+               	leaq	-0x140(%rbp), %rsi
                	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rdi
+               	leaq	-0x150(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movl	$0x1, (%rbx)
                	leaq	0x4(%rdi), %rbx
@@ -84,9 +153,9 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %rbx
                	movl	$0x1b, (%rbx)
                	movups	(%rdi), %xmm2
-               	leaq	-0x60(%rbp), %rbx
+               	leaq	-0x160(%rbp), %rbx
                	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %rdi
+               	leaq	-0x170(%rbp), %rdi
                	leaq	(%rdi), %r12
                	movl	$0x0, (%r12)
                	leaq	0x4(%rdi), %r12
@@ -96,531 +165,326 @@ Disassembly of section .text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x380(%rbp)
+               	movups	%xmm14, -0x310(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %rdi
+               	addl	%eax, %edx
+               	leaq	-0x180(%rbp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %r12
                	movl	%edx, (%r12)
                	movups	(%rdi), %xmm0
                	leaq	0x8(%rdi), %rdx
                	movl	(%rdx), %edi
-               	addl	%ecx, %edi
-               	leaq	-0x90(%rbp), %r12
+               	addl	%eax, %edi
+               	leaq	-0x190(%rbp), %r12
                	movups	%xmm0, (%r12)
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x320(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	addl	%eax, %esi
+               	leaq	-0x1a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
                	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r13
+               	addl	%eax, %edx
+               	leaq	-0x1b0(%rbp), %r13
                	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%edx, (%rcx)
+               	leaq	0xc(%r13), %rax
+               	movl	%edx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x3a0(%rbp)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm14, -0x330(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x320(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x330(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x340(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x340(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x320(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L3>
 <L3>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x330(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L4>
 <L4>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movq	%rax, %r8
+               	movq	%r8, -0x2c8(%rbp)
+               	movq	-0x2c8(%rbp), %r8
+               	leaq	(%r12), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2d0(%rbp)
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%r13), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%r13), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%r13), %rax
+               	movl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	-0x1d0(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x2d0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x200(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2c8(%rbp), %r8
+               	movq	%r8, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L6>
-<L6>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L7>
-<L7>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L8>
-<L8>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L9>
-<L9>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L10>
-<L10>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L11>
-<L11>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L12>
-<L12>:
-               	movaps	-0x390(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L13>
-<L13>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L14>
-<L14>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L15>
-<L15>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x3a0(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L18>
-<L18>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L19>
-<L19>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L20>
-<L20>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0x240(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm0
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L21>
-<L21>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L22>
-<L22>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L23>
-<L23>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L24>
-<L24>:
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %edi
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r14d
-               	imull	%r14d, %r12d
-               	leaq	-0x280(%rbp), %rcx
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
-               	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0xc(%r14), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L25>
-<L25>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L26>
-<L26>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L27>
-<L27>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L28>
-<L28>:
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r12d
-               	imull	%r12d, %edi
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %r12d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0xc(%r13), %rcx
-               	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x4(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L30>
-<L30>:
-               	leaq	0x8(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L31>
-<L31>:
-               	leaq	0xc(%r13), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x390(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x2d8(%rbp)
+               	movq	-0x2d8(%rbp), %r8
+               	leaq	(%r12), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %edi
                	imull	%edi, %esi
-               	leaq	0x4(%rcx), %rdx
+               	leaq	0x4(%r12), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %edi
+               	leaq	0x8(%r12), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %eax
+               	imull	%eax, %r15d
+               	leaq	0xc(%r12), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x210(%rbp), %rax
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movl	%esi, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x220(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x230(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%r15d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x240(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
+               	movq	-0x2d8(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	leaq	(%r13), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r13), %rdx
                	movl	(%rdx), %edi
                	leaq	0x4(%rbx), %rdx
                	movl	(%rdx), %r12d
                	imull	%r12d, %edi
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%r13), %rdx
                	movl	(%rdx), %r12d
                	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r12d
+               	leaq	0xc(%r13), %rdx
                	movl	(%rdx), %r13d
-               	imull	%r13d, %r12d
-               	leaq	0xc(%rcx), %rdx
-               	movl	(%rdx), %ecx
                	leaq	0xc(%rbx), %rdx
-               	movl	(%rdx), %r13d
-               	imull	%r13d, %ecx
-               	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %r13
-               	movl	%esi, (%r13)
+               	movl	(%rdx), %r15d
+               	imull	%r15d, %r13d
+               	leaq	-0x250(%rbp), %rdx
+               	movups	-0x330(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movl	%esi, (%r15)
                	movups	(%rdx), %xmm0
-               	leaq	-0x320(%rbp), %rdx
+               	leaq	-0x260(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x330(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
                	movups	(%rdx), %xmm0
-               	leaq	-0x340(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rdx
-               	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm0
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	leaq	-0x280(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	callq	 <L7>
+<L7>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	imull	%edi, %esi
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r12d
+               	imull	%r12d, %edi
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r12d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %r13d
+               	imull	%r13d, %r12d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %r13d
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %r13d
+               	leaq	-0x290(%rbp), %rdx
+               	movups	-0x340(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movl	%esi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movl	%r12d, (%rsi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x2c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rsi
+               	movl	%r13d, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L35>
-<L35>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L36>
-<L36>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x350(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L37>
-<L37>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L39>
-<L39>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L40>
-<L40>:
-               	movaps	-0x380(%rbp), %xmm14
-               	psubd	-0x3a0(%rbp), %xmm14
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x320(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pand	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3b0(%rbp), %xmm0
-               	callq	 <L42>
-<L42>:
-               	movaps	-0x390(%rbp), %xmm14
-               	por	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x3c0(%rbp), %xmm0
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x390(%rbp), %xmm14
-               	pxor	-0x3a0(%rbp), %xmm14
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x310(%rbp), %xmm14
+               	psubd	-0x330(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	movaps	-0x390(%rbp), %xmm14
+               	callq	 <L10>
+<L10>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pand	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x350(%rbp), %xmm0
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x320(%rbp), %xmm14
+               	por	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0x360(%rbp), %xmm0
+               	callq	 <L12>
+<L12>:
+               	movaps	-0x320(%rbp), %xmm14
+               	pxor	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x320(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
-               	movaps	-0x3a0(%rbp), %xmm14
+               	callq	 <L14>
+<L14>:
+               	movaps	-0x330(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x3b0(%rbp), %xmm14
-               	pxor	-0x3c0(%rbp), %xmm14
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x350(%rbp), %xmm14
+               	pxor	-0x360(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L47>
-<L47>:
+               	callq	 <L16>
+<L16>:
                	movq	%rax, %r12
-               	movups	-0x390(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	movups	-0x380(%rbp), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	-0x320(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	movups	-0x310(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
                	movq	$0x0, %r13
-<L48>:
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x3e0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L61>
-               	leaq	-0x140(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x90(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -630,358 +494,260 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movl	(%rax), %ecx
+               	movl	(%rax), %edx
                	leaq	(%rbx), %rax
-               	movl	(%rax), %edx
-               	movl	%ecx, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x358(%rbp)
+               	movl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x2e0(%rbp)
                	leaq	0x4(%r14), %rax
-               	movl	(%rax), %edx
+               	movl	(%rax), %esi
                	leaq	0x4(%rbx), %rax
+               	movl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2e8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movl	(%rax), %edx
+               	imull	%edx, %edi
+               	leaq	0xc(%r14), %rax
+               	movl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
                	movl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0x8(%r14), %rax
-               	movl	(%rax), %esi
-               	leaq	0x8(%rbx), %rax
-               	movl	(%rax), %edi
-               	imull	%edi, %esi
-               	leaq	0xc(%r14), %rax
-               	movl	(%rax), %edi
-               	leaq	0xc(%rbx), %rax
-               	movl	(%rax), %ecx
-               	imull	%ecx, %edi
-               	leaq	-0x150(%rbp), %rax
-               	movups	-0x3e0(%rbp), %xmm14
+               	leaq	-0xa0(%rbp), %rax
+               	movups	-0x380(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rcx
-               	movq	-0x358(%rbp), %r8
-               	movl	%r8d, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x160(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x4(%rax), %rcx
-               	movl	%edx, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x170(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movl	%esi, (%rcx)
-               	movups	(%rax), %xmm2
-               	leaq	-0x180(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movl	%edi, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rsi
+               	movq	-0x2e0(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xb0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x2e8(%rbp), %r8
+               	movl	%r8d, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xc0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movl	%edi, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0xd0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movl	%edx, (%rsi)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x3f0(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	$0x0, %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-               	jmp	 <L54>
-<L49>:
-               	movq	-0x408(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x410(%rbp)
-               	movq	-0x410(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x410(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x360(%rbp)
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x360(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L50>
-<L50>:
-               	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0x4(%r8), %rsi
-               	movl	(%rsi), %r8d
                	movq	%r8, -0x368(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	-0x3a8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%r8, %rsi
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
                	movq	-0x368(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L51>
-<L51>:
+               	movq	%r8, %rdi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x3a8(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	-0x3a8(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x100(%rbp), %r8
+               	movq	%r8, -0x3b0(%rbp)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x2f0(%rbp)
+               	movq	-0x368(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x2f0(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movl	(%rsi), %r8d
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
-               	movl	%r8d, %esi
-               	callq	 <L52>
-<L52>:
-               	movq	%rax, %rdi
-               	movq	-0x410(%rbp), %r8
-               	leaq	0xc(%r8), %rsi
+               	callq	 <L23>
+<L23>:
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rdx
-               	movq	-0x408(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x3c8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L49>
-<L54>:
-               	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x418(%rbp)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x418(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x418(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x3c8(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L55>
-<L55>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x1d0(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L56>
-<L56>:
-               	leaq	0x4(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x8(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L58>
-<L58>:
-               	leaq	0xc(%r15), %rdx
-               	movl	(%rdx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L59>
-<L59>:
-               	movq	-0x418(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L60>
-<L60>:
-               	movq	-0x468(%rbp), %rbx
-               	movq	-0x470(%rbp), %r12
-               	movq	-0x478(%rbp), %r13
-               	movq	-0x480(%rbp), %r14
-               	movq	-0x488(%rbp), %r15
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x3f8(%rbp), %rbx
+               	movq	-0x400(%rbp), %r12
+               	movq	-0x408(%rbp), %r13
+               	movq	-0x410(%rbp), %r14
+               	movq	-0x418(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L61>:
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %esi
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edi
-               	imull	%edi, %esi
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edi
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %r15d
+<L26>:
+               	leaq	(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	(%rbx), %rdx
+               	movl	(%rdx), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x2f8(%rbp)
+               	leaq	0x4(%r14), %rdx
+               	movl	(%rdx), %edi
+               	leaq	0x4(%rbx), %rdx
+               	movl	(%rdx), %r15d
                	imull	%r15d, %edi
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %r14d
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %r15d
-               	imull	%r15d, %r14d
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x3e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r15
-               	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm2, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x100(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	0xc(%r15), %rcx
-               	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	leaq	(%r15), %rcx
-               	movl	(%rcx), %edx
+               	leaq	0x8(%r14), %rdx
+               	movl	(%rdx), %r15d
+               	leaq	0x8(%rbx), %rdx
+               	movl	(%rdx), %esi
+               	imull	%esi, %r15d
+               	leaq	0xc(%r14), %rdx
+               	movl	(%rdx), %esi
+               	leaq	0xc(%rbx), %rdx
+               	movl	(%rdx), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	-0x2f8(%rbp), %r8
+               	movl	%r8d, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x4(%rdx), %r14
+               	movl	%edi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x40(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rdi
+               	movl	%r15d, (%rdi)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x50(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0xc(%rdx), %rdi
+               	movl	%esi, (%rdi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x3c0(%rbp)
                	movq	%r12, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3c0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3d0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x8(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3d0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x3a0(%rbp), %xmm14
+               	paddd	-0x380(%rbp), %xmm14
+               	movaps	%xmm14, -0x3e0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	leaq	0xc(%r15), %rcx
-               	movl	(%rcx), %edx
+               	movups	-0x3e0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x380(%rbp), %xmm14
+               	paddd	-0x330(%rbp), %xmm14
+               	movaps	%xmm14, -0x3f0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	pxor	-0x430(%rbp), %xmm14
-               	movaps	%xmm14, -0x440(%rbp)
-               	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L69>
-<L69>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x3e0(%rbp), %xmm14
-               	movaps	%xmm14, -0x450(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L72>
-<L72>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x3e0(%rbp), %xmm14
-               	paddd	-0x3a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x460(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L75>
-<L75>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L76>
-<L76>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
+               	movups	-0x3f0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x460(%rbp), %xmm14
-               	movups	%xmm14, -0x3e0(%rbp)
-               	movups	-0x440(%rbp), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
-               	movups	-0x450(%rbp), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
-               	jmp	 <L48>
+               	movups	-0x3f0(%rbp), %xmm14
+               	movups	%xmm14, -0x380(%rbp)
+               	movups	-0x3d0(%rbp), %xmm14
+               	movups	%xmm14, -0x390(%rbp)
+               	movups	-0x3e0(%rbp), %xmm14
+               	movups	%xmm14, -0x3a0(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-linux/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-linux/vec/vec_u64x2.dis
@@ -7,18 +7,56 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rsi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	callq	 <L1>
+               	movq	%rdx, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rsi, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rdx
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L0>
 <L1>:
+               	leaq	0x8(%rax), %rdx
+               	movq	(%rdx), %rax
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+               	jmp	 <L3>
+<L2>:
+               	movq	%rdx, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rax, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rdx
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rdx
+               	jb	 <L2>
+<L3>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -26,334 +64,255 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3a0, %rsp            # imm = 0x3A0
-               	movq	%rbx, -0x378(%rbp)
-               	movq	%r12, -0x380(%rbp)
-               	movq	%r13, -0x388(%rbp)
-               	movq	%r14, -0x390(%rbp)
-               	movq	%r15, -0x398(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	leaq	-0x10(%rbp), %rcx
-               	leaq	(%rcx), %rdx
+               	subq	$0x310, %rsp            # imm = 0x310
+               	movq	%rbx, -0x2e8(%rbp)
+               	movq	%r12, -0x2f0(%rbp)
+               	movq	%r13, -0x2f8(%rbp)
+               	movq	%r14, -0x300(%rbp)
+               	movq	%r15, -0x308(%rbp)
+               	leaq	-0xd0(%rbp), %rax
+               	leaq	(%rax), %rdx
                	movq	$-0x10, (%rdx)
-               	leaq	0x8(%rcx), %rdx
+               	leaq	0x8(%rax), %rdx
                	movq	$0x12345678, (%rdx)     # imm = 0x12345678
-               	movups	(%rcx), %xmm0
-               	leaq	-0x20(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	-0x30(%rbp), %rdx
+               	movups	(%rax), %xmm0
+               	leaq	-0xe0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0xf0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movq	$0x11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$-0x1, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x40(%rbp), %rdx
+               	leaq	-0x100(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	-0x50(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x1, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x1b, (%rdi)
+               	leaq	-0x110(%rbp), %rsi
+               	leaq	(%rsi), %rbx
+               	movq	$0x1, (%rbx)
+               	leaq	0x8(%rsi), %rbx
+               	movq	$0x1b, (%rbx)
                	movups	(%rsi), %xmm2
-               	leaq	-0x60(%rbp), %r12
-               	movups	%xmm2, (%r12)
-               	leaq	-0x70(%rbp), %rsi
-               	leaq	(%rsi), %rdi
-               	movq	$0x0, (%rdi)
-               	leaq	0x8(%rsi), %rdi
-               	movq	$0x0, (%rdi)
+               	leaq	-0x120(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x130(%rbp), %rsi
+               	leaq	(%rsi), %r12
+               	movq	$0x0, (%r12)
+               	leaq	0x8(%rsi), %r12
+               	movq	$0x0, (%r12)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
-               	leaq	(%rcx), %rsi
-               	movq	(%rsi), %rcx
-               	addq	%rbx, %rcx
-               	leaq	-0x80(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	(%r13), %rsi
-               	movq	%rcx, (%rsi)
+               	movups	%xmm14, -0x200(%rbp)
+               	leaq	(%rax), %rsi
+               	movq	(%rsi), %rax
+               	addq	%rdi, %rax
+               	leaq	-0x140(%rbp), %r12
+               	movups	%xmm0, (%r12)
+               	leaq	(%r12), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%r12), %xmm14
+               	movups	%xmm14, -0x210(%rbp)
+               	leaq	0x8(%rdx), %rax
+               	movq	(%rax), %rdx
+               	addq	%rdi, %rdx
+               	leaq	-0x150(%rbp), %r13
+               	movups	%xmm1, (%r13)
+               	leaq	0x8(%r13), %rax
+               	movq	%rdx, (%rax)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
-               	leaq	0x8(%rdx), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rbx, %rdx
-               	leaq	-0x90(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x2b0(%rbp)
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movups	%xmm14, -0x220(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x210(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
                	movq	%rax, %rdi
+               	movups	-0x220(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x230(%rbp)
+               	leaq	-0x160(%rbp), %r14
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
+               	movups	-0x230(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L3>
 <L3>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x190(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %r15
+               	imulq	%r15, %rdi
+               	leaq	-0x170(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r15
+               	movq	%rsi, (%r15)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x180(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L5>
 <L5>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x190(%rbp), %rdx
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1a0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r13), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r13), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1c0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L7>
 <L7>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r12
+               	imulq	%r12, %rdi
+               	leaq	-0x1d0(%rbp), %rdx
+               	movups	-0x230(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r12
+               	movq	%rsi, (%r12)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x1e0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm0
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x210(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
                	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x200(%rbp), %xmm14
+               	psubq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm0, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm0
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pand	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	por	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x200(%rbp), %rcx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x8(%r13), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm0
-               	leaq	(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pxor	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L13>
 <L13>:
-               	leaq	0x8(%r13), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x210(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	-0x220(%rbp), %rcx
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L16>
-<L16>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	(%rdx), %rsi
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rsi
-               	leaq	0x8(%rcx), %rdx
-               	movq	(%rdx), %rcx
-               	leaq	0x8(%r12), %rdx
-               	movq	(%rdx), %rdi
-               	imulq	%rdi, %rcx
-               	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	(%rdx), %rdi
-               	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	0x8(%rbx), %rdx
-               	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm0
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L17>
-<L17>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L18>
-<L18>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L19>
-<L19>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L20>
-<L20>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L21>
-<L21>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pand	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2c0(%rbp), %xmm0
-               	callq	 <L22>
-<L22>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	por	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2d0(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0x2d0(%rbp), %xmm0
-               	callq	 <L23>
-<L23>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L24>
-<L24>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L25>
-<L25>:
-               	movaps	-0x2b0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movq	%rax, %rdi
-               	callq	 <L26>
-<L26>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
                	movaps	%xmm4, %xmm0
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-               	movups	-0x2a0(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	callq	 <L16>
+<L16>:
+               	movq	%rax, %r12
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x200(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	movq	$0x0, %r13
-<L28>:
-               	leaq	-0xa0(%rbp), %r14
-               	movups	-0x2f0(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L37>
-               	leaq	-0x100(%rbp), %r15
+               	jb	 <L26>
+               	leaq	-0x70(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -363,231 +322,211 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	(%r14), %rax
-               	movq	(%rax), %rcx
-               	leaq	(%r12), %rax
                	movq	(%rax), %rdx
-               	imulq	%rdx, %rcx
-               	leaq	0x8(%r14), %rax
-               	movq	(%rax), %rdx
-               	leaq	0x8(%r12), %rax
+               	leaq	(%rbx), %rax
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
-               	leaq	-0x110(%rbp), %rax
-               	movups	-0x2f0(%rbp), %xmm14
+               	leaq	0x8(%r14), %rax
+               	movq	(%rax), %rsi
+               	leaq	0x8(%rbx), %rax
+               	movq	(%rax), %rdi
+               	imulq	%rdi, %rsi
+               	leaq	-0x80(%rbp), %rax
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	leaq	(%rax), %rsi
-               	movq	%rcx, (%rsi)
-               	movups	(%rax), %xmm2
-               	leaq	-0x120(%rbp), %rax
-               	movups	%xmm2, (%rax)
-               	leaq	0x8(%rax), %rcx
-               	movq	%rdx, (%rcx)
-               	movups	(%rax), %xmm2
+               	leaq	(%rax), %rdi
+               	movq	%rdx, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x90(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rsi, (%rdx)
+               	movups	(%rax), %xmm0
                	leaq	0x20(%r15), %rax
-               	movups	%xmm2, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x300(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movq	%rbx, %r8
-               	movq	%r8, -0x2d8(%rbp)
+               	movq	%r12, %r8
+               	movq	%r8, -0x258(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L29>
-               	jmp	 <L32>
-<L29>:
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rdx
-               	imulq	$0x10, %rdx, %rdx
-               	leaq	(%r15,%rdx), %rsi
-               	movups	(%rsi), %xmm2
-               	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x320(%rbp)
-               	movq	-0x320(%rbp), %r8
-               	movups	%xmm2, (%r8)
-               	movq	-0x320(%rbp), %r8
-               	leaq	(%r8), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x278(%rbp)
-               	movq	-0x2d8(%rbp), %r8
-               	movq	%r8, %rdi
-               	movq	-0x278(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0x298(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L30>
-<L30>:
-               	movq	%rax, %rdi
-               	movq	-0x320(%rbp), %r8
-               	leaq	0x8(%r8), %rsi
-               	movq	(%rsi), %rdx
-               	movq	%rdx, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rdx
-               	movq	-0x318(%rbp), %r8
-               	movq	%r8, %rcx
-               	addq	$0x1, %rcx
-               	movq	%rdx, %r8
-               	movq	%r8, -0x2d8(%rbp)
-               	movq	%rcx, %r8
-               	movq	%r8, -0x318(%rbp)
-               	movq	-0x318(%rbp), %r8
-               	cmpq	$0x4, %r8
-               	jb	 <L29>
-<L32>:
-               	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x328(%rbp)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, (%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x8(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x10(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x18(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x20(%r8)
-               	movq	-0x328(%rbp), %r8
-               	movq	$0x0, 0x28(%r8)
-               	movq	-0x328(%rbp), %r8
-               	leaq	(%r8), %rdx
-               	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
-               	leaq	0x20(%r15), %rsi
-               	movups	(%rsi), %xmm2
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x10(%r8), %r15
-               	movups	%xmm2, (%r15)
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rsi
-               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
-               	movl	(%rdx), %esi
-               	movq	-0x2d8(%rbp), %r8
+               	imulq	$0x10, %rsi, %rsi
+               	leaq	(%r15,%rsi), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x258(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L33>
-<L33>:
-               	movups	(%r15), %xmm2
-               	leaq	-0x170(%rbp), %r15
-               	movups	%xmm2, (%r15)
-               	leaq	(%r15), %rdx
-               	movq	(%rdx), %rsi
+               	callq	 <L19>
+<L19>:
+               	movq	-0x298(%rbp), %r8
+               	movq	%r8, %rdx
+               	addq	$0x1, %rdx
+               	movq	%rax, %r8
+               	movq	%r8, -0x258(%rbp)
+               	movq	%rdx, %r8
+               	movq	%r8, -0x298(%rbp)
+               	movq	-0x298(%rbp), %r8
+               	cmpq	$0x4, %r8
+               	jb	 <L18>
+<L20>:
+               	leaq	-0xc0(%rbp), %r8
+               	movq	%r8, -0x2a0(%rbp)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	(%r8), %rsi
+               	movl	$0xffffffff, (%rsi)     # imm = 0xFFFFFFFF
+               	leaq	0x20(%r15), %rdi
+               	movups	(%rdi), %xmm0
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rdi
+               	movups	%xmm0, (%rdi)
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rdi
+               	movl	$0x12345678, (%rdi)     # imm = 0x12345678
+               	movl	(%rsi), %edi
+               	movl	%edi, %r8d
+               	movq	%r8, -0x1e8(%rbp)
+               	movq	-0x258(%rbp), %r8
+               	movq	%r8, %rax
+               	movq	$0x0, %rdi
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+               	jmp	 <L22>
+<L21>:
+               	movq	%rdi, %r15
+               	imulq	$0x8, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x1e8(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	andq	$0xff, %r15
+               	movq	%rax, %rsi
+               	xorq	%r15, %rsi
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rsi
+               	addq	$0x1, %rdi
+               	movq	%rsi, %rax
+               	cmpq	$0x8, %rdi
+               	jb	 <L21>
+<L22>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
-               	leaq	0x8(%r15), %rdx
-               	movq	(%rdx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L35>
-<L35>:
-               	movq	-0x328(%rbp), %r8
-               	leaq	0x20(%r8), %rdx
-               	movl	(%rdx), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L36>
-<L36>:
-               	movq	-0x378(%rbp), %rbx
-               	movq	-0x380(%rbp), %r12
-               	movq	-0x388(%rbp), %r13
-               	movq	-0x390(%rbp), %r14
-               	movq	-0x398(%rbp), %r15
+               	callq	 <L23>
+<L23>:
+               	movq	-0x2a0(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	(%rsi), %edx
+               	movl	%edx, %esi
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rdx, %rdi
+               	imulq	$0x8, %rdi, %rdi
+               	movq	%rdi, %rcx
+               	movq	%rsi, %rdi
+               	shrq	%cl, %rdi
+               	andq	$0xff, %rdi
+               	movq	%rax, %r15
+               	xorq	%rdi, %r15
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r15
+               	addq	$0x1, %rdx
+               	movq	%r15, %rax
+               	cmpq	$0x8, %rdx
+               	jb	 <L24>
+<L25>:
+               	movq	-0x2e8(%rbp), %rbx
+               	movq	-0x2f0(%rbp), %r12
+               	movq	-0x2f8(%rbp), %r13
+               	movq	-0x300(%rbp), %r14
+               	movq	-0x308(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L37>:
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	imulq	%rsi, %rdx
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rdi
+<L26>:
+               	leaq	(%r14), %rdx
+               	movq	(%rdx), %rsi
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rdi
                	imulq	%rdi, %rsi
-               	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdi
-               	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm2
-               	leaq	-0xc0(%rbp), %r14
-               	movups	%xmm2, (%r14)
-               	leaq	0x8(%r14), %rcx
-               	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	leaq	0x8(%r14), %rdx
+               	movq	(%rdx), %rdi
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %r14
+               	imulq	%r14, %rdi
+               	leaq	-0x20(%rbp), %rdx
+               	movups	-0x270(%rbp), %xmm14
+               	movups	%xmm14, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rsi, (%r14)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x30(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	0x8(%rdx), %rsi
+               	movq	%rdi, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x2b0(%rbp)
+               	movq	%r12, %rdi
+               	movups	-0x2b0(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L39>
-<L39>:
-               	movaps	-0x300(%rbp), %xmm14
-               	pxor	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x350(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2c0(%rbp), %xmm0
+               	callq	 <L28>
+<L28>:
+               	movaps	-0x290(%rbp), %xmm14
+               	paddq	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L40>
-<L40>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
+               	movups	-0x2d0(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x270(%rbp), %xmm14
+               	paddq	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, -0x2e0(%rbp)
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x2f0(%rbp), %xmm14
-               	movaps	%xmm14, -0x360(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L43>
-<L43>:
-               	movaps	-0x2f0(%rbp), %xmm14
-               	paddq	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x370(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L44>
-<L44>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L45>
-<L45>:
+               	movups	-0x2e0(%rbp), %xmm0
+               	callq	 <L30>
+<L30>:
                	addq	$0x1, %r13
-               	movq	%rax, %rbx
-               	movups	-0x370(%rbp), %xmm14
-               	movups	%xmm14, -0x2f0(%rbp)
-               	movups	-0x350(%rbp), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
-               	movups	-0x360(%rbp), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
-               	jmp	 <L28>
+               	movq	%rax, %r12
+               	movups	-0x2e0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2d0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	jmp	 <L17>

--- a/test/golden/x86_64-linux/vec/vec_u8x16.dis
+++ b/test/golden/x86_64-linux/vec/vec_u8x16.dis
@@ -7,88 +7,380 @@ Disassembly of section .text:
                	movq	%rsp, %rbp
                	subq	$0x20, %rsp
                	movq	%rbx, -0x18(%rbp)
-               	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L0>
+               	movq	%r12, -0x20(%rbp)
+               	leaq	-0x10(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
+               	jmp	 <L1>
 <L0>:
-               	movq	%rax, %rdi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L1>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L0>
 <L1>:
-               	movq	%rax, %rdi
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L2>
+               	leaq	0x1(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
+               	jmp	 <L3>
 <L2>:
-               	movq	%rax, %rdi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L3>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L2>
 <L3>:
-               	movq	%rax, %rdi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L4>
+               	leaq	0x2(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
+               	jmp	 <L5>
 <L4>:
-               	movq	%rax, %rdi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L5>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L4>
 <L5>:
-               	movq	%rax, %rdi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L6>
+               	leaq	0x3(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
+               	jmp	 <L7>
 <L6>:
-               	movq	%rax, %rdi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L7>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L6>
 <L7>:
-               	movq	%rax, %rdi
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L8>
+               	leaq	0x4(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
+               	jmp	 <L9>
 <L8>:
-               	movq	%rax, %rdi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L9>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L8>
 <L9>:
-               	movq	%rax, %rdi
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L10>
+               	leaq	0x5(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
+               	jmp	 <L11>
 <L10>:
-               	movq	%rax, %rdi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L11>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L10>
 <L11>:
-               	movq	%rax, %rdi
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L12>
+               	leaq	0x6(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
+               	jmp	 <L13>
 <L12>:
-               	movq	%rax, %rdi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L13>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L12>
 <L13>:
-               	movq	%rax, %rdi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L14>
+               	leaq	0x7(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
+               	jmp	 <L15>
 <L14>:
-               	movq	%rax, %rdi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	callq	 <L15>
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L14>
 <L15>:
+               	leaq	0x8(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+               	jmp	 <L17>
+<L16>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L16>
+<L17>:
+               	leaq	0x9(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+               	jmp	 <L19>
+<L18>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L18>
+<L19>:
+               	leaq	0xa(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+               	jmp	 <L21>
+<L20>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L20>
+<L21>:
+               	leaq	0xb(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+               	jmp	 <L23>
+<L22>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L22>
+<L23>:
+               	leaq	0xc(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+               	jmp	 <L25>
+<L24>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L24>
+<L25>:
+               	leaq	0xd(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+               	jmp	 <L27>
+<L26>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L26>
+<L27>:
+               	leaq	0xe(%rax), %rdx
+               	movzbl	(%rdx), %esi
+               	movzbq	%sil, %rdx
+               	movq	$0x0, %rsi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+               	jmp	 <L29>
+<L28>:
+               	movq	%rsi, %rbx
+               	imulq	$0x8, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%rdx, %rbx
+               	shrq	%cl, %rbx
+               	andq	$0xff, %rbx
+               	movq	%rdi, %r12
+               	xorq	%rbx, %r12
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %r12
+               	addq	$0x1, %rsi
+               	movq	%r12, %rdi
+               	cmpq	$0x8, %rsi
+               	jb	 <L28>
+<L29>:
+               	leaq	0xf(%rax), %rdx
+               	movzbl	(%rdx), %eax
+               	movzbq	%al, %rdx
+               	movq	$0x0, %rax
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+               	jmp	 <L31>
+<L30>:
+               	movq	%rax, %rsi
+               	imulq	$0x8, %rsi, %rsi
+               	movq	%rsi, %rcx
+               	movq	%rdx, %rsi
+               	shrq	%cl, %rsi
+               	andq	$0xff, %rsi
+               	movq	%rdi, %rbx
+               	xorq	%rsi, %rbx
+               	movabsq	$0x100000001b3, %r11    # imm = 0x100000001B3
+               	imulq	%r11, %rbx
+               	addq	$0x1, %rax
+               	movq	%rbx, %rdi
+               	cmpq	$0x8, %rax
+               	jb	 <L30>
+<L31>:
+               	movq	%rdi, %rax
                	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -96,1101 +388,1086 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xac0, %rsp            # imm = 0xAC0
-               	movq	%rbx, -0xa98(%rbp)
-               	movq	%r12, -0xaa0(%rbp)
-               	movq	%r13, -0xaa8(%rbp)
-               	movq	%r14, -0xab0(%rbp)
-               	movq	%r15, -0xab8(%rbp)
-               	movq	%rdi, %rbx
-               	callq	 <L0>
-<L0>:
-               	movq	%rax, %rdi
-               	movb	%bl, %cl
-               	leaq	-0x10(%rbp), %rdx
+               	subq	$0xaa0, %rsp            # imm = 0xAA0
+               	movq	%rbx, -0xa78(%rbp)
+               	movq	%r12, -0xa80(%rbp)
+               	movq	%r13, -0xa88(%rbp)
+               	movq	%r14, -0xa90(%rbp)
+               	movq	%r15, -0xa98(%rbp)
+               	movb	%dil, %al
+               	leaq	-0x290(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movb	$-0x10, (%rdx)
+               	leaq	0x1(%rcx), %rdx
+               	movb	$0x1, (%rdx)
+               	leaq	0x2(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0x3(%rcx), %rdx
+               	movb	$-0x1, (%rdx)
+               	leaq	0x4(%rcx), %rdx
+               	movb	$0x11, (%rdx)
+               	leaq	0x5(%rcx), %rdx
+               	movb	$0x2, (%rdx)
+               	leaq	0x6(%rcx), %rdx
+               	movb	$-0x38, (%rdx)
+               	leaq	0x7(%rcx), %rdx
+               	movb	$0x63, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movb	$0x0, (%rdx)
+               	leaq	0x9(%rcx), %rdx
+               	movb	$0x7, (%rdx)
+               	leaq	0xa(%rcx), %rdx
+               	movb	$-0x6, (%rdx)
+               	leaq	0xb(%rcx), %rdx
+               	movb	$0x21, (%rdx)
+               	leaq	0xc(%rcx), %rdx
+               	movb	$-0x80, (%rdx)
+               	leaq	0xd(%rcx), %rdx
+               	movb	$0x40, (%rdx)
+               	leaq	0xe(%rcx), %rdx
+               	movb	$0x5, (%rdx)
+               	leaq	0xf(%rcx), %rdx
+               	movb	$-0x39, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x2b0(%rbp), %rdx
                	leaq	(%rdx), %rsi
-               	movb	$-0x10, (%rsi)
-               	leaq	0x1(%rdx), %rsi
-               	movb	$0x1, (%rsi)
-               	leaq	0x2(%rdx), %rsi
-               	movb	$-0x80, (%rsi)
-               	leaq	0x3(%rdx), %rsi
-               	movb	$-0x1, (%rsi)
-               	leaq	0x4(%rdx), %rsi
                	movb	$0x11, (%rsi)
-               	leaq	0x5(%rdx), %rsi
-               	movb	$0x2, (%rsi)
-               	leaq	0x6(%rdx), %rsi
+               	leaq	0x1(%rdx), %rsi
+               	movb	$-0x1, (%rsi)
+               	leaq	0x2(%rdx), %rsi
+               	movb	$-0x7f, (%rsi)
+               	leaq	0x3(%rdx), %rsi
+               	movb	$0x1, (%rsi)
+               	leaq	0x4(%rdx), %rsi
                	movb	$-0x38, (%rsi)
+               	leaq	0x5(%rdx), %rsi
+               	movb	$0x64, (%rsi)
+               	leaq	0x6(%rdx), %rsi
+               	movb	$0x39, (%rsi)
                	leaq	0x7(%rdx), %rsi
-               	movb	$0x63, (%rsi)
+               	movb	$0x15, (%rsi)
                	leaq	0x8(%rdx), %rsi
-               	movb	$0x0, (%rsi)
+               	movb	$-0x1, (%rsi)
                	leaq	0x9(%rdx), %rsi
-               	movb	$0x7, (%rsi)
+               	movb	$0x3, (%rsi)
                	leaq	0xa(%rdx), %rsi
-               	movb	$-0x6, (%rsi)
+               	movb	$0x6, (%rsi)
                	leaq	0xb(%rdx), %rsi
-               	movb	$0x21, (%rsi)
+               	movb	$-0x22, (%rsi)
                	leaq	0xc(%rdx), %rsi
                	movb	$-0x80, (%rsi)
                	leaq	0xd(%rdx), %rsi
-               	movb	$0x40, (%rsi)
+               	movb	$-0x40, (%rsi)
                	leaq	0xe(%rdx), %rsi
-               	movb	$0x5, (%rsi)
+               	movb	$-0x5, (%rsi)
                	leaq	0xf(%rdx), %rsi
-               	movb	$-0x39, (%rsi)
-               	movups	(%rdx), %xmm0
-               	leaq	-0x20(%rbp), %rdx
-               	movups	%xmm0, (%rdx)
-               	leaq	-0x30(%rbp), %rsi
-               	leaq	(%rsi), %rbx
-               	movb	$0x11, (%rbx)
-               	leaq	0x1(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	leaq	0x2(%rsi), %rbx
-               	movb	$-0x7f, (%rbx)
-               	leaq	0x3(%rsi), %rbx
-               	movb	$0x1, (%rbx)
-               	leaq	0x4(%rsi), %rbx
-               	movb	$-0x38, (%rbx)
-               	leaq	0x5(%rsi), %rbx
-               	movb	$0x64, (%rbx)
-               	leaq	0x6(%rsi), %rbx
-               	movb	$0x39, (%rbx)
-               	leaq	0x7(%rsi), %rbx
-               	movb	$0x15, (%rbx)
-               	leaq	0x8(%rsi), %rbx
-               	movb	$-0x1, (%rbx)
-               	leaq	0x9(%rsi), %rbx
-               	movb	$0x3, (%rbx)
-               	leaq	0xa(%rsi), %rbx
-               	movb	$0x6, (%rbx)
-               	leaq	0xb(%rsi), %rbx
-               	movb	$-0x22, (%rbx)
-               	leaq	0xc(%rsi), %rbx
-               	movb	$-0x80, (%rbx)
-               	leaq	0xd(%rsi), %rbx
-               	movb	$-0x40, (%rbx)
-               	leaq	0xe(%rsi), %rbx
-               	movb	$-0x5, (%rbx)
-               	leaq	0xf(%rsi), %rbx
-               	movb	$0x39, (%rbx)
-               	movups	(%rsi), %xmm1
-               	leaq	-0x40(%rbp), %rsi
-               	movups	%xmm1, (%rsi)
-               	leaq	-0x50(%rbp), %rbx
-               	leaq	(%rbx), %r12
-               	movb	$0x1, (%r12)
-               	leaq	0x1(%rbx), %r12
-               	movb	$0x3, (%r12)
-               	leaq	0x2(%rbx), %r12
-               	movb	$0x9, (%r12)
-               	leaq	0x3(%rbx), %r12
-               	movb	$0x1b, (%r12)
-               	leaq	0x4(%rbx), %r12
-               	movb	$0x2, (%r12)
-               	leaq	0x5(%rbx), %r12
-               	movb	$0x6, (%r12)
-               	leaq	0x6(%rbx), %r12
-               	movb	$0x12, (%r12)
-               	leaq	0x7(%rbx), %r12
-               	movb	$0x36, (%r12)
-               	leaq	0x8(%rbx), %r12
-               	movb	$0x4, (%r12)
-               	leaq	0x9(%rbx), %r12
-               	movb	$0xc, (%r12)
-               	leaq	0xa(%rbx), %r12
-               	movb	$0x24, (%r12)
-               	leaq	0xb(%rbx), %r12
-               	movb	$0x6c, (%r12)
-               	leaq	0xc(%rbx), %r12
-               	movb	$0x8, (%r12)
-               	leaq	0xd(%rbx), %r12
-               	movb	$0x18, (%r12)
-               	leaq	0xe(%rbx), %r12
-               	movb	$0x48, (%r12)
-               	leaq	0xf(%rbx), %r12
-               	movb	$-0x28, (%r12)
-               	movups	(%rbx), %xmm2
-               	leaq	-0x60(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	-0x70(%rbp), %r12
-               	leaq	(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x1(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x2(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x3(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x4(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x5(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x6(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x7(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x8(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0x9(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xa(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xb(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xc(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xd(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xe(%r12), %r13
-               	movb	$0x0, (%r13)
-               	leaq	0xf(%r12), %r13
-               	movb	$0x0, (%r13)
-               	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9b0(%rbp)
-               	leaq	(%rdx), %r12
-               	movzbl	(%r12), %edx
-               	addl	%ecx, %edx
-               	leaq	-0x80(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %r13
-               	movb	%dl, (%r13)
-               	movups	(%r12), %xmm0
-               	leaq	0x7(%r12), %rdx
-               	movzbl	(%rdx), %r12d
-               	addl	%ecx, %r12d
-               	leaq	-0x90(%rbp), %r13
-               	movups	%xmm0, (%r13)
-               	leaq	0x7(%r13), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x9c0(%rbp)
-               	leaq	0x3(%rsi), %rdx
-               	movzbl	(%rdx), %esi
-               	addl	%ecx, %esi
-               	leaq	-0xa0(%rbp), %rdx
+               	movb	$0x39, (%rsi)
+               	movups	(%rdx), %xmm1
+               	leaq	-0x2c0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
-               	leaq	0x3(%rdx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rdx), %xmm0
-               	leaq	0xc(%rdx), %rsi
-               	movzbl	(%rsi), %edx
-               	addl	%ecx, %edx
-               	leaq	-0xb0(%rbp), %r12
+               	leaq	-0x2d0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x1, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x3, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x9, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x1b, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x2, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x6, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x12, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x36, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x4, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0xc, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x24, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x6c, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x8, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x18, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x48, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$-0x28, (%rdi)
+               	movups	(%rsi), %xmm2
+               	leaq	-0x2e0(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	-0x2f0(%rbp), %rsi
+               	leaq	(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x1(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x2(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x3(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x4(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x5(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x6(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x7(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x8(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0x9(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xa(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xb(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xc(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xd(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xe(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	leaq	0xf(%rsi), %rdi
+               	movb	$0x0, (%rdi)
+               	movups	(%rsi), %xmm14
+               	movups	%xmm14, -0x990(%rbp)
+               	leaq	(%rcx), %rsi
+               	movzbl	(%rsi), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x300(%rbp), %rsi
+               	movups	%xmm0, (%rsi)
+               	leaq	(%rsi), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rsi), %xmm0
+               	leaq	0x7(%rsi), %rcx
+               	movzbl	(%rcx), %esi
+               	addl	%eax, %esi
+               	leaq	-0x310(%rbp), %r12
                	movups	%xmm0, (%r12)
-               	leaq	0xc(%r12), %rcx
-               	movb	%dl, (%rcx)
+               	leaq	0x7(%r12), %rcx
+               	movb	%sil, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x9d0(%rbp)
-               	movups	-0x9c0(%rbp), %xmm0
+               	movups	%xmm14, -0x9a0(%rbp)
+               	leaq	0x3(%rdx), %rcx
+               	movzbl	(%rcx), %edx
+               	addl	%eax, %edx
+               	leaq	-0x320(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	0x3(%rcx), %rsi
+               	movb	%dl, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	0xc(%rcx), %rdx
+               	movzbl	(%rdx), %ecx
+               	addl	%eax, %ecx
+               	leaq	-0x330(%rbp), %r13
+               	movups	%xmm0, (%r13)
+               	leaq	0xc(%r13), %rax
+               	movb	%cl, (%rax)
+               	movups	(%r13), %xmm14
+               	movups	%xmm14, -0x9b0(%rbp)
+               	movabsq	$-0x340d631b7bdddcdb, %rdi # imm = 0xCBF29CE484222325
+               	movups	-0x9a0(%rbp), %xmm0
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	movups	-0x9b0(%rbp), %xmm0
                	callq	 <L1>
 <L1>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9c0(%rbp)
+               	leaq	-0x340(%rbp), %r14
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
                	movq	%rax, %rdi
-               	movups	-0x9d0(%rbp), %xmm0
+               	movups	-0x9c0(%rbp), %xmm0
                	callq	 <L2>
 <L2>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9e0(%rbp)
-               	leaq	-0xc0(%rbp), %r14
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L3>
 <L3>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movq	%rax, %rdi
-               	movaps	-0x9d0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
-               	callq	 <L5>
-<L5>:
                	movq	%rax, %r8
                	movq	%r8, -0x748(%rbp)
                	movq	-0x748(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
                	leaq	(%r12), %rcx
+               	movzbl	(%rcx), %edx
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
                	movq	%r8, -0x750(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
                	leaq	0x1(%r12), %rcx
-               	movzbl	(%rcx), %r15d
+               	movzbl	(%rcx), %esi
+               	leaq	0x1(%r13), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
+               	imull	%edi, %r8d
                	movq	%r8, -0x758(%rbp)
-               	leaq	0x2(%r13), %rcx
-               	movzbl	(%rcx), %r15d
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x760(%rbp)
-               	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x768(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x770(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x780(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x788(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x790(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7a0(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x7a8(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7b0(%rbp)
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %rdx
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rdx
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rdx
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rdx
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rdx
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rdx
-               	movq	-0x778(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x130(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rdx
-               	movq	-0x780(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x140(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rdx
-               	movq	-0x788(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x150(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rdx
-               	movq	-0x790(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x160(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rdx
-               	movq	-0x798(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x170(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rdx
-               	movq	-0x7a0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x180(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rdx
-               	movq	-0x7a8(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x190(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdx
-               	movq	-0x7b0(%rbp), %r8
-               	movb	%r8b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x748(%rbp), %r8
-               	movq	%r8, %rdi
-               	callq	 <L6>
-<L6>:
-               	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
-               	leaq	(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x7c0(%rbp)
-               	leaq	0x1(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x2(%r13), %rcx
                	movzbl	(%rcx), %r15d
-               	leaq	0x2(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x760(%rbp)
+               	leaq	0x3(%r12), %rcx
+               	movzbl	(%rcx), %r15d
                	leaq	0x3(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x768(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7d8(%rbp)
-               	leaq	0x4(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x770(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x7e0(%rbp)
-               	leaq	0x5(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x778(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
-               	leaq	0x6(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x7f0(%rbp)
-               	leaq	0x7(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %edx
+               	movq	%r8, -0x780(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %r15d
                	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x788(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x790(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f8(%rbp)
-               	leaq	0x8(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x798(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x800(%rbp)
-               	leaq	0x9(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
+               	movq	%r8, -0x7a0(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
-               	leaq	0xa(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x810(%rbp)
-               	leaq	0xb(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x818(%rbp)
-               	leaq	0xc(%r13), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x7a8(%rbp)
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %esi
                	imull	%esi, %edx
-               	leaq	0xd(%r13), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %esi
-               	leaq	0xe(%r13), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xf(%r13), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %edi
-               	leaq	-0x1d0(%rbp), %rcx
-               	movups	-0x9c0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r13
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x7f0(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x7f8(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x800(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x808(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x270(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x810(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x280(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x818(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r15b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%dil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x7b8(%rbp), %r8
+               	leaq	-0x350(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %rsi
+               	movq	-0x750(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x360(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rsi
+               	movq	-0x758(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x370(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rsi
+               	movq	-0x760(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x380(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rsi
+               	movq	-0x768(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x390(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rsi
+               	movq	-0x770(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %rsi
+               	movq	-0x778(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %rsi
+               	movq	-0x780(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %rsi
+               	movq	-0x788(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %rsi
+               	movq	-0x790(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %rsi
+               	movq	-0x798(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x3f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rsi
+               	movq	-0x7a0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x400(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rsi
+               	movq	-0x7a8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x410(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x420(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x430(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x440(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x748(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L7>
-<L7>:
+               	callq	 <L5>
+<L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x7b0(%rbp)
+               	movq	-0x7b0(%rbp), %r8
                	leaq	(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x7b8(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7c0(%rbp)
                	leaq	0x2(%r12), %rcx
-               	movzbl	(%rcx), %r13d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x7c8(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %eax
                	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x840(%rbp)
-               	leaq	0x4(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x7d0(%rbp)
+               	leaq	0x4(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x4(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x848(%rbp)
-               	leaq	0x5(%r12), %rcx
+               	movq	%r8, -0x7d8(%rbp)
+               	leaq	0x5(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x7e0(%rbp)
+               	leaq	0x6(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x7e8(%rbp)
+               	leaq	0x7(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%edi, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x7f0(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	movl	%r15d, %r8d
+               	imull	%ecx, %r8d
+               	movq	%r8, -0x7f8(%rbp)
+               	leaq	0x9(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x800(%rbp)
+               	leaq	0xa(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x808(%rbp)
+               	leaq	0xb(%r12), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xc(%r12), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %edi
+               	leaq	0xd(%r12), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xe(%r12), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xf(%r12), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edx
+               	leaq	-0x450(%rbp), %rax
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r12
+               	movq	-0x7b8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x460(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r12
+               	movq	-0x7c0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x470(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r12
+               	movq	-0x7c8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x480(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r12
+               	movq	-0x7d0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x490(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r12
+               	movq	-0x7d8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r12
+               	movq	-0x7e0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r12
+               	movq	-0x7e8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r12
+               	movq	-0x7f0(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r12
+               	movq	-0x7f8(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r12
+               	movq	-0x800(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x4f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r12
+               	movq	-0x808(%rbp), %r8
+               	movb	%r8b, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x500(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r12
+               	movb	%sil, (%r12)
+               	movups	(%rax), %xmm0
+               	leaq	-0x510(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rsi
+               	movb	%dil, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x520(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rsi
+               	movb	%r15b, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x530(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rsi
+               	movb	%cl, (%rsi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x540(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x7b0(%rbp), %r8
+               	movq	%r8, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	%rax, %r8
+               	movq	%r8, -0x810(%rbp)
+               	movq	-0x810(%rbp), %r8
+               	leaq	(%r13), %rcx
                	movzbl	(%rcx), %edx
-               	leaq	0x5(%rbx), %rcx
+               	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x850(%rbp)
-               	leaq	0x6(%r12), %rcx
+               	movq	%r8, -0x818(%rbp)
+               	leaq	0x1(%r13), %rcx
                	movzbl	(%rcx), %esi
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	leaq	0x1(%rbx), %rcx
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x858(%rbp)
-               	leaq	0x7(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x7(%rbx), %rcx
+               	imull	%edi, %r8d
+               	movq	%r8, -0x820(%rbp)
+               	leaq	0x2(%r13), %rcx
+               	movzbl	(%rcx), %edi
+               	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x828(%rbp)
+               	leaq	0x3(%r13), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
+               	movl	%r12d, %r8d
+               	imull	%r15d, %r8d
+               	movq	%r8, -0x830(%rbp)
+               	leaq	0x4(%r13), %rcx
+               	movzbl	(%rcx), %r15d
+               	leaq	0x4(%rbx), %rcx
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x838(%rbp)
+               	leaq	0x5(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x5(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
+               	imull	%edx, %r8d
+               	movq	%r8, -0x840(%rbp)
+               	leaq	0x6(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	movl	%edx, %r8d
+               	imull	%esi, %r8d
+               	movq	%r8, -0x848(%rbp)
+               	leaq	0x7(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	movl	%esi, %r8d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x850(%rbp)
+               	leaq	0x8(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x858(%rbp)
+               	leaq	0x9(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	movl	%r12d, %r8d
                	imull	%r15d, %r8d
                	movq	%r8, -0x860(%rbp)
-               	leaq	0x8(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x868(%rbp)
-               	leaq	0x9(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
-               	imull	%edx, %r8d
-               	movq	%r8, -0x870(%rbp)
-               	leaq	0xa(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	movl	%edx, %r8d
-               	imull	%esi, %r8d
-               	movq	%r8, -0x878(%rbp)
-               	leaq	0xb(%r12), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	imull	%r13d, %esi
-               	leaq	0xc(%r12), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	imull	%r15d, %r13d
-               	leaq	0xd(%r12), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xe(%r12), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xf(%r12), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %edx
-               	leaq	-0x2d0(%rbp), %rcx
-               	movups	-0x9d0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r12
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r12
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r12
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r12
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r12
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r12
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r12
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r12
-               	movq	-0x860(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x350(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r12
-               	movq	-0x868(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x360(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r12
-               	movq	-0x870(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x370(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r12
-               	movq	-0x878(%rbp), %r8
-               	movb	%r8b, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x380(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r12
-               	movb	%sil, (%r12)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rsi
-               	movb	%r13b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rsi
-               	movb	%r15b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rsi
-               	movb	%dil, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rsi
-               	movb	%dl, (%rsi)
-               	movups	(%rcx), %xmm0
+               	leaq	0xa(%r13), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xb(%r13), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xc(%r13), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xd(%r13), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edi
+               	imull	%edi, %esi
+               	leaq	0xe(%r13), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xf(%r13), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r13d
+               	imull	%r13d, %r12d
+               	leaq	-0x550(%rbp), %rax
+               	movups	-0x9b0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r13
+               	movq	-0x818(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x560(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r13
                	movq	-0x820(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x570(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r13
+               	movq	-0x828(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x580(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r13
+               	movq	-0x830(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x590(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r13
+               	movq	-0x838(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r13
+               	movq	-0x840(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r13
+               	movq	-0x848(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r13
+               	movq	-0x850(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r13
+               	movq	-0x858(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r13
+               	movq	-0x860(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x5f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %r13
+               	movb	%r15b, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x600(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %r13
+               	movb	%cl, (%r13)
+               	movups	(%rax), %xmm0
+               	leaq	-0x610(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x620(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x630(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dil, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x640(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%r12b, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x810(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L8>
-<L8>:
+               	callq	 <L7>
+<L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x868(%rbp)
+               	movq	-0x868(%rbp), %r8
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x870(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	imull	%edi, %r8d
+               	movq	%r8, -0x878(%rbp)
                	leaq	0x2(%r14), %rcx
-               	movzbl	(%rcx), %r12d
+               	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
+               	movzbl	(%rcx), %r12d
+               	movl	%edi, %r8d
+               	imull	%r12d, %r8d
+               	movq	%r8, -0x880(%rbp)
+               	leaq	0x3(%r14), %rcx
+               	movzbl	(%rcx), %r12d
+               	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%r12d, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x898(%rbp)
-               	leaq	0x3(%r14), %rcx
+               	movq	%r8, -0x888(%rbp)
+               	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %r13d
-               	leaq	0x3(%rbx), %rcx
+               	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r13d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
-               	leaq	0x4(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0x4(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	movl	%r15d, %r8d
-               	imull	%edi, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0x890(%rbp)
                	leaq	0x5(%r14), %rcx
-               	movzbl	(%rcx), %edi
+               	movzbl	(%rcx), %r15d
                	leaq	0x5(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	movl	%edi, %r8d
+               	movzbl	(%rcx), %eax
+               	movl	%r15d, %r8d
+               	imull	%eax, %r8d
+               	movq	%r8, -0x898(%rbp)
+               	leaq	0x6(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0x6(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
-               	leaq	0x6(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0x6(%rbx), %rcx
-               	movzbl	(%rcx), %esi
+               	movq	%r8, -0x8a0(%rbp)
+               	leaq	0x7(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0x7(%rbx), %rax
+               	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
-               	leaq	0x7(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0x7(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
+               	movq	%r8, -0x8a8(%rbp)
+               	leaq	0x8(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0x8(%rbx), %rax
+               	movzbl	(%rax), %edi
                	movl	%esi, %r8d
-               	imull	%r12d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
-               	leaq	0x8(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0x8(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
-               	movl	%r12d, %r8d
-               	imull	%r13d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
-               	leaq	0x9(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0x9(%rbx), %rcx
-               	movzbl	(%rcx), %r15d
-               	movl	%r13d, %r8d
-               	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
-               	leaq	0xa(%r14), %rcx
-               	movzbl	(%rcx), %r15d
-               	leaq	0xa(%rbx), %rcx
-               	movzbl	(%rcx), %edi
-               	imull	%edi, %r15d
-               	leaq	0xb(%r14), %rcx
-               	movzbl	(%rcx), %edi
-               	leaq	0xb(%rbx), %rcx
-               	movzbl	(%rcx), %edx
-               	imull	%edx, %edi
-               	leaq	0xc(%r14), %rcx
-               	movzbl	(%rcx), %edx
-               	leaq	0xc(%rbx), %rcx
-               	movzbl	(%rcx), %esi
-               	imull	%esi, %edx
-               	leaq	0xd(%r14), %rcx
-               	movzbl	(%rcx), %esi
-               	leaq	0xd(%rbx), %rcx
-               	movzbl	(%rcx), %r12d
-               	imull	%r12d, %esi
-               	leaq	0xe(%r14), %rcx
-               	movzbl	(%rcx), %r12d
-               	leaq	0xe(%rbx), %rcx
-               	movzbl	(%rcx), %r13d
+               	imull	%edi, %r8d
+               	movq	%r8, -0x8b0(%rbp)
+               	leaq	0x9(%r14), %rax
+               	movzbl	(%rax), %edi
+               	leaq	0x9(%rbx), %rax
+               	movzbl	(%rax), %r12d
+               	imull	%r12d, %edi
+               	leaq	0xa(%r14), %rax
+               	movzbl	(%rax), %r12d
+               	leaq	0xa(%rbx), %rax
+               	movzbl	(%rax), %r13d
                	imull	%r13d, %r12d
-               	leaq	0xf(%r14), %rcx
-               	movzbl	(%rcx), %r13d
-               	leaq	0xf(%rbx), %rcx
-               	movzbl	(%rcx), %r14d
-               	imull	%r14d, %r13d
-               	leaq	-0x3d0(%rbp), %rcx
-               	movups	-0x9e0(%rbp), %xmm14
-               	movups	%xmm14, (%rcx)
-               	leaq	(%rcx), %r14
+               	leaq	0xb(%r14), %rax
+               	movzbl	(%rax), %r13d
+               	leaq	0xb(%rbx), %rax
+               	movzbl	(%rax), %r15d
+               	imull	%r15d, %r13d
+               	leaq	0xc(%r14), %rax
+               	movzbl	(%rax), %r15d
+               	leaq	0xc(%rbx), %rax
+               	movzbl	(%rax), %ecx
+               	imull	%ecx, %r15d
+               	leaq	0xd(%r14), %rax
+               	movzbl	(%rax), %ecx
+               	leaq	0xd(%rbx), %rax
+               	movzbl	(%rax), %edx
+               	imull	%edx, %ecx
+               	leaq	0xe(%r14), %rax
+               	movzbl	(%rax), %edx
+               	leaq	0xe(%rbx), %rax
+               	movzbl	(%rax), %esi
+               	imull	%esi, %edx
+               	leaq	0xf(%r14), %rax
+               	movzbl	(%rax), %esi
+               	leaq	0xf(%rbx), %rax
+               	movzbl	(%rax), %r14d
+               	imull	%r14d, %esi
+               	leaq	-0x650(%rbp), %rax
+               	movups	-0x9c0(%rbp), %xmm14
+               	movups	%xmm14, (%rax)
+               	leaq	(%rax), %r14
+               	movq	-0x870(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x660(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %r14
+               	movq	-0x878(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x670(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %r14
+               	movq	-0x880(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rax), %xmm0
+               	leaq	-0x680(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %r14
                	movq	-0x888(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x690(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %r14
                	movq	-0x890(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x5(%rax), %r14
                	movq	-0x898(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6b0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x6(%rax), %r14
                	movq	-0x8a0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6c0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x7(%rax), %r14
                	movq	-0x8a8(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6d0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x8(%rax), %r14
                	movq	-0x8b0(%rbp), %r8
                	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x460(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x470(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r14
-               	movb	%r15b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r14
+               	movups	(%rax), %xmm0
+               	leaq	-0x6e0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x9(%rax), %r14
                	movb	%dil, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %rdi
-               	movb	%dl, (%rdi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xd(%rcx), %rdx
-               	movb	%sil, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xe(%rcx), %rdx
-               	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xf(%rcx), %rdx
-               	movb	%r13b, (%rdx)
-               	movups	(%rcx), %xmm0
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rax), %xmm0
+               	leaq	-0x6f0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xa(%rax), %rdi
+               	movb	%r12b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x700(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xb(%rax), %rdi
+               	movb	%r13b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x710(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xc(%rax), %rdi
+               	movb	%r15b, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x720(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xd(%rax), %rdi
+               	movb	%cl, (%rdi)
+               	movups	(%rax), %xmm0
+               	leaq	-0x730(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xe(%rax), %rcx
+               	movb	%dl, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x740(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0xf(%rax), %rcx
+               	movb	%sil, (%rcx)
+               	movups	(%rax), %xmm0
+               	movq	-0x868(%rbp), %r8
                	movq	%r8, %rdi
+               	callq	 <L8>
+<L8>:
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L9>
 <L9>:
-               	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9c0(%rbp), %xmm14
+               	movaps	-0x990(%rbp), %xmm14
+               	psubb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L10>
 <L10>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pand	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9d0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9b0(%rbp), %xmm14
-               	psubb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movups	-0x9d0(%rbp), %xmm0
                	callq	 <L11>
 <L11>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	por	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x9e0(%rbp)
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pand	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0x9f0(%rbp)
-               	movups	-0x9f0(%rbp), %xmm0
+               	movups	-0x9e0(%rbp), %xmm0
                	callq	 <L12>
 <L12>:
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pxor	-0x9b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	por	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa00(%rbp)
-               	movups	-0xa00(%rbp), %xmm0
                	callq	 <L13>
 <L13>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
-               	pxor	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L14>
 <L14>:
-               	movq	%rax, %rdi
-               	movaps	-0x9c0(%rbp), %xmm14
+               	movaps	-0x9b0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
+               	movq	%rax, %rdi
                	callq	 <L15>
 <L15>:
-               	movq	%rax, %rdi
                	movaps	-0x9d0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
+               	pxor	-0x9e0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
+               	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L16>
 <L16>:
-               	movq	%rax, %rdi
-               	movaps	-0x9f0(%rbp), %xmm14
-               	pxor	-0xa00(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm0
-               	callq	 <L17>
-<L17>:
                	movq	%rax, %r12
-               	movups	-0x9c0(%rbp), %xmm14
+               	movups	-0x9a0(%rbp), %xmm14
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0x990(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0x990(%rbp), %xmm14
                	movups	%xmm14, -0xa20(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0x9b0(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
                	movq	$0x0, %r13
-<L18>:
-               	leaq	-0x4d0(%rbp), %r14
-               	movups	-0xa20(%rbp), %xmm14
+<L17>:
+               	leaq	-0x10(%rbp), %r14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L25>
-               	leaq	-0x610(%rbp), %r15
+               	jb	 <L24>
+               	leaq	-0x150(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -1200,10 +1477,10 @@ Disassembly of section .text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	leaq	0x10(%r15), %rax
                	movups	%xmm0, (%rax)
@@ -1213,91 +1490,91 @@ Disassembly of section .text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0x8b8(%rbp)
                	leaq	0x1(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x2(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x2(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x3(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x3(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x4(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x5(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x6(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0x6(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x7(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0x7(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x8(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x9(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rbx), %rax
                	movzbl	(%rax), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0xa(%r14), %rax
                	movzbl	(%rax), %esi
                	leaq	0xa(%rbx), %rax
                	movzbl	(%rax), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xb(%r14), %rax
                	movzbl	(%rax), %edi
                	leaq	0xb(%rbx), %rax
                	movzbl	(%rax), %ecx
                	movl	%edi, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xc(%r14), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rbx), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xd(%r14), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rbx), %rax
@@ -1313,96 +1590,96 @@ Disassembly of section .text:
                	leaq	0xf(%rbx), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %edi
-               	leaq	-0x620(%rbp), %rax
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x160(%rbp), %rax
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
+               	movq	-0x8b8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x170(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x1(%rax), %rcx
+               	movq	-0x8c0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x180(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x2(%rax), %rcx
+               	movq	-0x8c8(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x3(%rax), %rcx
+               	movq	-0x8d0(%rbp), %r8
+               	movb	%r8b, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	-0x1a0(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	0x4(%rax), %rcx
                	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x1b0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x1(%rax), %rcx
+               	leaq	0x5(%rax), %rcx
                	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x1c0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x2(%rax), %rcx
+               	leaq	0x6(%rax), %rcx
                	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x1d0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x3(%rax), %rcx
+               	leaq	0x7(%rax), %rcx
                	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x1e0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x4(%rax), %rcx
+               	leaq	0x8(%rax), %rcx
                	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x1f0(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x5(%rax), %rcx
+               	leaq	0x9(%rax), %rcx
                	movq	-0x900(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x200(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x6(%rax), %rcx
+               	leaq	0xa(%rax), %rcx
                	movq	-0x908(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x210(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x7(%rax), %rcx
+               	leaq	0xb(%rax), %rcx
                	movq	-0x910(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x220(%rbp), %rax
                	movups	%xmm0, (%rax)
-               	leaq	0x8(%rax), %rcx
+               	leaq	0xc(%rax), %rcx
                	movq	-0x918(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
-               	movups	%xmm0, (%rax)
-               	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
-               	movb	%r8b, (%rcx)
-               	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x230(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x240(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%sil, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x250(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%dil, (%rcx)
@@ -1410,163 +1687,175 @@ Disassembly of section .text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0xa30(%rbp), %xmm14
+               	movups	-0xa10(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-               	jmp	 <L21>
-<L19>:
-               	movq	-0xa48(%rbp), %r8
+               	jb	 <L18>
+               	jmp	 <L20>
+<L18>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm0
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L20>
-<L20>:
-               	movq	-0xa48(%rbp), %r8
+               	callq	 <L19>
+<L19>:
+               	movq	-0xa28(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rax, %r8
-               	movq	%r8, -0xa08(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xa48(%rbp)
-               	movq	-0xa48(%rbp), %r8
+               	movq	%r8, -0xa28(%rbp)
+               	movq	-0xa28(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L19>
-<L21>:
-               	leaq	-0x740(%rbp), %rcx
-               	movq	$0x0, (%rcx)
-               	movq	$0x0, 0x8(%rcx)
-               	movq	$0x0, 0x10(%rcx)
-               	movq	$0x0, 0x18(%rcx)
-               	movq	$0x0, 0x20(%rcx)
-               	movq	$0x0, 0x28(%rcx)
-               	leaq	(%rcx), %rdx
+               	jb	 <L18>
+<L20>:
+               	leaq	-0x280(%rbp), %r8
+               	movq	%r8, -0xa30(%rbp)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, (%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x8(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x10(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x18(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x20(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	movq	$0x0, 0x28(%r8)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     # imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm0
-               	leaq	0x10(%rcx), %r15
-               	movups	%xmm0, (%r15)
-               	leaq	0x20(%rcx), %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
-               	movl	$0x12345678, (%r8)      # imm = 0x12345678
-               	movl	(%rdx), %ecx
-               	movq	-0xa08(%rbp), %r8
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rsi
+               	movups	%xmm0, (%rsi)
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rsi
+               	movl	$0x12345678, (%rsi)     # imm = 0x12345678
+               	movl	(%rdx), %esi
+               	movl	%esi, %edx
+               	movq	-0x9e8(%rbp), %r8
                	movq	%r8, %rdi
-               	movl	%ecx, %esi
+               	movq	%rdx, %rsi
+               	callq	 <L21>
+<L21>:
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x10(%r8), %rdx
+               	movups	(%rdx), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L22>
 <L22>:
-               	movups	(%r15), %xmm0
+               	movq	-0xa30(%rbp), %r8
+               	leaq	0x20(%r8), %rdx
+               	movl	(%rdx), %ecx
+               	movl	%ecx, %esi
                	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	-0x940(%rbp), %r8
-               	movl	(%r8), %ecx
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	callq	 <L24>
-<L24>:
-               	movq	-0xa98(%rbp), %rbx
-               	movq	-0xaa0(%rbp), %r12
-               	movq	-0xaa8(%rbp), %r13
-               	movq	-0xab0(%rbp), %r14
-               	movq	-0xab8(%rbp), %r15
+               	movq	-0xa78(%rbp), %rbx
+               	movq	-0xa80(%rbp), %r12
+               	movq	-0xa88(%rbp), %r13
+               	movq	-0xa90(%rbp), %r14
+               	movq	-0xa98(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L25>:
+<L24>:
                	leaq	(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0x1(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0x928(%rbp)
                	leaq	0x2(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x3(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x4(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x5(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x6(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x7(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x8(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %esi
                	movl	%edx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x9(%r14), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edi
                	movl	%esi, %r8d
                	imull	%edi, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0xa(%r14), %rcx
                	movzbl	(%rcx), %edi
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%edi, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0xb(%r14), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x9a0(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xc(%r14), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rbx), %rcx
@@ -1587,131 +1876,131 @@ Disassembly of section .text:
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r14d
-               	leaq	-0x4e0(%rbp), %rcx
-               	movups	-0xa20(%rbp), %xmm14
+               	leaq	-0x20(%rbp), %rcx
+               	movups	-0xa00(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x30(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x1(%rcx), %r15
+               	movq	-0x928(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x40(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r15
+               	movq	-0x930(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x50(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r15
+               	movq	-0x938(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x60(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r15
+               	movq	-0x940(%rbp), %r8
+               	movb	%r8b, (%r15)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x70(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r15
                	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x80(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r15
+               	leaq	0x6(%rcx), %r15
                	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x90(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r15
+               	leaq	0x7(%rcx), %r15
                	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0xa0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r15
+               	leaq	0x8(%rcx), %r15
                	movq	-0x960(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0xb0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r15
+               	leaq	0x9(%rcx), %r15
                	movq	-0x968(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0xc0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r15
+               	leaq	0xa(%rcx), %r15
                	movq	-0x970(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0xd0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r15
+               	leaq	0xb(%rcx), %r15
                	movq	-0x978(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r15
-               	movq	-0x9a0(%rbp), %r8
-               	movb	%r8b, (%r15)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0xe0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0xf0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x100(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%dil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x110(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0xa60(%rbp)
+               	movups	%xmm14, -0xa40(%rbp)
                	movq	%r12, %rdi
-               	movups	-0xa60(%rbp), %xmm0
+               	movups	-0xa40(%rbp), %xmm0
+               	callq	 <L25>
+<L25>:
+               	movaps	-0xa10(%rbp), %xmm14
+               	pxor	-0xa40(%rbp), %xmm14
+               	movaps	%xmm14, -0xa50(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa50(%rbp), %xmm0
                	callq	 <L26>
 <L26>:
-               	movaps	-0xa30(%rbp), %xmm14
-               	pxor	-0xa60(%rbp), %xmm14
+               	movaps	-0xa20(%rbp), %xmm14
+               	paddb	-0xa00(%rbp), %xmm14
+               	movaps	%xmm14, -0xa60(%rbp)
+               	movq	%rax, %rdi
+               	movups	-0xa60(%rbp), %xmm0
+               	callq	 <L27>
+<L27>:
+               	movaps	-0xa00(%rbp), %xmm14
+               	paddb	-0x9b0(%rbp), %xmm14
                	movaps	%xmm14, -0xa70(%rbp)
                	movq	%rax, %rdi
                	movups	-0xa70(%rbp), %xmm0
-               	callq	 <L27>
-<L27>:
-               	movaps	-0xa40(%rbp), %xmm14
-               	paddb	-0xa20(%rbp), %xmm14
-               	movaps	%xmm14, -0xa80(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa80(%rbp), %xmm0
                	callq	 <L28>
 <L28>:
-               	movaps	-0xa20(%rbp), %xmm14
-               	paddb	-0x9d0(%rbp), %xmm14
-               	movaps	%xmm14, -0xa90(%rbp)
-               	movq	%rax, %rdi
-               	movups	-0xa90(%rbp), %xmm0
-               	callq	 <L29>
-<L29>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0xa90(%rbp), %xmm14
-               	movups	%xmm14, -0xa20(%rbp)
                	movups	-0xa70(%rbp), %xmm14
-               	movups	%xmm14, -0xa30(%rbp)
-               	movups	-0xa80(%rbp), %xmm14
-               	movups	%xmm14, -0xa40(%rbp)
-               	jmp	 <L18>
+               	movups	%xmm14, -0xa00(%rbp)
+               	movups	-0xa50(%rbp), %xmm14
+               	movups	%xmm14, -0xa10(%rbp)
+               	movups	-0xa60(%rbp), %xmm14
+               	movups	%xmm14, -0xa20(%rbp)
+               	jmp	 <L17>


### PR DESCRIPTION
Roadmap N6, phase 1 for #3110: inventory, extraction of the three candidate inline commits from `archive/3218-candidate-era` onto `dev`, and acceptance tests for every bullet the compiler policy can demonstrate with local fixtures. The std-side annotations for the eight atomic wrappers are Track C's S4; under the policy landed here they are not needed for elimination (every wrapper is well under the size bar).

Inventory: `doc/design/inline-acceptance-3110.md` (per bullet: `dev` today with its test, what the candidate adds, verdict, and the corpus golden evidence).

Extraction, one conventional commit per candidate commit, resolved against `dev` rather than overwriting it:

- `feat(inline)`: `c2fbd635`'s inline-body hunks (`me/ir/body.mach`, `me/pass/inline.mach`, `Function.body_module`, `Q_INLINE_BODIES` in the driver, `stamp_body_provider`, decorators doc, two driver tests). Resolutions: the product is registered equatable under the F2 contract; `body.mach` handles the typed pointer reference that arrived with #3268 and has no `IRT_TAG`; the parallel-lowering gate keeps `dev`'s shape; `#[inline]` leaves the lowered surface since it is no longer monomorphized. Hunks owned by other lanes (SPIR-V, RISC-V, linker, object formats, codegen, `ct.mach`) are listed under "not taken".
- `fix(inline)`: `602cf806` weak-provider retention with its driver test.
- `fix(inline)`: `d2a9842d` debug-independent body cost with its unit test.

Acceptance map for #3110:

| bullet | evidence |
| --- | --- |
| same-module elimination | `driver:inline_same_module_helper_leaves_no_call_in_x86_64_text` counts `call` in the x86-64 assembly codegen writes (noinline round as the counter's control) |
| cross-module elimination | `driver:inline_cross_module_helper_leaves_no_call_in_x86_64_text` (record constructor and integer helper from another module), `driver:inline_bodies_cross_modules_preserve_identity_effects_and_owned_metadata`, all 91 corpus goldens per target lose calls |
| bounded growth | `inline.run:helper_at_the_size_bar_keeps_its_call` (24 live instructions inlined, 25 kept; bar and budgets in `body.mach`), the over-the-bar leg of the rule test |
| recursion, indirect, noinline, unsupported asm | `driver:inline_rule_keeps_recursive_indirect_noinline_naked_and_large_calls`; rule documented in `doc/language/decorators.md` |
| effects and order | `driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order`: load/store/fence shaped like `std.sync.atomic`, two loads stay two asms, an unused load survives, store/fence/store order holds in IR and at MIR with both bindings |
| secrecy | `inline.run:oblivious_callee_inlines_only_into_an_oblivious_caller`, `driver:inline_oblivious_callee_stays_a_call_in_a_public_caller`; new rule, see below |
| debug mapping | `driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_bar`, `body:debug_annotation_does_not_move_a_bodys_cost`, existing DWARF inline-site tests |
| cache and query dependency invalidation | `driver:inline_body_availability_refreshes_after_unannotated_provider_edits`, `driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equal`, retargeted `driver:incremental_lower_inline_body_invalidates_importers` |
| pure vs atomic controls | the effect legs above; nothing classifies an asm body as pure (`ir/opdesc.mach`) |
| the eight atomic wrappers | phase 2: link and run the std wrappers themselves on x86_64, aarch64 and riscv64 once S4 lands (or without it, since they clear the bar); phase 1 covers the compiler policy with fixtures of their shape |

Two defects the tests forced, fixed here:

- An `#[oblivious]` callee was inlined into a public caller, moving its secret instructions out of the only function `ctvalidate` looks at. The inline pass now expands an `#[oblivious]` body only into an `#[oblivious]` caller.
- The candidate's release `Q_LOWER` recorded no dependency on the module's own typed definition when it took the raw module `Q_INLINE_BODIES` had captured; with the equatable registration a provider edit that left the extracted bodies equal reused the provider's own stale IR. `lower_inputs` records the definition and target reads on every product built from a raw lowering.

Mutation controls (one compiler built with all four guards mutated): dropping the oblivious check fails both oblivious tests, `<` to `<=` on the bar fails the size-bar test, counting `dbg_value` in `body.counted()` fails the `-g` identity and cost tests, and dropping `lower_inputs` from the capture path fails the propagation test; every other inline test still passes on that build.

Corpus: all 91 layer B goldens on `x86_64-linux` and on `aarch64-linux` moved, every one classified "calls removed" (x86-64: 4304 calls to 1791, 31 cases reach zero, frame larger 37 / same 44 / smaller 10; aarch64: 4304 to 1791, 31 reach zero, frame larger 26 / same 9 / smaller 32 / none 24), re-blessed with the per-golden table in `doc/design/inline-acceptance-3110.md` following `doc/design/corpus-goldens-3218.md`. Layers A and B pass on both targets against the blessed goldens.

Verification: full suite through the from-source compiler on the dev-merged branch, 2754 passed, 0 failed (16 tests added, none removed), `sh test/census.sh` ok (three new real bools listed), corpus layers A and B on x86_64-linux and aarch64-linux (364 cells pass, 0 fail, 0 skip each).

Phase 2 (what remains for `Closes #3110`): the std wrappers themselves linked and run on the three native targets with the call counts read from the linked image, and the darwin and windows layer B columns re-blessed on their runners.

#3110
